### PR TITLE
Add make target to build with Pack and paketo tiny

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,9 @@ docker-build: test ## Build docker image with the manager.
 docker-push: ## Push docker image with the manager.
 	docker push ${IMG}
 
+pack-build:
+	pack build ${IMG} --builder paketobuildpacks/builder:tiny
+
 ##@ Deployment
 
 install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.


### PR DESCRIPTION
## Is there a related GitHub Issue?
No.

## What is this change about?
Add make target to build image with Pack and paketo tiny.

## Does this PR introduce a breaking change?
No.

## Acceptance Steps
Deploy as normal.
