### PR TITLE
Fix helm template in install-dependencies script

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,10 +103,12 @@ Clone the eirini-controller repo and go to its root directory, render the Helm c
 # Set the certificate authority value for the eirini installation
 export webhooks_ca_bundle="$(kubectl get secret -n eirini-controller eirini-webhooks-certs -o jsonpath="{.data['tls\.ca']}")"
 # Run from the eirini-controller repository root
-helm template eirini-controller deployment/helm \
+helm template eirini-controller "deployment/helm" \
+  --values "deployment/helm/values-template.yaml"
   --set "webhooks.ca_bundle=${webhooks_ca_bundle}" \
   --set "workloads.create_namespaces=true" \
   --set "workloads.default_namespace=cf" \
+  --set "controller.registry_secret_name=image-registry-credentials" \
   --set "images.eirini_controller=eirini/eirini-controller@sha256:4dc6547537e30d778e81955065686b6d4d6162821f1ce29f7b80b3aefe20afb3" \
   --namespace "eirini-controller" | kubectl apply -f -
 ```

--- a/hack/install-dependencies.sh
+++ b/hack/install-dependencies.sh
@@ -140,11 +140,13 @@ EIRINI_DIR="$(cd "$(dirname "$0")/../../eirini-controller" && pwd)"
 
 webhooks_ca_bundle="$(kubectl get secret -n eirini-controller eirini-webhooks-certs -o jsonpath="{.data['tls\.ca']}")"
 
-# Install image built based on eirini-controller/main@c048d6
+# Install image built based on eirini-controller/main@c048d6 w/ values-template as default values file
 helm template eirini-controller "${EIRINI_DIR}/deployment/helm" \
+  --values "${EIRINI_DIR}/deployment/helm/values-template.yaml"
   --set "webhooks.ca_bundle=${webhooks_ca_bundle}" \
   --set "workloads.create_namespaces=true" \
   --set "workloads.default_namespace=cf" \
+  --set "controller.registry_secret_name=image-registry-credentials" \
   --set "images.eirini_controller=eirini/eirini-controller@sha256:4dc6547537e30d778e81955065686b6d4d6162821f1ce29f7b80b3aefe20afb3" \
   --namespace "eirini-controller" | kubectl apply -f -
 


### PR DESCRIPTION
## Is there a related GitHub Issue?
CI failure: https://github.com/cloudfoundry/cf-k8s-api/runs/4039034734?check_suite_focus=true

## What is this change about?
Fix install-dependencies script to run without provided values file, defaulting to values-template in eirini-controller.

## Does this PR introduce a breaking change?
No, quite the opposite.

## Acceptance Steps
Run the `./hack/install-dependencies.sh` script according to the README instructions.

## Tag your pair, your PM, and/or team
cc @davewalter @tcdowney 
