### PR TITLE
Fix missing line extension typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Clone the eirini-controller repo and go to its root directory, render the Helm c
 export webhooks_ca_bundle="$(kubectl get secret -n eirini-controller eirini-webhooks-certs -o jsonpath="{.data['tls\.ca']}")"
 # Run from the eirini-controller repository root
 helm template eirini-controller "deployment/helm" \
-  --values "deployment/helm/values-template.yaml"
+  --values "deployment/helm/values-template.yaml" \
   --set "webhooks.ca_bundle=${webhooks_ca_bundle}" \
   --set "workloads.create_namespaces=true" \
   --set "workloads.default_namespace=cf" \

--- a/hack/install-dependencies.sh
+++ b/hack/install-dependencies.sh
@@ -142,7 +142,7 @@ webhooks_ca_bundle="$(kubectl get secret -n eirini-controller eirini-webhooks-ce
 
 # Install image built based on eirini-controller/main@c048d6 w/ values-template as default values file
 helm template eirini-controller "${EIRINI_DIR}/deployment/helm" \
-  --values "${EIRINI_DIR}/deployment/helm/values-template.yaml"
+  --values "${EIRINI_DIR}/deployment/helm/values-template.yaml" \
   --set "webhooks.ca_bundle=${webhooks_ca_bundle}" \
   --set "workloads.create_namespaces=true" \
   --set "workloads.default_namespace=cf" \


### PR DESCRIPTION
Co-authored-by: Dave Walter <walterda@vmware.com>

## Is there a related GitHub Issue?
Typo in #128

## What is this change about?
Missing line extension in bash script command

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Run `./hack/install-dependencies.sh` according to README instructions.

## Tag your pair, your PM, and/or team
@davewalter 