### PR TITLE
Update readme/installation scripts to support older openssl versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,11 +296,6 @@ for usage notes.
 # modify kpack dependency files to point towards your registry
 scripts/install-dependencies.sh -g "<PATH_TO_GCR_CREDENTIALS>"
 ```
-**Note**: This will not work by default on OSX with a `libressl` version prior to `v3.1.0`. You can install the latest version of `openssl` by running the following commands:
-```sh
-brew install openssl
-ln -s /usr/local/opt/openssl@3/bin/openssl /usr/local/bin/openssl
-```
 
 ---
 ## Build, Install and Deploy to a K8s cluster

--- a/scripts/generate-eirini-certs-secret.sh
+++ b/scripts/generate-eirini-certs-secret.sh
@@ -12,7 +12,8 @@ pushd "${keys}"
 {
   kubectl create namespace "${EIRINI_NAMESPACE}" || true
 
-  openssl req -x509 -newkey rsa:4096 -keyout tls.key -out tls.crt -nodes -subj '/CN=localhost' -addext "subjectAltName = DNS:${otherDNS}, DNS:${otherDNS}.cluster.local" -days 365
+  openssl req -x509 -newkey rsa:4096 -keyout tls.key -out tls.crt -nodes -subj '/CN=localhost' -addext "subjectAltName = DNS:${otherDNS}, DNS:${otherDNS}.cluster.local" -days 365 || \
+  openssl req -x509 -newkey rsa:4096 -keyout tls.key -out tls.crt -nodes -subj '/CN=localhost' -extensions SAN -config <(cat /etc/ssl/openssl.cnf <(printf "[ SAN ]\nsubjectAltName='DNS:${otherDNS}, DNS:${otherDNS}.cluster.local'")) -days 365
 
   for secret_name in eirini-webhooks-certs; do
     if kubectl -n "${EIRINI_NAMESPACE}" get secret "${secret_name}" >/dev/null 2>&1; then


### PR DESCRIPTION
[TME-1638](https://jira.eng.vmware.com/browse/TME-1638)

<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Update the installation scripts to support older versions of openssl. This enables Mac users to run scripts without having to upgrade their openssl versions.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Run deploy-on-kind.sh script with a version of openssl prior to v3.1.0.

## Tag your pair, your PM, and/or team
@julian-hj 

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
