### PR TITLE
Bug: Fix GET CFApp Droplet Not Found message for CLI

### DIFF
--- a/api/apierrors/errors.go
+++ b/api/apierrors/errors.go
@@ -290,3 +290,33 @@ func ForbiddenAsNotFound(err error) error {
 	}
 	return err
 }
+
+// DropletForbiddenAsNotFound is a special case due to the CF CLI expecting the error message "Droplet not found" exactly instead of the generic case
+// https://github.com/cloudfoundry/korifi/issues/965
+func DropletForbiddenAsNotFound(err error) error {
+	var forbiddenErr ForbiddenError
+	if errors.As(err, &forbiddenErr) {
+		return NotFoundError{
+			apiError{
+				cause:      forbiddenErr.Unwrap(),
+				title:      "CF-ResourceNotFound",
+				detail:     "Droplet not found",
+				code:       10010,
+				httpStatus: http.StatusNotFound,
+			},
+		}
+	}
+	var notFoundErr NotFoundError
+	if errors.As(err, &notFoundErr) {
+		return NotFoundError{
+			apiError{
+				cause:      notFoundErr.Unwrap(),
+				title:      "CF-ResourceNotFound",
+				detail:     "Droplet not found",
+				code:       10010,
+				httpStatus: http.StatusNotFound,
+			},
+		}
+	}
+	return err
+}

--- a/api/apierrors/errors_test.go
+++ b/api/apierrors/errors_test.go
@@ -154,6 +154,61 @@ var _ = Describe("ForbiddenAsNotFound", func() {
 	})
 })
 
+var _ = Describe("DropletForbiddenAsNotFound", func() {
+	var (
+		err       error
+		actualErr error
+	)
+
+	BeforeEach(func() {
+		err = nil
+	})
+
+	JustBeforeEach(func() {
+		actualErr = apierrors.DropletForbiddenAsNotFound(err)
+	})
+
+	It("returns nil", func() {
+		Expect(actualErr).To(BeNil())
+	})
+
+	When("forbidden error", func() {
+		BeforeEach(func() {
+			err = apierrors.NewForbiddenError(errors.New("foo"), "Droplet")
+		})
+
+		It("returns a not found error", func() {
+			var notFoundError apierrors.NotFoundError
+			Expect(errors.As(actualErr, &notFoundError)).To(BeTrue())
+			Expect(notFoundError.Detail()).To(Equal("Droplet not found"))
+			Expect(notFoundError.Unwrap()).To(MatchError("foo"))
+		})
+	})
+
+	When("not found error", func() {
+		BeforeEach(func() {
+			err = apierrors.NewNotFoundError(errors.New("foo"), "Droplet")
+		})
+
+		It("returns a not found error", func() {
+			var notFoundError apierrors.NotFoundError
+			Expect(errors.As(actualErr, &notFoundError)).To(BeTrue())
+			Expect(notFoundError.Detail()).To(Equal("Droplet not found"))
+			Expect(notFoundError.Unwrap()).To(MatchError("foo"))
+		})
+	})
+
+	When("any other error", func() {
+		BeforeEach(func() {
+			err = errors.New("other")
+		})
+
+		It("returns it", func() {
+			Expect(actualErr).To(Equal(err))
+		})
+	})
+})
+
 var _ = Describe("AsUnprocessibleEntity", func() {
 	var (
 		err       error

--- a/api/apis/app_handler.go
+++ b/api/apis/app_handler.go
@@ -222,13 +222,13 @@ func (h *AppHandler) appGetCurrentDropletHandler(authInfo authorization.Info, r 
 
 	if app.DropletGUID == "" {
 		h.logger.Info("App does not have a current droplet assigned", "appGUID", app.GUID)
-		return nil, apierrors.NewNotFoundError(err, repositories.DropletResourceType)
+		return nil, apierrors.DropletForbiddenAsNotFound(apierrors.NewNotFoundError(err, repositories.DropletResourceType))
 	}
 
 	droplet, err := h.dropletRepo.GetDroplet(ctx, authInfo, app.DropletGUID)
 	if err != nil {
 		h.logger.Error(err, "Failed to fetch droplet from Kubernetes", "dropletGUID", app.DropletGUID)
-		return nil, apierrors.ForbiddenAsNotFound(err)
+		return nil, apierrors.DropletForbiddenAsNotFound(err)
 	}
 
 	return NewHandlerResponse(http.StatusOK).WithBody(presenter.ForDroplet(droplet, h.serverURL)), nil

--- a/api/apis/app_handler_test.go
+++ b/api/apis/app_handler_test.go
@@ -9,6 +9,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-http-utils/headers"
+	"github.com/onsi/gomega/gstruct"
+
 	"code.cloudfoundry.org/korifi/api/apierrors"
 	. "code.cloudfoundry.org/korifi/api/apis"
 	"code.cloudfoundry.org/korifi/api/apis/fake"
@@ -2307,8 +2310,21 @@ var _ = Describe("AppHandler", func() {
 				appRepo.GetAppReturns(repositories.AppRecord{GUID: appGUID, SpaceGUID: spaceGUID, DropletGUID: ""}, nil)
 			})
 
-			It("returns an error", func() {
-				expectNotFoundError("Droplet not found")
+			// This test case is special due to [issue/965](https://github.com/cloudfoundry/korifi/issues/965)
+			It("returns a Not Found error", func() {
+				Expect(rr).To(HaveHTTPStatus(http.StatusNotFound))
+				Expect(rr).To(HaveHTTPHeaderWithValue(headers.ContentType, jsonHeader))
+				var bodyJSON map[string]interface{}
+				Expect(json.Unmarshal(rr.Body.Bytes(), &bodyJSON)).To(Succeed())
+				Expect(bodyJSON).To(HaveKey("errors"))
+				Expect(bodyJSON["errors"]).To(HaveLen(1))
+				Expect(bodyJSON["errors"]).To(ConsistOf(
+					gstruct.MatchAllKeys(gstruct.Keys{
+						"code":   BeEquivalentTo(10010),
+						"title":  Equal("CF-ResourceNotFound"),
+						"detail": Equal("Droplet not found"),
+					}),
+				))
 			})
 		})
 
@@ -2317,8 +2333,21 @@ var _ = Describe("AppHandler", func() {
 				dropletRepo.GetDropletReturns(repositories.DropletRecord{}, apierrors.NewForbiddenError(nil, repositories.DropletResourceType))
 			})
 
-			It("returns an error", func() {
-				expectNotFoundError("Droplet not found")
+			// This test case is special due to [issue/965](https://github.com/cloudfoundry/korifi/issues/965)
+			It("returns a Not Found error", func() {
+				Expect(rr).To(HaveHTTPStatus(http.StatusNotFound))
+				Expect(rr).To(HaveHTTPHeaderWithValue(headers.ContentType, jsonHeader))
+				var bodyJSON map[string]interface{}
+				Expect(json.Unmarshal(rr.Body.Bytes(), &bodyJSON)).To(Succeed())
+				Expect(bodyJSON).To(HaveKey("errors"))
+				Expect(bodyJSON["errors"]).To(HaveLen(1))
+				Expect(bodyJSON["errors"]).To(ConsistOf(
+					gstruct.MatchAllKeys(gstruct.Keys{
+						"code":   BeEquivalentTo(10010),
+						"title":  Equal("CF-ResourceNotFound"),
+						"detail": Equal("Droplet not found"),
+					}),
+				))
 			})
 		})
 

--- a/api/apis/droplet_handler_test.go
+++ b/api/apis/droplet_handler_test.go
@@ -148,7 +148,7 @@ var _ = Describe("DropletHandler", func() {
 				router.ServeHTTP(rr, req)
 			})
 
-			It("returns an error", func() {
+			It("returns a Not Found error", func() {
 				expectNotFoundError("Droplet not found")
 			})
 		})


### PR DESCRIPTION


<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->
closes #965
## What is this change about?
<!-- _Please describe the change here._ -->


- Adds new apierror specifically for wrapping Droplet NotFound and Forbidden errors

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->
no
## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->
see issue.
## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

@clintyoshimura 
## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
