### PR TITLE
Add DELETE endpoint for route destinations

### DIFF
--- a/api/apis/fake/cfroute_repository.go
+++ b/api/apis/fake/cfroute_repository.go
@@ -100,6 +100,21 @@ type CFRouteRepository struct {
 		result1 []repositories.RouteRecord
 		result2 error
 	}
+	RemoveDestinationFromRouteStub        func(context.Context, authorization.Info, repositories.RemoveDestinationFromRouteMessage) (repositories.RouteRecord, error)
+	removeDestinationFromRouteMutex       sync.RWMutex
+	removeDestinationFromRouteArgsForCall []struct {
+		arg1 context.Context
+		arg2 authorization.Info
+		arg3 repositories.RemoveDestinationFromRouteMessage
+	}
+	removeDestinationFromRouteReturns struct {
+		result1 repositories.RouteRecord
+		result2 error
+	}
+	removeDestinationFromRouteReturnsOnCall map[int]struct {
+		result1 repositories.RouteRecord
+		result2 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -498,6 +513,72 @@ func (fake *CFRouteRepository) ListRoutesForAppReturnsOnCall(i int, result1 []re
 	}{result1, result2}
 }
 
+func (fake *CFRouteRepository) RemoveDestinationFromRoute(arg1 context.Context, arg2 authorization.Info, arg3 repositories.RemoveDestinationFromRouteMessage) (repositories.RouteRecord, error) {
+	fake.removeDestinationFromRouteMutex.Lock()
+	ret, specificReturn := fake.removeDestinationFromRouteReturnsOnCall[len(fake.removeDestinationFromRouteArgsForCall)]
+	fake.removeDestinationFromRouteArgsForCall = append(fake.removeDestinationFromRouteArgsForCall, struct {
+		arg1 context.Context
+		arg2 authorization.Info
+		arg3 repositories.RemoveDestinationFromRouteMessage
+	}{arg1, arg2, arg3})
+	stub := fake.RemoveDestinationFromRouteStub
+	fakeReturns := fake.removeDestinationFromRouteReturns
+	fake.recordInvocation("RemoveDestinationFromRoute", []interface{}{arg1, arg2, arg3})
+	fake.removeDestinationFromRouteMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *CFRouteRepository) RemoveDestinationFromRouteCallCount() int {
+	fake.removeDestinationFromRouteMutex.RLock()
+	defer fake.removeDestinationFromRouteMutex.RUnlock()
+	return len(fake.removeDestinationFromRouteArgsForCall)
+}
+
+func (fake *CFRouteRepository) RemoveDestinationFromRouteCalls(stub func(context.Context, authorization.Info, repositories.RemoveDestinationFromRouteMessage) (repositories.RouteRecord, error)) {
+	fake.removeDestinationFromRouteMutex.Lock()
+	defer fake.removeDestinationFromRouteMutex.Unlock()
+	fake.RemoveDestinationFromRouteStub = stub
+}
+
+func (fake *CFRouteRepository) RemoveDestinationFromRouteArgsForCall(i int) (context.Context, authorization.Info, repositories.RemoveDestinationFromRouteMessage) {
+	fake.removeDestinationFromRouteMutex.RLock()
+	defer fake.removeDestinationFromRouteMutex.RUnlock()
+	argsForCall := fake.removeDestinationFromRouteArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *CFRouteRepository) RemoveDestinationFromRouteReturns(result1 repositories.RouteRecord, result2 error) {
+	fake.removeDestinationFromRouteMutex.Lock()
+	defer fake.removeDestinationFromRouteMutex.Unlock()
+	fake.RemoveDestinationFromRouteStub = nil
+	fake.removeDestinationFromRouteReturns = struct {
+		result1 repositories.RouteRecord
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *CFRouteRepository) RemoveDestinationFromRouteReturnsOnCall(i int, result1 repositories.RouteRecord, result2 error) {
+	fake.removeDestinationFromRouteMutex.Lock()
+	defer fake.removeDestinationFromRouteMutex.Unlock()
+	fake.RemoveDestinationFromRouteStub = nil
+	if fake.removeDestinationFromRouteReturnsOnCall == nil {
+		fake.removeDestinationFromRouteReturnsOnCall = make(map[int]struct {
+			result1 repositories.RouteRecord
+			result2 error
+		})
+	}
+	fake.removeDestinationFromRouteReturnsOnCall[i] = struct {
+		result1 repositories.RouteRecord
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *CFRouteRepository) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -513,6 +594,8 @@ func (fake *CFRouteRepository) Invocations() map[string][][]interface{} {
 	defer fake.listRoutesMutex.RUnlock()
 	fake.listRoutesForAppMutex.RLock()
 	defer fake.listRoutesForAppMutex.RUnlock()
+	fake.removeDestinationFromRouteMutex.RLock()
+	defer fake.removeDestinationFromRouteMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/api/apis/route_handler_test.go
+++ b/api/apis/route_handler_test.go
@@ -1293,6 +1293,20 @@ var _ = Describe("RouteHandler", func() {
 				})
 			})
 
+			When("the user lacks permission to fetch the route", func() {
+				BeforeEach(func() {
+					routeRepo.GetRouteReturns(repositories.RouteRecord{}, apierrors.NewForbiddenError(nil, repositories.RouteResourceType))
+				})
+
+				It("responds with 404 and an error", func() {
+					expectNotFoundError("Route not found")
+				})
+
+				It("doesn't add any destinations to a route", func() {
+					Expect(routeRepo.AddDestinationsToRouteCallCount()).To(Equal(0))
+				})
+			})
+
 			When("the destination protocol is not provided", func() {
 				BeforeEach(func() {
 					requestBody = fmt.Sprintf(`{
@@ -1483,6 +1497,151 @@ var _ = Describe("RouteHandler", func() {
 
 				It("doesn't add any destinations to a route", func() {
 					Expect(routeRepo.AddDestinationsToRouteCallCount()).To(Equal(0))
+				})
+			})
+		})
+	})
+
+	Describe("the DELETE /v3/routes/:guid/destinations/:destination_guid endpoint", func() {
+		const (
+			routeGuid       = "test-route-guid"
+			domainGuid      = "test-domain-guid"
+			spaceGuid       = "test-space-guid"
+			routeHost       = "test-app"
+			appGuid         = "1cb006ee-fb05-47e1-b541-c34179ddc446"
+			destinationGuid = "destination-guid"
+		)
+
+		var (
+			domain      repositories.DomainRecord
+			routeRecord repositories.RouteRecord
+		)
+
+		BeforeEach(func() {
+			routeRecord = repositories.RouteRecord{
+				GUID:      routeGuid,
+				SpaceGUID: spaceGuid,
+				Domain:    repositories.DomainRecord{GUID: domainGuid},
+				Host:      routeHost,
+				Path:      "",
+				Protocol:  "http",
+				Destinations: []repositories.DestinationRecord{
+					{
+						GUID:        destinationGuid,
+						AppGUID:     appGuid,
+						ProcessType: "web",
+						Port:        8080,
+						Protocol:    "http1",
+					},
+				},
+			}
+
+			domain = repositories.DomainRecord{
+				GUID: domainGuid,
+				Name: "my-tld.com",
+			}
+
+			routeRepo.GetRouteReturns(routeRecord, nil)
+			domainRepo.GetDomainReturns(domain, nil)
+
+			updatedRoute := routeRecord
+			updatedRoute.Domain = domain
+			updatedRoute.Destinations = nil
+			routeRepo.AddDestinationsToRouteReturns(updatedRoute, nil)
+
+			requestMethod = http.MethodDelete
+			requestPath = "/v3/routes/" + routeGuid + "/destinations/" + destinationGuid
+			requestBody = ""
+		})
+
+		When("the request is valid", func() {
+			It("passes the authInfo into the repo calls", func() {
+				Expect(routeRepo.GetRouteCallCount()).To(Equal(1))
+				_, actualAuthInfo, _ := routeRepo.GetRouteArgsForCall(0)
+				Expect(actualAuthInfo).To(Equal(authInfo))
+
+				Expect(domainRepo.GetDomainCallCount()).To(Equal(1))
+				_, actualAuthInfo, _ = domainRepo.GetDomainArgsForCall(0)
+				Expect(actualAuthInfo).To(Equal(authInfo))
+
+				Expect(routeRepo.RemoveDestinationFromRouteCallCount()).To(Equal(1))
+				_, actualAuthInfo, _ = routeRepo.RemoveDestinationFromRouteArgsForCall(0)
+				Expect(actualAuthInfo).To(Equal(authInfo))
+			})
+
+			It("returns a success and a valid response", func() {
+				Expect(rr.Code).To(Equal(http.StatusNoContent), "Matching HTTP response code:")
+
+				Expect(rr.Body.String()).To(BeEmpty())
+			})
+
+			It("removes the destination from the Route", func() {
+				Expect(routeRepo.RemoveDestinationFromRouteCallCount()).To(Equal(1))
+				_, _, message := routeRepo.RemoveDestinationFromRouteArgsForCall(0)
+				Expect(message.RouteGUID).To(Equal(routeGuid))
+				Expect(message.SpaceGUID).To(Equal(spaceGuid))
+				Expect(message.DestinationGuid).To(Equal(destinationGuid))
+
+				Expect(message.ExistingDestinations).To(ConsistOf(
+					MatchAllFields(Fields{
+						"GUID":        Equal(destinationGuid),
+						"AppGUID":     Equal(appGuid),
+						"ProcessType": Equal("web"),
+						"Port":        Equal(8080),
+						"Protocol":    Equal("http1"),
+					}),
+				))
+			})
+
+			When("the route doesn't exist", func() {
+				BeforeEach(func() {
+					routeRepo.GetRouteReturns(repositories.RouteRecord{}, apierrors.NewNotFoundError(nil, repositories.RouteResourceType))
+				})
+
+				It("responds with 404 and an error", func() {
+					expectNotFoundError("Route not found")
+				})
+
+				It("doesn't add any destinations to a route", func() {
+					Expect(routeRepo.AddDestinationsToRouteCallCount()).To(Equal(0))
+				})
+			})
+
+			When("the user lacks permission to fetch the route", func() {
+				BeforeEach(func() {
+					routeRepo.GetRouteReturns(repositories.RouteRecord{}, apierrors.NewForbiddenError(nil, repositories.RouteResourceType))
+				})
+
+				It("responds with 404 and an error", func() {
+					expectNotFoundError("Route not found")
+				})
+
+				It("doesn't add any destinations to a route", func() {
+					Expect(routeRepo.AddDestinationsToRouteCallCount()).To(Equal(0))
+				})
+			})
+
+			When("fetching the route errors", func() {
+				BeforeEach(func() {
+					routeRepo.GetRouteReturns(repositories.RouteRecord{}, errors.New("boom"))
+				})
+
+				It("responds with an Unknown Error", func() {
+					expectUnknownError()
+				})
+
+				It("doesn't add any destinations to a route", func() {
+					Expect(routeRepo.AddDestinationsToRouteCallCount()).To(Equal(0))
+				})
+			})
+
+			When("removing the destinations from the Route errors", func() {
+				BeforeEach(func() {
+					routeRepo.RemoveDestinationFromRouteReturns(repositories.RouteRecord{}, errors.New("boom"))
+				})
+
+				It("responds with an Unknown Error", func() {
+					expectUnknownError()
 				})
 			})
 		})

--- a/api/apis/route_handler_test.go
+++ b/api/apis/route_handler_test.go
@@ -1544,11 +1544,6 @@ var _ = Describe("RouteHandler", func() {
 			routeRepo.GetRouteReturns(routeRecord, nil)
 			domainRepo.GetDomainReturns(domain, nil)
 
-			updatedRoute := routeRecord
-			updatedRoute.Domain = domain
-			updatedRoute.Destinations = nil
-			routeRepo.AddDestinationsToRouteReturns(updatedRoute, nil)
-
 			requestMethod = http.MethodDelete
 			requestPath = "/v3/routes/" + routeGuid + "/destinations/" + destinationGuid
 			requestBody = ""

--- a/docs/api.md
+++ b/docs/api.md
@@ -259,28 +259,29 @@ curl "http://localhost:9000/v3/domains?names=cf-apps.io" \
 
 ### Routes
 
-| Resource                  | Endpoint                              |
-| ------------------------- | ------------------------------------- |
-| Get Route                 | GET /v3/routes/\<guid>                |
-| Get Route List            | GET /v3/routes                        |
-| Get Route Destinations    | GET /v3/routes/\<guid\>/destinations  |
-| Create Route              | POST /v3/routes                       |
-| Add Destinations to Route | POST /v3/routes/\<guid\>/destinations |
-| Delete Route              | [DELETE /v3/routes/:guid](https://v3-apidocs.cloudfoundry.org/version/3.111.0/index.html#delete-a-route)
+| Resource                      | Endpoint                                                                                                 |
+|-------------------------------|----------------------------------------------------------------------------------------------------------|
+| Get Route                     | GET /v3/routes/\<guid>                                                                                   |
+| Get Route List                | GET /v3/routes                                                                                           |
+| Get Route Destinations        | GET /v3/routes/\<guid\>/destinations                                                                     |
+| Create Route                  | POST /v3/routes                                                                                          |
+| Add Destinations to Route     | POST /v3/routes/\<guid\>/destinations                                                                    |
+| Remove Destination from Route | DELETE /v3/routes/\<guid\>/destinations/\<destination-guid\>                                             |
+| Delete Route                  | [DELETE /v3/routes/:guid](https://v3-apidocs.cloudfoundry.org/version/3.111.0/index.html#delete-a-route) 
 
 #### [List Routes](https://v3-apidocs.cloudfoundry.org/version/3.111.0/index.html#list-routes)
 **Query Parameters:** Currently supports filtering by `app_guids`, `space_guids`, `domain_guids`, `hosts` and `paths`.
 
 #### [Creating Routes](https://v3-apidocs.cloudfoundry.org/version/3.107.0/index.html#create-a-route)
 ```bash
-curl "http://localhost:9000/v3/routes/<guid>/destinations" \
+curl "http://localhost:9000/v3/routes" \
   -X POST \
   -d '{"host": "hostname","path": "/path","relationships": {"domain": {"data": { "guid": "<domain-guid-goes-here>" }},"space": {"data": { "guid": "<namespace-name>" }}}}'
 ```
 
 #### [Add Destinations to Route](https://v3-apidocs.cloudfoundry.org/version/3.108.0/index.html#insert-destinations-for-a-route)
 ```bash
-curl "http://localhost:9000/v3/routes" \
+curl "http://localhost:9000/v3/routes/<guid>/destinations" \
   -X POST \
   -d '{
         "destinations": [
@@ -303,6 +304,11 @@ curl "http://localhost:9000/v3/routes" \
       }'
 ```
 
+#### [Remove Destination from Route](https://v3-apidocs.cloudfoundry.org/version/3.108.0/index.html#remove-destination-for-a-route)
+```bash
+curl "http://localhost:9000/v3/routes/<guid>/destinations/<destination-guid>" \
+  -X DELETE
+```
 ### Manifest
 
 | Resource         | Endpoint                                             |


### PR DESCRIPTION
## Is there a related GitHub Issue?
[#957]

## What is this change about?
- Implements DELETE /v3/routes/{guid}/destinations/{destination_guid}
- Extra credit: added a unit test to validate 404 behavior when an
  unprivileged user tries to add a route.
- Other extra credit: correct wrong URLs in the docs for routes.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
[#957]

## Tag your pair, your PM, and/or team
@matt-royal PTAL
