### PR TITLE
Revert auth on v1/info endpoint

### DIFF
--- a/api/apis/authentication_middleware.go
+++ b/api/apis/authentication_middleware.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"code.cloudfoundry.org/korifi/api/authorization"
+
 	"github.com/go-http-utils/headers"
 	"github.com/go-logr/logr"
 )
@@ -27,8 +28,9 @@ func NewAuthenticationMiddleware(logger logr.Logger, authInfoParser AuthInfoPars
 		authInfoParser:   authInfoParser,
 		identityProvider: identityProvider,
 		unauthenticatedEndpoints: map[string]interface{}{
-			"/":   struct{}{},
-			"/v3": struct{}{},
+			"/":            struct{}{},
+			"/v3":          struct{}{},
+			"/api/v1/info": struct{}{},
 		},
 	}
 }

--- a/api/apis/authentication_middleware_test.go
+++ b/api/apis/authentication_middleware_test.go
@@ -8,6 +8,7 @@ import (
 	"code.cloudfoundry.org/korifi/api/apis"
 	"code.cloudfoundry.org/korifi/api/apis/fake"
 	"code.cloudfoundry.org/korifi/api/authorization"
+
 	"github.com/go-http-utils/headers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -69,6 +70,21 @@ var _ = Describe("Authentication Middleware", func() {
 		Describe("/v3", func() {
 			BeforeEach(func() {
 				requestPath = "/v3"
+			})
+
+			It("passes through", func() {
+				Expect(rr).To(HaveHTTPStatus(http.StatusTeapot))
+			})
+
+			It("does not inject an authorization.Info in the context", func() {
+				_, ok := authorization.InfoFromContext(actualReq.Context())
+				Expect(ok).To(BeFalse())
+			})
+		})
+
+		Describe("/api/v1/info", func() {
+			BeforeEach(func() {
+				requestPath = "/api/v1/info"
 			})
 
 			It("passes through", func() {

--- a/api/apis/log_cache_handler.go
+++ b/api/apis/log_cache_handler.go
@@ -4,12 +4,11 @@ import (
 	"context"
 	"net/http"
 
-	"code.cloudfoundry.org/korifi/api/repositories"
-
 	"code.cloudfoundry.org/korifi/api/apierrors"
 	"code.cloudfoundry.org/korifi/api/authorization"
 	"code.cloudfoundry.org/korifi/api/payloads"
 	"code.cloudfoundry.org/korifi/api/presenter"
+	"code.cloudfoundry.org/korifi/api/repositories"
 
 	"github.com/go-logr/logr"
 	"github.com/go-playground/validator"
@@ -46,11 +45,11 @@ func NewLogCacheHandler(logger logr.Logger, appRepo CFAppRepository,
 	}
 }
 
-func (h *LogCacheHandler) logCacheInfoHandler(authInfo authorization.Info, r *http.Request) (*HandlerResponse, error) {
-	return NewHandlerResponse(http.StatusOK).WithBody(map[string]interface{}{
+func (h *LogCacheHandler) logCacheInfoHandler(w http.ResponseWriter, r *http.Request) {
+	writeResponse(w, http.StatusOK, map[string]interface{}{
 		"version":   logCacheVersion,
 		"vm_uptime": "0",
-	}), nil
+	})
 }
 
 func (h *LogCacheHandler) logCacheReadHandler(authInfo authorization.Info, r *http.Request) (*HandlerResponse, error) {
@@ -103,6 +102,6 @@ func (h *LogCacheHandler) logCacheReadHandler(authInfo authorization.Info, r *ht
 
 func (h *LogCacheHandler) RegisterRoutes(router *mux.Router) {
 	w := NewAuthAwareHandlerFuncWrapper(h.logger)
-	router.Path(LogCacheInfoPath).Methods("GET").HandlerFunc(w.Wrap(h.logCacheInfoHandler))
+	router.Path(LogCacheInfoPath).Methods("GET").HandlerFunc(h.logCacheInfoHandler)
 	router.Path(LogCacheReadPath).Methods("GET").HandlerFunc(w.Wrap(h.logCacheReadHandler))
 }

--- a/api/apis/log_cache_handler_test.go
+++ b/api/apis/log_cache_handler_test.go
@@ -8,10 +8,10 @@ import (
 	"time"
 
 	"code.cloudfoundry.org/korifi/api/apierrors"
-
 	. "code.cloudfoundry.org/korifi/api/apis"
 	"code.cloudfoundry.org/korifi/api/apis/fake"
 	"code.cloudfoundry.org/korifi/api/repositories"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -49,7 +49,7 @@ var _ = Describe("LogCacheHandler", func() {
 	Describe("the GET /api/v1/info endpoint", func() {
 		BeforeEach(func() {
 			var err error
-			req, err = http.NewRequestWithContext(ctx, "GET", "/api/v1/info", nil)
+			req, err = http.NewRequest("GET", "/api/v1/info", nil)
 			Expect(err).NotTo(HaveOccurred())
 		})
 


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->
No 🤠 
## What is this change about?
<!-- _Please describe the change here._ -->
Reverts the auth on the v1 info endpoint- we were seeing an issue with `cf push` getting an unauthorized response:
```
REQUEST: [2022-04-27T10:54:47-07:00]
GET /api/v1/info HTTP/1.1
Host: localhost
Authorization: 
User-Agent: cf/0.0.0-unknown-version (go1.17.2; amd64 linux)


RESPONSE: [2022-04-27T10:54:47-07:00]
HTTP/1.1 401 Unauthorized
Content-Type: application/json
Date: Wed, 27 Apr 2022 17:54:47 GMT
X-Envoy-Upstream-Service-Time: 0
Vary: Accept-Encoding
Server: envoy
```

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->
No.

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->
Run `cf push` observe that we no longer see 401 errors

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->
@acosta11 @tcdowney 

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
