### PR TITLE
Add validation webhook for CFOrg and CFSpace for enforcing naming constraints

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,3 +35,7 @@ issues:
     - path: service\w+_controller\.go
       linters:
         - dupl
+    # Ignore false positive duplicate linter errors comparing validating webhooks for cforg and cfapp.
+    - path: workloads/cf\w+_validation\.go
+      linters:
+        - dupl

--- a/api/apis/fake/cfspace_repository.go
+++ b/api/apis/fake/cfspace_repository.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"sync"
 
+	"code.cloudfoundry.org/korifi/api/apis"
 	"code.cloudfoundry.org/korifi/api/authorization"
 	"code.cloudfoundry.org/korifi/api/repositories"
 )
@@ -363,4 +364,4 @@ func (fake *CFSpaceRepository) recordInvocation(key string, args []interface{}) 
 	fake.invocations[key] = append(fake.invocations[key], args)
 }
 
-var _ repositories.CFSpaceRepository = new(CFSpaceRepository)
+var _ apis.CFSpaceRepository = new(CFSpaceRepository)

--- a/api/apis/space_manifest_handler.go
+++ b/api/apis/space_manifest_handler.go
@@ -20,12 +20,21 @@ const (
 	SpaceManifestDiffPath  = "/v3/spaces/{spaceGUID}/manifest_diff"
 )
 
+//counterfeiter:generate -o fake -fake-name CFSpaceRepository . CFSpaceRepository
+
+type CFSpaceRepository interface {
+	CreateSpace(context.Context, authorization.Info, repositories.CreateSpaceMessage) (repositories.SpaceRecord, error)
+	ListSpaces(context.Context, authorization.Info, repositories.ListSpacesMessage) ([]repositories.SpaceRecord, error)
+	GetSpace(context.Context, authorization.Info, string) (repositories.SpaceRecord, error)
+	DeleteSpace(context.Context, authorization.Info, repositories.DeleteSpaceMessage) error
+}
+
 type SpaceManifestHandler struct {
 	logger              logr.Logger
 	serverURL           url.URL
 	defaultDomainName   string
 	applyManifestAction ApplyManifestAction
-	spaceRepo           repositories.CFSpaceRepository
+	spaceRepo           CFSpaceRepository
 	decoderValidator    *DecoderValidator
 }
 
@@ -37,7 +46,7 @@ func NewSpaceManifestHandler(
 	serverURL url.URL,
 	defaultDomainName string,
 	applyManifestAction ApplyManifestAction,
-	spaceRepo repositories.CFSpaceRepository,
+	spaceRepo CFSpaceRepository,
 	decoderValidator *DecoderValidator,
 ) *SpaceManifestHandler {
 	return &SpaceManifestHandler{

--- a/api/apis/space_manifest_handler_test.go
+++ b/api/apis/space_manifest_handler_test.go
@@ -7,8 +7,6 @@ import (
 
 	"code.cloudfoundry.org/korifi/api/apierrors"
 	"code.cloudfoundry.org/korifi/api/repositories"
-	repositoriesfake "code.cloudfoundry.org/korifi/api/repositories/fake"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -20,14 +18,14 @@ import (
 var _ = Describe("SpaceManifestHandler", func() {
 	var (
 		applyManifestAction *fake.ApplyManifestAction
-		spaceRepo           *repositoriesfake.CFSpaceRepository
+		spaceRepo           *fake.CFSpaceRepository
 		req                 *http.Request
 		defaultDomainName   string
 	)
 
 	BeforeEach(func() {
 		applyManifestAction = new(fake.ApplyManifestAction)
-		spaceRepo = new(repositoriesfake.CFSpaceRepository)
+		spaceRepo = new(fake.CFSpaceRepository)
 		defaultDomainName = "apps.example.org"
 
 		decoderValidator, err := NewDefaultDecoderValidator()

--- a/api/repositories/route_repository.go
+++ b/api/repositories/route_repository.go
@@ -418,6 +418,7 @@ func (f *RouteRepo) RemoveDestinationFromRoute(ctx context.Context, authInfo aut
 
 	return cfRouteToRouteRecord(*cfRoute), err
 }
+
 func mergeDestinations(existingDestinations []DestinationRecord, newDestinations []DestinationMessage) []networkingv1alpha1.Destination {
 	result := destinationRecordsToCFDestinations(existingDestinations)
 

--- a/api/repositories/route_repository_test.go
+++ b/api/repositories/route_repository_test.go
@@ -1261,7 +1261,6 @@ var _ = Describe("RouteRepository", func() {
 				DestinationGuid:      destinationGUID,
 			}
 			_, removeDestinationErr = routeRepo.RemoveDestinationFromRoute(testCtx, authInfo, destinationDeleteMessage)
-
 		})
 
 		AfterEach(func() {

--- a/api/repositories/space_repository.go
+++ b/api/repositories/space_repository.go
@@ -22,16 +22,6 @@ import (
 
 //+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=create
 
-//counterfeiter:generate -o fake -fake-name CFSpaceRepository . CFSpaceRepository
-
-// TODO: Move this into space_manifest_handler.go
-type CFSpaceRepository interface {
-	CreateSpace(context.Context, authorization.Info, CreateSpaceMessage) (SpaceRecord, error)
-	ListSpaces(context.Context, authorization.Info, ListSpacesMessage) ([]SpaceRecord, error)
-	GetSpace(context.Context, authorization.Info, string) (SpaceRecord, error)
-	DeleteSpace(context.Context, authorization.Info, DeleteSpaceMessage) error
-}
-
 const (
 	SpaceNameLabel    = "cloudfoundry.org/space-name"
 	SpacePrefix       = "cf-space-"

--- a/api/tests/e2e/orgs_test.go
+++ b/api/tests/e2e/orgs_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Orgs", func() {
 			Expect(result.GUID).To(HavePrefix("cf-org-"))
 		})
 
-		When("the org name already exists", Pending, func() {
+		When("the org name already exists", func() {
 			var duplOrgGUID string
 
 			BeforeEach(func() {

--- a/controllers/config/webhook/manifests.yaml
+++ b/controllers/config/webhook/manifests.yaml
@@ -168,6 +168,28 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validate-workloads-cloudfoundry-org-v1alpha1-cfspace
+  failurePolicy: Fail
+  name: vcfspace.workloads.cloudfoundry.org
+  rules:
+  - apiGroups:
+    - workloads.cloudfoundry.org
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - cfspaces
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-hnc-x-k8s-io-v1alpha2-subnamespaceanchor
   failurePolicy: Fail
   name: vsubns.workloads.cloudfoundry.org

--- a/controllers/config/webhook/manifests.yaml
+++ b/controllers/config/webhook/manifests.yaml
@@ -146,6 +146,28 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validate-workloads-cloudfoundry-org-v1alpha1-cforg
+  failurePolicy: Fail
+  name: vcforg.workloads.cloudfoundry.org
+  rules:
+  - apiGroups:
+    - workloads.cloudfoundry.org
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - cforgs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-hnc-x-k8s-io-v1alpha2-subnamespaceanchor
   failurePolicy: Fail
   name: vsubns.workloads.cloudfoundry.org

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -290,6 +290,13 @@ func main() {
 			os.Exit(1)
 		}
 
+		if err = workloads.NewCFOrgValidation(
+			webhooks.NewDuplicateValidator(coordination.NewNameRegistry(mgr.GetClient(), workloads.CFOrgEntityType)),
+		).SetupWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "CFOrg")
+			os.Exit(1)
+		}
+
 		if err = (&networkingv1alpha1.CFRoute{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "CFRoute")
 			os.Exit(1)

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -297,6 +297,13 @@ func main() {
 			os.Exit(1)
 		}
 
+		if err = workloads.NewCFSpaceValidation(
+			webhooks.NewDuplicateValidator(coordination.NewNameRegistry(mgr.GetClient(), workloads.CFSpaceEntityType)),
+		).SetupWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "CFSpace")
+			os.Exit(1)
+		}
+
 		if err = (&networkingv1alpha1.CFRoute{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "CFRoute")
 			os.Exit(1)

--- a/controllers/reference/korifi-controllers.yaml
+++ b/controllers/reference/korifi-controllers.yaml
@@ -3074,6 +3074,28 @@ webhooks:
     service:
       name: korifi-controllers-webhook-service
       namespace: korifi-controllers-system
+      path: /validate-workloads-cloudfoundry-org-v1alpha1-cforg
+  failurePolicy: Fail
+  name: vcforg.workloads.cloudfoundry.org
+  rules:
+  - apiGroups:
+    - workloads.cloudfoundry.org
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - cforgs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: korifi-controllers-webhook-service
+      namespace: korifi-controllers-system
       path: /validate-hnc-x-k8s-io-v1alpha2-subnamespaceanchor
   failurePolicy: Fail
   name: vsubns.workloads.cloudfoundry.org

--- a/controllers/reference/korifi-controllers.yaml
+++ b/controllers/reference/korifi-controllers.yaml
@@ -3096,6 +3096,28 @@ webhooks:
     service:
       name: korifi-controllers-webhook-service
       namespace: korifi-controllers-system
+      path: /validate-workloads-cloudfoundry-org-v1alpha1-cfspace
+  failurePolicy: Fail
+  name: vcfspace.workloads.cloudfoundry.org
+  rules:
+  - apiGroups:
+    - workloads.cloudfoundry.org
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - cfspaces
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: korifi-controllers-webhook-service
+      namespace: korifi-controllers-system
       path: /validate-hnc-x-k8s-io-v1alpha2-subnamespaceanchor
   failurePolicy: Fail
   name: vsubns.workloads.cloudfoundry.org

--- a/controllers/webhooks/workloads/cforg_validation.go
+++ b/controllers/webhooks/workloads/cforg_validation.go
@@ -1,0 +1,97 @@
+package workloads
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"code.cloudfoundry.org/korifi/controllers/apis/workloads/v1alpha1"
+	"code.cloudfoundry.org/korifi/controllers/webhooks"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+const (
+	CFOrgEntityType       = "cforg"
+	OrgDecodingErrorType  = "OrgDecodingError"
+	DuplicateOrgErrorType = "DuplicateOrgNameError"
+)
+
+var cforglog = logf.Log.WithName("cforg-validate")
+
+//+kubebuilder:webhook:path=/validate-workloads-cloudfoundry-org-v1alpha1-cforg,mutating=false,failurePolicy=fail,sideEffects=None,groups=workloads.cloudfoundry.org,resources=cforgs,verbs=create;update;delete,versions=v1alpha1,name=vcforg.workloads.cloudfoundry.org,admissionReviewVersions={v1,v1beta1}
+
+type CFOrgValidation struct {
+	decoder            *admission.Decoder
+	duplicateValidator NameValidator
+}
+
+func NewCFOrgValidation(duplicateValidator NameValidator) *CFOrgValidation {
+	return &CFOrgValidation{
+		duplicateValidator: duplicateValidator,
+	}
+}
+
+func (v *CFOrgValidation) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	mgr.GetWebhookServer().Register("/validate-workloads-cloudfoundry-org-v1alpha1-cforg", &webhook.Admission{Handler: v})
+
+	return nil
+}
+
+func (v *CFOrgValidation) Handle(ctx context.Context, req admission.Request) admission.Response {
+	cforglog.Info("Validate", "name", req.Name)
+
+	var cfOrg, oldCFOrg v1alpha1.CFOrg
+	if req.Operation == admissionv1.Create || req.Operation == admissionv1.Update {
+		err := v.decoder.Decode(req, &cfOrg)
+		if err != nil { // untested
+			errMessage := "Error while decoding CFOrg object"
+			cforglog.Error(err, errMessage)
+			return admission.Denied(webhooks.ValidationError{Type: OrgDecodingErrorType, Message: errMessage}.Marshal())
+		}
+	}
+	if req.Operation == admissionv1.Update || req.Operation == admissionv1.Delete {
+		err := v.decoder.DecodeRaw(req.OldObject, &oldCFOrg)
+		if err != nil { // untested
+			errMessage := "Error while decoding old CFOrg object"
+			cforglog.Error(err, errMessage)
+			return admission.Denied(webhooks.ValidationError{Type: OrgDecodingErrorType, Message: errMessage}.Marshal())
+		}
+	}
+
+	var validatorErr error
+	cfOrgNameLeaseValue := strings.ToLower(cfOrg.Spec.DisplayName)
+	switch req.Operation {
+	case admissionv1.Create:
+		validatorErr = v.duplicateValidator.ValidateCreate(ctx, cforglog, cfOrg.Namespace, cfOrgNameLeaseValue)
+
+	case admissionv1.Update:
+		oldCFOrgNameLeaseValue := strings.ToLower(oldCFOrg.Spec.DisplayName)
+		validatorErr = v.duplicateValidator.ValidateUpdate(ctx, cforglog, cfOrg.Namespace, oldCFOrgNameLeaseValue, cfOrgNameLeaseValue)
+
+	case admissionv1.Delete:
+		oldCFOrgNameLeaseValue := strings.ToLower(oldCFOrg.Spec.DisplayName)
+		validatorErr = v.duplicateValidator.ValidateDelete(ctx, cforglog, oldCFOrg.Namespace, oldCFOrgNameLeaseValue)
+	}
+
+	if validatorErr != nil {
+		if errors.Is(validatorErr, webhooks.ErrorDuplicateName) {
+			errorMessage := fmt.Sprintf("Organization '%s' already exists.", cfOrg.Spec.DisplayName)
+			return admission.Denied(webhooks.ValidationError{Type: DuplicateOrgErrorType, Message: errorMessage}.Marshal())
+		}
+
+		return admission.Denied(webhooks.AdmissionUnknownErrorReason())
+	}
+
+	return admission.Allowed("")
+}
+
+func (v *CFOrgValidation) InjectDecoder(d *admission.Decoder) error {
+	v.decoder = d
+	return nil
+}

--- a/controllers/webhooks/workloads/cforg_validation_test.go
+++ b/controllers/webhooks/workloads/cforg_validation_test.go
@@ -1,0 +1,265 @@
+package workloads_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	workloadsv1alpha1 "code.cloudfoundry.org/korifi/controllers/apis/workloads/v1alpha1"
+	"code.cloudfoundry.org/korifi/controllers/webhooks"
+	"code.cloudfoundry.org/korifi/controllers/webhooks/workloads"
+	"code.cloudfoundry.org/korifi/controllers/webhooks/workloads/fake"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+var _ = Describe("CFOrgValidatingWebhook", func() {
+	const (
+		testOrgGUID   = "test-org-guid"
+		testOrgName   = "test-org"
+		rootNamespace = "cf"
+	)
+
+	var (
+		ctx                context.Context
+		duplicateValidator *fake.NameValidator
+		realDecoder        *admission.Decoder
+		org                *workloadsv1alpha1.CFOrg
+		request            admission.Request
+		validatingWebhook  *workloads.CFOrgValidation
+		response           admission.Response
+		cfOrgJSON          []byte
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+
+		scheme := runtime.NewScheme()
+		err := workloadsv1alpha1.AddToScheme(scheme)
+		Expect(err).NotTo(HaveOccurred())
+
+		realDecoder, err = admission.NewDecoder(scheme)
+		Expect(err).NotTo(HaveOccurred())
+
+		org = &workloadsv1alpha1.CFOrg{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testOrgGUID,
+				Namespace: rootNamespace,
+			},
+			Spec: workloadsv1alpha1.CFOrgSpec{
+				DisplayName: testOrgName,
+			},
+		}
+
+		cfOrgJSON, err = json.Marshal(org)
+		Expect(err).NotTo(HaveOccurred())
+
+		duplicateValidator = new(fake.NameValidator)
+		validatingWebhook = workloads.NewCFOrgValidation(duplicateValidator)
+
+		Expect(validatingWebhook.InjectDecoder(realDecoder)).To(Succeed())
+	})
+
+	Describe("Create", func() {
+		JustBeforeEach(func() {
+			response = validatingWebhook.Handle(ctx, request)
+		})
+
+		BeforeEach(func() {
+			request = admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name:      testOrgGUID,
+					Namespace: rootNamespace,
+					Operation: admissionv1.Create,
+					Object: runtime.RawExtension{
+						Raw: cfOrgJSON,
+					},
+				},
+			}
+		})
+
+		It("allows the request", func() {
+			Expect(response.Allowed).To(BeTrue())
+		})
+
+		It("invokes the validator correctly", func() {
+			Expect(duplicateValidator.ValidateCreateCallCount()).To(Equal(1))
+			actualContext, _, namespace, name := duplicateValidator.ValidateCreateArgsForCall(0)
+			Expect(actualContext).To(Equal(ctx))
+			Expect(namespace).To(Equal(rootNamespace))
+			Expect(name).To(Equal(testOrgName))
+		})
+
+		When("the org name is a duplicate", func() {
+			BeforeEach(func() {
+				duplicateValidator.ValidateCreateReturns(webhooks.ErrorDuplicateName)
+			})
+
+			It("denies the request", func() {
+				Expect(response.Allowed).To(BeFalse())
+				Expect(string(response.Result.Reason)).To(Equal(webhooks.ValidationError{Type: workloads.DuplicateOrgErrorType, Message: `Organization '` + org.Spec.DisplayName + `' already exists.`}.Marshal()))
+			})
+		})
+
+		When("there is an issue decoding the request", func() {
+			BeforeEach(func() {
+				cfOrgJSON, err := json.Marshal(org)
+				Expect(err).NotTo(HaveOccurred())
+				badCFOrgJSON := []byte("}" + string(cfOrgJSON))
+
+				request = admission.Request{
+					AdmissionRequest: admissionv1.AdmissionRequest{
+						Name:      testOrgGUID,
+						Namespace: rootNamespace,
+						Operation: admissionv1.Create,
+						Object: runtime.RawExtension{
+							Raw: badCFOrgJSON,
+						},
+					},
+				}
+			})
+
+			It("denies the request", func() {
+				Expect(response.Allowed).To(BeFalse())
+			})
+
+			It("does not attempt to register a name", func() {
+				Expect(duplicateValidator.ValidateCreateCallCount()).To(Equal(0))
+			})
+		})
+
+		When("validating the org name fails", func() {
+			BeforeEach(func() {
+				duplicateValidator.ValidateCreateReturns(errors.New("boom"))
+			})
+
+			It("denies the request", func() {
+				Expect(response.Allowed).To(BeFalse())
+				Expect(string(response.Result.Reason)).To(Equal(webhooks.AdmissionUnknownErrorReason()))
+			})
+		})
+	})
+
+	Describe("Update", func() {
+		var updatedOrg *workloadsv1alpha1.CFOrg
+
+		BeforeEach(func() {
+			updatedOrg = &workloadsv1alpha1.CFOrg{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testOrgGUID,
+					Namespace: rootNamespace,
+				},
+				Spec: workloadsv1alpha1.CFOrgSpec{
+					DisplayName: "the-new-name",
+				},
+			}
+		})
+
+		JustBeforeEach(func() {
+			orgJSON, err := json.Marshal(org)
+			Expect(err).NotTo(HaveOccurred())
+
+			updatedOrgJSON, err := json.Marshal(updatedOrg)
+			Expect(err).NotTo(HaveOccurred())
+
+			request = admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name:      testOrgGUID,
+					Namespace: rootNamespace,
+					Operation: admissionv1.Update,
+					Object: runtime.RawExtension{
+						Raw: updatedOrgJSON,
+					},
+					OldObject: runtime.RawExtension{
+						Raw: orgJSON,
+					},
+				},
+			}
+
+			response = validatingWebhook.Handle(ctx, request)
+		})
+
+		It("allows the request", func() {
+			Expect(response.Allowed).To(BeTrue())
+		})
+
+		It("invokes the validator correctly", func() {
+			Expect(duplicateValidator.ValidateUpdateCallCount()).To(Equal(1))
+			actualContext, _, namespace, oldName, newName := duplicateValidator.ValidateUpdateArgsForCall(0)
+			Expect(actualContext).To(Equal(ctx))
+			Expect(namespace).To(Equal(org.Namespace))
+			Expect(oldName).To(Equal(org.Spec.DisplayName))
+			Expect(newName).To(Equal(updatedOrg.Spec.DisplayName))
+		})
+
+		When("the new org name is a duplicate", func() {
+			BeforeEach(func() {
+				duplicateValidator.ValidateUpdateReturns(webhooks.ErrorDuplicateName)
+			})
+
+			It("denies the request", func() {
+				Expect(response.Allowed).To(BeFalse())
+				Expect(string(response.Result.Reason)).To(Equal(webhooks.ValidationError{Type: workloads.DuplicateOrgErrorType, Message: `Organization '` + updatedOrg.Spec.DisplayName + `' already exists.`}.Marshal()))
+			})
+		})
+
+		When("the update validation fails for another reason", func() {
+			BeforeEach(func() {
+				duplicateValidator.ValidateUpdateReturns(errors.New("boom!"))
+			})
+
+			It("denies the request", func() {
+				Expect(response.Allowed).To(BeFalse())
+				Expect(string(response.Result.Reason)).To(Equal(webhooks.AdmissionUnknownErrorReason()))
+			})
+		})
+	})
+
+	Describe("Delete", func() {
+		JustBeforeEach(func() {
+			orgJSON, err := json.Marshal(org)
+			Expect(err).NotTo(HaveOccurred())
+
+			request = admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name:      testOrgGUID,
+					Namespace: rootNamespace,
+					Operation: admissionv1.Delete,
+					OldObject: runtime.RawExtension{
+						Raw: orgJSON,
+					},
+				},
+			}
+
+			response = validatingWebhook.Handle(ctx, request)
+		})
+
+		It("allows the request", func() {
+			Expect(response.Allowed).To(BeTrue())
+		})
+
+		It("invokes the validator correctly", func() {
+			Expect(duplicateValidator.ValidateDeleteCallCount()).To(Equal(1))
+			actualContext, _, namespace, name := duplicateValidator.ValidateDeleteArgsForCall(0)
+			Expect(actualContext).To(Equal(ctx))
+			Expect(namespace).To(Equal(org.Namespace))
+			Expect(name).To(Equal(org.Spec.DisplayName))
+		})
+
+		When("delete validation fails", func() {
+			BeforeEach(func() {
+				duplicateValidator.ValidateDeleteReturns(errors.New("boom!"))
+			})
+
+			It("disallows the request", func() {
+				Expect(response.Allowed).To(BeFalse())
+				Expect(string(response.Result.Reason)).To(Equal(webhooks.AdmissionUnknownErrorReason()))
+			})
+		})
+	})
+})

--- a/controllers/webhooks/workloads/cfspace_validation.go
+++ b/controllers/webhooks/workloads/cfspace_validation.go
@@ -1,0 +1,167 @@
+package workloads
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	workloadsv1alpha1 "code.cloudfoundry.org/korifi/controllers/apis/workloads/v1alpha1"
+	"code.cloudfoundry.org/korifi/controllers/webhooks"
+
+	"github.com/go-logr/logr"
+	admissionv1 "k8s.io/api/admission/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+//+kubebuilder:webhook:path=/validate-workloads-cloudfoundry-org-v1alpha1-cfspace,mutating=false,failurePolicy=fail,sideEffects=None,groups=workloads.cloudfoundry.org,resources=cfspaces,verbs=create;update;delete,versions=v1alpha1,name=vcfspace.workloads.cloudfoundry.org,admissionReviewVersions={v1,v1beta1}
+
+const CFSpaceEntityType = "cfspace"
+
+var spaceLogger = logf.Log.WithName("cfspace-validate")
+
+type CFSpaceValidation struct {
+	duplicateSpaceValidator NameValidator
+	decoder                 *admission.Decoder
+}
+
+func NewCFSpaceValidation(duplicateSpaceValidator NameValidator) *CFSpaceValidation {
+	return &CFSpaceValidation{
+		duplicateSpaceValidator: duplicateSpaceValidator,
+	}
+}
+
+func (v *CFSpaceValidation) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	mgr.GetWebhookServer().Register("/validate-workloads-cloudfoundry-org-v1alpha1-cfspace", &webhook.Admission{Handler: v})
+
+	return nil
+}
+
+func (v *CFSpaceValidation) Handle(ctx context.Context, req admission.Request) admission.Response {
+	var handler cfSpaceHandler
+
+	cfSpace := &workloadsv1alpha1.CFSpace{}
+	if req.Operation == admissionv1.Create || req.Operation == admissionv1.Update {
+		if err := v.decoder.Decode(req, cfSpace); err != nil {
+			spaceLogger.Error(err, "failed to decode CFSpace", "request", req)
+			return admission.Denied(webhooks.AdmissionUnknownErrorReason())
+		}
+
+		var err error
+		handler, err = v.newHandler()
+		if err != nil {
+			return admission.Denied(webhooks.AdmissionUnknownErrorReason())
+		}
+
+	}
+
+	oldCFSpace := &workloadsv1alpha1.CFSpace{}
+	if req.Operation == admissionv1.Update || req.Operation == admissionv1.Delete {
+		if err := v.decoder.DecodeRaw(req.OldObject, oldCFSpace); err != nil {
+			spaceLogger.Error(err, "failed to decode old CFSpace", "request", req)
+			return admission.Denied(webhooks.AdmissionUnknownErrorReason())
+		}
+
+		var err error
+		handler, err = v.newHandler()
+		if err != nil {
+			return admission.Allowed("")
+		}
+
+	}
+
+	switch req.Operation {
+	case admissionv1.Create:
+		return handler.handleCreate(ctx, cfSpace)
+
+	case admissionv1.Update:
+		return handler.handleUpdate(ctx, oldCFSpace, cfSpace)
+
+	case admissionv1.Delete:
+		return handler.handleDelete(ctx, oldCFSpace)
+	}
+
+	spaceLogger.Info("unexpected operation", "operation", req.Operation)
+	return admission.Denied(webhooks.AdmissionUnknownErrorReason())
+}
+
+func (v *CFSpaceValidation) newHandler() (cfSpaceHandler, error) {
+	return NewCFSpaceHandler(
+		spaceLogger.WithValues("entityType", CFSpaceEntityType),
+		v.duplicateSpaceValidator,
+		SpaceNameLabel,
+		webhooks.ValidationError{Type: DuplicateSpaceNameErrorType, Message: duplicateSpaceNameErrorMessage},
+	), nil
+}
+
+func (h *cfSpaceHandler) RenderDuplicateError(duplicateName string) string {
+	formattedDuplicateError := webhooks.ValidationError{
+		Type:    h.duplicateError.Type,
+		Message: fmt.Sprintf(h.duplicateError.Message, duplicateName),
+	}
+	return formattedDuplicateError.Marshal()
+}
+
+type cfSpaceHandler struct {
+	duplicateValidator NameValidator
+	nameLabel          string
+	duplicateError     webhooks.ValidationError
+	logger             logr.Logger
+}
+
+func NewCFSpaceHandler(
+	logger logr.Logger,
+	duplicateValidator NameValidator,
+	nameLabel string,
+	duplicateError webhooks.ValidationError,
+) cfSpaceHandler {
+	return cfSpaceHandler{
+		duplicateValidator: duplicateValidator,
+		nameLabel:          nameLabel,
+		duplicateError:     duplicateError,
+		logger:             logger,
+	}
+}
+
+func (h cfSpaceHandler) handleCreate(ctx context.Context, cfSpace *workloadsv1alpha1.CFSpace) admission.Response {
+	spaceName := strings.ToLower(cfSpace.Spec.DisplayName)
+	if err := h.duplicateValidator.ValidateCreate(ctx, h.logger, cfSpace.Namespace, spaceName); err != nil {
+		if errors.Is(err, webhooks.ErrorDuplicateName) {
+			return admission.Denied(h.RenderDuplicateError(spaceName))
+		}
+
+		return admission.Denied(webhooks.AdmissionUnknownErrorReason())
+	}
+
+	return admission.Allowed("")
+}
+
+func (h cfSpaceHandler) handleUpdate(ctx context.Context, oldCFSpace, newCFSpace *workloadsv1alpha1.CFSpace) admission.Response {
+	newSpaceName := strings.ToLower(newCFSpace.Spec.DisplayName)
+	oldSpaceName := strings.ToLower(oldCFSpace.Spec.DisplayName)
+	if err := h.duplicateValidator.ValidateUpdate(ctx, h.logger, oldCFSpace.Namespace, oldSpaceName, newSpaceName); err != nil {
+		if errors.Is(err, webhooks.ErrorDuplicateName) {
+			return admission.Denied(h.RenderDuplicateError(newSpaceName))
+		}
+
+		return admission.Denied(webhooks.AdmissionUnknownErrorReason())
+	}
+
+	return admission.Allowed("")
+}
+
+func (h cfSpaceHandler) handleDelete(ctx context.Context, oldCFSpace *workloadsv1alpha1.CFSpace) admission.Response {
+	if err := h.duplicateValidator.ValidateDelete(ctx, h.logger, oldCFSpace.Namespace, oldCFSpace.Spec.DisplayName); err != nil {
+		return admission.Denied(webhooks.AdmissionUnknownErrorReason())
+	}
+
+	return admission.Allowed("")
+}
+
+func (v *CFSpaceValidation) InjectDecoder(d *admission.Decoder) error {
+	v.decoder = d
+	return nil
+}

--- a/controllers/webhooks/workloads/cfspace_validation_test.go
+++ b/controllers/webhooks/workloads/cfspace_validation_test.go
@@ -1,0 +1,248 @@
+package workloads_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"code.cloudfoundry.org/korifi/controllers/webhooks"
+	"code.cloudfoundry.org/korifi/controllers/webhooks/workloads"
+	"code.cloudfoundry.org/korifi/controllers/webhooks/workloads/fake"
+	"code.cloudfoundry.org/korifi/controllers/webhooks/workloads/integration/helpers"
+
+	workloadsv1alpha1 "code.cloudfoundry.org/korifi/controllers/apis/workloads/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	admissionv1 "k8s.io/api/admission/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+var _ = Describe("CFSpaceValidation", func() {
+	var (
+		ctx                     context.Context
+		validatingWebhook       *workloads.CFSpaceValidation
+		namespace               string
+		cfSpace                 *workloadsv1alpha1.CFSpace
+		orgDuplicateValidator   *fake.NameValidator
+		spaceDuplicateValidator *fake.NameValidator
+		request                 admission.Request
+		response                admission.Response
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		namespace = "my-namespace"
+		orgDuplicateValidator = new(fake.NameValidator)
+		spaceDuplicateValidator = new(fake.NameValidator)
+		validatingWebhook = workloads.NewCFSpaceValidation(spaceDuplicateValidator)
+
+		scheme := runtime.NewScheme()
+		err := workloadsv1alpha1.AddToScheme(scheme)
+		Expect(err).NotTo(HaveOccurred())
+
+		decoder, err := admission.NewDecoder(scheme)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(validatingWebhook.InjectDecoder(decoder)).To(Succeed())
+
+		cfSpace = &workloadsv1alpha1.CFSpace{}
+	})
+
+	Describe("Create", func() {
+		BeforeEach(func() {
+			cfSpace = helpers.MakeCFSpace(namespace, "my-space")
+		})
+
+		JustBeforeEach(func() {
+			cfSpaceJSON, err := json.Marshal(cfSpace)
+			Expect(err).NotTo(HaveOccurred())
+
+			request = admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name:      cfSpace.Name,
+					Namespace: namespace,
+					Operation: admissionv1.Create,
+					Object: runtime.RawExtension{
+						Raw: cfSpaceJSON,
+					},
+				},
+			}
+			response = validatingWebhook.Handle(ctx, request)
+		})
+
+		It("validates the space name", func() {
+			Expect(spaceDuplicateValidator.ValidateCreateCallCount()).To(Equal(1))
+			Expect(orgDuplicateValidator.ValidateCreateCallCount()).To(Equal(0))
+			_, _, actualNamespace, name := spaceDuplicateValidator.ValidateCreateArgsForCall(0)
+			Expect(actualNamespace).To(Equal(namespace))
+			Expect(name).To(Equal("my-space"))
+		})
+
+		When("the space name is unique in the namespace", func() {
+			It("allows the request", func() {
+				Expect(response.Allowed).To(BeTrue())
+			})
+		})
+
+		When("the space name already exists in the namespace", func() {
+			BeforeEach(func() {
+				spaceDuplicateValidator.ValidateCreateReturns(webhooks.ErrorDuplicateName)
+			})
+
+			It("denies the request", func() {
+				Expect(response.Allowed).To(BeFalse())
+			})
+		})
+
+		When("create validate throws another error", func() {
+			BeforeEach(func() {
+				cfSpace = helpers.MakeCFSpace(namespace, "my-space")
+				spaceDuplicateValidator.ValidateCreateReturns(errors.New("another error"))
+			})
+
+			It("denies the request", func() {
+				Expect(response.Allowed).To(BeFalse())
+			})
+		})
+	})
+
+	Describe("Update", func() {
+		var newCFSpace *workloadsv1alpha1.CFSpace
+
+		BeforeEach(func() {
+			cfSpace = helpers.MakeCFSpace(namespace, "my-space")
+			newCFSpace = helpers.MakeCFSpace(namespace, "another-space")
+		})
+
+		JustBeforeEach(func() {
+			cfSpaceJSON, err := json.Marshal(cfSpace)
+			Expect(err).NotTo(HaveOccurred())
+
+			newCFSpaceJSON, err := json.Marshal(newCFSpace)
+			Expect(err).NotTo(HaveOccurred())
+
+			request = admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name:      cfSpace.Name,
+					Namespace: namespace,
+					Operation: admissionv1.Update,
+					Object: runtime.RawExtension{
+						Raw: newCFSpaceJSON,
+					},
+					OldObject: runtime.RawExtension{
+						Raw: cfSpaceJSON,
+					},
+				},
+			}
+			response = validatingWebhook.Handle(ctx, request)
+		})
+
+		When("the space name hasn't changed", func() {
+			BeforeEach(func() {
+				newCFSpace.Labels["something"] = "else"
+				newCFSpace.Spec.DisplayName = "my-space"
+			})
+
+			It("succeeds", func() {
+				Expect(response.Allowed).To(BeTrue())
+			})
+		})
+
+		When("the new space name is unique in the namespace", func() {
+			It("allows the request", func() {
+				Expect(response.Allowed).To(BeTrue())
+			})
+		})
+
+		When("the new space name already exists in the namespace", func() {
+			BeforeEach(func() {
+				spaceDuplicateValidator.ValidateUpdateReturns(webhooks.ErrorDuplicateName)
+			})
+
+			It("denies the request", func() {
+				Expect(response.Allowed).To(BeFalse())
+			})
+		})
+
+		When("validate fails for another reason", func() {
+			BeforeEach(func() {
+				spaceDuplicateValidator.ValidateUpdateReturns(errors.New("boom!"))
+			})
+
+			It("denies the request", func() {
+				Expect(response.Allowed).To(BeFalse())
+			})
+		})
+
+		Context("failures", func() {
+			When("decoding fails", func() {
+				It("denies the request", func() {
+					request.Object.Raw = []byte(`"[1,`)
+					response = validatingWebhook.Handle(ctx, request)
+					Expect(response.Allowed).To(BeFalse())
+				})
+
+				It("does not attempt to lock any names", func() {
+					// ignore the calls from the JustBeforeEach()
+					spaceValidateUpdateCount := spaceDuplicateValidator.ValidateUpdateCallCount()
+
+					request.Object.Raw = []byte(`"[1,`)
+					response = validatingWebhook.Handle(ctx, request)
+					Expect(spaceDuplicateValidator.ValidateUpdateCallCount()).To(Equal(spaceValidateUpdateCount))
+				})
+			})
+		})
+	})
+
+	Describe("Deletion", func() {
+		BeforeEach(func() {
+			cfSpace = helpers.MakeCFSpace(namespace, "my-space")
+		})
+
+		JustBeforeEach(func() {
+			cfSpaceJSON, err := json.Marshal(cfSpace)
+			Expect(err).NotTo(HaveOccurred())
+			request = admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name:      cfSpace.Name,
+					Namespace: namespace,
+					Operation: admissionv1.Delete,
+					OldObject: runtime.RawExtension{
+						Raw: cfSpaceJSON,
+					},
+				},
+			}
+			response = validatingWebhook.Handle(ctx, request)
+		})
+
+		It("removes the name from the registry", func() {
+			Expect(spaceDuplicateValidator.ValidateDeleteCallCount()).To(Equal(1))
+			_, _, requestNamespace, name := spaceDuplicateValidator.ValidateDeleteArgsForCall(0)
+			Expect(requestNamespace).To(Equal(namespace))
+			Expect(name).To(Equal("my-space"))
+		})
+	})
+
+	Describe("Request validation", func() {
+		BeforeEach(func() {
+			request = admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name:      cfSpace.Name,
+					Namespace: namespace,
+					Operation: admissionv1.Create,
+					Object: runtime.RawExtension{
+						Raw: []byte(`"[1,`),
+					},
+				},
+			}
+			response = validatingWebhook.Handle(ctx, request)
+		})
+		It("denies the request", func() {
+			Expect(response.Allowed).To(BeFalse())
+		})
+
+		It("does not attempt to register any names", func() {
+			Expect(spaceDuplicateValidator.ValidateCreateCallCount()).To(Equal(0))
+		})
+	})
+})

--- a/controllers/webhooks/workloads/integration/cforg_validation_integration_test.go
+++ b/controllers/webhooks/workloads/integration/cforg_validation_integration_test.go
@@ -1,0 +1,186 @@
+package integration_test
+
+import (
+	"code.cloudfoundry.org/korifi/controllers/apis/workloads/v1alpha1"
+	"context"
+	"fmt"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"strings"
+
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("CFOrgValidatingWebhook", func() {
+	var (
+		ctx           context.Context
+		rootNamespace string
+		org1Guid      string
+		org2Guid      string
+		org1Name      string
+		org2Name      string
+		org1          *v1alpha1.CFOrg
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+
+		rootNamespace = "root-" + uuid.NewString()
+
+		Expect(k8sClient.Create(ctx, &v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: rootNamespace,
+			},
+		})).To(Succeed())
+
+		org1Guid = "guid-1-" + uuid.NewString()
+		org2Guid = "guid-2-" + uuid.NewString()
+		org1Name = "name-1-" + uuid.NewString()
+		org2Name = "name-2-" + uuid.NewString()
+	})
+
+	Describe("Create", func() {
+		var createErr error
+
+		BeforeEach(func() {
+			org1 = makeCFOrg(org1Guid, rootNamespace, org1Name)
+		})
+
+		JustBeforeEach(func() {
+			createErr = k8sClient.Create(ctx, org1)
+		})
+
+		It("should succeed", func() {
+			Expect(createErr).NotTo(HaveOccurred())
+		})
+
+		When("another CFOrg exists with a different name in the same namespace", func() {
+			BeforeEach(func() {
+				org2 := makeCFOrg(org2Guid, rootNamespace, org2Name)
+				Expect(k8sClient.Create(ctx, org2)).To(Succeed())
+			})
+
+			It("should succeed", func() {
+				Expect(createErr).NotTo(HaveOccurred())
+			})
+		})
+
+		When("another CFOrg exists with the same name in the same namespace", func() {
+			BeforeEach(func() {
+				org2 := makeCFOrg(org2Guid, rootNamespace, org1Name)
+				Expect(k8sClient.Create(ctx, org2)).To(Succeed())
+			})
+
+			It("should fail", func() {
+				Expect(createErr).To(MatchError(ContainSubstring("Organization '%s' already exists.", org1Name)))
+			})
+		})
+
+		When("another CFOrg exists with the same name(case insensitive) in the same namespace", func() {
+			BeforeEach(func() {
+				org2 := makeCFOrg(org2Guid, rootNamespace, strings.ToUpper(org1Name))
+				Expect(
+					k8sClient.Create(ctx, org2),
+				).To(Succeed())
+			})
+
+			It("should fail", func() {
+				Expect(createErr).To(MatchError(ContainSubstring(fmt.Sprintf("Organization '%s' already exists.", org1Name))))
+			})
+		})
+	})
+
+	Describe("Update", func() {
+		var updateErr error
+
+		BeforeEach(func() {
+			org1 = makeCFOrg(org1Guid, rootNamespace, org1Name)
+			Expect(k8sClient.Create(ctx, org1)).To(Succeed())
+		})
+
+		JustBeforeEach(func() {
+			updateErr = k8sClient.Update(context.Background(), org1)
+		})
+
+		When("changing the name", func() {
+			var newName string
+
+			BeforeEach(func() {
+				newName = uuid.NewString()
+				org1.Spec.DisplayName = newName
+			})
+
+			It("should succeed", func() {
+				Expect(updateErr).NotTo(HaveOccurred())
+				org1Actual := v1alpha1.CFOrg{}
+				Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(org1), &org1Actual)).To(Succeed())
+				Expect(org1Actual.Spec.DisplayName).To(Equal(newName))
+			})
+
+			When("reusing an old name", func() {
+				It("allows creating another org with the old name", func() {
+					Expect(updateErr).NotTo(HaveOccurred())
+
+					reuseOldNameOrg := makeCFOrg(uuid.NewString(), rootNamespace, org1Name)
+					Expect(k8sClient.Create(ctx, reuseOldNameOrg)).To(Succeed())
+				})
+			})
+		})
+
+		When("not changing the name", func() {
+			It("should succeed", func() {
+				Expect(updateErr).NotTo(HaveOccurred())
+				org1Actual := v1alpha1.CFOrg{}
+				Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(org1), &org1Actual)).To(Succeed())
+			})
+		})
+
+		When("modifying spec.DisplayName to match another CFOrg spec.DisplayName", func() {
+			BeforeEach(func() {
+				org2 := makeCFOrg(org2Guid, rootNamespace, org2Name)
+				org1.Spec.DisplayName = org2Name
+				Expect(k8sClient.Create(ctx, org2)).To(Succeed())
+			})
+
+			It("should fail", func() {
+				Expect(updateErr).To(MatchError(ContainSubstring(fmt.Sprintf("Organization '%s' already exists.", org2Name))))
+			})
+		})
+	})
+
+	Describe("Delete", func() {
+		var deleteErr error
+
+		BeforeEach(func() {
+			org1 = makeCFOrg(org1Guid, rootNamespace, org1Name)
+			Expect(k8sClient.Create(ctx, org1)).To(Succeed())
+		})
+
+		JustBeforeEach(func() {
+			deleteErr = k8sClient.Delete(ctx, org1)
+		})
+
+		It("succeeds", func() {
+			Expect(deleteErr).NotTo(HaveOccurred())
+		})
+	})
+})
+
+func makeCFOrg(cfOrgGUID string, namespace string, name string) *v1alpha1.CFOrg {
+	return &v1alpha1.CFOrg{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "CFOrg",
+			APIVersion: v1alpha1.GroupVersion.Identifier(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cfOrgGUID,
+			Namespace: namespace,
+		},
+		Spec: v1alpha1.CFOrgSpec{
+			DisplayName: name,
+		},
+	}
+}

--- a/controllers/webhooks/workloads/integration/cfspace_validation_integration_test.go
+++ b/controllers/webhooks/workloads/integration/cfspace_validation_integration_test.go
@@ -1,0 +1,126 @@
+package integration_test
+
+import (
+	"context"
+	"fmt"
+
+	workloadsv1alpha1 "code.cloudfoundry.org/korifi/controllers/apis/workloads/v1alpha1"
+	. "code.cloudfoundry.org/korifi/controllers/webhooks/workloads/integration/helpers"
+
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("CFSpaceValidatingWebhook", func() {
+	var (
+		ctx               context.Context
+		cfSpace, cfSpace2 *workloadsv1alpha1.CFSpace
+		orgNamespace      string
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+
+		orgNamespace = "test-org" + uuid.NewString()
+		Expect(k8sClient.Create(ctx, &v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: orgNamespace,
+			},
+		})).To(Succeed())
+	})
+
+	Describe("creating a space", func() {
+		var (
+			err error
+		)
+
+		BeforeEach(func() {
+			cfSpace = MakeCFSpace(orgNamespace, "my-space")
+		})
+
+		JustBeforeEach(func() {
+			err = k8sClient.Create(ctx, cfSpace)
+		})
+
+		It("succeeds", func() {
+			Expect(err).To(Succeed())
+		})
+
+		When("the name already exists in the org namespace", func() {
+			BeforeEach(func() {
+				cfSpace2 = MakeCFSpace(orgNamespace, "my-space")
+				Expect(k8sClient.Create(ctx, cfSpace2)).To(Succeed())
+			})
+
+			It("fails", func() {
+				Expect(err).To(MatchError(ContainSubstring("Name must be unique per organization")))
+			})
+		})
+
+		When("another CFSpace exists with the same name(case insensitive) in the same namespace", func() {
+			BeforeEach(func() {
+				cfSpace2 = MakeCFSpace(orgNamespace, "My-Space")
+				Expect(k8sClient.Create(ctx, cfSpace2)).To(Succeed())
+			})
+
+			It("should fail", func() {
+				Expect(err).To(MatchError(ContainSubstring(fmt.Sprintf("Space '%s' already exists.", cfSpace.Spec.DisplayName))))
+			})
+		})
+	})
+
+	Describe("updating a space", func() {
+		var (
+			updatedCFSpace *workloadsv1alpha1.CFSpace
+			err            error
+		)
+
+		BeforeEach(func() {
+			cfSpace = MakeCFSpace(orgNamespace, "my-space")
+			err = k8sClient.Create(ctx, cfSpace)
+			Expect(err).NotTo(HaveOccurred())
+			updatedCFSpace = cfSpace.DeepCopy()
+		})
+
+		When("the space name is changed to another which is unique in the root CF namespace", func() {
+			BeforeEach(func() {
+				updatedCFSpace.Spec.DisplayName = "another-space"
+			})
+
+			It("succeeds", func() {
+				Expect(k8sClient.Patch(ctx, updatedCFSpace, client.MergeFrom(cfSpace))).To(Succeed())
+			})
+		})
+
+		When("the new space name already exists in the org namespace", func() {
+			BeforeEach(func() {
+				cfSpace2 = MakeCFSpace(orgNamespace, "another-space")
+				Expect(k8sClient.Create(ctx, cfSpace2)).To(Succeed())
+				updatedCFSpace.Spec.DisplayName = "another-space"
+			})
+
+			It("fails", func() {
+				Expect(k8sClient.Patch(ctx, updatedCFSpace, client.MergeFrom(cfSpace))).To(MatchError(ContainSubstring("Name must be unique per organization")))
+			})
+		})
+	})
+
+	Describe("deleting a space", func() {
+		var (
+			err error
+		)
+		BeforeEach(func() {
+			cfSpace = MakeCFSpace(orgNamespace, "my-space")
+			err = k8sClient.Create(ctx, cfSpace)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("can delete the space", func() {
+			Expect(k8sClient.Delete(ctx, cfSpace)).To(Succeed())
+		})
+	})
+})

--- a/controllers/webhooks/workloads/integration/helpers/subnamespace_anchors.go
+++ b/controllers/webhooks/workloads/integration/helpers/subnamespace_anchors.go
@@ -1,7 +1,10 @@
 package helpers
 
 import (
+	"code.cloudfoundry.org/korifi/controllers/apis/workloads/v1alpha1"
+	workloadsv1alpha1 "code.cloudfoundry.org/korifi/controllers/apis/workloads/v1alpha1"
 	"code.cloudfoundry.org/korifi/controllers/webhooks/workloads"
+
 	"github.com/google/uuid"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	hnsv1alpha2 "sigs.k8s.io/hierarchical-namespaces/api/v1alpha2"
@@ -13,6 +16,35 @@ func MakeOrg(namespace, name string) *hnsv1alpha2.SubnamespaceAnchor {
 
 func MakeSpace(namespace, name string) *hnsv1alpha2.SubnamespaceAnchor {
 	return MakeSubnamespaceAnchor(namespace, map[string]string{workloads.SpaceNameLabel: name})
+}
+
+func MakeCFSpace(namespace string, displayName string) *workloadsv1alpha1.CFSpace {
+	return &workloadsv1alpha1.CFSpace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      uuid.NewString(),
+			Namespace: namespace,
+			Labels:    map[string]string{workloads.SpaceNameLabel: displayName},
+		},
+		Spec: workloadsv1alpha1.CFSpaceSpec{
+			DisplayName: displayName,
+		},
+	}
+}
+
+func MakeCFOrg(cfOrgGUID string, namespace string, name string) *v1alpha1.CFOrg {
+	return &v1alpha1.CFOrg{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "CFOrg",
+			APIVersion: v1alpha1.GroupVersion.Identifier(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cfOrgGUID,
+			Namespace: namespace,
+		},
+		Spec: v1alpha1.CFOrgSpec{
+			DisplayName: name,
+		},
+	}
 }
 
 func MakeSubnamespaceAnchor(namespace string, labels map[string]string) *hnsv1alpha2.SubnamespaceAnchor {

--- a/controllers/webhooks/workloads/integration/suite_integration_test.go
+++ b/controllers/webhooks/workloads/integration/suite_integration_test.go
@@ -95,14 +95,17 @@ var _ = BeforeSuite(func() {
 	cfAppValidatingWebhook := workloads.NewCFAppValidation(appNameDuplicateValidator)
 	Expect(cfAppValidatingWebhook.SetupWebhookWithManager(mgr)).To(Succeed())
 
-	orgNameDuplicateValidator := webhooks.NewDuplicateValidator(coordination.NewNameRegistry(mgr.GetClient(), workloads.OrgEntityType))
-	spaceNameDuplicateValidator := webhooks.NewDuplicateValidator(coordination.NewNameRegistry(mgr.GetClient(), workloads.SpaceEntityType))
+	orgNameDuplicateValidator := webhooks.NewDuplicateValidator(coordination.NewNameRegistry(mgr.GetClient(), workloads.CFOrgEntityType))
+	spaceNameDuplicateValidator := webhooks.NewDuplicateValidator(coordination.NewNameRegistry(mgr.GetClient(), workloads.CFSpaceEntityType))
 
 	anchorValidationWebhook := workloads.NewSubnamespaceAnchorValidation(orgNameDuplicateValidator, spaceNameDuplicateValidator)
 	Expect(anchorValidationWebhook.SetupWebhookWithManager(mgr)).To(Succeed())
 
 	orgValidationWebhook := workloads.NewCFOrgValidation(orgNameDuplicateValidator)
 	Expect(orgValidationWebhook.SetupWebhookWithManager(mgr)).To(Succeed())
+
+	spaceValidationWebhook := workloads.NewCFSpaceValidation(spaceNameDuplicateValidator)
+	Expect(spaceValidationWebhook.SetupWebhookWithManager(mgr)).To(Succeed())
 
 	//+kubebuilder:scaffold:webhook
 

--- a/controllers/webhooks/workloads/integration/suite_integration_test.go
+++ b/controllers/webhooks/workloads/integration/suite_integration_test.go
@@ -97,8 +97,12 @@ var _ = BeforeSuite(func() {
 
 	orgNameDuplicateValidator := webhooks.NewDuplicateValidator(coordination.NewNameRegistry(mgr.GetClient(), workloads.OrgEntityType))
 	spaceNameDuplicateValidator := webhooks.NewDuplicateValidator(coordination.NewNameRegistry(mgr.GetClient(), workloads.SpaceEntityType))
+
 	anchorValidationWebhook := workloads.NewSubnamespaceAnchorValidation(orgNameDuplicateValidator, spaceNameDuplicateValidator)
 	Expect(anchorValidationWebhook.SetupWebhookWithManager(mgr)).To(Succeed())
+
+	orgValidationWebhook := workloads.NewCFOrgValidation(orgNameDuplicateValidator)
+	Expect(orgValidationWebhook.SetupWebhookWithManager(mgr)).To(Succeed())
 
 	//+kubebuilder:scaffold:webhook
 


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->
#768

## What is this change about?
<!-- _Please describe the change here._ -->
Adds validating webhook for `CFOrg` and `CFSpace` that uses leases mechanism for denying requests trying to create duplicate spaces.

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->
No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->
See issue #768 

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->
@julian-hj 
