### PR TITLE
Suppress acsii art from openssl

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -20,7 +20,7 @@ createCert() {
     -keyout "${priv_key_file}" \
     -out "${csr_file}" \
     -nodes \
-    -subj "/CN=${username}"
+    -subj "/CN=${username}" 2> /dev/null
 
   cat <<EOF | kubectl create -f -
 apiVersion: certificates.k8s.io/v1

--- a/scripts/deploy-on-kind.sh
+++ b/scripts/deploy-on-kind.sh
@@ -120,7 +120,7 @@ function create_tls_secret() {
       -nodes \
       -subj "/CN=${tls_cn}" \
       -addext "subjectAltName = DNS:${tls_cn}" \
-      -days 365
+      -days 365 2> /dev/null
   else
     openssl req -x509 -newkey rsa:4096 \
       -keyout ${tmp_dir}/tls.key \
@@ -128,7 +128,7 @@ function create_tls_secret() {
       -nodes \
       -subj "/CN=${tls_cn}" \
       -extensions SAN -config <(cat /etc/ssl/openssl.cnf <(printf "[ SAN ]\nsubjectAltName='DNS:${tls_cn}'")) \
-      -days 365
+      -days 365 2> /dev/null
   fi
 
   cat <<EOF >${tmp_dir}/kustomization.yml

--- a/scripts/generate-eirini-certs-secret.sh
+++ b/scripts/generate-eirini-certs-secret.sh
@@ -19,7 +19,7 @@ if [[ "$(openssl version | awk '{ print $1 }')" == "OpenSSL" ]]; then
     -nodes \
     -subj '/CN=localhost' \
     -addext "subjectAltName = DNS:${otherDNS}, DNS:${otherDNS}.cluster.local" \
-    -days 365
+    -days 365 2> /dev/null
 else
   openssl req -x509 -newkey rsa:4096 \
     -keyout "${keys}/tls.key" \
@@ -27,7 +27,7 @@ else
     -nodes \
     -subj '/CN=localhost' \
     -extensions SAN -config <(cat /etc/ssl/openssl.cnf <(printf "[ SAN ]\nsubjectAltName='DNS:${otherDNS}, DNS:${otherDNS}.cluster.local'")) \
-    -days 365
+    -days 365 2> /dev/null
 fi
 
 for secret_name in eirini-webhooks-certs; do


### PR DESCRIPTION
## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->
No.

## What is this change about?
- openssl creates an ascii representation of a key every time we
  generate one, which results in a big glob of useless dots and plusses
  in our script output.
- this change redirects that output to /dev/null

## Does this PR introduce a breaking change?
No.

## Acceptance Steps
- run ./scripts/deploy-on-kind.sh or run the e2e tests
- observe that the output is 15% less annoying

## Tag your pair, your PM, and/or team
![Anyone? Bueller? Bueller?](https://media.giphy.com/media/39u4cdrGn47m4hbmhZ/giphy.gif)
