### PR TITLE
Allow ginkgo nodes and --race to be set by env vars for all tests

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -9,6 +9,10 @@ ENVTEST_ASSETS_DIR="${SCRIPT_DIR}/../testbin"
 mkdir -p "${ENVTEST_ASSETS_DIR}"
 
 extra_args=()
+if [[ -n "$GINKGO_NODES" ]]; then
+  extra_args+=("--procs=${GINKGO_NODES}")
+fi
+
 if ! egrep -q e2e <(echo "$@"); then
   test -f "${ENVTEST_ASSETS_DIR}/setup-envtest.sh" || curl -sSLo "${ENVTEST_ASSETS_DIR}/setup-envtest.sh" https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.8.3/hack/setup-envtest.sh
   source "${ENVTEST_ASSETS_DIR}/setup-envtest.sh"
@@ -33,10 +37,6 @@ else
     export API_SERVER_ROOT=https://localhost
   fi
 
-  if [[ -n "$GINKGO_NODES" ]]; then
-    extra_args+=("--procs=${GINKGO_NODES}")
-  fi
-
   # creates user keys/certs and service accounts and exports vars for them
   source "$SCRIPT_DIR/account-creation.sh" "$SCRIPT_DIR"
 
@@ -55,4 +55,8 @@ if [[ -n "$SEED" ]]; then
   extra_args+=("--seed=${SEED}")
 fi
 
-ginkgo --race -p --randomize-all --randomize-suites "${extra_args[@]}" $@
+if [[ -z "$NO_RACE" ]]; then
+  extra_args+=("--race")
+fi
+
+echo ginkgo -p --randomize-all --randomize-suites "${extra_args[@]}" $@


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
ENVVAR tweaks to the run-tests.sh script:
- GINKGO_NODES previously only affected e2e tests. Now it will work on any.
- Add NO_RACE to disable the --race flag.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Setting the env vars above has the intended effect.

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
