### PR TITLE
Configure TLS connection to API

### DIFF
--- a/api/config/base/certificate.yaml
+++ b/api/config/base/certificate.yaml
@@ -1,0 +1,31 @@
+# The following manifests contain a self-signed issuer CR and a certificate CR.
+# More document can be found at https://docs.cert-manager.io
+# WARNING: Targets CertManager v1.0. Check https://cert-manager.io/docs/installation/upgrading/ for breaking changes.
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+  namespace: system
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: internal-cert
+  namespace: system
+spec:
+  # $(SERVICE_NAME) and $(SERVICE_NAMESPACE) will be substituted by kustomize
+  commonName: $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local
+  dnsNames:
+  - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
+  - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local
+  subject:
+    organizations:
+    - korifi
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: korifi-api-internal-cert # this secret will not be prefixed, since it's not managed by kustomize
+  usages:
+  - server auth

--- a/api/config/base/deployment.yaml
+++ b/api/config/base/deployment.yaml
@@ -26,11 +26,19 @@ spec:
         env:
         - name: APICONFIG
           value: "/etc/korifi-api-config"
+        - name: TLSCONFIG
+          value: "/etc/korifi-tls-config"
         volumeMounts:
         - name: &configname korifi-api-config
           mountPath: /etc/korifi-api-config
+          readOnly: true
+        - name: &tlsname korifi-tls-config
+          mountPath: /etc/korifi-tls-config
           readOnly: true
       volumes:
       - name: *configname
         configMap:
           name: korifi-api-config
+      - name: *tlsname
+        secret:
+          secretName: korifi-api-internal-cert

--- a/api/config/base/ingress.yaml
+++ b/api/config/base/ingress.yaml
@@ -15,5 +15,8 @@ spec:
     services:
     - name: korifi-api-svc
       port: 443
+      validation:
+        caSecret: korifi-api-internal-cert
+        subjectName: $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local
     timeoutPolicy:
       response: "5m"

--- a/api/config/base/kustomization.yaml
+++ b/api/config/base/kustomization.yaml
@@ -9,11 +9,12 @@ namespace: korifi-api-system
 namePrefix: korifi-api-
 
 resources:
-- namespace.yaml
+- certificate.yaml
 - deployment.yaml
 - ingress.yaml
-- service.yaml
+- namespace.yaml
 - rbac
+- service.yaml
 
 configMapGenerator:
 - files:
@@ -35,3 +36,22 @@ patches:
     kind: HTTPProxy
     name: proxy
     version: v1
+
+# the following config is for teaching kustomize how to do var substitution
+vars:
+- fieldref:
+    fieldPath: metadata.namespace
+  name: SERVICE_NAMESPACE
+  objref:
+    kind: Service
+    name: svc
+    version: v1
+- fieldref: {}
+  name: SERVICE_NAME
+  objref:
+    kind: Service
+    name: svc
+    version: v1
+
+configurations:
+- kustomizeconfig.yaml

--- a/api/config/base/kustomizeconfig.yaml
+++ b/api/config/base/kustomizeconfig.yaml
@@ -1,0 +1,19 @@
+# This configuration is for teaching kustomize how to update name ref and var substitution 
+nameReference:
+- kind: Issuer
+  group: cert-manager.io
+  fieldSpecs:
+  - kind: Certificate
+    group: cert-manager.io
+    path: spec/issuerRef/name
+
+varReference:
+- kind: Certificate
+  group: cert-manager.io
+  path: spec/commonName
+- kind: Certificate
+  group: cert-manager.io
+  path: spec/dnsNames
+- kind: HTTPProxy
+  group: projectcontour.io
+  path: spec/routes/services/validation/subjectName

--- a/api/config/base/service.yaml
+++ b/api/config/base/service.yaml
@@ -1,9 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
+  name: svc
   labels:
     app: korifi-api
-  name: svc
+  annotations:
+    projectcontour.io/upstream-protocol.tls: "443"
 spec:
   type: ClusterIP
   ports:

--- a/api/main.go
+++ b/api/main.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path"
 	"time"
 
 	"code.cloudfoundry.org/korifi/api/actions"
@@ -298,8 +299,14 @@ func main() {
 	).Middleware)
 
 	portString := fmt.Sprintf(":%v", config.InternalPort)
-	log.Println("Listening on ", portString)
-	log.Fatal(http.ListenAndServe(portString, router))
+	tlsPath, tlsFound := os.LookupEnv("TLSCONFIG")
+	if tlsFound {
+		log.Println("Listening with TLS on ", portString)
+		log.Fatal(http.ListenAndServeTLS(portString, path.Join(tlsPath, "tls.crt"), path.Join(tlsPath, "tls.key"), router))
+	} else {
+		log.Println("Listening without TLS on ", portString)
+		log.Fatal(http.ListenAndServe(portString, router))
+	}
 }
 
 func wireIdentityProvider(client client.Client, restConfig *rest.Config) authorization.IdentityProvider {

--- a/api/reference/korifi-api.yaml
+++ b/api/reference/korifi-api.yaml
@@ -164,6 +164,8 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    projectcontour.io/upstream-protocol.tls: "443"
   labels:
     app: korifi-api
   name: korifi-api-svc
@@ -200,6 +202,8 @@ spec:
       - env:
         - name: APICONFIG
           value: /etc/korifi-api-config
+        - name: TLSCONFIG
+          value: /etc/korifi-tls-config
         image: cloudfoundry/korifi-api:latest
         name: korifi-api
         ports:
@@ -210,11 +214,45 @@ spec:
         - mountPath: /etc/korifi-api-config
           name: korifi-api-config
           readOnly: true
+        - mountPath: /etc/korifi-tls-config
+          name: korifi-tls-config
+          readOnly: true
       serviceAccountName: korifi-api-system-serviceaccount
       volumes:
       - configMap:
           name: korifi-api-config-f8ccbtc64g
         name: korifi-api-config
+      - name: korifi-tls-config
+        secret:
+          secretName: korifi-api-internal-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: korifi-api-internal-cert
+  namespace: korifi-api-system
+spec:
+  commonName: korifi-api-svc.korifi-api-system.svc.cluster.local
+  dnsNames:
+  - korifi-api-svc.korifi-api-system.svc
+  - korifi-api-svc.korifi-api-system.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: korifi-api-selfsigned-issuer
+  secretName: korifi-api-internal-cert
+  subject:
+    organizations:
+    - korifi
+  usages:
+  - server auth
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: korifi-api-selfsigned-issuer
+  namespace: korifi-api-system
+spec:
+  selfSigned: {}
 ---
 apiVersion: projectcontour.io/v1
 kind: HTTPProxy
@@ -230,6 +268,9 @@ spec:
     services:
     - name: korifi-api-svc
       port: 443
+      validation:
+        caSecret: korifi-api-internal-cert
+        subjectName: korifi-api-svc.korifi-api-system.svc.cluster.local
     timeoutPolicy:
       response: 5m
   virtualhost:

--- a/scripts/deploy-on-kind.sh
+++ b/scripts/deploy-on-kind.sh
@@ -165,6 +165,8 @@ function ensure_kind_cluster() {
     cat <<EOF | kind create cluster --name "${cluster}" --wait 5m --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+featureGates:
+  EphemeralContainers: true
 nodes:
 - role: control-plane
   kubeadmConfigPatches:


### PR DESCRIPTION
## Is there a related GitHub Issue?
#850

## What is this change about?
This PR updates the Korifi API to listen on TLS with an internal certificate generated by cert-manager, and tells the Contour HTTPProxy to connect over TLS and validate the API certificate.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
See #850

## Tag your pair, your PM, and/or team
@clintyoshimura @tcdowney @matt-royal 