### PR TITLE
Ignore forbidden errors when listing spaces

### DIFF
--- a/api/repositories/space_repository.go
+++ b/api/repositories/space_repository.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -230,6 +231,9 @@ func (r *SpaceRepo) ListSpaces(ctx context.Context, info authorization.Info, mes
 		cfSpaceList := new(workloads.CFSpaceList)
 
 		err = userClient.List(ctx, cfSpaceList, client.InNamespace(org))
+		if k8serrors.IsForbidden(err) {
+			continue
+		}
 		if err != nil {
 			return nil, apierrors.FromK8sError(err, SpaceResourceType)
 		}

--- a/api/repositories/space_repository_test.go
+++ b/api/repositories/space_repository_test.go
@@ -408,6 +408,22 @@ var _ = Describe("SpaceRepository", func() {
 				Expect(spaces).To(BeEmpty())
 			})
 		})
+
+		When("an org exists with a rolebinding for the user, but without permission to list spaces", func() {
+			var org *workloads.CFOrg
+
+			BeforeEach(func() {
+				org = createOrgWithCleanup(ctx, "org-without-list-space-perm")
+				createRoleBinding(ctx, userName, rootNamespaceUserRole.Name, org.Name)
+			})
+
+			It("returns the 6 spaces", func() {
+				spaces, err := spaceRepo.ListSpaces(ctx, authInfo, repositories.ListSpacesMessage{})
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(spaces).To(HaveLen(6))
+			})
+		})
 	})
 
 	Describe("Get", func() {


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
#1035 

## What is this change about?
We are only guessing which namespaces to list in by iterating through any namespace containing a rolebinding for the user. The rolebinding might not give cfspace listing permission. So we must not fail when we encounter a k8s forbidden error.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
You must create an org whose namespace contains a role binding for the current user, but that role binding does not provide list cfspace permission. Then attempt to list spaces as that user. This changes the 403 error into omitting spaces from that org in the results.

Creating such a rolebinding via CF is tricky. Maybe resort to doing it manually with kubectl.

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
