### PR TITLE
Fix accidentally left debug line

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -59,4 +59,4 @@ if [[ -z "$NO_RACE" ]]; then
   extra_args+=("--race")
 fi
 
-echo ginkgo -p --randomize-all --randomize-suites "${extra_args[@]}" $@
+ginkgo -p --randomize-all --randomize-suites "${extra_args[@]}" $@


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
I accidentally committed 'echo' in front of ginkgo in `run-tests.sh`. This fixes it.

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
