### PR TITLE
Fix unsafe references to local for loop variables

### DIFF
--- a/api/apierrors/errors.go
+++ b/api/apierrors/errors.go
@@ -255,25 +255,25 @@ func AsUnprocessableEntity(err error, detail string, errTypes ...ApiError) error
 		return nil
 	}
 
-	for _, errType := range errTypes {
+	for i := range errTypes {
 		// At this point in time the errors in the errType array are downgraded
 		// to `ApiError`. This means that pointers to api errors that only
 		// embed `apiError` are assignable to each other. Therefore `errors.As`
 		// would return `true` and would change the initial value type of the
 		// array entry. That is why we need to get the "desiredType" first and
 		// compare it to the type that has been set by `errors.As`
-		desiredErrType := reflect.ValueOf(errType).Type()
+		desiredErrType := reflect.ValueOf(errTypes[i]).Type()
 
-		if !errors.As(err, &errType) {
+		if !errors.As(err, &errTypes[i]) {
 			continue
 		}
 
-		asErrType := reflect.ValueOf(errType).Type()
+		asErrType := reflect.ValueOf(errTypes[i]).Type()
 		if asErrType != desiredErrType {
 			continue
 		}
 
-		return NewUnprocessableEntityError(errType.Unwrap(), detail)
+		return NewUnprocessableEntityError(errTypes[i].Unwrap(), detail)
 	}
 
 	return err

--- a/api/repositories/domain_repository.go
+++ b/api/repositories/domain_repository.go
@@ -131,8 +131,8 @@ func applyDomainListFilterAndOrder(domainList []networkingv1alpha1.CFDomain, mes
 func returnDomainList(domainList []networkingv1alpha1.CFDomain) []DomainRecord {
 	domainRecords := make([]DomainRecord, 0, len(domainList))
 
-	for _, domain := range domainList {
-		domainRecords = append(domainRecords, cfDomainToDomainRecord(&domain))
+	for i := range domainList {
+		domainRecords = append(domainRecords, cfDomainToDomainRecord(&domainList[i]))
 	}
 	return domainRecords
 }

--- a/api/repositories/pod_repository.go
+++ b/api/repositories/pod_repository.go
@@ -381,7 +381,7 @@ func (r *PodRepo) GetRuntimeLogsForApp(ctx context.Context, authInfo authorizati
 				if err == io.EOF {
 					break
 				} else {
-					logReadCloser.Close()
+					_ = logReadCloser.Close()
 					return nil, fmt.Errorf("failed to parse pod logs: %w", err)
 				}
 			}
@@ -398,7 +398,7 @@ func (r *PodRepo) GetRuntimeLogsForApp(ctx context.Context, authInfo authorizati
 			appLogs = append(appLogs, logRecord)
 		}
 
-		logReadCloser.Close()
+		_ = logReadCloser.Close()
 	}
 
 	return appLogs, nil

--- a/controllers/controllers/services/cfserviceinstance_controller.go
+++ b/controllers/controllers/services/cfserviceinstance_controller.go
@@ -156,8 +156,8 @@ func (r *CFServiceInstanceReconciler) finalizeCFServiceInstance(ctx context.Cont
 		return ctrl.Result{}, fmt.Errorf("error listing CFServiceBindings: %w", err)
 	}
 
-	for _, cfServiceBinding := range cfServiceBindingList.Items {
-		err = r.Client.Delete(ctx, &cfServiceBinding)
+	for i, cfServiceBinding := range cfServiceBindingList.Items {
+		err = r.Client.Delete(ctx, &cfServiceBindingList.Items[i])
 		if err != nil {
 			r.Log.Error(err, fmt.Sprintf("Error deleting %s", cfServiceBinding.Name))
 			return ctrl.Result{}, err

--- a/controllers/controllers/workloads/cfapp_controller.go
+++ b/controllers/controllers/workloads/cfapp_controller.go
@@ -250,19 +250,19 @@ func (r *CFAppReconciler) finalizeCFApp(ctx context.Context, cfApp *workloadsv1a
 
 func (r *CFAppReconciler) removeRouteDestinations(ctx context.Context, cfAppGUID string, cfRoutes []networkingv1alpha1.CFRoute) error {
 	var updatedDestinations []networkingv1alpha1.Destination
-	for _, cfRoute := range cfRoutes {
-		originalCFRoute := cfRoute.DeepCopy()
-		if cfRoute.Spec.Destinations != nil {
-			for _, destination := range cfRoute.Spec.Destinations {
+	for i := range cfRoutes {
+		originalCFRoute := cfRoutes[i].DeepCopy()
+		if cfRoutes[i].Spec.Destinations != nil {
+			for _, destination := range cfRoutes[i].Spec.Destinations {
 				if destination.AppRef.Name != cfAppGUID {
 					updatedDestinations = append(updatedDestinations, destination)
 				} else {
-					r.Log.Info(fmt.Sprintf("Removing destination for cfapp %s from cfroute %s", cfAppGUID, cfRoute.Name))
+					r.Log.Info(fmt.Sprintf("Removing destination for cfapp %s from cfroute %s", cfAppGUID, cfRoutes[i].Name))
 				}
 			}
 		}
-		cfRoute.Spec.Destinations = updatedDestinations
-		err := r.Client.Patch(ctx, &cfRoute, client.MergeFrom(originalCFRoute))
+		cfRoutes[i].Spec.Destinations = updatedDestinations
+		err := r.Client.Patch(ctx, &cfRoutes[i], client.MergeFrom(originalCFRoute))
 		if err != nil {
 			r.Log.Error(err, "failed to patch cfRoute to remove a destination")
 			return err

--- a/controllers/controllers/workloads/cfprocess_controller.go
+++ b/controllers/controllers/workloads/cfprocess_controller.go
@@ -173,9 +173,9 @@ func (r *CFProcessReconciler) cleanUpLRPs(ctx context.Context, cfProcess *worklo
 		return err
 	}
 
-	for _, currentLRP := range lrpsForProcess {
+	for i, currentLRP := range lrpsForProcess {
 		if desiredState == workloadsv1alpha1.StoppedState || currentLRP.Labels[workloadsv1alpha1.CFAppRevisionKey] != cfAppRev {
-			err := r.Client.Delete(ctx, &currentLRP)
+			err := r.Client.Delete(ctx, &lrpsForProcess[i])
 			if err != nil {
 				r.Log.Info(fmt.Sprintf("Error occurred deleting LRP: %s, %s", currentLRP.Name, err))
 				return err


### PR DESCRIPTION
## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->
No.

## What is this change about?
- for loop uses a local copy when looping. This shouldn't be
  dereferenced, as the for loop will overwrite it and leave an
  unreliable pointer behind.
- also, add underscore receivers for error returns we don't care about
  in order to make golint/gosec happy.

## Does this PR introduce a breaking change?
No.

## Tag your pair, your PM, and/or team
@akrishna90 