### PR TITLE
Include spec.displayName as an additionalPrinterColumn

### DIFF
--- a/controllers/apis/services/v1alpha1/cfservicebinding_types.go
+++ b/controllers/apis/services/v1alpha1/cfservicebinding_types.go
@@ -48,6 +48,8 @@ type CFServiceBindingStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="Display Name",type=string,JSONPath=`.spec.displayName`
+//+kubebuilder:printcolumn:name="Age",type="date",JSONPath=`.metadata.creationTimestamp`
 
 // CFServiceBinding is the Schema for the cfservicebindings API
 type CFServiceBinding struct {

--- a/controllers/apis/services/v1alpha1/cfserviceinstance_types.go
+++ b/controllers/apis/services/v1alpha1/cfserviceinstance_types.go
@@ -59,6 +59,8 @@ type CFServiceInstanceStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="Display Name",type=string,JSONPath=`.spec.displayName`
+//+kubebuilder:printcolumn:name="Age",type="date",JSONPath=`.metadata.creationTimestamp`
 
 // CFServiceInstance is the Schema for the cfserviceinstances API
 type CFServiceInstance struct {

--- a/controllers/apis/workloads/v1alpha1/cfapp_types.go
+++ b/controllers/apis/workloads/v1alpha1/cfapp_types.go
@@ -58,6 +58,8 @@ type CFAppStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="Display Name",type=string,JSONPath=`.spec.displayName`
+//+kubebuilder:printcolumn:name="Age",type="date",JSONPath=`.metadata.creationTimestamp`
 
 // CFApp is the Schema for the cfapps API
 type CFApp struct {

--- a/controllers/apis/workloads/v1alpha1/cforg_types.go
+++ b/controllers/apis/workloads/v1alpha1/cforg_types.go
@@ -44,6 +44,8 @@ type CFOrgStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="Display Name",type=string,JSONPath=`.spec.displayName`
+//+kubebuilder:printcolumn:name="Age",type="date",JSONPath=`.metadata.creationTimestamp`
 
 // CFOrg is the Schema for the cforgs API
 type CFOrg struct {

--- a/controllers/apis/workloads/v1alpha1/cfspace_types.go
+++ b/controllers/apis/workloads/v1alpha1/cfspace_types.go
@@ -37,6 +37,8 @@ type CFSpaceStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="Display Name",type=string,JSONPath=`.spec.displayName`
+//+kubebuilder:printcolumn:name="Age",type="date",JSONPath=`.metadata.creationTimestamp`
 
 // CFSpace is the Schema for the cfspaces API
 type CFSpace struct {

--- a/controllers/config/crd/bases/services.cloudfoundry.org_cfservicebindings.yaml
+++ b/controllers/config/crd/bases/services.cloudfoundry.org_cfservicebindings.yaml
@@ -15,7 +15,14 @@ spec:
     singular: cfservicebinding
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.displayName
+      name: Display Name
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: CFServiceBinding is the Schema for the cfservicebindings API

--- a/controllers/config/crd/bases/services.cloudfoundry.org_cfserviceinstances.yaml
+++ b/controllers/config/crd/bases/services.cloudfoundry.org_cfserviceinstances.yaml
@@ -15,7 +15,14 @@ spec:
     singular: cfserviceinstance
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.displayName
+      name: Display Name
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: CFServiceInstance is the Schema for the cfserviceinstances API

--- a/controllers/config/crd/bases/workloads.cloudfoundry.org_cfapps.yaml
+++ b/controllers/config/crd/bases/workloads.cloudfoundry.org_cfapps.yaml
@@ -15,7 +15,14 @@ spec:
     singular: cfapp
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.displayName
+      name: Display Name
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: CFApp is the Schema for the cfapps API

--- a/controllers/config/crd/bases/workloads.cloudfoundry.org_cforgs.yaml
+++ b/controllers/config/crd/bases/workloads.cloudfoundry.org_cforgs.yaml
@@ -15,7 +15,14 @@ spec:
     singular: cforg
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.displayName
+      name: Display Name
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: CFOrg is the Schema for the cforgs API

--- a/controllers/config/crd/bases/workloads.cloudfoundry.org_cfspaces.yaml
+++ b/controllers/config/crd/bases/workloads.cloudfoundry.org_cfspaces.yaml
@@ -15,7 +15,14 @@ spec:
     singular: cfspace
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.displayName
+      name: Display Name
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: CFSpace is the Schema for the cfspaces API

--- a/controllers/reference/korifi-controllers.yaml
+++ b/controllers/reference/korifi-controllers.yaml
@@ -31,7 +31,14 @@ spec:
     singular: cfapp
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.displayName
+      name: Display Name
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: CFApp is the Schema for the cfapps API
@@ -540,7 +547,14 @@ spec:
     singular: cforg
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.displayName
+      name: Display Name
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: CFOrg is the Schema for the cforgs API
@@ -1363,7 +1377,14 @@ spec:
     singular: cfservicebinding
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.displayName
+      name: Display Name
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: CFServiceBinding is the Schema for the cfservicebindings API
@@ -1548,7 +1569,14 @@ spec:
     singular: cfserviceinstance
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.displayName
+      name: Display Name
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: CFServiceInstance is the Schema for the cfserviceinstances API
@@ -1703,7 +1731,14 @@ spec:
     singular: cfspace
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.displayName
+      name: Display Name
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: CFSpace is the Schema for the cfspaces API


### PR DESCRIPTION
`kubectl` will now print the display name and age of the following resources:
  - CFOrg
  - CFSpace
  - CFApp
  - CFServiceInstance
  - CFServieBinding

## Is there a related GitHub Issue?
Issue: https://github.com/cloudfoundry/korifi/issues/1069

## What is this change about?
Improve the UX of kubectl users by printing the display name of a resource when its available.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Create an org, space, push an app, create a user-provided service instance, and then bind the instance. This will create all the affected custom resources on the cluster. Then view them all with `kubectl`.

These were the specific CF commands I ran:

1. `cf create-org o && sleep 1 && cf create-space s -o o && sleep 1 && cf target -o o -s s`
2. `cf push node`
3. `cf cups my-upsi`
4. `cf bind-service node my-upsi --binding-name my-binding` (if you don't specify a binding-name then the display name for that resource is blank)

Attached is a screenshot of how it looks in my env.

![Screen Shot 2022-05-11 at 11 47 08 AM](https://user-images.githubusercontent.com/2096955/167915065-b068791c-a401-4b8b-b983-cd57023e3ee4.png)

## Tag your pair, your PM, and/or team
I soloed on this, just tagging a couple folks from the team to review: @matt-royal @clintyoshimura 
