### PR TITLE
API server remote debug support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,9 @@ docker-build-controllers-debug:
 docker-build-api:
 	docker buildx build --load -f api/Dockerfile -t ${IMG_API} .
 
+docker-build-api-debug:
+	docker buildx build --load -f api/remote-debug/Dockerfile -t ${IMG_API} .
+
 docker-push: docker-push-controllers docker-push-api
 
 docker-push-controllers:
@@ -156,6 +159,9 @@ deploy-api-kind: install-kustomize build-reference-api
 
 deploy-api-kind-local: install-kustomize build-reference-api
 	$(KUSTOMIZE) build api/config/overlays/kind-local-registry | kubectl apply -f -
+
+deploy-api-kind-local-debug: install-kustomize build-reference-api
+	$(KUSTOMIZE) build api/config/overlays/kind-api-debug | kubectl apply -f -
 
 undeploy-controllers: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build controllers/config/default | kubectl delete -f -

--- a/README.md
+++ b/README.md
@@ -350,6 +350,56 @@ Of these options, `cf-admin` is the user with permissions set up by default. Sel
 successfully create resources, but you may notice that the user lacks the permissions to list those resources once created.
 
 ---
+## Deploying to `kind` for remote debugging with a locally deployed container registry
+This is the above method, but run with `dlv` for remote debugging.
+
+```
+./scripts/deploy-on-kind <kind-cluster-name> --local --debug
+```
+To remote debug, connect with `dlv` on `localhost:30051` (controller) or `localhost:30052` (api)
+
+A sample VSCode `launch.json` configuration is provided below:
+```
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Attach to Debug Controller on Kind",
+            "type": "go",
+            "debugAdapter": "dlv-dap",
+            "request": "attach",
+            "mode": "remote",
+            "substitutePath": [
+                {
+                    "from": "${workspaceFolder}",
+                    "to": "/workspace"
+                }
+            ],
+            "host": "localhost",
+            "port": 30051
+        },
+        {
+            "name": "Attach to Debug API on Kind",
+            "type": "go",
+            "debugAdapter": "dlv-dap",
+            "request": "attach",
+            "mode": "remote",
+            "substitutePath": [
+                {
+                    "from": "${workspaceFolder}",
+                    "to": "/workspace"
+                }
+            ],
+            "host": "localhost",
+            "port": 30052
+        }
+    ]
+}
+
+```
+
+
+---
 ## Install all dependencies with script
 ```sh
 # modify kpack dependency files to point towards your registry

--- a/api/config/overlays/kind-api-debug/api_debug_container.yaml
+++ b/api/config/overlays/kind-api-debug/api_debug_container.yaml
@@ -1,0 +1,65 @@
+---
+# This patch sets up the manger container to run Delve and exposes the debug port at
+# :40000
+# It requires the `remote-debug` controller container built with ubuntu and Delve
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: korifi-api
+  name: deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: korifi-api
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: korifi-api
+    spec:
+      securityContext:
+        runAsNonRoot: false
+      serviceAccountName: system-serviceaccount
+      containers:
+      - name: korifi-api
+        command:
+        - "/dlv"
+        args:
+        - "--listen=:40000"
+        - "--headless=true"
+        - "--api-version=2"
+        - "exec"
+        - "/cfapi"
+        - "--continue"
+        - "--accept-multiclient"
+        securityContext:
+          runAsNonRoot: false
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+              - SYS_PTRACE
+        ports:
+        - containerPort: 9000
+          name: web
+        resources: {}
+        env:
+        - name: APICONFIG
+          value: "/etc/korifi-api-config"
+        - name: TLSCONFIG
+          value: "/etc/korifi-tls-config"
+        volumeMounts:
+        - name: &configname korifi-api-config
+          mountPath: /etc/korifi-api-config
+          readOnly: true
+        - name: &tlsname korifi-tls-config
+          mountPath: /etc/korifi-tls-config
+          readOnly: true
+      volumes:
+      - name: *configname
+        configMap:
+          name: korifi-api-config
+      - name: *tlsname
+        secret:
+          secretName: korifi-api-internal-cert

--- a/api/config/overlays/kind-api-debug/api_debug_nodeport.yaml
+++ b/api/config/overlays/kind-api-debug/api_debug_nodeport.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-debug-port
+  namespace: korifi-api-system
+spec:
+  ports:
+    - name: debug-30052
+      nodePort: 30052
+      port: 30052
+      protocol: TCP
+      targetPort: 40000
+  selector:
+    app: korifi-api
+  type: NodePort

--- a/api/config/overlays/kind-api-debug/kustomization.yaml
+++ b/api/config/overlays/kind-api-debug/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../kind-local-registry
+  - api_debug_nodeport.yaml
+
+patchesStrategicMerge:
+  - api_debug_container.yaml

--- a/api/remote-debug/Dockerfile
+++ b/api/remote-debug/Dockerfile
@@ -1,0 +1,36 @@
+# syntax = docker/dockerfile:experimental
+FROM golang:1.18.1 as builder
+
+WORKDIR /workspace
+
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+
+COPY controllers/apis controllers/apis/
+COPY controllers/webhooks controllers/webhooks/
+COPY api/actions api/actions/
+COPY api/apis api/apis/
+COPY api/apierrors api/apierrors
+COPY api/authorization api/authorization/
+COPY api/payloads api/payloads/
+COPY api/presenter api/presenter/
+COPY api/repositories api/repositories/
+COPY api/config/config.go api/config/
+COPY api/main.go api/
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg/mod \
+    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -gcflags=all="-N -l" -o cfapi api/main.go
+
+# Get Delve from a GOPATH not from a Go Modules project
+WORKDIR /go/src/
+RUN go install github.com/go-delve/delve/cmd/dlv@latest
+
+FROM ubuntu
+
+WORKDIR /
+COPY --from=builder /workspace/cfapi .
+COPY --from=builder /go/bin/dlv .
+USER 1000:1000
+
+ENTRYPOINT [ "/cfapi" ]

--- a/controllers/config/overlays/kind-controller-debug/manager_debug_container.yaml
+++ b/controllers/config/overlays/kind-controller-debug/manager_debug_container.yaml
@@ -19,8 +19,9 @@ spec:
         runAsNonRoot: false
       containers:
       - name: manager
-        args:
+        command:
         - "/dlv"
+        args:
         - "--listen=:40000"
         - "--headless=true"
         - "--api-version=2"

--- a/controllers/remote-debug/Dockerfile
+++ b/controllers/remote-debug/Dockerfile
@@ -19,7 +19,7 @@ COPY controllers/config/config.go controllers/config/
 COPY controllers/main.go controllers/
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
-    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o manager controllers/main.go
+    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -gcflags=all="-N -l" -o manager controllers/main.go
 
 # Get Delve from a GOPATH not from a Go Modules project
 WORKDIR /go/src/


### PR DESCRIPTION
## Is there a related GitHub Issue?
No.

## What is this change about?
Allow remote debugging of the api container

## Does this PR introduce a breaking change?
No.

## Acceptance Steps
Follow updated instructions in README
> Deploying to `kind` for remote debugging with a locally deployed container registry

## Tag your pair, your PM, and/or team
@davewalter