### PR TITLE
Add support for "app memory" manifest field

### DIFF
--- a/api/actions/apply_manifest.go
+++ b/api/actions/apply_manifest.go
@@ -12,6 +12,10 @@ import (
 	"code.cloudfoundry.org/korifi/api/repositories"
 )
 
+const (
+	processTypeWeb = "web"
+)
+
 type ApplyManifest struct {
 	appRepo     CFAppRepository
 	domainRepo  CFDomainRepository
@@ -37,6 +41,22 @@ func (a *ApplyManifest) Invoke(ctx context.Context, authInfo authorization.Info,
 			exists = false
 		} else {
 			return apierrors.ForbiddenAsNotFound(err)
+		}
+	}
+
+	if appInfo.Memory != nil {
+		found := false
+		for _, process := range appInfo.Processes {
+			if process.Type == processTypeWeb {
+				found = true
+			}
+		}
+
+		if !found {
+			appInfo.Processes = append(appInfo.Processes, payloads.ManifestApplicationProcess{
+				Type:   processTypeWeb,
+				Memory: appInfo.Memory,
+			})
 		}
 	}
 

--- a/api/payloads/manifest.go
+++ b/api/payloads/manifest.go
@@ -15,8 +15,9 @@ type Manifest struct {
 type ManifestApplication struct {
 	Name         string                       `yaml:"name" validate:"required"`
 	Env          map[string]string            `yaml:"env"`
-	Processes    []ManifestApplicationProcess `yaml:"processes" validate:"dive"`
 	DefaultRoute bool                         `yaml:"default-route"`
+	Memory       *string                      `yaml:"memory" validate:"megabytestring"`
+	Processes    []ManifestApplicationProcess `yaml:"processes" validate:"dive"`
 	Routes       []ManifestRoute              `yaml:"routes" validate:"dive"`
 }
 

--- a/api/payloads/manifest_test.go
+++ b/api/payloads/manifest_test.go
@@ -1,12 +1,12 @@
 package payloads_test
 
 import (
+	. "code.cloudfoundry.org/korifi/api/payloads"
+	"code.cloudfoundry.org/korifi/api/repositories"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
-
-	. "code.cloudfoundry.org/korifi/api/payloads"
-	"code.cloudfoundry.org/korifi/api/repositories"
 )
 
 var _ = Describe("ManifestApplicationProcess", func() {


### PR DESCRIPTION
## Is there a related GitHub Issue?
#406

## What is this change about?
This PR adds support for the memory field in an application manifest, which will create a "web" process if one does not already exist with the specific memory request.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
See #406

## Tag your pair, your PM, and/or team
@akrishna90 