### PR TITLE
Filter API logs by correlation ID on E2E failure

### DIFF
--- a/api/tests/e2e/domains_test.go
+++ b/api/tests/e2e/domains_test.go
@@ -3,6 +3,7 @@ package e2e_test
 import (
 	"net/http"
 
+	"code.cloudfoundry.org/korifi/api/tests/e2e/helpers"
 	"github.com/go-resty/resty/v2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -10,7 +11,7 @@ import (
 )
 
 var _ = Describe("Domain", func() {
-	var restyClient *resty.Client
+	var restyClient *helpers.CorrelatedRestyClient
 
 	BeforeEach(func() {
 		restyClient = certClient

--- a/api/tests/e2e/orgs_test.go
+++ b/api/tests/e2e/orgs_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"sync"
 
+	"code.cloudfoundry.org/korifi/api/tests/e2e/helpers"
 	"github.com/go-resty/resty/v2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -15,7 +16,7 @@ import (
 var _ = Describe("Orgs", func() {
 	var (
 		resp        *resty.Response
-		restyClient *resty.Client
+		restyClient *helpers.CorrelatedRestyClient
 	)
 
 	BeforeEach(func() {

--- a/api/tests/e2e/processes_test.go
+++ b/api/tests/e2e/processes_test.go
@@ -6,6 +6,7 @@ import (
 
 	"code.cloudfoundry.org/korifi/api/presenter"
 	"code.cloudfoundry.org/korifi/api/repositories"
+	"code.cloudfoundry.org/korifi/api/tests/e2e/helpers"
 
 	"github.com/go-resty/resty/v2"
 	. "github.com/onsi/ginkgo/v2"
@@ -19,7 +20,7 @@ var _ = Describe("Processes", func() {
 		spaceGUID   string
 		appGUID     string
 		processGUID string
-		restyClient *resty.Client
+		restyClient *helpers.CorrelatedRestyClient
 		resp        *resty.Response
 		errResp     cfErrs
 	)

--- a/api/tests/e2e/roles_test.go
+++ b/api/tests/e2e/roles_test.go
@@ -3,6 +3,7 @@ package e2e_test
 import (
 	"net/http"
 
+	"code.cloudfoundry.org/korifi/api/tests/e2e/helpers"
 	"github.com/go-resty/resty/v2"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
@@ -15,7 +16,7 @@ var _ = Describe("Roles", func() {
 		userName string
 		resp     *resty.Response
 		result   typedResource
-		client   *resty.Client
+		client   *helpers.CorrelatedRestyClient
 	)
 
 	BeforeEach(func() {

--- a/api/tests/e2e/routes_test.go
+++ b/api/tests/e2e/routes_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"code.cloudfoundry.org/korifi/api/tests/e2e/helpers"
 	networkingv1alpha1 "code.cloudfoundry.org/korifi/controllers/apis/networking/v1alpha1"
 	"github.com/google/uuid"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -22,7 +23,7 @@ import (
 
 var _ = Describe("Routes", func() {
 	var (
-		client     *resty.Client
+		client     *helpers.CorrelatedRestyClient
 		domainGUID string
 		domainName string
 		spaceGUID  string

--- a/api/tests/e2e/spaces_test.go
+++ b/api/tests/e2e/spaces_test.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"code.cloudfoundry.org/korifi/api/repositories"
+	"code.cloudfoundry.org/korifi/api/tests/e2e/helpers"
 
 	"github.com/go-resty/resty/v2"
 	. "github.com/onsi/ginkgo/v2"
@@ -20,7 +21,7 @@ import (
 var _ = Describe("Spaces", func() {
 	var (
 		resp        *resty.Response
-		restyClient *resty.Client
+		restyClient *helpers.CorrelatedRestyClient
 	)
 
 	BeforeEach(func() {


### PR DESCRIPTION
## Is there a related GitHub Issue?
https://github.com/cloudfoundry/korifi/issues/656

## What is this change about?
This is implemented by transparently sending a unique correlation ID by
every `It`

* Wrapper for the resty client that would inject the correlation ID for
  every API request
* The fail handler filters out API log entries that do not contain the
  correlation ID
* The fail handler does not filter controllers logs though (as there is
  no correlation ID)
* The correlation ID is being reset in a `BeforeEach` in the suite so
  that every `It` gets a new value and does not have to care to do that


## Does this PR introduce a breaking change?
No

## Acceptance Steps
* Make a e2e test deliberately fail by e.g. changing the HTTP status code it expects
* Look at the api logs printed by the fail handler - it should only contain entries that contain the correlation ID available in the failed resty request headers
