### PR TITLE
Fix kpack-builder Kustomization

### DIFF
--- a/kpack-image-builder/Makefile
+++ b/kpack-image-builder/Makefile
@@ -93,11 +93,11 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	cd config/manager && $(KUSTOMIZE) edit set image cloudfoundry/korifi-kpack-image-builder=${IMG}
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
 
 deploy-on-kind: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	cd config/manager && $(KUSTOMIZE) edit set image cloudfoundry/korifi-kpack-image-builder=${IMG}
 	$(KUSTOMIZE) build config/overlays/kind-local-registry | kubectl apply -f -
 
 .PHONY: undeploy


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
- the Kustomize command we were using in the makefile didn't target the
  image we want to replace when we build the controller.

## Does this PR introduce a breaking change?
no?

## Acceptance Steps
run deploy-on-kind.sh

## Tag your pair, your PM, and/or team
@clintyoshimura 

