### PR TITLE
Make e2e app bits configurable

### DIFF
--- a/api/tests/e2e/apps_test.go
+++ b/api/tests/e2e/apps_test.go
@@ -182,7 +182,7 @@ var _ = Describe("Apps", func() {
 		)
 
 		BeforeEach(func() {
-			appGUID = pushTestApp(space1GUID)
+			appGUID = pushTestApp(space1GUID, appBitsFile)
 			processGUID = getProcess(appGUID, "web")
 		})
 
@@ -239,7 +239,7 @@ var _ = Describe("Apps", func() {
 		BeforeEach(func() {
 			appGUID = createApp(space1GUID, generateGUID("app"))
 			pkgGUID = createPackage(appGUID)
-			uploadTestApp(pkgGUID)
+			uploadTestApp(pkgGUID, appBitsFile)
 			buildGUID = createBuild(pkgGUID)
 			waitForDroplet(buildGUID)
 
@@ -362,7 +362,7 @@ var _ = Describe("Apps", func() {
 		var processGUID string
 
 		BeforeEach(func() {
-			appGUID = pushTestApp(space1GUID)
+			appGUID = pushTestApp(space1GUID, appBitsFile)
 			processGUID = getProcess(appGUID, "web")
 		})
 

--- a/api/tests/e2e/droplets_test.go
+++ b/api/tests/e2e/droplets_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Droplets", func() {
 		BeforeEach(func() {
 			appGUID := createApp(spaceGUID, generateGUID("app"))
 			pkgGUID := createPackage(appGUID)
-			uploadTestApp(pkgGUID)
+			uploadTestApp(pkgGUID, appBitsFile)
 			buildGUID = createBuild(pkgGUID)
 		})
 

--- a/api/tests/e2e/log_cache_test.go
+++ b/api/tests/e2e/log_cache_test.go
@@ -19,7 +19,7 @@ var _ = Describe("LogCache", func() {
 
 	BeforeEach(func() {
 		spaceGUID = createSpace(generateGUID("space"), commonTestOrgGUID)
-		appGUID = pushTestApp(spaceGUID)
+		appGUID = pushTestApp(spaceGUID, appBitsFile)
 		createSpaceRole("space_developer", rbacv1.UserKind, certUserName, spaceGUID)
 	})
 

--- a/api/tests/e2e/packages_test.go
+++ b/api/tests/e2e/packages_test.go
@@ -167,7 +167,7 @@ var _ = Describe("Package", func() {
 		BeforeEach(func() {
 			resultList = resourceList{}
 			packageGUID = createPackage(appGUID)
-			uploadTestApp(packageGUID)
+			uploadTestApp(packageGUID, appBitsFile)
 			buildGUID = createBuild(packageGUID)
 
 			Eventually(func() (*resty.Response, error) {

--- a/api/tests/e2e/processes_test.go
+++ b/api/tests/e2e/processes_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Processes", func() {
 		restyClient = certClient
 		errResp = cfErrs{}
 		spaceGUID = createSpace(generateGUID("space"), commonTestOrgGUID)
-		appGUID = pushTestApp(spaceGUID)
+		appGUID = pushTestApp(spaceGUID, appBitsFile)
 		processGUID = getProcess(appGUID, "web")
 	})
 
@@ -69,7 +69,7 @@ var _ = Describe("Processes", func() {
 		When("the user is NOT authorized in the space", func() {
 			BeforeEach(func() {
 				space2GUID = createSpace(generateGUID("space2"), commonTestOrgGUID)
-				app2GUID = pushTestApp(space2GUID)
+				app2GUID = pushTestApp(space2GUID, appBitsFile)
 				requestAppGUID = app2GUID
 			})
 

--- a/api/tests/e2e/routes_test.go
+++ b/api/tests/e2e/routes_test.go
@@ -384,7 +384,7 @@ var _ = Describe("Routes", func() {
 
 		When("the user is a space developer in the space", func() {
 			BeforeEach(func() {
-				appGUID = pushTestApp(spaceGUID)
+				appGUID = pushTestApp(spaceGUID, appBitsFile)
 				createSpaceRole("space_developer", rbacv1.UserKind, certUserName, spaceGUID)
 			})
 


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
Update end to end tests to use a configurable file for app bits instead of the hardcoded binary. By default, behavior remains the same.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Deploy korifi normally for development and run end to end tests. See that tests continue to pass and that the prebuilt node app is still being pushed by default.

Prepare a different app known to successfully build with the default builder in the assets dir like the previously used `assets/node.zip`, set the "APP_BITS_FILE" environment variable accordingly to that file, and see that the tests continue to pass while pushing that app.

## Tag your pair, your PM, and/or team
paired w/ @Birdrock
