### PR TITLE
Add check for long-lived client certificates

### DIFF
--- a/api/apis/org_handler_test.go
+++ b/api/apis/org_handler_test.go
@@ -41,7 +41,7 @@ var _ = Describe("OrgHandler", func() {
 		decoderValidator, err := apis.NewDefaultDecoderValidator()
 		Expect(err).NotTo(HaveOccurred())
 
-		orgHandler = apis.NewOrgHandler(*serverURL, orgRepo, domainRepo, decoderValidator)
+		orgHandler = apis.NewOrgHandler(*serverURL, orgRepo, domainRepo, decoderValidator, time.Hour)
 		orgHandler.RegisterRoutes(router)
 	})
 
@@ -270,10 +270,11 @@ var _ = Describe("OrgHandler", func() {
 			req.Header.Add(headers.Authorization, "Bearer my-token")
 		})
 
+		JustBeforeEach(func() {
+			router.ServeHTTP(rr, req)
+		})
+
 		When("happy path", func() {
-			BeforeEach(func() {
-				router.ServeHTTP(rr, req)
-			})
 
 			It("returns 200", func() {
 				Expect(rr.Result().StatusCode).To(Equal(http.StatusOK))
@@ -352,8 +353,6 @@ var _ = Describe("OrgHandler", func() {
 					"names": []string{"foo,bar"},
 				}
 				req.URL.RawQuery = values.Encode()
-
-				router.ServeHTTP(rr, req)
 			})
 
 			It("filters by them", func() {
@@ -367,7 +366,6 @@ var _ = Describe("OrgHandler", func() {
 		When("fetching the orgs fails", func() {
 			BeforeEach(func() {
 				orgRepo.ListOrgsReturns(nil, errors.New("boom!"))
-				router.ServeHTTP(rr, req)
 			})
 
 			It("returns an error", func() {

--- a/api/config/overlays/kind-local-registry/apiconfig/korifi_api_config.yaml
+++ b/api/config/overlays/kind-local-registry/apiconfig/korifi_api_config.yaml
@@ -11,3 +11,4 @@ packageRegistryBase: localregistry-docker-registry.default.svc.cluster.local:300
 packageRegistrySecretName: image-registry-credentials
 clusterBuilderName: cf-kpack-cluster-builder
 defaultDomainName: vcap.me
+userCertificateExpirationWarningDuration: 168h

--- a/api/config/overlays/kind/apiconfig/korifi_api_config.yaml
+++ b/api/config/overlays/kind/apiconfig/korifi_api_config.yaml
@@ -11,3 +11,4 @@ packageRegistryBase: gcr.io/cf-relint-greengrass/korifi/kpack/beta
 packageRegistrySecretName: image-registry-credentials
 clusterBuilderName: cf-kpack-cluster-builder
 defaultDomainName: vcap.me
+userCertificateExpirationWarningDuration: 168h

--- a/api/main.go
+++ b/api/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"k8s.io/client-go/rest"
 	"log"
 	"net/http"
 	"net/url"
@@ -26,7 +27,6 @@ import (
 	"k8s.io/client-go/dynamic"
 	k8sclient "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
@@ -223,6 +223,7 @@ func main() {
 			orgRepo,
 			domainRepo,
 			decoderValidator,
+			config.GetUserCertificateDuration(),
 		),
 
 		apis.NewSpaceHandler(

--- a/api/tests/e2e/e2e_suite_test.go
+++ b/api/tests/e2e/e2e_suite_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -30,6 +31,7 @@ var (
 	adminClient         *helpers.CorrelatedRestyClient
 	certClient          *helpers.CorrelatedRestyClient
 	tokenClient         *helpers.CorrelatedRestyClient
+	longCertClient      *helpers.CorrelatedRestyClient
 	apiServerRoot       string
 	serviceAccountName  string
 	serviceAccountToken string
@@ -38,11 +40,14 @@ var (
 	certAuthHeader      string
 	adminAuthHeader     string
 	certPEM             string
-
-	rootNamespace     string
-	appFQDN           string
-	commonTestOrgGUID string
-	appBitsFile       string
+	longCertUserName    string
+	longCertPEM         string
+	rootNamespace       string
+	appFQDN             string
+	commonTestOrgGUID   string
+	appBitsFile         string
+	clusterVersionMinor int
+	clusterVersionMajor int
 )
 
 const (
@@ -717,8 +722,12 @@ func commonTestSetup() {
 	serviceAccountToken = mustHaveEnv("E2E_SERVICE_ACCOUNT_TOKEN")
 	certUserName = mustHaveEnv("E2E_USER_NAME")
 	certPEM = mustHaveEnv("E2E_USER_PEM")
+	longCertUserName = mustHaveEnv("E2E_LONGCERT_USER_NAME")
+	longCertPEM = mustHaveEnv("E2E_LONGCERT_USER_PEM")
 	appFQDN = mustHaveEnv("APP_FQDN")
 	appBitsFile = getAppBitsFile()
+	clusterVersionMinor, _ = strconv.Atoi(mustHaveEnv("CLUSTER_VERSION_MINOR"))
+	clusterVersionMajor, _ = strconv.Atoi(mustHaveEnv("CLUSTER_VERSION_MAJOR"))
 
 	ensureServerIsUp()
 
@@ -728,4 +737,5 @@ func commonTestSetup() {
 	tokenAuthHeader = fmt.Sprintf("Bearer %s", serviceAccountToken)
 	certClient = helpers.NewCorrelatedRestyClient(apiServerRoot, getCorrelationId).SetAuthScheme("ClientCert").SetAuthToken(certPEM).SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true})
 	tokenClient = helpers.NewCorrelatedRestyClient(apiServerRoot, getCorrelationId).SetAuthToken(serviceAccountToken).SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true})
+	longCertClient = helpers.NewCorrelatedRestyClient(apiServerRoot, getCorrelationId).SetAuthScheme("ClientCert").SetAuthToken(longCertPEM).SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true})
 }

--- a/scripts/account-creation.sh
+++ b/scripts/account-creation.sh
@@ -24,6 +24,12 @@ if [[ -z "${E2E_USER_NAME:=}" ]]; then
 
   export E2E_USER_PEM="$(cat $tmp/cert.pem $tmp/key.pem | base64 | tr -d "\n\r")"
 fi
+if [[ -z "${E2E_LONGCERT_USER_NAME:=}" ]]; then
+  export E2E_LONGCERT_USER_NAME="e2e-longcert-user"
+  createCert "$E2E_LONGCERT_USER_NAME" "$tmp/longkey.pem" "$tmp/longcert.pem" "365"
+
+  export E2E_LONGCERT_USER_PEM="$(cat $tmp/longcert.pem $tmp/longkey.pem | base64 | tr -d "\n\r")"
+fi
 
 if [[ -z "${E2E_SERVICE_ACCOUNT:=}" ]]; then
   export E2E_SERVICE_ACCOUNT="e2e-service-account"
@@ -45,3 +51,6 @@ if [[ -z "${CF_ADMIN_CERT:=}" ]]; then
   CF_ADMIN_CERT="$(base64 $tmp/cf-admin-cert.pem | tr -d "\n\r")"
   export CF_ADMIN_CERT CF_ADMIN_KEY
 fi
+
+export CLUSTER_VERSION_MINOR="$(kubectl version -ojson | jq -r .serverVersion.minor)"
+export CLUSTER_VERSION_MAJOR="$(kubectl version -ojson | jq -r .serverVersion.major)"

--- a/scripts/deploy-on-kind.sh
+++ b/scripts/deploy-on-kind.sh
@@ -118,7 +118,7 @@ function ensure_kind_cluster() {
   if [[ -n "${api_only}" ]]; then return 0; fi
 
   if ! kind get clusters | grep -q "${cluster}"; then
-    cat <<EOF | kind create cluster --name "${cluster}" --wait 5m --config=-
+    cat <<EOF | kind create cluster --name "${cluster}" --wait 5m --image kindest/node:v1.23.4 --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 featureGates:


### PR DESCRIPTION
## Is there a related GitHub Issue?
#1090 

## What is this change about?
- The intent is to display a warning at login when a user with a
  long-lived certificate logs in.
- We do this by setting the X-Cf-Warnings header when we detect such a
  certificate. The CLI will relay the header string value to STDOUT.
- However the CLI doesn't check for warnings on the /whoami enpoint, so
  we settled on the /v3/orgs endpoint because that gets called by the
  CLI on each login.
- In the future we might consider enhancing the CLI to check for
  warnings on /whoami and then moving the check into the whoami handler.
- The default threshold for warnings is 7 days, but that value is
  configurable on the API shim configuration as
  `userCertificateExpirationWarningDuration`
- Note: we could not unit test this code because the authentication
  middleware isn't wired into the unit tests, so there's not a good way
  to pass auth info into the handler. We settled on an e2e test as the
  best option.

  [#1090]


## Does this PR introduce a breaking change?
Mostly not; it pins the kind node image to `v1.23.4` which might cause some interesting side effects. The reason for this is that we want to create client certs with a shorter expiry time and in order to do that we need to use the `expirationSeconds` field on the `CertificateSigningRequest` object which isn't supported in k8s before v1.22

If we run e2e tests on an older cluster, there's some possibility we could hit snags. It's also possible that this PR will fail e2e because we added some new mandatory env variables that might not get set by the PR check pipeline. 🤞
 
## Acceptance Steps
See #1090 

## Tag your pair, your PM, and/or team
@clintyoshimura @matt-royal @tcdowney 
