### PR TITLE
Use the kpack-image-builder image built on previous step

### DIFF
--- a/.github/workflows/test-build-push-main.yml
+++ b/.github/workflows/test-build-push-main.yml
@@ -330,8 +330,7 @@ jobs:
         SKIP_DOCKER_BUILD: true
         IMG_API: cloudfoundry/korifi-api:${{ github.sha }}
         IMG_CONTROLLERS: cloudfoundry/korifi-controllers:${{ github.sha }}
-        # TODO: uncomment once we actually use this variable
-        # IMG_KPACK_IMAGE_BUILDER: cloudfoundry/korifi-kpack-image-builder:${{ github.sha }}
+        IMG_KIB: cloudfoundry/korifi-kpack-image-builder:${{ github.sha }}
       run: make test-e2e
       working-directory: ./korifi
 


### PR DESCRIPTION


## Is there a related GitHub Issue?
No


## What is this change about?
The `deploy-on-kind` with `SKIP_DEPLOY=true` assumes that the image is
present and it is set into the `IMG_KIB` env var

## Does this PR introduce a breaking change?
No

## Acceptance Steps
E2E on main actions workflow should succeed

## Tag your pair, your PM, and/or team
@gcapizzi 

