### PR TITLE
Fix env-test server after modifying it for test

### DIFF
--- a/api/authorization/token_reviewer_test.go
+++ b/api/authorization/token_reviewer_test.go
@@ -50,6 +50,10 @@ var _ = Describe("TokenReviewer", func() {
 			tokenReviewer = authorization.NewTokenReviewer(k8sClient)
 		})
 
+		AfterEach(func() {
+			restartEnvTest(authProvider.APIServerExtraArgs(oidcPrefix))
+		})
+
 		It("extracts the identity of the serviceaccount", func() {
 			Expect(id.Kind).To(Equal(rbacv1.ServiceAccountKind))
 			Expect(id.Name).To(Equal("my-serviceaccount"))
@@ -65,6 +69,10 @@ var _ = Describe("TokenReviewer", func() {
 			)
 			tokenReviewer = authorization.NewTokenReviewer(k8sClient)
 			passErrConstraints = MatchError(ContainSubstring("invalid serviceaccount name"))
+		})
+
+		AfterEach(func() {
+			restartEnvTest(authProvider.APIServerExtraArgs(oidcPrefix))
 		})
 
 		It("returns an error", func() {


### PR DESCRIPTION
## Is there a related GitHub Issue?
#1095 

## What is this change about?
Since we have an env-test server per ginkgo process, we must restore it after modifying it so that subsequent tests run against an env-test with the expected configuration.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
The token-reviewer test stops flaking.

## Tag your pair, your PM, and/or team

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
