### PR TITLE
Update the description for CFProcessSpec

### DIFF
--- a/controllers/apis/v1alpha1/cfprocess_types.go
+++ b/controllers/apis/v1alpha1/cfprocess_types.go
@@ -38,10 +38,10 @@ type CFProcessSpec struct {
 	// Specifies the desired number of Process replicas to deploy
 	DesiredInstances int `json:"desiredInstances"`
 
-	// Specifies the Process memory limit
+	// Specifies the Process memory limit in MiB
 	MemoryMB int64 `json:"memoryMB"`
 
-	// Specifies the Process disk limit
+	// Specifies the Process disk limit in MiB
 	DiskQuotaMB int64 `json:"diskQuotaMB"`
 
 	// Specifies the Process ports to expose

--- a/controllers/config/crd/bases/korifi.cloudfoundry.org_cfprocesses.yaml
+++ b/controllers/config/crd/bases/korifi.cloudfoundry.org_cfprocesses.yaml
@@ -51,7 +51,7 @@ spec:
                 description: Specifies the desired number of Process replicas to deploy
                 type: integer
               diskQuotaMB:
-                description: Specifies the Process disk limit
+                description: Specifies the Process disk limit in MiB
                 format: int64
                 type: integer
               healthCheck:
@@ -90,7 +90,7 @@ spec:
                 - type
                 type: object
               memoryMB:
-                description: Specifies the Process memory limit
+                description: Specifies the Process memory limit in MiB
                 format: int64
                 type: integer
               ports:

--- a/controllers/reference/korifi-controllers.yaml
+++ b/controllers/reference/korifi-controllers.yaml
@@ -1306,7 +1306,7 @@ spec:
                 description: Specifies the desired number of Process replicas to deploy
                 type: integer
               diskQuotaMB:
-                description: Specifies the Process disk limit
+                description: Specifies the Process disk limit in MiB
                 format: int64
                 type: integer
               healthCheck:
@@ -1345,7 +1345,7 @@ spec:
                 - type
                 type: object
               memoryMB:
-                description: Specifies the Process memory limit
+                description: Specifies the Process memory limit in MiB
                 format: int64
                 type: integer
               ports:


### PR DESCRIPTION
## Is there a related GitHub Issue?
#720 

## What is this change about?
Update the descriptions for the memory and disk quota fields in the CFProcessSpec object to reflect the MiB units

## Does this PR introduce a breaking change?
no

## Acceptance Steps
See issue

## Tag your pair, your PM, and/or team
@gnovv 

