### PR TITLE
Explicitly create service account token

### DIFF
--- a/scripts/account-creation.sh
+++ b/scripts/account-creation.sh
@@ -6,16 +6,6 @@ fi
 
 source "$SCRIPT_DIR/common.sh"
 
-getToken() {
-  local name namespace secret
-  name=${1:?}
-  namespace=${2:?}
-  secretName="$(kubectl get serviceaccounts -n "$namespace" "$name" -ojsonpath='{.secrets[0].name}')"
-  if [[ -n "$secretName" ]]; then
-    kubectl get secrets -n "$namespace" "$secretName" -ojsonpath='{.data.token}' | base64 -d
-  fi
-}
-
 tmp="$(mktemp -d)"
 trap "rm -rf $tmp" EXIT
 if [[ -z "${E2E_USER_NAME:=}" ]]; then
@@ -35,10 +25,26 @@ if [[ -z "${E2E_SERVICE_ACCOUNT:=}" ]]; then
   export E2E_SERVICE_ACCOUNT="e2e-service-account"
   kubectl delete serviceaccount --ignore-not-found=true -n "$ROOT_NAMESPACE" "$E2E_SERVICE_ACCOUNT" &>/dev/null
   kubectl create serviceaccount -n "$ROOT_NAMESPACE" "$E2E_SERVICE_ACCOUNT"
+fi
+
+if [[ -z "$E2E_SERVICE_ACCOUNT_TOKEN" ]]; then
+  E2E_SERVICE_ACCOUNT_TOKEN_NAME="${E2E_SERVICE_ACCOUNT}-token"
+  kubectl delete secret --ignore-not-found=true -n "$ROOT_NAMESPACE" "$E2E_SERVICE_ACCOUNT_TOKEN_NAME" &>/dev/null
+  kubectl apply -f - <<TOKEN_SECRET
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: "$E2E_SERVICE_ACCOUNT_TOKEN_NAME"
+      namespace: "$ROOT_NAMESPACE"
+      annotations:
+        kubernetes.io/service-account.name: "$E2E_SERVICE_ACCOUNT"
+    type: kubernetes.io/service-account-token
+    data:
+TOKEN_SECRET
 
   token=""
   while [ -z "$token" ]; do
-    token="$(getToken "e2e-service-account" "$ROOT_NAMESPACE")"
+    token="$(kubectl get secrets -n "$ROOT_NAMESPACE" "$E2E_SERVICE_ACCOUNT_TOKEN_NAME" -ojsonpath='{.data.token}' | base64 -d)"
     sleep 0.5
   done
 

--- a/scripts/account-creation.sh
+++ b/scripts/account-creation.sh
@@ -27,7 +27,7 @@ if [[ -z "${E2E_SERVICE_ACCOUNT:=}" ]]; then
   kubectl create serviceaccount -n "$ROOT_NAMESPACE" "$E2E_SERVICE_ACCOUNT"
 fi
 
-if [[ -z "$E2E_SERVICE_ACCOUNT_TOKEN" ]]; then
+if [[ -z "${E2E_SERVICE_ACCOUNT_TOKEN:=}" ]]; then
   E2E_SERVICE_ACCOUNT_TOKEN_NAME="${E2E_SERVICE_ACCOUNT}-token"
   kubectl delete secret --ignore-not-found=true -n "$ROOT_NAMESPACE" "$E2E_SERVICE_ACCOUNT_TOKEN_NAME" &>/dev/null
   kubectl apply -f - <<TOKEN_SECRET

--- a/scripts/deploy-on-kind.sh
+++ b/scripts/deploy-on-kind.sh
@@ -118,7 +118,7 @@ function ensure_kind_cluster() {
   if [[ -n "${api_only}" ]]; then return 0; fi
 
   if ! kind get clusters | grep -q "${cluster}"; then
-    cat <<EOF | kind create cluster --name "${cluster}" --wait 5m --image kindest/node:v1.23.4 --config=-
+    cat <<EOF | kind create cluster --name "${cluster}" --wait 5m --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 featureGates:


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->No related issue.

## What is this change about?
<!-- _Please describe the change here._ -->
This PR changes our e2e test setup so that it explicitly creates the ServiceAccount token, rather than assuming that the k8s cluster will automatically make a token secret. The automatic secret creation was removed in k8s 1.24.

This PR also changes the kind image back to the default, since we no longer require k8s 1.23 or older.

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->Sadly, we won't really know if this PR works until it's merged and we confirm that the github actions against the commit on main pass.

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
