### PR TITLE
lower resource requests for korifi deployments

### DIFF
--- a/api/config/base/deployment.yaml
+++ b/api/config/base/deployment.yaml
@@ -22,7 +22,10 @@ spec:
         ports:
         - containerPort: 9000
           name: web
-        resources: {}
+        resources:
+          requests:
+            cpu: 50m
+            memory: 100Mi
         env:
         - name: APICONFIG
           value: "/etc/korifi-api-config"

--- a/api/reference/korifi-api.yaml
+++ b/api/reference/korifi-api.yaml
@@ -209,7 +209,10 @@ spec:
         ports:
         - containerPort: 9000
           name: web
-        resources: {}
+        resources:
+          requests:
+            cpu: 50m
+            memory: 100Mi
         volumeMounts:
         - mountPath: /etc/korifi-api-config
           name: korifi-api-config

--- a/controllers/config/manager/manager.yaml
+++ b/controllers/config/manager/manager.yaml
@@ -50,8 +50,8 @@ spec:
             cpu: 1000m
             memory: 1Gi
           requests:
-            cpu: 500m
-            memory: 500Mi
+            cpu: 50m
+            memory: 100Mi
         env:
         - name: CONTROLLERSCONFIG
           value: "/etc/korifi-controllers-config"

--- a/controllers/reference/korifi-controllers.yaml
+++ b/controllers/reference/korifi-controllers.yaml
@@ -3267,8 +3267,8 @@ spec:
             cpu: 1000m
             memory: 1Gi
           requests:
-            cpu: 500m
-            memory: 500Mi
+            cpu: 50m
+            memory: 100Mi
         securityContext:
           allowPrivilegeEscalation: false
         volumeMounts:

--- a/kpack-image-builder/config/manager/manager.yaml
+++ b/kpack-image-builder/config/manager/manager.yaml
@@ -52,8 +52,8 @@ spec:
             cpu: 1000m
             memory: 1Gi
           requests:
-            cpu: 500m
-            memory: 500Mi
+            cpu: 50m
+            memory: 100Mi
         env:
           - name: CONTROLLERSCONFIG
             value: "/etc/kpack-build-controllers-config"


### PR DESCRIPTION
## Is there a related GitHub Issue?
no

## What is this change about?
Lowering resource requests in an effort to get e2e tests working again in github actions.

We've seen that deployments are consistently failing trying to deploy the kpack-build-controller-manager, which is the last deployment in the installation. I'm speculating that the environment is just out of CPU, as it has a [quota of 2 cores](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources) and both of our controller managers were asking for .5 cores. This change reduces the request to something a bit more modest that should still work.

- reduce the memory and CPU request sizes for the api shim, controller
  and kpack-build controller deployments
- this brings the request sizes more in line with other pods such as HNC
  and kube-rbac-proxy
- it should allow us to deploy in lower memory/cpu environments (such as
  github)

## Does this PR introduce a breaking change?
no.

## Acceptance Steps
CI passes (finally)

## Tag your pair, your PM, and/or team
@matt-royal @acosta11 @gcapizzi 

