### PR TITLE
Don't change the image in kind-local-registry overlay

### DIFF
--- a/kpack-image-builder/config/manager/kustomization.yaml
+++ b/kpack-image-builder/config/manager/kustomization.yaml
@@ -11,3 +11,8 @@ configMapGenerator:
 - files:
   - controller_manager_config.yaml
   name: manager-config
+
+images:
+  - name: cloudfoundry/korifi-kpack-image-builder
+    newName: cloudfoundry/korifi-kpack-image-builder
+    newTag: latest

--- a/kpack-image-builder/config/overlays/kind-local-registry/kustomization.yaml
+++ b/kpack-image-builder/config/overlays/kind-local-registry/kustomization.yaml
@@ -9,8 +9,3 @@ configMapGenerator:
 
 resources:
   - ../../default
-
-images:
-- name: cloudfoundry/korifi-kpack-image-builder
-  newName: korifi-kpack-image-builder
-  newTag: latest


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
<!-- _Please describe the change here._ -->
This PR fixes a problem with how the image is set/overridden for the kpack-image-builder subproject. This problem was leading to failure in the e2e tests on github due to the pod having an incorrect image ref

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->Merge this PR and confirm that the github action checks against main begin to pass

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
