### PR TITLE
Listing droplets and processes must tolerate 403 errors

### DIFF
--- a/api/repositories/droplet_repository.go
+++ b/api/repositories/droplet_repository.go
@@ -8,6 +8,7 @@ import (
 	"code.cloudfoundry.org/korifi/api/authorization"
 	"code.cloudfoundry.org/korifi/controllers/apis/v1alpha1"
 
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -131,6 +132,9 @@ func (r *DropletRepo) ListDroplets(ctx context.Context, authInfo authorization.I
 	var allBuilds []v1alpha1.CFBuild
 	for ns := range namespaces {
 		err := userClient.List(ctx, buildList, client.InNamespace(ns))
+		if k8serrors.IsForbidden(err) {
+			continue
+		}
 		if err != nil {
 			return []DropletRecord{}, apierrors.FromK8sError(err, BuildResourceType)
 		}

--- a/api/repositories/process_repository.go
+++ b/api/repositories/process_repository.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -141,6 +142,9 @@ func (r *ProcessRepo) ListProcesses(ctx context.Context, authInfo authorization.
 			continue
 		}
 		err = userClient.List(ctx, processList, client.InNamespace(ns))
+		if k8serrors.IsForbidden(err) {
+			continue
+		}
 		if err != nil {
 			return []ProcessRecord{}, apierrors.FromK8sError(err, ProcessResourceType)
 		}

--- a/api/repositories/process_repository_test.go
+++ b/api/repositories/process_repository_test.go
@@ -200,6 +200,17 @@ var _ = Describe("ProcessRepo", func() {
 					Expect(processes).ToNot(BeNil())
 				})
 			})
+
+			When("a space exists with a rolebinding for the user, but without permission to list processes", func() {
+				BeforeEach(func() {
+					anotherSpace := createSpaceWithCleanup(ctx, org.Name, "space-without-process-space-perm")
+					createRoleBinding(ctx, userName, rootNamespaceUserRole.Name, anotherSpace.Name)
+				})
+
+				It("returns the processes", func() {
+					Expect(processes).To(HaveLen(2))
+				})
+			})
 		})
 	})
 


### PR DESCRIPTION
The list of namespaces we list a resource in is just a list of namespaces containing a `RoleBinding` for the current user. This does not mean the user will be authorised for the list action we are attempting in the namespace. Therefore we should silently ignore forbidden errors during list.
