### PR TITLE
Job handler no longer requires Job IDs contain a GUID

### DIFF
--- a/api/handlers/app_handler.go
+++ b/api/handlers/app_handler.go
@@ -398,7 +398,7 @@ func (h *AppHandler) appDeleteHandler(ctx context.Context, logger logr.Logger, a
 		return nil, err
 	}
 
-	return NewHandlerResponse(http.StatusAccepted).WithHeader("Location", fmt.Sprintf("%s/v3/jobs/app.delete-%s", h.serverURL.String(), appGUID)), nil
+	return NewHandlerResponse(http.StatusAccepted).WithHeader("Location", presenter.JobURLForRedirects(appGUID, presenter.AppDeleteOperation, h.serverURL)), nil
 }
 
 func (h *AppHandler) lookupAppRouteAndDomainList(ctx context.Context, authInfo authorization.Info, appGUID, spaceGUID string) ([]repositories.RouteRecord, error) {

--- a/api/handlers/app_handler_test.go
+++ b/api/handlers/app_handler_test.go
@@ -2683,7 +2683,7 @@ var _ = Describe("AppHandler", func() {
 
 			It("responds with a job URL in a location header", func() {
 				locationHeader := rr.Header().Get("Location")
-				Expect(locationHeader).To(Equal("https://api.example.org/v3/jobs/app.delete-"+appGUID), "Matching Location header")
+				Expect(locationHeader).To(Equal("https://api.example.org/v3/jobs/app.delete~"+appGUID), "Matching Location header")
 			})
 
 			It("fetches the right App", func() {

--- a/api/handlers/integration/apply_manifest_test.go
+++ b/api/handlers/integration/apply_manifest_test.go
@@ -148,7 +148,7 @@ var _ = Describe("POST /v3/spaces/<space-guid>/actions/apply_manifest endpoint",
 				Expect(err).NotTo(HaveOccurred())
 				Expect(body).To(BeEmpty())
 
-				Expect(rr.Header().Get("Location")).To(Equal(serverURI("/v3/jobs/space.apply_manifest-", space.Name)))
+				Expect(rr.Header().Get("Location")).To(Equal(serverURI("/v3/jobs/space.apply_manifest~", space.Name)))
 
 				var app1 korifiv1alpha1.CFApp
 				By("confirming that the app was created", func() {
@@ -605,7 +605,7 @@ var _ = Describe("POST /v3/spaces/<space-guid>/actions/apply_manifest endpoint",
 				Expect(err).NotTo(HaveOccurred())
 				Expect(body).To(BeEmpty())
 
-				Expect(rr.Header().Get("Location")).To(Equal(serverURI("/v3/jobs/space.apply_manifest-", space.Name)))
+				Expect(rr.Header().Get("Location")).To(Equal(serverURI("/v3/jobs/space.apply_manifest~", space.Name)))
 
 				var app1 korifiv1alpha1.CFApp
 				By("confirming that the app fields are unchanged", func() {

--- a/api/handlers/job_handler.go
+++ b/api/handlers/job_handler.go
@@ -70,8 +70,10 @@ func (h *JobHandler) RegisterRoutes(router *mux.Router) {
 }
 
 func parseJobGUID(jobGUID string) (string, string, bool) {
-	// Match job.type-GUID and capture the job type and GUID for later use
-	jobRegexp := regexp.MustCompile("([a-z_-]+[.][a-z_]+)-(?:cf-[a-z]+-)?([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})")
+	// Parse the job identifier and capture the job operation and resource name for later use
+	jobOperationPattern := `([a-z_\-]+[\.][a-z_]+)`   // (e.g. app.delete, space.apply_manifest, etc.)
+	resourceIdentifierPattern := `([A-Za-z0-9\-\.]+)` // (e.g. cf-space-a4cd478b-0b02-452f-8498-ce87ec5c6649, CUSTOM_ORG_ID, etc.)
+	jobRegexp := regexp.MustCompile(jobOperationPattern + presenter.JobGUIDDelimiter + resourceIdentifierPattern)
 	matches := jobRegexp.FindStringSubmatch(jobGUID)
 
 	if len(matches) != 3 {

--- a/api/handlers/job_handler_test.go
+++ b/api/handlers/job_handler_test.go
@@ -38,7 +38,7 @@ var _ = Describe("JobHandler", func() {
 
 		When("getting an existing job", func() {
 			BeforeEach(func() {
-				jobGUID = "space.apply_manifest-" + resourceGUID
+				jobGUID = "space.apply_manifest~" + resourceGUID
 			})
 
 			It("returns status 200 OK", func() {
@@ -73,7 +73,7 @@ var _ = Describe("JobHandler", func() {
 
 			When("the existing job operation is app.delete", func() {
 				BeforeEach(func() {
-					jobGUID = "app.delete-" + resourceGUID
+					jobGUID = "app.delete~" + resourceGUID
 				})
 
 				It("returns the job", func() {
@@ -97,7 +97,7 @@ var _ = Describe("JobHandler", func() {
 			When("the existing job operation is org.delete", func() {
 				BeforeEach(func() {
 					resourceGUID = "cf-org-" + uuid.NewString()
-					jobGUID = "org.delete-" + resourceGUID
+					jobGUID = "org.delete~" + resourceGUID
 				})
 
 				It("returns the job", func() {
@@ -121,7 +121,7 @@ var _ = Describe("JobHandler", func() {
 			When("the existing job operation is space.delete", func() {
 				BeforeEach(func() {
 					resourceGUID = "cf-space-" + uuid.NewString()
-					jobGUID = "space.delete-" + resourceGUID
+					jobGUID = "space.delete~" + resourceGUID
 				})
 
 				It("returns the job", func() {
@@ -145,7 +145,7 @@ var _ = Describe("JobHandler", func() {
 			When("the existing job operation is route.delete", func() {
 				BeforeEach(func() {
 					resourceGUID = "cf-route-" + uuid.NewString()
-					jobGUID = "route.delete-" + resourceGUID
+					jobGUID = "route.delete~" + resourceGUID
 				})
 
 				It("returns the job", func() {
@@ -167,13 +167,35 @@ var _ = Describe("JobHandler", func() {
 			})
 		})
 
-		When("guid provided is not a valid job guid", func() {
-			BeforeEach(func() {
-				jobGUID = "some-guid"
+		Describe("job guid validation", func() {
+			When("the job guid provided does not have the expected delimiter", func() {
+				BeforeEach(func() {
+					jobGUID = "job.operation;some-resource-guid"
+				})
+
+				It("returns an error", func() {
+					expectNotFoundError("Job not found")
+				})
 			})
 
-			It("return an error", func() {
-				expectNotFoundError("Job not found")
+			When("the resource identifier portion has a prefixed guid", func() {
+				BeforeEach(func() {
+					jobGUID = "space.delete~cf-space-a4cd478b-0b02-452f-8498-ce87ec5c6649"
+				})
+
+				It("returns status 200 OK", func() {
+					Expect(rr.Code).To(Equal(http.StatusOK))
+				})
+			})
+
+			When("the resource identifier portion does not include a guid", func() {
+				BeforeEach(func() {
+					jobGUID = "space.apply_manifest~cf-space-staging-space"
+				})
+
+				It("returns status 200 OK", func() {
+					Expect(rr.Code).To(Equal(http.StatusOK))
+				})
 			})
 		})
 	})

--- a/api/handlers/org_handler.go
+++ b/api/handlers/org_handler.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/x509"
 	"encoding/pem"
-	"fmt"
 	"net/http"
 	"net/url"
 	"time"
@@ -84,7 +83,7 @@ func (h *OrgHandler) orgDeleteHandler(ctx context.Context, logger logr.Logger, a
 		return nil, apierrors.ForbiddenAsNotFound(err)
 	}
 
-	return NewHandlerResponse(http.StatusAccepted).WithHeader("Location", fmt.Sprintf("%s/v3/jobs/org.delete-%s", h.apiBaseURL.String(), orgGUID)), nil
+	return NewHandlerResponse(http.StatusAccepted).WithHeader("Location", presenter.JobURLForRedirects(orgGUID, presenter.OrgDeleteOperation, h.apiBaseURL)), nil
 }
 
 func (h *OrgHandler) orgListHandler(ctx context.Context, logger logr.Logger, authInfo authorization.Info, r *http.Request) (*HandlerResponse, error) {

--- a/api/handlers/org_handler_test.go
+++ b/api/handlers/org_handler_test.go
@@ -397,7 +397,7 @@ var _ = Describe("OrgHandler", func() {
 			})
 
 			It("responds with a job URL in a location header", func() {
-				Expect(rr).To(HaveHTTPHeaderWithValue("Location", "https://api.example.org/v3/jobs/org.delete-"+orgGUID))
+				Expect(rr).To(HaveHTTPHeaderWithValue("Location", "https://api.example.org/v3/jobs/org.delete~"+orgGUID))
 			})
 
 			It("deletes the K8s record via the repository", func() {

--- a/api/handlers/route_handler.go
+++ b/api/handlers/route_handler.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"net/url"
 
@@ -236,7 +235,7 @@ func (h *RouteHandler) routeDeleteHandler(ctx context.Context, logger logr.Logge
 		return nil, err
 	}
 
-	return NewHandlerResponse(http.StatusAccepted).WithHeader("Location", fmt.Sprintf("%s/v3/jobs/route.delete-%s", h.serverURL.String(), routeGUID)), nil
+	return NewHandlerResponse(http.StatusAccepted).WithHeader("Location", presenter.JobURLForRedirects(routeGUID, presenter.RouteDeleteOperation, h.serverURL)), nil
 }
 
 func (h *RouteHandler) RegisterRoutes(router *mux.Router) {

--- a/api/handlers/route_handler_test.go
+++ b/api/handlers/route_handler_test.go
@@ -1675,7 +1675,7 @@ var _ = Describe("RouteHandler", func() {
 			})
 
 			It("responds with a job URL in a location header", func() {
-				Expect(rr).To(HaveHTTPHeaderWithValue("Location", "https://api.example.org/v3/jobs/route.delete-"+testRouteGUID))
+				Expect(rr).To(HaveHTTPHeaderWithValue("Location", "https://api.example.org/v3/jobs/route.delete~"+testRouteGUID))
 			})
 
 			It("fetches the right route", func() {

--- a/api/handlers/space_handler.go
+++ b/api/handlers/space_handler.go
@@ -2,12 +2,10 @@ package handlers
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
 
-	"github.com/go-http-utils/headers"
 	"github.com/go-logr/logr"
 	"github.com/gorilla/mux"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -106,7 +104,7 @@ func (h *SpaceHandler) spaceDeleteHandler(ctx context.Context, logger logr.Logge
 		return nil, err
 	}
 
-	return NewHandlerResponse(http.StatusAccepted).WithHeader(headers.Location, fmt.Sprintf("%s/v3/jobs/space.delete-%s", h.apiBaseURL.String(), spaceGUID)), nil
+	return NewHandlerResponse(http.StatusAccepted).WithHeader("Location", presenter.JobURLForRedirects(spaceGUID, presenter.SpaceDeleteOperation, h.apiBaseURL)), nil
 }
 
 func (h *SpaceHandler) RegisterRoutes(router *mux.Router) {

--- a/api/handlers/space_handler_test.go
+++ b/api/handlers/space_handler_test.go
@@ -340,7 +340,7 @@ var _ = Describe("Spaces", func() {
 			})
 
 			It("responds with a job URL in a location header", func() {
-				Expect(rr).To(HaveHTTPHeaderWithValue("Location", "https://api.example.org/v3/jobs/space.delete-"+spaceGUID))
+				Expect(rr).To(HaveHTTPHeaderWithValue("Location", "https://api.example.org/v3/jobs/space.delete~"+spaceGUID))
 			})
 
 			It("fetches the right space", func() {

--- a/api/handlers/space_manifest_handler.go
+++ b/api/handlers/space_manifest_handler.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"net/url"
 
@@ -14,6 +13,7 @@ import (
 	"code.cloudfoundry.org/korifi/api/apierrors"
 	"code.cloudfoundry.org/korifi/api/authorization"
 	"code.cloudfoundry.org/korifi/api/payloads"
+	"code.cloudfoundry.org/korifi/api/presenter"
 	"code.cloudfoundry.org/korifi/api/repositories"
 )
 
@@ -79,7 +79,7 @@ func (h *SpaceManifestHandler) applyManifestHandler(ctx context.Context, logger 
 	}
 
 	return NewHandlerResponse(http.StatusAccepted).
-		WithHeader(headers.Location, fmt.Sprintf("%s/v3/jobs/space.apply_manifest-%s", h.serverURL.String(), spaceGUID)), nil
+		WithHeader(headers.Location, presenter.JobURLForRedirects(spaceGUID, presenter.SpaceApplyManifestOperation, h.serverURL)), nil
 }
 
 func (h *SpaceManifestHandler) diffManifestHandler(ctx context.Context, logger logr.Logger, authInfo authorization.Info, r *http.Request) (*HandlerResponse, error) {

--- a/api/handlers/space_manifest_handler_test.go
+++ b/api/handlers/space_manifest_handler_test.go
@@ -75,7 +75,8 @@ var _ = Describe("SpaceManifestHandler", func() {
 
 			It("returns 202 with a Location header", func() {
 				Expect(rr).To(HaveHTTPStatus(http.StatusAccepted))
-				Expect(rr).To(HaveHTTPHeaderWithValue("Location", Not(BeEmpty())))
+
+				Expect(rr).To(HaveHTTPHeaderWithValue("Location", ContainSubstring("space.apply_manifest~"+spaceGUID)))
 			})
 
 			It("calls applyManifestAction and passes it the authInfo from the context", func() {

--- a/api/presenter/job.go
+++ b/api/presenter/job.go
@@ -1,6 +1,19 @@
 package presenter
 
-import "net/url"
+import (
+	"fmt"
+	"net/url"
+)
+
+const (
+	JobGUIDDelimiter = "~"
+
+	AppDeleteOperation          = "app.delete"
+	OrgDeleteOperation          = "org.delete"
+	RouteDeleteOperation        = "route.delete"
+	SpaceApplyManifestOperation = "space.apply_manifest"
+	SpaceDeleteOperation        = "space.delete"
+)
 
 type JobResponse struct {
 	GUID      string   `json:"guid"`
@@ -13,7 +26,6 @@ type JobResponse struct {
 	Links     JobLinks `json:"links"`
 }
 
-// TODO: Generalize job links or just omit missing links for jobs that do not require them?
 type JobLinks struct {
 	Self  Link  `json:"self"`
 	Space *Link `json:"space,omitempty"`
@@ -24,7 +36,7 @@ func ForManifestApplyJob(jobGUID string, spaceGUID string, baseURL url.URL) JobR
 		GUID:      jobGUID,
 		Errors:    nil,
 		Warnings:  nil,
-		Operation: "space.apply_manifest",
+		Operation: SpaceApplyManifestOperation,
 		State:     "COMPLETE",
 		CreatedAt: "",
 		UpdatedAt: "",
@@ -54,4 +66,9 @@ func ForDeleteJob(jobGUID string, operation string, baseURL url.URL) JobResponse
 			},
 		},
 	}
+}
+
+func JobURLForRedirects(resourceName string, operation string, baseURL url.URL) string {
+	jobGUID := fmt.Sprintf("%s%s%s", operation, JobGUIDDelimiter, resourceName)
+	return buildURL(baseURL).appendPath("/v3/jobs", jobGUID).build()
 }

--- a/tests/e2e/orgs_test.go
+++ b/tests/e2e/orgs_test.go
@@ -225,7 +225,7 @@ var _ = Describe("Orgs", func() {
 		It("succeeds with a job redirect", func() {
 			Expect(resp).To(SatisfyAll(
 				HaveRestyStatusCode(http.StatusAccepted),
-				HaveRestyHeaderWithValue("Location", HaveSuffix("/v3/jobs/org.delete-"+orgGUID)),
+				HaveRestyHeaderWithValue("Location", HaveSuffix("/v3/jobs/org.delete~"+orgGUID)),
 			))
 
 			jobURL := resp.Header().Get("Location")
@@ -244,7 +244,7 @@ var _ = Describe("Orgs", func() {
 			It("can still delete the org and eventually returns a successful job redirect", func() {
 				Expect(resp).To(SatisfyAll(
 					HaveRestyStatusCode(http.StatusAccepted),
-					HaveRestyHeaderWithValue("Location", HaveSuffix("/v3/jobs/org.delete-"+orgGUID)),
+					HaveRestyHeaderWithValue("Location", HaveSuffix("/v3/jobs/org.delete~"+orgGUID)),
 				))
 
 				jobURL := resp.Header().Get("Location")

--- a/tests/e2e/routes_test.go
+++ b/tests/e2e/routes_test.go
@@ -343,7 +343,7 @@ var _ = Describe("Routes", func() {
 			Expect(resp).To(HaveRestyStatusCode(http.StatusAccepted))
 			Expect(resp).To(HaveRestyHeaderWithValue("Location", SatisfyAll(
 				HavePrefix(apiServerRoot),
-				ContainSubstring("/v3/jobs/route.delete-"),
+				ContainSubstring("/v3/jobs/route.delete~"+routeGUID),
 			)))
 		})
 

--- a/tests/e2e/spaces_test.go
+++ b/tests/e2e/spaces_test.go
@@ -270,7 +270,7 @@ var _ = Describe("Spaces", func() {
 		It("succeeds with a job redirect", func() {
 			Expect(resp).To(SatisfyAll(
 				HaveRestyStatusCode(http.StatusAccepted),
-				HaveRestyHeaderWithValue("Location", HaveSuffix("/v3/jobs/space.delete-"+spaceGUID)),
+				HaveRestyHeaderWithValue("Location", HaveSuffix("/v3/jobs/space.delete~"+spaceGUID)),
 			))
 
 			jobURL := resp.Header().Get("Location")
@@ -354,7 +354,7 @@ var _ = Describe("Spaces", func() {
 				It("succeeds with a job redirect", func() {
 					Expect(resp).To(SatisfyAll(
 						HaveRestyStatusCode(http.StatusAccepted),
-						HaveRestyHeaderWithValue("Location", HaveSuffix("/v3/jobs/space.apply_manifest-"+spaceGUID)),
+						HaveRestyHeaderWithValue("Location", HaveSuffix("/v3/jobs/space.apply_manifest~"+spaceGUID)),
 					))
 
 					jobURL := resp.Header().Get("Location")
@@ -374,7 +374,7 @@ var _ = Describe("Spaces", func() {
 					It("succeeds with a job redirect", func() {
 						Expect(resp).To(SatisfyAll(
 							HaveRestyStatusCode(http.StatusAccepted),
-							HaveRestyHeaderWithValue("Location", HaveSuffix("/v3/jobs/space.apply_manifest-"+spaceGUID)),
+							HaveRestyHeaderWithValue("Location", HaveSuffix("/v3/jobs/space.apply_manifest~"+spaceGUID)),
 						))
 
 						jobURL := resp.Header().Get("Location")


### PR DESCRIPTION
## Is there a related GitHub Issue?
Issue: https://github.com/cloudfoundry/korifi/issues/1116

## What is this change about?
This issue came from some real world usage where an operator was mirroring orgs/spaces from a CF for VMs environment and was using the `CFOrg` and `CFSpace` resources directly. They wanted to include the org/space names in the `metadata.name` instead of the GUID for operational convenience (they did not care to support org/space renaming).

From the commit message:
- We previously required that Job identifiers adhered
to a strict structure of `<operation>-<optional prefix>-<GUID>`.
- This change loosens this restriction so that Kubectl users are not required
to use a GUID and instead are able to use any valid Kubernetes resource.
- Changes the delimiter between job operation and resource
identifier to be "~". The "~" character is not used by any CF Job
operation types, is a valid non-reserved URL character, and is not a
valid character for Kubernetes resource names. This allows us to
simplify the regular expression and have fewer assumptions around
resource naming.
- Refactors job redirect URL building by centralizing the logic in
the Job Presenter

## Does this PR introduce a breaking change?
Slightly. There will be a small chance that any job redirects issues during an upgrade to this change will be invalid. However, we are still in beta and these jobs are not persisted anywhere so the risk is low. Users will just need to retry their request.

## Acceptance Steps
After this change you should still be able to continue to do the following:
* `cf push` an app
* `cf delete` an app
* Delete orgs, spaces, and routes

## Tag your pair, your PM, and/or team
@akrishna90 @Birdrock 
