### PR TITLE
Add link to releases page to INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,6 @@
 # Introduction
 
-The following lines will guide you through the process of deploying a released version of [Korifi](https://github.com/cloudfoundry/korifi). This document is written with the intent to act both as a runbook as well as a starting point in understanding basic concepts of Korifi and its dependencies.
+The following lines will guide you through the process of deploying a [released version](https://github.com/cloudfoundry/korifi/releases) of [Korifi](https://github.com/cloudfoundry/korifi). This document is written with the intent to act both as a runbook as well as a starting point in understanding basic concepts of Korifi and its dependencies.
 
 # Prerequisites
 


### PR DESCRIPTION
This might help clarifying that the instructions are for released tarballs, not git checkouts.