### PR TITLE
Ignore the HTTP result on status code not 2XX

### DIFF
--- a/tests/e2e/buildpacks_test.go
+++ b/tests/e2e/buildpacks_test.go
@@ -48,7 +48,6 @@ var _ = Describe("Buildpacks", func() {
 
 			It("returns forbidden", func() {
 				Expect(resp).To(HaveRestyStatusCode(http.StatusForbidden))
-				Expect(result.Resources).To(BeEmpty())
 			})
 		})
 	})


### PR DESCRIPTION

## Is there a related GitHub Issue?
No

## What is this change about?
Resty client would only set the `result` when the HTTP status code is
2XX. Therefore, it makes no sense to verify the result when the response
code is `Forbidden`

Doing that causes flakes as the result might have been set by a previous
test that succeeded.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Green e2es

## Tag your pair, your PM, and/or team
@kieron-dev 

