### PR TITLE
Wait for cert-manager to be ready during install-deps

### DIFF
--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -59,6 +59,9 @@ echo "*************************"
 
 # Install Cert Manager
 kubectl apply -f "${DEP_DIR}/cert-manager.yaml"
+kubectl -n cert-manager rollout status deployment/cert-manager --watch=true
+kubectl -n cert-manager rollout status deployment/cert-manager-webhook --watch=true
+kubectl -n cert-manager rollout status deployment/cert-manager-cainjector --watch=true
 
 echo "*******************"
 echo "Installing Kpack"


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
No

## What is this change about?
The removal of HNC installation means the installation process happens more quickly and eirini might be installed before its dependency, cert-manager, is able to serve its registered webhooks. Eirini-controller creates a cert-manager certificate, so will fail if the webhook is not listening yet.

This change simply waits till cert-manager is ready after installing it.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
