### PR TITLE
Add version warning to INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,3 +1,6 @@
+> **Warning**
+> Make sure you are using the correct version of these instructions by using the link in the release notes for the version you're trying to install. If you're not sure, check our [latest release](https://github.com/cloudfoundry/korifi/releases/latest).
+
 # Introduction
 
 The following lines will guide you through the process of deploying a [released version](https://github.com/cloudfoundry/korifi/releases) of [Korifi](https://github.com/cloudfoundry/korifi). This document is written with the intent to act both as a runbook as well as a starting point in understanding basic concepts of Korifi and its dependencies.


### PR DESCRIPTION
The instructions will constantly change to track `main`, but people will still try to use them to install our latest release. We should warn them and point them to the correct version of this file, which I'm going to add to the release notes for every release.