### PR TITLE
Crating tasks without `Command` causes validation error

### DIFF
--- a/api/handlers/task_handler_test.go
+++ b/api/handlers/task_handler_test.go
@@ -90,6 +90,18 @@ var _ = Describe("TaskHandler", func() {
             }`))
 		})
 
+		When("the task has no command", func() {
+			BeforeEach(func() {
+				var err error
+				req, err = http.NewRequestWithContext(ctx, "POST", "/v3/apps/the-app-guid/tasks", strings.NewReader(`{}`))
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("returns an unprocessable entity error", func() {
+				Expect(rr.Code).To(Equal(http.StatusUnprocessableEntity))
+			})
+		})
+
 		When("the app does not exist", func() {
 			BeforeEach(func() {
 				appRepo.GetAppReturns(repositories.AppRecord{}, apierrors.NewNotFoundError(nil, repositories.TaskResourceType))

--- a/controllers/config/webhook/manifests.yaml
+++ b/controllers/config/webhook/manifests.yaml
@@ -269,3 +269,23 @@ webhooks:
     resources:
     - cfspaces
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-korifi-cloudfoundry-org-v1alpha1-cftask
+  failurePolicy: Fail
+  name: vcftask.korifi.cloudfoundry.org
+  rules:
+  - apiGroups:
+    - korifi.cloudfoundry.org
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    resources:
+    - cftasks
+  sideEffects: None

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -310,6 +310,11 @@ func main() {
 			setupLog.Error(err, "unable to create webhook", "webhook", "CFRoute")
 			os.Exit(1)
 		}
+
+		if err = workloads.NewCFTaskValidator().SetupWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "CFTask")
+			os.Exit(1)
+		}
 	} else {
 		setupLog.Info("Skipping webhook setup because ENABLE_WEBHOOKS set to false.")
 	}

--- a/controllers/webhooks/workloads/cftask_validator.go
+++ b/controllers/webhooks/workloads/cftask_validator.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workloads
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
+	"code.cloudfoundry.org/korifi/controllers/webhooks"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	runtime "k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+const MissingRequredFieldErrorType = "MissingRequiredFieldError"
+
+// log is for logging in this package.
+var cftasklog = logf.Log.WithName("cftask-resource")
+
+//+kubebuilder:webhook:path=/validate-korifi-cloudfoundry-org-v1alpha1-cftask,mutating=false,failurePolicy=fail,sideEffects=None,groups=korifi.cloudfoundry.org,resources=cftasks,verbs=create,versions=v1alpha1,name=vcftask.korifi.cloudfoundry.org,admissionReviewVersions={v1,v1beta1}
+
+type CFTaskValidator struct{}
+
+func NewCFTaskValidator() *CFTaskValidator {
+	return &CFTaskValidator{}
+}
+
+func (v *CFTaskValidator) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(&v1alpha1.CFTask{}).
+		WithValidator(v).
+		Complete()
+}
+
+var _ webhook.CustomValidator = &CFTaskValidator{}
+
+func (v *CFTaskValidator) ValidateCreate(ctx context.Context, obj runtime.Object) error {
+	task, ok := obj.(*v1alpha1.CFTask)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a CFTask but got a %T", obj))
+	}
+
+	cftasklog.Info("validate task creation", "namespace", task.Namespace, "name", task.Name)
+
+	if len(task.Spec.Command) == 0 {
+		return errors.New(webhooks.ValidationError{
+			Type:    MissingRequredFieldErrorType,
+			Message: fmt.Sprintf("task %s:%s is missing required field 'Spec.Command'", task.Namespace, task.Name),
+		}.Marshal())
+	}
+
+	return nil
+}
+
+func (v *CFTaskValidator) ValidateUpdate(ctx context.Context, oldObj runtime.Object, obj runtime.Object) error {
+	return nil
+}
+
+func (v *CFTaskValidator) ValidateDelete(ctx context.Context, obj runtime.Object) error {
+	return nil
+}

--- a/controllers/webhooks/workloads/integration/cftask_validator_test.go
+++ b/controllers/webhooks/workloads/integration/cftask_validator_test.go
@@ -1,0 +1,58 @@
+package integration_test
+
+import (
+	"context"
+
+	"code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
+	"code.cloudfoundry.org/korifi/controllers/controllers/workloads/testutils"
+	"code.cloudfoundry.org/korifi/controllers/webhooks"
+	"code.cloudfoundry.org/korifi/controllers/webhooks/workloads"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("CFTask Webhook", func() {
+	var (
+		cftask      v1alpha1.CFTask
+		creationErr error
+	)
+
+	BeforeEach(func() {
+		cftask = v1alpha1.CFTask{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testutils.GenerateGUID(),
+				Namespace: rootNamespace,
+			},
+			Spec: v1alpha1.CFTaskSpec{
+				Command: []string{"echo", "hello"},
+				AppRef: corev1.LocalObjectReference{
+					Name: "cfapp",
+				},
+			},
+		}
+	})
+
+	JustBeforeEach(func() {
+		creationErr = k8sClient.Create(context.Background(), &cftask)
+	})
+
+	It("suceeds", func() {
+		Expect(creationErr).NotTo(HaveOccurred())
+	})
+
+	When("command is missing", func() {
+		BeforeEach(func() {
+			cftask.Spec.Command = nil
+		})
+
+		It("returns a validation error", func() {
+			validationErr, ok := webhooks.WebhookErrorToValidationError(creationErr)
+			Expect(ok).To(BeTrue())
+
+			Expect(validationErr.Type).To(Equal(workloads.MissingRequredFieldErrorType))
+			Expect(validationErr.Message).To(ContainSubstring("missing required field 'Spec.Command'"))
+		})
+	})
+})

--- a/controllers/webhooks/workloads/integration/suite_integration_test.go
+++ b/controllers/webhooks/workloads/integration/suite_integration_test.go
@@ -115,6 +115,8 @@ var _ = BeforeSuite(func() {
 	spaceValidationWebhook := workloads.NewCFSpaceValidation(spaceNameDuplicateValidator, spacePlacementValidator)
 	Expect(spaceValidationWebhook.SetupWebhookWithManager(mgr)).To(Succeed())
 
+	Expect(workloads.NewCFTaskValidator().SetupWebhookWithManager(mgr)).To(Succeed())
+
 	//+kubebuilder:scaffold:webhook
 
 	go func() {


### PR DESCRIPTION
## Is there a related GitHub Issue?
https://github.com/cloudfoundry/korifi/issues/1020

## What is this change about?
Introduce a `CFTask` validator to ensure that the `Spec.Command` field
is set

## Does this PR introduce a breaking change?
No

## Acceptance Steps
See https://github.com/cloudfoundry/korifi/issues/1020 for acceptance

## Tag your pair, your PM, and/or team
@georgethebeatle 

