### PR TITLE
Bump to latest v3 API Version

### DIFF
--- a/api/handlers/root_handler_test.go
+++ b/api/handlers/root_handler_test.go
@@ -58,7 +58,7 @@ var _ = Describe("RootHandler", func() {
 					"cloud_controller_v2": nil,
 					"cloud_controller_v3": {
 						Link: presenter.Link{HREF: defaultServerURL + "/v3"},
-						Meta: presenter.APILinkMeta{Version: "3.111.0+cf-k8s"},
+						Meta: presenter.APILinkMeta{Version: presenter.V3APIVersion},
 					},
 					"network_policy_v0": nil,
 					"network_policy_v1": nil,

--- a/api/presenter/root.go
+++ b/api/presenter/root.go
@@ -14,7 +14,7 @@ type RootResponse struct {
 	CFOnK8s bool                `json:"cf_on_k8s"`
 }
 
-const v3APIVersion = "3.111.0+cf-k8s"
+const V3APIVersion = "3.117.0+cf-k8s"
 
 func GetRootResponse(serverURL string) RootResponse {
 	return RootResponse{
@@ -22,7 +22,7 @@ func GetRootResponse(serverURL string) RootResponse {
 			"self":                {Link: Link{HREF: serverURL}},
 			"bits_service":        nil,
 			"cloud_controller_v2": nil,
-			"cloud_controller_v3": {Link: Link{HREF: serverURL + "/v3"}, Meta: APILinkMeta{Version: v3APIVersion}},
+			"cloud_controller_v3": {Link: Link{HREF: serverURL + "/v3"}, Meta: APILinkMeta{Version: V3APIVersion}},
 			"network_policy_v0":   nil,
 			"network_policy_v1":   nil,
 			"login":               nil,

--- a/docs/api.md
+++ b/docs/api.md
@@ -6,7 +6,7 @@
 
 ### Root
 
-Docs: https://v3-apidocs.cloudfoundry.org/version/3.110.0/index.html#root
+Docs: https://v3-apidocs.cloudfoundry.org/version/3.117.0/index.html#root
 
 | Resource        | Endpoint |
 | --------------- | -------- |
@@ -15,13 +15,13 @@ Docs: https://v3-apidocs.cloudfoundry.org/version/3.110.0/index.html#root
 
 ### Resource Matches
 
-Docs: https://v3-apidocs.cloudfoundry.org/version/3.110.0/index.html#resource-matches
+Docs: https://v3-apidocs.cloudfoundry.org/version/3.117.0/index.html#resource-matches
 
 | Resource                | Endpoint                  |
 | ----------------------- | ------------------------- |
 | Create a Resource Match | POST /v3/resource_matches |
 
-#### [Create a Resource Match](https://v3-apidocs.cloudfoundry.org/version/3.110.0/index.html#create-a-resource-match)
+#### [Create a Resource Match](https://v3-apidocs.cloudfoundry.org/version/3.117.0/index.html#create-a-resource-match)
 ```bash
 curl "http://localhost:9000/v3/resource_matches" \
   -X POST \
@@ -30,20 +30,20 @@ curl "http://localhost:9000/v3/resource_matches" \
 
 ### Orgs
 
-Docs: https://v3-apidocs.cloudfoundry.org/version/3.110.0/index.html#organizations
+Docs: https://v3-apidocs.cloudfoundry.org/version/3.117.0/index.html#organizations
 
 | Resource   | Endpoint      |
 | ---------- | ------------- |
 | List Orgs  | GET /v3/organizations  |
 | Create Org | POST /v3/organizations |
-| Delete Space | [DELETE /v3/organizations/:guid](https://v3-apidocs.cloudfoundry.org/version/3.113.0/index.html#delete-an-organization)
+| Delete Space | [DELETE /v3/organizations/:guid](https://v3-apidocs.cloudfoundry.org/version/3.117.0/index.html#delete-an-organization)
 | List Org Domains | GET /v3/organizations/:guid/domains |
-#### [List Orgs](https://v3-apidocs.cloudfoundry.org/version/3.110.0/index.html#list-organizations)
+#### [List Orgs](https://v3-apidocs.cloudfoundry.org/version/3.117.0/index.html#list-organizations)
 **Query Parameters:** Currently only supports filtering by organization `names`.
 ```bash
 curl "http://localhost:9000/v3/organizations?names=org1,org2"
 ```
-#### [Creating Orgs](https://v3-apidocs.cloudfoundry.org/version/3.110.0/index.html#create-an-organization)
+#### [Creating Orgs](https://v3-apidocs.cloudfoundry.org/version/3.117.0/index.html#create-an-organization)
 ```bash
 curl "http://localhost:9000/v3/organizations" \
   -X POST \
@@ -52,22 +52,22 @@ curl "http://localhost:9000/v3/organizations" \
 
 ### Spaces
 
-Docs: https://v3-apidocs.cloudfoundry.org/version/3.110.0/index.html#spaces
+Docs: https://v3-apidocs.cloudfoundry.org/version/3.117.0/index.html#spaces
 
 | Resource     | Endpoint                                                                                                   |
-| ------------ | ---------------------------------------------------------------------------------------------------------- |
+| ------------ |------------------------------------------------------------------------------------------------------------|
 | List Spaces  | GET /v3/spaces                                                                                             |
 | Create Space | POST /v3/spaces                                                                                            |
-| Delete Space | [DELETE /v3/spaces/\<guid>](https://v3-apidocs.cloudfoundry.org/version/3.111.0/index.html#delete-a-space) |
+| Delete Space | [DELETE /v3/spaces/\<guid>](https://v3-apidocs.cloudfoundry.org/version/3.117.0/index.html#delete-a-space) |
 
-#### [List Spaces](https://v3-apidocs.cloudfoundry.org/version/3.110.0/index.html#list-spaces)
+#### [List Spaces](https://v3-apidocs.cloudfoundry.org/version/3.117.0/index.html#list-spaces)
 **Query Parameters:** Currently supports filtering by space `names` and `organization_guids`.
 
 ```bash
 curl "http://localhost:9000/v3/spaces?names=space1,space2&organization_guids=ad0836b5-09f4-48c0-adb2-2c61e515562f,6030b015-f003-4c9f-8bb4-1ed7ae3d3659"
 ```
 
-#### [Creating Spaces](https://v3-apidocs.cloudfoundry.org/version/3.110.0/index.html#create-a-space)
+#### [Creating Spaces](https://v3-apidocs.cloudfoundry.org/version/3.117.0/index.html#create-a-space)
 
 ```bash
 curl "http://localhost:9000/v3/spaces" \
@@ -77,34 +77,34 @@ curl "http://localhost:9000/v3/spaces" \
 
 ### Apps
 
-Docs: https://v3-apidocs.cloudfoundry.org/version/3.107.0/index.html#apps
+Docs: https://v3-apidocs.cloudfoundry.org/version/3.117.0/index.html#apps
 
-| Resource                            | Endpoint                                                                                                |
-|-------------------------------------|---------------------------------------------------------------------------------------------------------|
-| List Apps                           | GET /v3/apps                                                                                            |
-| Get App                             | GET /v3/apps/\<guid>                                                                                    |
-| Create App                          | POST /v3/apps                                                                                           |
-| Set App's Current Droplet           | PATCH /v3/apps/\<guid>/relationships/current_droplet                                                    |
-| Get App's Current Droplet           | GET /v3/apps/\<guid>/droplets/current                                                                   |
-| Start App                           | POST /v3/apps/\<guid>/actions/start                                                                     |
-| Stop App                            | POST /v3/apps/\<guid>/actions/stop                                                                      |
-| Restart App                         | POST /v3/apps/\<guid>/actions/restart                                                                   |
-| List App Processes                  | GET /v3/apps/\<guid>/processes                                                                          |
-| Scale App Process                   | POST /v3/apps/<guid>/processes/<type>/actions/scale                                                     |
-| List App Routes                     | GET /v3/apps/\<guid>/routes                                                                             |
-| Delete App                          | [DELETE /v3/apps/\<guid>](https://v3-apidocs.cloudfoundry.org/version/3.111.0/index.html#delete-an-app) |
- | Get App Env                         | GET /v3/apps/\<guid>/env                                                                            |
-| Update App's Environment Variables  | PATCH /v3/apps/\<guid>/environment_variables    
-| Get App Processes by Type           | [GET /v3/apps/\<guid>/processes/\<web>](https://v3-apidocs.cloudfoundry.org/version/3.113.0/#get-a-process) 
+| Resource                            | Endpoint                                                                                                    |
+|-------------------------------------|-------------------------------------------------------------------------------------------------------------|
+| List Apps                           | GET /v3/apps                                                                                                |
+| Get App                             | GET /v3/apps/\<guid>                                                                                        |
+| Create App                          | POST /v3/apps                                                                                               |
+| Set App's Current Droplet           | PATCH /v3/apps/\<guid>/relationships/current_droplet                                                        |
+| Get App's Current Droplet           | GET /v3/apps/\<guid>/droplets/current                                                                       |
+| Start App                           | POST /v3/apps/\<guid>/actions/start                                                                         |
+| Stop App                            | POST /v3/apps/\<guid>/actions/stop                                                                          |
+| Restart App                         | POST /v3/apps/\<guid>/actions/restart                                                                       |
+| List App Processes                  | GET /v3/apps/\<guid>/processes                                                                              |
+| Scale App Process                   | POST /v3/apps/<guid>/processes/<type>/actions/scale                                                         |
+| List App Routes                     | GET /v3/apps/\<guid>/routes                                                                                 |
+| Delete App                          | [DELETE /v3/apps/\<guid>](https://v3-apidocs.cloudfoundry.org/version/3.117.0/index.html#delete-an-app)     |
+| Get App Env                         | GET /v3/apps/\<guid>/env                                                                                    |
+| Update App's Environment Variables  | PATCH /v3/apps/\<guid>/environment_variables                                                                |
+| Get App Processes by Type           | [GET /v3/apps/\<guid>/processes/\<web>](https://v3-apidocs.cloudfoundry.org/version/3.117.0/#get-a-process) |
 
-#### [List Apps](https://v3-apidocs.cloudfoundry.org/version/3.110.0/index.html#list-apps)
+#### [List Apps](https://v3-apidocs.cloudfoundry.org/version/3.117.0/index.html#list-apps)
 **Query Parameters:** Currently supports filtering by app `names` and `space_guids` and ordering by `name`.
 
 ```bash
 curl "http://localhost:9000/v3/apps?names=app1,app2&space_guids=ad0836b5-09f4-48c0-adb2-2c61e515562f,6030b015-f003-4c9f-8bb4-1ed7ae3d3659"
 ```
 
-#### [Creating Apps](https://v3-apidocs.cloudfoundry.org/version/3.110.0/index.html#create-an-app)
+#### [Creating Apps](https://v3-apidocs.cloudfoundry.org/version/3.117.0/index.html#create-an-app)
 Note : `namespace` needs to exist before creating the app.
 ```bash
 curl "http://localhost:9000/v3/apps" \
@@ -112,49 +112,49 @@ curl "http://localhost:9000/v3/apps" \
   -d '{"name":"my-app","relationships":{"space":{"data":{"guid":"<space-guid>"}}}}'
 ```
 
-#### [Setting App's Current Droplet](https://v3-apidocs.cloudfoundry.org/version/3.108.0/index.html#update-a-droplet)
+#### [Setting App's Current Droplet](https://v3-apidocs.cloudfoundry.org/version/3.117.0/index.html#update-a-droplet)
 ```bash
 curl "http://localhost:9000/v3/apps/<app-guid>/relationships/current_droplet" \
   -X PATCH \
   -d '{"data":{"guid":"<droplet-guid>"}}'
 ```
 
-#### [Getting App's Current Droplet](https://v3-apidocs.cloudfoundry.org/version/3.109.0/index.html#get-current-droplet)
+#### [Getting App's Current Droplet](https://v3-apidocs.cloudfoundry.org/version/3.117.0/index.html#get-current-droplet)
 ```bash
 curl "http://localhost:9000/v3/apps/<app-guid>/droplets/current"
 ```
 
-#### [Scaling App's Process](https://v3-apidocs.cloudfoundry.org/version/3.107.0/index.html#scale-a-process)
+#### [Scaling App's Process](https://v3-apidocs.cloudfoundry.org/version/3.117.0/index.html#scale-a-process)
 ```bash
 curl "http://localhost:9000/v3/apps/<guid>/processes/<type>/actions/scale" \
   -X POST \
   -d '{ "instances": 5, "memory_in_mb": 256, "disk_in_mb": 1024 }'
 ```
 
-#### [Start an app](https://v3-apidocs.cloudfoundry.org/version/3.100.0/index.html#start-an-app)
+#### [Start an app](https://v3-apidocs.cloudfoundry.org/version/3.117.0/index.html#start-an-app)
 ```bash
 curl "http://localhost:9000/v3/apps/<app-guid>/actions/start" \
   -X POST
 ```
 
-#### [Stop an app](https://v3-apidocs.cloudfoundry.org/version/3.100.0/index.html#stop-an-app)
+#### [Stop an app](https://v3-apidocs.cloudfoundry.org/version/3.117.0/index.html#stop-an-app)
 ```bash
 curl "http://localhost:9000/v3/apps/<app-guid>/actions/stop" \
   -X POST
 ```
 
-#### [Restart an app](https://v3-apidocs.cloudfoundry.org/version/3.110.0/index.html#restart-an-app)
+#### [Restart an app](https://v3-apidocs.cloudfoundry.org/version/3.117.0/index.html#restart-an-app)
 ```bash
 curl "http://localhost:9000/v3/apps/<app-guid>/actions/restart" \
   -X POST
 ```
 
-#### [Get app env](https://v3-apidocs.cloudfoundry.org/version/3.113.0/index.html#get-environment-for-an-app)
+#### [Get app env](https://v3-apidocs.cloudfoundry.org/version/3.117.0/index.html#get-environment-for-an-app)
 ```bash
 curl "http://localhost:9000/v3/apps/<app-guid>/env" 
 ```
 
-#### [Update app's environment variables](https://v3-apidocs.cloudfoundry.org/version/3.113.0/index.hml#update-environment-variables-for-an-app)
+#### [Update app's environment variables](https://v3-apidocs.cloudfoundry.org/version/3.117.0/index.hml#update-environment-variables-for-an-app)
 ```bash
 curl "http://localhost:9000/v3/apps/<app-guid>/environment_variables" \
   -X PATCH \
@@ -164,27 +164,27 @@ curl "http://localhost:9000/v3/apps/<app-guid>/environment_variables" \
 ### Packages
 
 | Resource                                                                                                                | Endpoint                         |
-| ----------------------------------------------------------------------------------------------------------------------- | -------------------------------- |
+|-------------------------------------------------------------------------------------------------------------------------| -------------------------------- |
 | Create Package                                                                                                          | POST /v3/packages                |
 | List Package                                                                                                            | GET /v3/packages                 |
 | Upload Package Bits                                                                                                     | POST /v3/packages/<guid>/upload  |
-| [List Droplets for Package](https://v3-apidocs.cloudfoundry.org/version/3.111.0/index.html#list-droplets-for-a-package) | GET /v3/packages/<guid>/droplets |
+| [List Droplets for Package](https://v3-apidocs.cloudfoundry.org/version/3.117.0/index.html#list-droplets-for-a-package) | GET /v3/packages/<guid>/droplets |
 
-#### [Creating Packages](https://v3-apidocs.cloudfoundry.org/version/3.107.0/index.html#create-a-package)
+#### [Creating Packages](https://v3-apidocs.cloudfoundry.org/version/3.117.0/index.html#create-a-package)
 ```bash
 curl "http://localhost:9000/v3/packages" \
   -X POST \
   -d '{"type":"bits","relationships":{"app":{"data":{"guid":"<app-guid-goes-here>"}}}}'
 ```
 
-#### [Uploading Package Bits](https://v3-apidocs.cloudfoundry.org/version/3.107.0/index.html#upload-package-bits)
+#### [Uploading Package Bits](https://v3-apidocs.cloudfoundry.org/version/3.117.0/index.html#upload-package-bits)
 ```bash
 curl "http://localhost:9000/v3/packages/<guid>/upload" \
   -X POST \
   -F bits=@"<path-to-app-source.zip>"
 ```
 
-#### [List Package](https://v3-apidocs.cloudfoundry.org/version/3.111.0/index.html#list-packages)
+#### [List Package](https://v3-apidocs.cloudfoundry.org/version/3.117.0/index.html#list-packages)
 **Query Parameters:** Currently supports filtering by `app_guids`.
 
 ```bash
@@ -193,14 +193,14 @@ curl "http://localhost:9000/v3/packages"
 
 ### Builds
 
-Docs: https://v3-apidocs.cloudfoundry.org/version/3.100.0/index.html#builds
+Docs: https://v3-apidocs.cloudfoundry.org/version/3.117.0/index.html#builds
 
 | Resource     | Endpoint               |
 | ------------ | ---------------------- |
 | Get Build    | GET /v3/builds/\<guid> |
 | Create Build | POST /v3/builds        |
 
-#### [Creating Builds](https://v3-apidocs.cloudfoundry.org/version/3.107.0/index.html#create-a-build)
+#### [Creating Builds](https://v3-apidocs.cloudfoundry.org/version/3.117.0/index.html#create-a-build)
 ```bash
 curl "http://localhost:9000/v3/builds" \
   -X POST \
@@ -209,7 +209,7 @@ curl "http://localhost:9000/v3/builds" \
 
 ### Droplet
 
-Docs: https://v3-apidocs.cloudfoundry.org/version/3.100.0/index.html#droplets
+Docs: https://v3-apidocs.cloudfoundry.org/version/3.117.0/index.html#droplets
 
 | Resource    | Endpoint                 |
 | ----------- | ------------------------ |
@@ -217,41 +217,41 @@ Docs: https://v3-apidocs.cloudfoundry.org/version/3.100.0/index.html#droplets
 
 ### Process
 
-Docs: https://v3-apidocs.cloudfoundry.org/version/3.100.0/index.html#processes
+Docs: https://v3-apidocs.cloudfoundry.org/version/3.117.0/index.html#processes
 
-| Resource             | Endpoint                                 |
-| -------------------- | ---------------------------------------- |
-| Get Process          | GET /v3/processes/\<guid>/sidecars       |
-| Get Process Sidecars | GET /v3/processes/\<guid>/sidecars       |
-| Scale Process        | POST /v3/processes/\<guid>/actions/scale |
-| Get Process Stats    | POST /v3/processes/\<guid>/stats         |
-| List Process         | POST /v3/processes                       |
-| Patch Process        | [PATCH /v3/processes/\<guid>](https://v3-apidocs.cloudfoundry.org/version/3.113.0/#update-a-process)|
+| Resource             | Endpoint                                                                                             |
+| -------------------- |------------------------------------------------------------------------------------------------------|
+| Get Process          | GET /v3/processes/\<guid>/sidecars                                                                   |
+| Get Process Sidecars | GET /v3/processes/\<guid>/sidecars                                                                   |
+| Scale Process        | POST /v3/processes/\<guid>/actions/scale                                                             |
+| Get Process Stats    | POST /v3/processes/\<guid>/stats                                                                     |
+| List Process         | POST /v3/processes                                                                                   |
+| Patch Process        | [PATCH /v3/processes/\<guid>](https://v3-apidocs.cloudfoundry.org/version/3.117.0/#update-a-process) |
 
-#### [Scaling Processes](https://v3-apidocs.cloudfoundry.org/version/3.107.0/index.html#scale-a-process)
+#### [Scaling Processes](https://v3-apidocs.cloudfoundry.org/version/3.117.0/index.html#scale-a-process)
 ```bash
 curl "http://localhost:9000/v3/processes/<guid>/actions/scale" \
   -X POST \
   -d '{ "instances": 5, "memory_in_mb": 256, "disk_in_mb": 1024 }'
 ```
 
-#### [Get Process Stats](https://v3-apidocs.cloudfoundry.org/version/3.110.0/index.html#get-stats-for-a-process)
+#### [Get Process Stats](https://v3-apidocs.cloudfoundry.org/version/3.117.0/index.html#get-stats-for-a-process)
 Currently, we only support fetching stats using the process guid endpoint, i.e., POST /v3/processes/\<guid>/stats.
 This endpoint supports populating only the index and state details on the response.
 Support for populating other fields will come later.
 
-#### [List Processes](https://v3-apidocs.cloudfoundry.org/version/3.111.0/index.html#list-processes)
+#### [List Processes](https://v3-apidocs.cloudfoundry.org/version/3.117.0/index.html#list-processes)
 **Query Parameters:** Currently supports filtering by `app_guids`.
 
 ### Domain
 
-https://v3-apidocs.cloudfoundry.org/version/3.107.0/index.html#domains
+https://v3-apidocs.cloudfoundry.org/version/3.117.0/index.html#domains
 
 | Resource     | Endpoint        |
 | ------------ | --------------- |
 | List Domains | GET /v3/domains |
 
-#### [List Domains](https://v3-apidocs.cloudfoundry.org/version/3.107.0/index.html#list-domains)
+#### [List Domains](https://v3-apidocs.cloudfoundry.org/version/3.117.0/index.html#list-domains)
 ```bash
 curl "http://localhost:9000/v3/domains?names=cf-apps.io" \
   -X GET
@@ -267,19 +267,19 @@ curl "http://localhost:9000/v3/domains?names=cf-apps.io" \
 | Create Route                  | POST /v3/routes                                                                                          |
 | Add Destinations to Route     | POST /v3/routes/\<guid\>/destinations                                                                    |
 | Remove Destination from Route | DELETE /v3/routes/\<guid\>/destinations/\<destination-guid\>                                             |
-| Delete Route                  | [DELETE /v3/routes/:guid](https://v3-apidocs.cloudfoundry.org/version/3.111.0/index.html#delete-a-route) 
+| Delete Route                  | [DELETE /v3/routes/:guid](https://v3-apidocs.cloudfoundry.org/version/3.117.0/index.html#delete-a-route) |
 
-#### [List Routes](https://v3-apidocs.cloudfoundry.org/version/3.111.0/index.html#list-routes)
+#### [List Routes](https://v3-apidocs.cloudfoundry.org/version/3.117.0/index.html#list-routes)
 **Query Parameters:** Currently supports filtering by `app_guids`, `space_guids`, `domain_guids`, `hosts` and `paths`.
 
-#### [Creating Routes](https://v3-apidocs.cloudfoundry.org/version/3.107.0/index.html#create-a-route)
+#### [Creating Routes](https://v3-apidocs.cloudfoundry.org/version/3.117.0/index.html#create-a-route)
 ```bash
 curl "http://localhost:9000/v3/routes" \
   -X POST \
   -d '{"host": "hostname","path": "/path","relationships": {"domain": {"data": { "guid": "<domain-guid-goes-here>" }},"space": {"data": { "guid": "<namespace-name>" }}}}'
 ```
 
-#### [Add Destinations to Route](https://v3-apidocs.cloudfoundry.org/version/3.108.0/index.html#insert-destinations-for-a-route)
+#### [Add Destinations to Route](https://v3-apidocs.cloudfoundry.org/version/3.117.0/index.html#insert-destinations-for-a-route)
 ```bash
 curl "http://localhost:9000/v3/routes/<guid>/destinations" \
   -X POST \
@@ -304,7 +304,7 @@ curl "http://localhost:9000/v3/routes/<guid>/destinations" \
       }'
 ```
 
-#### [Remove Destination from Route](https://v3-apidocs.cloudfoundry.org/version/3.108.0/index.html#remove-destination-for-a-route)
+#### [Remove Destination from Route](https://v3-apidocs.cloudfoundry.org/version/3.117.0/index.html#remove-destination-for-a-route)
 ```bash
 curl "http://localhost:9000/v3/routes/<guid>/destinations/<destination-guid>" \
   -X DELETE
@@ -315,7 +315,7 @@ curl "http://localhost:9000/v3/routes/<guid>/destinations/<destination-guid>" \
 | ---------------- | ---------------------------------------------------- |
 | Apply a manifest | POST /v3/spaces/\<space-guid>/actions/apply_manifest |
 
-#### [Applying a manifest](https://v3-apidocs.cloudfoundry.org/version/3.107.0/index.html#create-a-route)
+#### [Applying a manifest](https://v3-apidocs.cloudfoundry.org/version/3.117.0/index.html#create-a-route)
 ```bash
 curl "http://localhost:9000/v3/spaces/<space-guid>/actions/apply_manifest" \
   -X POST \
@@ -327,7 +327,7 @@ curl "http://localhost:9000/v3/spaces/<space-guid>/actions/apply_manifest" \
 | ---------------------------------- | ------------------------------------------- |
 | Create a manifest diff for a space | POST /v3/spaces/\<space-guid>/manifest_diff |
 
-#### [Create a manifest diff for a space](https://v3-apidocs.cloudfoundry.org/version/3.109.0/index.html#create-a-manifest-diff-for-a-space-experimental)
+#### [Create a manifest diff for a space](https://v3-apidocs.cloudfoundry.org/version/3.117.0/index.html#create-a-manifest-diff-for-a-space-experimental)
 **WARNING:** Currently this endpoint always returns an empty diff.
 
 ##### Example Request
@@ -353,7 +353,7 @@ Content-Type: application/json
 |--|--|
 | List Buildpacks | GET /v3/buildpacks |
 
-#### [List Buildpacks](https://v3-apidocs.cloudfoundry.org/version/3.111.0/index.html#list-buildpacks)
+#### [List Buildpacks](https://v3-apidocs.cloudfoundry.org/version/3.117.0/index.html#list-buildpacks)
 ```bash
 curl "http://localhost:9000/v3/buildpacks?order_by=postion" \
   -X GET
@@ -377,14 +377,14 @@ We support basic, unauthenticated versions of the following [log-cache](https://
 
 ### Service Instances
 
-Docs: https://v3-apidocs.cloudfoundry.org/version/3.113.0/index.html#service-instances
+Docs: https://v3-apidocs.cloudfoundry.org/version/3.117.0/index.html#service-instances
 
 | Resource                     | Endpoint         |
 | ---------------------------- | ---------------- |
 | Create Service Instance | POST /v3/service_instances |
 | List Service Instance | GET /v3/service_instances |
 
-#### [Create Service Instances](https://v3-apidocs.cloudfoundry.org/version/3.113.0/index.html#create-a-service-instance) 
+#### [Create Service Instances](https://v3-apidocs.cloudfoundry.org/version/3.117.0/index.html#create-a-service-instance)
 Currently, we support creation of user-provided service instances
 ```bash
 curl "https://localhost:9000/v3/service_instances" \
@@ -419,14 +419,14 @@ curl "https://localhost:9000/v3/service_instances" \
   }'
 ```
 
-#### [List Service Instances](https://v3-apidocs.cloudfoundry.org/version/3.113.0/index.html#list-service-instances)
+#### [List Service Instances](https://v3-apidocs.cloudfoundry.org/version/3.117.0/index.html#list-service-instances)
 **Query Parameters:** Currently supports filtering by service instance
 `names` and `space_guids` and ordering by `name`, `created_at` or `updated_at`.
 The `fields` and `per_page` parameters will be silently ignored.
 
 ### Service Credential Bindings
 
-Docs: https://v3-apidocs.cloudfoundry.org/version/3.115.0/index.html#service-credential-binding
+Docs: https://v3-apidocs.cloudfoundry.org/version/3.117.0/index.html#service-credential-binding
 
 | Resource                          | Endpoint                                     |
 |-----------------------------------|----------------------------------------------|
@@ -434,16 +434,16 @@ Docs: https://v3-apidocs.cloudfoundry.org/version/3.115.0/index.html#service-cre
 | Create Service Credential Binding | POST /v3/service_credential_bindings         |
 | Delete Service Credential Binding | DELETE /v3/service_credential_bindings/:guid |
 
-#### [List Service Credential Binding](https://v3-apidocs.cloudfoundry.org/version/3.115.0/index.html#list-service-credential-bindings)
+#### [List Service Credential Binding](https://v3-apidocs.cloudfoundry.org/version/3.117.0/index.html#list-service-credential-bindings)
 
 **Query Parameters:** Currently supports filtering by `service_instance_guids`, `app_guids`, and `type`. `include` is
 supported, but only for the value `app`.
 
-#### [Create Service Credential Binding](https://v3-apidocs.cloudfoundry.org/version/3.115.0/index.html#create-a-service-credential-binding)
+#### [Create Service Credential Binding](https://v3-apidocs.cloudfoundry.org/version/3.117.0/index.html#create-a-service-credential-binding)
 
 The only supported value for the `type` is `app`. 
 
-#### [Delete Service Credential Binding](https://v3-apidocs.cloudfoundry.org/version/3.115.0/index.html#delete-a-service-credential-binding)
+#### [Delete Service Credential Binding](https://v3-apidocs.cloudfoundry.org/version/3.117.0/index.html#delete-a-service-credential-binding)
 
 This endpoint is fully supported.
 


### PR DESCRIPTION
## Is there a related GitHub Issue?
Nope

## What is this change about?
- The CF CLI has a rolling window of minimum CF API versions that they support
  - The current minimum API version supported for the 8.x CLI line is `1.109.0` which is getting close to `3.111.0`. I figured it's better to just go ahead and bump this.
  - CLI's versioning policy is defined here: https://github.com/cloudfoundry/cli/wiki/Versioning-and-Support-Policy
- `3.117.0` is the latest v3 version in a capi-release and there do not appear to be any breaking changes in the API contracts that we support. I read through the [capi-release](https://github.com/cloudfoundry/capi-release/releases) release notes and skimmed the latest v3 API docs to validate this. I also went ahead and updated our doc links internally.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
1. Target the API and confirm that the new version is reported (can also `cf curl /`)
2. Create some orgs and push an app or run the smoke tests

## Misc
Per the [CLI's versioning and support policy](https://github.com/cloudfoundry/cli/wiki/Versioning-and-Support-Policy), they adjust these at the beginning of each year. We should have something that reminds us to bump this.

I've thought about automating this, but I'm concerned that there may actually be API contract changes between versions so I think it might be useful to have someone review the capi-release and cloud_controller_ng release notes before doing the bump. For now I just set up a quarterly reminder in `#korifi-dev` on Slack. Definitely open to opinions / suggestions on this point.
