### PR TITLE
Remove references to production code in the e2es

### DIFF
--- a/scripts/check-everything.sh
+++ b/scripts/check-everything.sh
@@ -3,9 +3,6 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-CF_K8S_CONTROLLERS_DIR="$SCRIPT_DIR/.."
-
 RED=1
 GREEN=2
 print_message() {

--- a/tests/e2e/apps_test.go
+++ b/tests/e2e/apps_test.go
@@ -3,8 +3,6 @@ package e2e_test
 import (
 	"net/http"
 
-	"code.cloudfoundry.org/korifi/api/repositories"
-
 	"github.com/go-resty/resty/v2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -380,7 +378,7 @@ var _ = Describe("Apps", func() {
 			})
 
 			It("returns not found for users with no role in the space", func() {
-				expectNotFoundError(resp, errResp, repositories.AppResourceType)
+				expectNotFoundError(resp, errResp, "App")
 			})
 
 			When("the user is a space manager", func() {

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -11,8 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"code.cloudfoundry.org/korifi/api/handlers"
-	"code.cloudfoundry.org/korifi/api/presenter"
 	"code.cloudfoundry.org/korifi/tests/e2e/helpers"
 
 	"code.cloudfoundry.org/go-loggregator/v8/rpc/loggregator_v2"
@@ -133,8 +131,19 @@ type dropletResource struct {
 	Data resource `json:"data"`
 }
 
+type statsUsage struct {
+	Time *string  `json:"time,omitempty"`
+	CPU  *float64 `json:"cpu,omitempty"`
+	Mem  *int64   `json:"mem,omitempty"`
+	Disk *int64   `json:"disk,omitempty"`
+}
+
+type statsResource struct {
+	Usage statsUsage
+}
+
 type statsResourceList struct {
-	Resources []presenter.ProcessStatsResource `json:"resources"`
+	Resources []statsResource `json:"resources"`
 }
 
 type manifestResource struct {
@@ -376,7 +385,7 @@ func asyncCreateSpace(spaceName, orgGUID string, createdSpaceGUID *string, wg *s
 // createRole creates an org or space role
 // You should probably invoke this via createOrgRole or createSpaceRole
 func createRole(roleName, kind, orgSpaceType, userName, orgSpaceGUID string) {
-	rolesURL := apiServerRoot + handlers.RolesPath
+	rolesURL := apiServerRoot + "/v3/roles"
 
 	userOrServiceAccount := "user"
 	if kind == rbacv1.ServiceAccountKind {

--- a/tests/e2e/helpers/resty.go
+++ b/tests/e2e/helpers/resty.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"strings"
 
-	"code.cloudfoundry.org/korifi/api/handlers"
 	"github.com/go-http-utils/headers"
 	"github.com/go-resty/resty/v2"
 )
@@ -100,7 +99,7 @@ func NewCorrelatedRestyClient(apiServerRoot string, getCorrelationId func() stri
 
 func (c *CorrelatedRestyClient) R() *resty.Request {
 	request := c.Client.R()
-	request.SetHeader(handlers.CorrelationIDHeader, c.getCorrelationId())
+	request.SetHeader("X-Correlation-ID", c.getCorrelationId())
 
 	return request
 }

--- a/tests/e2e/processes_test.go
+++ b/tests/e2e/processes_test.go
@@ -4,8 +4,6 @@ import (
 	"net/http"
 	"time"
 
-	"code.cloudfoundry.org/korifi/api/presenter"
-	"code.cloudfoundry.org/korifi/api/repositories"
 	"code.cloudfoundry.org/korifi/tests/e2e/helpers"
 
 	"github.com/go-resty/resty/v2"
@@ -143,7 +141,7 @@ var _ = Describe("Processes", func() {
 
 		When("we wait for the metrics to be ready", func() {
 			BeforeEach(func() {
-				Eventually(func() presenter.ProcessUsage {
+				Eventually(func() statsUsage {
 					var err error
 					resp, err = restyClient.R().
 						SetResult(&processStats).
@@ -152,7 +150,7 @@ var _ = Describe("Processes", func() {
 					Expect(err).NotTo(HaveOccurred())
 
 					return processStats.Resources[0].Usage
-				}, 60*time.Second).ShouldNot(Equal(presenter.ProcessUsage{}))
+				}, 60*time.Second).ShouldNot(Equal(statsUsage{}))
 			})
 
 			It("succeeds", func() {
@@ -212,8 +210,9 @@ var _ = Describe("Processes", func() {
 		})
 
 		It("returns not found for users with no role in the space", func() {
-			expectNotFoundError(resp, errResp, repositories.ProcessResourceType)
+			expectNotFoundError(resp, errResp, "Process")
 		})
+
 		When("the user is a space manager", func() {
 			BeforeEach(func() {
 				createSpaceRole("space_manager", rbacv1.UserKind, certUserName, spaceGUID)

--- a/tests/e2e/spaces_test.go
+++ b/tests/e2e/spaces_test.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"sync"
 
-	"code.cloudfoundry.org/korifi/api/repositories"
 	"code.cloudfoundry.org/korifi/tests/e2e/helpers"
 
 	"github.com/go-resty/resty/v2"
@@ -466,7 +465,7 @@ var _ = Describe("Spaces", func() {
 			})
 
 			It("returns a Not-Found error", func() {
-				expectNotFoundError(resp, errResp, repositories.SpaceResourceType)
+				expectNotFoundError(resp, errResp, "Space")
 			})
 		})
 	})


### PR DESCRIPTION
This decouples the tests from the code and makes sure we detect any breaking change in the future.