### PR TITLE
Remove unused kind argument from role helpers

### DIFF
--- a/tests/e2e/apps_test.go
+++ b/tests/e2e/apps_test.go
@@ -7,7 +7,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
-	rbacv1 "k8s.io/api/rbac/v1"
 )
 
 var _ = Describe("Apps", func() {
@@ -37,8 +36,8 @@ var _ = Describe("Apps", func() {
 			space2GUID = createSpace(generateGUID("space2"), commonTestOrgGUID)
 			space3GUID = createSpace(generateGUID("space3"), commonTestOrgGUID)
 
-			createSpaceRole("space_developer", rbacv1.UserKind, certUserName, space1GUID)
-			createSpaceRole("space_developer", rbacv1.UserKind, certUserName, space3GUID)
+			createSpaceRole("space_developer", certUserName, space1GUID)
+			createSpaceRole("space_developer", certUserName, space3GUID)
 
 			app1GUID = createApp(space1GUID, generateGUID("app1"))
 			app2GUID = createApp(space1GUID, generateGUID("app2"))
@@ -102,7 +101,7 @@ var _ = Describe("Apps", func() {
 
 		When("the user has space developer role in the space", func() {
 			BeforeEach(func() {
-				createSpaceRole("space_developer", rbacv1.UserKind, certUserName, space1GUID)
+				createSpaceRole("space_developer", certUserName, space1GUID)
 			})
 
 			It("succeeds", func() {
@@ -123,7 +122,7 @@ var _ = Describe("Apps", func() {
 
 		When("the user cannot create apps in the space", func() {
 			BeforeEach(func() {
-				createSpaceRole("space_manager", rbacv1.UserKind, certUserName, space1GUID)
+				createSpaceRole("space_manager", certUserName, space1GUID)
 			})
 
 			It("fails", func() {
@@ -137,7 +136,7 @@ var _ = Describe("Apps", func() {
 		var result resource
 
 		BeforeEach(func() {
-			createSpaceRole("space_developer", rbacv1.UserKind, certUserName, space1GUID)
+			createSpaceRole("space_developer", certUserName, space1GUID)
 			appGUID = createApp(space1GUID, generateGUID("app1"))
 		})
 
@@ -157,7 +156,7 @@ var _ = Describe("Apps", func() {
 		var result resourceList
 
 		BeforeEach(func() {
-			createSpaceRole("space_developer", rbacv1.UserKind, certUserName, space1GUID)
+			createSpaceRole("space_developer", certUserName, space1GUID)
 			appGUID = createApp(space1GUID, generateGUID("app"))
 		})
 
@@ -197,7 +196,7 @@ var _ = Describe("Apps", func() {
 
 		When("the user is a space developer", func() {
 			BeforeEach(func() {
-				createSpaceRole("space_developer", rbacv1.UserKind, certUserName, space1GUID)
+				createSpaceRole("space_developer", certUserName, space1GUID)
 			})
 
 			It("successfully returns the process", func() {
@@ -211,7 +210,7 @@ var _ = Describe("Apps", func() {
 		var result resourceList
 
 		BeforeEach(func() {
-			createSpaceRole("space_developer", rbacv1.UserKind, certUserName, space1GUID)
+			createSpaceRole("space_developer", certUserName, space1GUID)
 			appGUID = createApp(space1GUID, generateGUID("app"))
 		})
 
@@ -241,7 +240,7 @@ var _ = Describe("Apps", func() {
 			buildGUID = createBuild(pkgGUID)
 			waitForDroplet(buildGUID)
 
-			createSpaceRole("space_developer", rbacv1.UserKind, certUserName, space1GUID)
+			createSpaceRole("space_developer", certUserName, space1GUID)
 		})
 
 		Describe("Get app current droplet", func() {
@@ -383,7 +382,7 @@ var _ = Describe("Apps", func() {
 
 			When("the user is a space manager", func() {
 				BeforeEach(func() {
-					createSpaceRole("space_manager", rbacv1.UserKind, certUserName, space1GUID)
+					createSpaceRole("space_manager", certUserName, space1GUID)
 				})
 
 				It("returns forbidden", func() {
@@ -393,7 +392,7 @@ var _ = Describe("Apps", func() {
 
 			When("the user is a space developer", func() {
 				BeforeEach(func() {
-					createSpaceRole("space_developer", rbacv1.UserKind, certUserName, space1GUID)
+					createSpaceRole("space_developer", certUserName, space1GUID)
 				})
 
 				It("succeeds, and returns the process", func() {

--- a/tests/e2e/builds_test.go
+++ b/tests/e2e/builds_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/go-resty/resty/v2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	rbacv1 "k8s.io/api/rbac/v1"
 )
 
 var _ = Describe("Builds", func() {
@@ -20,7 +19,7 @@ var _ = Describe("Builds", func() {
 
 	BeforeEach(func() {
 		spaceGUID = createSpace(generateGUID("space1"), commonTestOrgGUID)
-		createSpaceRole("space_developer", rbacv1.UserKind, certUserName, spaceGUID)
+		createSpaceRole("space_developer", certUserName, spaceGUID)
 		appGUID = createApp(spaceGUID, generateGUID("app"))
 		pkgGUID = createPackage(appGUID)
 	})

--- a/tests/e2e/droplets_test.go
+++ b/tests/e2e/droplets_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/go-resty/resty/v2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	rbacv1 "k8s.io/api/rbac/v1"
 )
 
 var _ = Describe("Droplets", func() {
@@ -14,7 +13,7 @@ var _ = Describe("Droplets", func() {
 
 	BeforeEach(func() {
 		spaceGUID = createSpace(generateGUID("space1"), commonTestOrgGUID)
-		createSpaceRole("space_developer", rbacv1.UserKind, certUserName, spaceGUID)
+		createSpaceRole("space_developer", certUserName, spaceGUID)
 	})
 
 	AfterEach(func() {

--- a/tests/e2e/log_cache_test.go
+++ b/tests/e2e/log_cache_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/go-resty/resty/v2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	rbacv1 "k8s.io/api/rbac/v1"
 )
 
 var _ = Describe("LogCache", func() {
@@ -20,7 +19,7 @@ var _ = Describe("LogCache", func() {
 	BeforeEach(func() {
 		spaceGUID = createSpace(generateGUID("space"), commonTestOrgGUID)
 		appGUID = pushTestApp(spaceGUID, appBitsFile)
-		createSpaceRole("space_developer", rbacv1.UserKind, certUserName, spaceGUID)
+		createSpaceRole("space_developer", certUserName, spaceGUID)
 	})
 
 	AfterEach(func() {

--- a/tests/e2e/orgs_test.go
+++ b/tests/e2e/orgs_test.go
@@ -9,7 +9,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
-	rbacv1 "k8s.io/api/rbac/v1"
 
 	"code.cloudfoundry.org/korifi/tests/e2e/helpers"
 )
@@ -121,9 +120,9 @@ var _ = Describe("Orgs", func() {
 			Expect(errChan).ToNot(Receive(&err), func() string { return fmt.Sprintf("unexpected error occurred while creating orgs: %v", err) })
 			close(errChan)
 
-			createOrgRole("organization_manager", rbacv1.UserKind, certUserName, org1GUID)
-			createOrgRole("organization_manager", rbacv1.UserKind, certUserName, org2GUID)
-			createOrgRole("organization_manager", rbacv1.UserKind, certUserName, org3GUID)
+			createOrgRole("organization_manager", certUserName, org1GUID)
+			createOrgRole("organization_manager", certUserName, org2GUID)
+			createOrgRole("organization_manager", certUserName, org3GUID)
 		})
 
 		AfterEach(func() {
@@ -188,7 +187,7 @@ var _ = Describe("Orgs", func() {
 		When("The client has a certificate with a long expiry date", func() {
 			BeforeEach(func() {
 				restyClient = longCertClient
-				createOrgRole("organization_manager", rbacv1.UserKind, longCertUserName, org3GUID)
+				createOrgRole("organization_manager", longCertUserName, org3GUID)
 			})
 			It("returns orgs that the client has a role in and sets an HTTP warning header", func() {
 				Expect(resp).To(HaveRestyStatusCode(http.StatusOK))
@@ -285,7 +284,7 @@ var _ = Describe("Orgs", func() {
 
 		BeforeEach(func() {
 			orgGUID = createOrg(generateGUID("org"))
-			createOrgRole("organization_user", rbacv1.UserKind, certUserName, orgGUID)
+			createOrgRole("organization_user", certUserName, orgGUID)
 			domainName = mustHaveEnv("APP_FQDN")
 		})
 

--- a/tests/e2e/packages_test.go
+++ b/tests/e2e/packages_test.go
@@ -7,7 +7,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
-	rbacv1 "k8s.io/api/rbac/v1"
 )
 
 var _ = Describe("Package", func() {
@@ -61,7 +60,7 @@ var _ = Describe("Package", func() {
 
 		When("the user is a SpaceDeveloper", func() {
 			BeforeEach(func() {
-				createSpaceRole("space_developer", rbacv1.UserKind, certUserName, spaceGUID)
+				createSpaceRole("space_developer", certUserName, spaceGUID)
 			})
 
 			It("succeeds", func() {
@@ -73,7 +72,7 @@ var _ = Describe("Package", func() {
 
 		When("the user is a SpaceManager (i.e. can get apps but cannot create packages)", func() {
 			BeforeEach(func() {
-				createSpaceRole("space_manager", rbacv1.UserKind, certUserName, spaceGUID)
+				createSpaceRole("space_manager", certUserName, spaceGUID)
 			})
 
 			It("fails with a forbidden error", func() {
@@ -104,7 +103,7 @@ var _ = Describe("Package", func() {
 
 		When("the user is a SpaceManager (i.e. can get apps but cannot update packages)", func() {
 			BeforeEach(func() {
-				createSpaceRole("space_manager", rbacv1.UserKind, certUserName, spaceGUID)
+				createSpaceRole("space_manager", certUserName, spaceGUID)
 			})
 
 			It("fails with a forbidden error", func() {
@@ -119,7 +118,7 @@ var _ = Describe("Package", func() {
 
 		When("the user is a SpaceDeveloper", func() {
 			BeforeEach(func() {
-				createSpaceRole("space_developer", rbacv1.UserKind, certUserName, spaceGUID)
+				createSpaceRole("space_developer", certUserName, spaceGUID)
 			})
 
 			It("succeeds", func() {
@@ -150,7 +149,7 @@ var _ = Describe("Package", func() {
 
 		When("the user is a space developer", func() {
 			BeforeEach(func() {
-				createSpaceRole("space_developer", rbacv1.UserKind, certUserName, spaceGUID)
+				createSpaceRole("space_developer", certUserName, spaceGUID)
 			})
 
 			It("can fetch the package", func() {
@@ -190,7 +189,7 @@ var _ = Describe("Package", func() {
 
 		When("the user is a space manager", func() {
 			BeforeEach(func() {
-				createSpaceRole("space_manager", rbacv1.UserKind, certUserName, spaceGUID)
+				createSpaceRole("space_manager", certUserName, spaceGUID)
 			})
 
 			It("lists the droplet", func() {
@@ -215,8 +214,8 @@ var _ = Describe("Package", func() {
 			space2GUID = createSpace(generateGUID("space2"), commonTestOrgGUID)
 			space3GUID = createSpace(generateGUID("space3"), commonTestOrgGUID)
 
-			createSpaceRole("space_developer", rbacv1.UserKind, certUserName, spaceGUID)
-			createSpaceRole("space_developer", rbacv1.UserKind, certUserName, space2GUID)
+			createSpaceRole("space_developer", certUserName, spaceGUID)
+			createSpaceRole("space_developer", certUserName, space2GUID)
 
 			package1GUID = createPackage(appGUID)
 			app2GUID := createApp(space2GUID, generateGUID("app2"))

--- a/tests/e2e/processes_test.go
+++ b/tests/e2e/processes_test.go
@@ -10,7 +10,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
-	rbacv1 "k8s.io/api/rbac/v1"
 )
 
 var _ = Describe("Processes", func() {
@@ -51,7 +50,7 @@ var _ = Describe("Processes", func() {
 
 		When("the user is authorized in the space", func() {
 			BeforeEach(func() {
-				createSpaceRole("space_developer", rbacv1.UserKind, certUserName, spaceGUID)
+				createSpaceRole("space_developer", certUserName, spaceGUID)
 				requestAppGUID = appGUID
 			})
 
@@ -88,7 +87,7 @@ var _ = Describe("Processes", func() {
 		BeforeEach(func() {
 			list = resourceList{}
 
-			createSpaceRole("space_developer", rbacv1.UserKind, certUserName, spaceGUID)
+			createSpaceRole("space_developer", certUserName, spaceGUID)
 		})
 
 		JustBeforeEach(func() {
@@ -121,7 +120,7 @@ var _ = Describe("Processes", func() {
 		var processStats statsResourceList
 
 		BeforeEach(func() {
-			createSpaceRole("space_developer", rbacv1.UserKind, certUserName, spaceGUID)
+			createSpaceRole("space_developer", certUserName, spaceGUID)
 		})
 
 		JustBeforeEach(func() {
@@ -180,7 +179,7 @@ var _ = Describe("Processes", func() {
 		var result resource
 
 		BeforeEach(func() {
-			createSpaceRole("space_developer", rbacv1.UserKind, certUserName, spaceGUID)
+			createSpaceRole("space_developer", certUserName, spaceGUID)
 		})
 
 		JustBeforeEach(func() {
@@ -215,7 +214,7 @@ var _ = Describe("Processes", func() {
 
 		When("the user is a space manager", func() {
 			BeforeEach(func() {
-				createSpaceRole("space_manager", rbacv1.UserKind, certUserName, spaceGUID)
+				createSpaceRole("space_manager", certUserName, spaceGUID)
 			})
 
 			It("returns forbidden", func() {
@@ -225,7 +224,7 @@ var _ = Describe("Processes", func() {
 
 		When("the user is a space developer", func() {
 			BeforeEach(func() {
-				createSpaceRole("space_developer", rbacv1.UserKind, certUserName, spaceGUID)
+				createSpaceRole("space_developer", certUserName, spaceGUID)
 			})
 
 			It("succeeds, and returns the process", func() {
@@ -250,7 +249,7 @@ var _ = Describe("Processes", func() {
 
 		When("the user is a space developer", func() {
 			BeforeEach(func() {
-				createSpaceRole("space_developer", rbacv1.UserKind, certUserName, spaceGUID)
+				createSpaceRole("space_developer", certUserName, spaceGUID)
 			})
 
 			It("returns success", func() {
@@ -261,7 +260,7 @@ var _ = Describe("Processes", func() {
 
 		When("the user is a space manager", func() {
 			BeforeEach(func() {
-				createSpaceRole("space_manager", rbacv1.UserKind, certUserName, spaceGUID)
+				createSpaceRole("space_manager", certUserName, spaceGUID)
 			})
 
 			It("returns forbidden", func() {

--- a/tests/e2e/roles_test.go
+++ b/tests/e2e/roles_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	rbacv1 "k8s.io/api/rbac/v1"
 )
 
 var _ = Describe("Roles", func() {
@@ -68,7 +67,7 @@ var _ = Describe("Roles", func() {
 		var spaceGUID string
 
 		BeforeEach(func() {
-			createOrgRole("organization_user", rbacv1.UserKind, userName, commonTestOrgGUID)
+			createOrgRole("organization_user", userName, commonTestOrgGUID)
 			spaceGUID = createSpace(uuid.NewString(), commonTestOrgGUID)
 		})
 

--- a/tests/e2e/routes_test.go
+++ b/tests/e2e/routes_test.go
@@ -11,7 +11,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
-	rbacv1 "k8s.io/api/rbac/v1"
 )
 
 var _ = Describe("Routes", func() {
@@ -49,7 +48,7 @@ var _ = Describe("Routes", func() {
 		)
 
 		BeforeEach(func() {
-			createSpaceRole("space_developer", rbacv1.UserKind, certUserName, spaceGUID)
+			createSpaceRole("space_developer", certUserName, spaceGUID)
 			routeGUID = createRoute(host, path, spaceGUID, domainGUID)
 		})
 
@@ -124,7 +123,7 @@ var _ = Describe("Routes", func() {
 
 		When("the user is authorized within one space, but not another", func() {
 			BeforeEach(func() {
-				createSpaceRole("space_developer", rbacv1.UserKind, certUserName, spaceGUID)
+				createSpaceRole("space_developer", certUserName, spaceGUID)
 			})
 
 			It("returns the list of routes in only the authorized spaces", func() {
@@ -192,7 +191,7 @@ var _ = Describe("Routes", func() {
 
 		When("the user is a space manager", func() {
 			BeforeEach(func() {
-				createSpaceRole("space_manager", rbacv1.UserKind, certUserName, spaceGUID)
+				createSpaceRole("space_manager", certUserName, spaceGUID)
 			})
 
 			It("returns an forbidden error", func() {
@@ -203,7 +202,7 @@ var _ = Describe("Routes", func() {
 
 		When("the user is a space developer", func() {
 			BeforeEach(func() {
-				createSpaceRole("space_developer", rbacv1.UserKind, certUserName, spaceGUID)
+				createSpaceRole("space_developer", certUserName, spaceGUID)
 			})
 
 			It("can create a route", func() {
@@ -277,7 +276,7 @@ var _ = Describe("Routes", func() {
 		)
 
 		BeforeEach(func() {
-			createSpaceRole("space_developer", rbacv1.UserKind, certUserName, spaceGUID)
+			createSpaceRole("space_developer", certUserName, spaceGUID)
 			routeGUID = createRoute(host, path, spaceGUID, domainGUID)
 		})
 
@@ -335,7 +334,7 @@ var _ = Describe("Routes", func() {
 		When("the user is a space developer in the space", func() {
 			BeforeEach(func() {
 				appGUID = pushTestApp(spaceGUID, defaultAppBitsFile)
-				createSpaceRole("space_developer", rbacv1.UserKind, certUserName, spaceGUID)
+				createSpaceRole("space_developer", certUserName, spaceGUID)
 			})
 
 			It("returns success and routes the host to the app", func() {
@@ -378,7 +377,7 @@ var _ = Describe("Routes", func() {
 		When("the user is a space manager in the space", func() {
 			BeforeEach(func() {
 				appGUID = createApp(spaceGUID, generateGUID("app"))
-				createSpaceRole("space_manager", rbacv1.UserKind, certUserName, spaceGUID)
+				createSpaceRole("space_manager", certUserName, spaceGUID)
 			})
 
 			It("returns a forbidden response", func() {
@@ -425,7 +424,7 @@ var _ = Describe("Routes", func() {
 
 		When("the user is a space developer in the space", func() {
 			BeforeEach(func() {
-				createSpaceRole("space_developer", rbacv1.UserKind, certUserName, spaceGUID)
+				createSpaceRole("space_developer", certUserName, spaceGUID)
 			})
 
 			It("returns the destinations", func() {
@@ -474,7 +473,7 @@ var _ = Describe("Routes", func() {
 
 		When("the user is a space developer in the space", func() {
 			BeforeEach(func() {
-				createSpaceRole("space_developer", rbacv1.UserKind, certUserName, spaceGUID)
+				createSpaceRole("space_developer", certUserName, spaceGUID)
 			})
 
 			It("succeeds with 204 No Content", func() {
@@ -484,7 +483,7 @@ var _ = Describe("Routes", func() {
 
 		When("the user is a space manager in the space", func() {
 			BeforeEach(func() {
-				createSpaceRole("space_manager", rbacv1.UserKind, certUserName, spaceGUID)
+				createSpaceRole("space_manager", certUserName, spaceGUID)
 			})
 
 			It("fails with 403 Forbidden", func() {

--- a/tests/e2e/service_bindings_test.go
+++ b/tests/e2e/service_bindings_test.go
@@ -7,7 +7,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
-	rbacv1 "k8s.io/api/rbac/v1"
 )
 
 var _ = Describe("Service Bindings", func() {
@@ -52,7 +51,7 @@ var _ = Describe("Service Bindings", func() {
 
 		When("the user has space manager role", func() {
 			BeforeEach(func() {
-				createSpaceRole("space_manager", rbacv1.UserKind, certUserName, spaceGUID)
+				createSpaceRole("space_manager", certUserName, spaceGUID)
 			})
 
 			It("returns a forbidden error", func() {
@@ -63,7 +62,7 @@ var _ = Describe("Service Bindings", func() {
 
 		When("the user has space developer role", func() {
 			BeforeEach(func() {
-				createSpaceRole("space_developer", rbacv1.UserKind, certUserName, spaceGUID)
+				createSpaceRole("space_developer", certUserName, spaceGUID)
 			})
 
 			It("succeeds", func() {
@@ -102,7 +101,7 @@ var _ = Describe("Service Bindings", func() {
 
 		When("the user has space manager role", func() {
 			BeforeEach(func() {
-				createSpaceRole("space_manager", rbacv1.UserKind, certUserName, spaceGUID)
+				createSpaceRole("space_manager", certUserName, spaceGUID)
 			})
 
 			It("returns a forbidden error", func() {
@@ -113,7 +112,7 @@ var _ = Describe("Service Bindings", func() {
 
 		When("the user has space developer role", func() {
 			BeforeEach(func() {
-				createSpaceRole("space_developer", rbacv1.UserKind, certUserName, spaceGUID)
+				createSpaceRole("space_developer", certUserName, spaceGUID)
 			})
 
 			It("succeeds", func() {
@@ -152,7 +151,7 @@ var _ = Describe("Service Bindings", func() {
 
 		When("the user has space manager role", func() {
 			BeforeEach(func() {
-				createSpaceRole("space_manager", rbacv1.UserKind, certUserName, spaceGUID)
+				createSpaceRole("space_manager", certUserName, spaceGUID)
 			})
 
 			It("succeeds", func() {
@@ -166,7 +165,7 @@ var _ = Describe("Service Bindings", func() {
 
 		When("the user has space developer role", func() {
 			BeforeEach(func() {
-				createSpaceRole("space_developer", rbacv1.UserKind, certUserName, spaceGUID)
+				createSpaceRole("space_developer", certUserName, spaceGUID)
 			})
 
 			It("succeeds", func() {

--- a/tests/e2e/service_instances_test.go
+++ b/tests/e2e/service_instances_test.go
@@ -8,7 +8,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
-	rbacv1 "k8s.io/api/rbac/v1"
 )
 
 var _ = Describe("Service Instances", func() {
@@ -36,7 +35,7 @@ var _ = Describe("Service Instances", func() {
 
 			BeforeEach(func() {
 				instanceName = generateGUID("service-instance")
-				createSpaceRole("space_developer", rbacv1.UserKind, certUserName, spaceGUID)
+				createSpaceRole("space_developer", certUserName, spaceGUID)
 			})
 
 			JustBeforeEach(func() {
@@ -108,7 +107,7 @@ var _ = Describe("Service Instances", func() {
 
 		When("the user has permissions to delete service instances", func() {
 			BeforeEach(func() {
-				createSpaceRole("space_developer", rbacv1.UserKind, certUserName, spaceGUID)
+				createSpaceRole("space_developer", certUserName, spaceGUID)
 			})
 
 			It("succeeds", func() {
@@ -128,7 +127,7 @@ var _ = Describe("Service Instances", func() {
 
 		When("the user has read only permissions over service instances", func() {
 			BeforeEach(func() {
-				createSpaceRole("space_manager", rbacv1.UserKind, certUserName, spaceGUID)
+				createSpaceRole("space_manager", certUserName, spaceGUID)
 			})
 
 			It("fails with 403 Forbidden", func() {

--- a/tests/e2e/spaces_test.go
+++ b/tests/e2e/spaces_test.go
@@ -14,7 +14,6 @@ import (
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 	"gopkg.in/yaml.v3"
-	rbacv1 "k8s.io/api/rbac/v1"
 )
 
 var _ = Describe("Spaces", func() {
@@ -167,16 +166,16 @@ var _ = Describe("Spaces", func() {
 			Expect(spaceErrChan).ToNot(Receive(&err), func() string { return fmt.Sprintf("unexpected error occurred while creating spaces: %v", err) })
 			close(spaceErrChan)
 
-			createOrgRole("organization_user", rbacv1.UserKind, certUserName, org1GUID)
-			createOrgRole("organization_user", rbacv1.UserKind, certUserName, org2GUID)
-			createOrgRole("organization_user", rbacv1.UserKind, certUserName, org3GUID)
+			createOrgRole("organization_user", certUserName, org1GUID)
+			createOrgRole("organization_user", certUserName, org2GUID)
+			createOrgRole("organization_user", certUserName, org3GUID)
 
-			createSpaceRole("space_developer", rbacv1.UserKind, certUserName, space12GUID)
-			createSpaceRole("space_developer", rbacv1.UserKind, certUserName, space11GUID)
-			createSpaceRole("space_developer", rbacv1.UserKind, certUserName, space21GUID)
-			createSpaceRole("space_developer", rbacv1.UserKind, certUserName, space22GUID)
-			createSpaceRole("space_developer", rbacv1.UserKind, certUserName, space31GUID)
-			createSpaceRole("space_developer", rbacv1.UserKind, certUserName, space32GUID)
+			createSpaceRole("space_developer", certUserName, space12GUID)
+			createSpaceRole("space_developer", certUserName, space11GUID)
+			createSpaceRole("space_developer", certUserName, space21GUID)
+			createSpaceRole("space_developer", certUserName, space22GUID)
+			createSpaceRole("space_developer", certUserName, space31GUID)
+			createSpaceRole("space_developer", certUserName, space32GUID)
 		})
 
 		AfterEach(func() {
@@ -347,7 +346,7 @@ var _ = Describe("Spaces", func() {
 
 			When("the user has space developer role in the space", func() {
 				BeforeEach(func() {
-					createSpaceRole("space_developer", rbacv1.UserKind, certUserName, spaceGUID)
+					createSpaceRole("space_developer", certUserName, spaceGUID)
 				})
 
 				It("succeeds with a job redirect", func() {
@@ -388,7 +387,7 @@ var _ = Describe("Spaces", func() {
 
 			When("the user has space manager role in the space", func() {
 				BeforeEach(func() {
-					createSpaceRole("space_manager", rbacv1.UserKind, certUserName, spaceGUID)
+					createSpaceRole("space_manager", certUserName, spaceGUID)
 				})
 
 				It("returns 403", func() {
@@ -445,7 +444,7 @@ var _ = Describe("Spaces", func() {
 
 		When("the user has space-developer permissions in the space", func() {
 			BeforeEach(func() {
-				createSpaceRole("space_developer", rbacv1.UserKind, certUserName, spaceGUID)
+				createSpaceRole("space_developer", certUserName, spaceGUID)
 			})
 
 			It("returns the diff response JSON", func() {

--- a/tests/e2e/tasks_test.go
+++ b/tests/e2e/tasks_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/go-resty/resty/v2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	rbacv1 "k8s.io/api/rbac/v1"
 )
 
 var _ = Describe("Tasks", func() {
@@ -39,7 +38,7 @@ var _ = Describe("Tasks", func() {
 
 		When("the user has space developer role in the space", func() {
 			BeforeEach(func() {
-				createSpaceRole("space_developer", rbacv1.UserKind, certUserName, spaceGUID)
+				createSpaceRole("space_developer", certUserName, spaceGUID)
 			})
 
 			It("succeeds", func() {
@@ -49,7 +48,7 @@ var _ = Describe("Tasks", func() {
 
 		When("the user cannot create tasks in the space", func() {
 			BeforeEach(func() {
-				createSpaceRole("space_manager", rbacv1.UserKind, certUserName, spaceGUID)
+				createSpaceRole("space_manager", certUserName, spaceGUID)
 			})
 
 			It("fails", func() {


### PR DESCRIPTION
This removes the `kind` argument from `createRole`, `createOrgRole` and `createSpaceRole,` as we never used anything different from `rbacv1.UserKind`.

We will need to reintroduce something similar when we add support for service accounts, but maybe the best idea is to have separate helpers.