### PR TITLE
`sequence_id` -> `sequenceId`

### DIFF
--- a/controllers/api/v1alpha1/cftask_types.go
+++ b/controllers/api/v1alpha1/cftask_types.go
@@ -38,7 +38,7 @@ type CFTaskStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	SequenceID int64 `json:"sequence_id"`
+	SequenceID int64 `json:"sequenceId"`
 }
 
 //+kubebuilder:object:root=true

--- a/controllers/config/crd/bases/korifi.cloudfoundry.org_cftasks.yaml
+++ b/controllers/config/crd/bases/korifi.cloudfoundry.org_cftasks.yaml
@@ -52,11 +52,11 @@ spec:
           status:
             description: CFTaskStatus defines the observed state of CFTask
             properties:
-              sequence_id:
+              sequenceId:
                 format: int64
                 type: integer
             required:
-            - sequence_id
+            - sequenceId
             type: object
         type: object
     served: true

--- a/controllers/controllers/workloads/cftask_controller_test.go
+++ b/controllers/controllers/workloads/cftask_controller_test.go
@@ -144,7 +144,7 @@ var _ = Describe("CFTask Controller", func() {
 			_, object, patch, _ := statusWriter.PatchArgsForCall(0)
 			patchBytes, patchErr := patch.Data(object)
 			Expect(patchErr).NotTo(HaveOccurred())
-			Expect(string(patchBytes)).To(MatchJSON(`{"status":{"sequence_id":314}}`))
+			Expect(string(patchBytes)).To(MatchJSON(`{"status":{"sequenceId":314}}`))
 		})
 
 		When("Status.SequenceID has been already set", func() {


### PR DESCRIPTION
We should use camel-casing in CRDs for consistency.