### PR TITLE
Introduce `created_at` and `updated_at` timestamps in tasks

### DIFF
--- a/api/handlers/task_handler_test.go
+++ b/api/handlers/task_handler_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net/http"
 	"strings"
+	"time"
 
 	"code.cloudfoundry.org/korifi/api/apierrors"
 	"code.cloudfoundry.org/korifi/api/handlers"
@@ -46,11 +47,12 @@ var _ = Describe("TaskHandler", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			taskRepo.CreateTaskReturns(repositories.TaskRecord{
-				Name:       "the-task-name",
-				GUID:       "the-task-guid",
-				Command:    "echo hello",
-				AppGUID:    "the-app-guid",
-				SequenceID: 123456,
+				Name:              "the-task-name",
+				GUID:              "the-task-guid",
+				Command:           "echo hello",
+				AppGUID:           "the-app-guid",
+				SequenceID:        123456,
+				CreationTimestamp: time.Date(2022, 6, 14, 13, 22, 34, 0, time.UTC),
 			}, nil)
 		})
 
@@ -74,6 +76,8 @@ var _ = Describe("TaskHandler", func() {
               "guid": "the-task-guid",
               "command": "echo hello",
               "sequence_id": 123456,
+              "created_at": "2022-06-14T13:22:34Z",
+              "updated_at": "2022-06-14T13:22:34Z",
               "relationships": {
                 "app": {
                   "data": {

--- a/api/presenter/task.go
+++ b/api/presenter/task.go
@@ -17,6 +17,8 @@ type TaskResponse struct {
 	Relationships Relationships `json:"relationships"`
 	Links         TaskLinks     `json:"links"`
 	SequenceID    int64         `json:"sequence_id"`
+	CreatedAt     string        `json:"created_at"`
+	UpdatedAt     string        `json:"updated_at"`
 }
 
 type TaskLinks struct {
@@ -25,11 +27,15 @@ type TaskLinks struct {
 }
 
 func ForTask(responseTask repositories.TaskRecord, baseURL url.URL) TaskResponse {
+	creationTimestamp := responseTask.CreationTimestamp.Format("2006-01-02T15:04:05Z")
+
 	return TaskResponse{
 		Name:       responseTask.Name,
 		GUID:       responseTask.GUID,
 		Command:    responseTask.Command,
 		SequenceID: responseTask.SequenceID,
+		CreatedAt:  creationTimestamp,
+		UpdatedAt:  creationTimestamp,
 		Relationships: Relationships{
 			"app": Relationship{
 				Data: &RelationshipData{

--- a/api/repositories/task_repository.go
+++ b/api/repositories/task_repository.go
@@ -22,11 +22,12 @@ const (
 )
 
 type TaskRecord struct {
-	Name       string
-	GUID       string
-	Command    string
-	AppGUID    string
-	SequenceID int64
+	Name              string
+	GUID              string
+	Command           string
+	AppGUID           string
+	SequenceID        int64
+	CreationTimestamp time.Time
 }
 
 type CreateTaskMessage struct {
@@ -82,11 +83,12 @@ func (r *TaskRepo) CreateTask(ctx context.Context, authInfo authorization.Info, 
 	}
 
 	return TaskRecord{
-		Name:       task.Name,
-		GUID:       task.Name,
-		Command:    strings.Join(task.Spec.Command, " "),
-		AppGUID:    task.Spec.AppRef.Name,
-		SequenceID: task.Status.SequenceID,
+		Name:              task.Name,
+		GUID:              task.Name,
+		Command:           strings.Join(task.Spec.Command, " "),
+		AppGUID:           task.Spec.AppRef.Name,
+		SequenceID:        task.Status.SequenceID,
+		CreationTimestamp: task.CreationTimestamp.Time,
 	}, nil
 }
 

--- a/api/repositories/task_repository_test.go
+++ b/api/repositories/task_repository_test.go
@@ -93,6 +93,7 @@ var _ = Describe("TaskRepository", func() {
 				Expect(taskRecord.Command).To(Equal("echo hello"))
 				Expect(taskRecord.AppGUID).To(Equal(cfApp.Name))
 				Expect(taskRecord.SequenceID).NotTo(BeZero())
+				Expect(taskRecord.CreationTimestamp).To(BeTemporally("~", time.Now(), time.Second))
 			})
 
 			When("the task never becomes ready", func() {


### PR DESCRIPTION
## Is there a related GitHub Issue?

#1196 

## What is this change about?

This adds the `created_at` and `updated_at` fields to task objects.

## Does this PR introduce a breaking change?

No.

## Tag your pair, your PM, and/or team

@georgethebeatle 
