### PR TITLE
CFRoute finalizer tolerates missing CFDomain

### DIFF
--- a/controllers/webhooks/networking/cfroute_validator.go
+++ b/controllers/webhooks/networking/cfroute_validator.go
@@ -101,6 +101,13 @@ func (v *CFRouteValidator) ValidateUpdate(ctx context.Context, oldObj, obj runti
 		return apierrors.NewBadRequest(fmt.Sprintf("expected a CFRoute but got a %T", obj))
 	}
 
+	if route.Spec.Host == oldRoute.Spec.Host &&
+		route.Spec.DomainRef.String() == oldRoute.Spec.DomainRef.String() &&
+		route.Spec.Path == oldRoute.Spec.Path &&
+		len(route.Finalizers) < len(oldRoute.Finalizers) {
+		return nil // we're removing a finalizer to delete this route, so we don't want to block deletion
+	}
+
 	domain, err := v.validateRoute(ctx, route)
 	if err != nil {
 		return err

--- a/controllers/webhooks/networking/cfroute_validator_test.go
+++ b/controllers/webhooks/networking/cfroute_validator_test.go
@@ -521,6 +521,18 @@ var _ = Describe("CFRouteValidator", func() {
 				})
 			})
 		})
+
+		When("the route is being finalized", func() {
+			BeforeEach(func() {
+				updatedCFRoute = cfRoute.DeepCopy()
+				cfRoute.Finalizers = append(cfRoute.Finalizers, "some-finalizer-we-are-trying-to-remove")
+			})
+
+			It("skips validation and allows the request", func() {
+				Expect(duplicateValidator.ValidateUpdateCallCount()).To(BeZero())
+				Expect(retErr).NotTo(HaveOccurred())
+			})
+		})
 	})
 
 	Describe("ValidateDelete", func() {


### PR DESCRIPTION
## Is there a related GitHub Issue?
[#1225]

## What is this change about?
- The CFDomain object may go missing either because the user deleted it,
  or because it got deleted first during uninstall.
- Our CFRoute controller should allow removal of routes in this
  scenario.
- This commit fixes two different failure cases that occur when the
  CFDomain no longer exists.

## Does this PR introduce a breaking change?
no

## Acceptance Steps
[#1225]
