### PR TITLE
Bump eirini to 0.4.0

### DIFF
--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -115,7 +115,7 @@ echo "*******************"
 echo "Installing Eirini"
 echo "*******************"
 
-EIRINI_VERSION="0.3.0"
+EIRINI_VERSION="0.4.0"
 cat <<EOF | kubectl apply -f -
 apiVersion: v1
 kind: Namespace


### PR DESCRIPTION
## Is there a related GitHub Issue?
https://github.com/cloudfoundry/korifi/issues/1197

## What is this change about?
Bump Eirini to 0.4.0 to propagate the disk/memory constraints to the pod template

## Does this PR introduce a breaking change?
No

## Acceptance Steps
See story for acceptance

## Tag your pair, your PM, and/or team
@georgethebeatle 

