### PR TITLE
Refactor the smoke test suite

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	code.cloudfoundry.org/go-loggregator/v8 v8.0.5
 	github.com/buildpacks/lifecycle v0.14.1
 	github.com/buildpacks/pack v0.26.0
-	github.com/cloudfoundry-incubator/cf-test-helpers v1.0.0
+	github.com/cloudfoundry/cf-test-helpers v1.0.1-0.20220603211108-d498b915ef74
 	github.com/go-http-utils/headers v0.0.0-20181008091004-fed159eddc2a
 	github.com/go-logr/logr v1.2.3
 	github.com/go-playground/locales v0.14.0

--- a/go.sum
+++ b/go.sum
@@ -441,8 +441,8 @@ github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/cfssl v0.0.0-20180223231731-4e2dcbde5004/go.mod h1:yMWuSON2oQp+43nFtAV/uvKQIFpSPerB57DCt9t8sSA=
 github.com/cloudflare/cloudflare-go v0.20.0/go.mod h1:sPWL/lIC6biLEdyGZwBQ1rGQKF1FhM7N60fuNiFdYTI=
-github.com/cloudfoundry-incubator/cf-test-helpers v1.0.0 h1:vk4gthT4ime81HI16e8MLctmjZE4U5EMuM90vs1dO4E=
-github.com/cloudfoundry-incubator/cf-test-helpers v1.0.0/go.mod h1:I21tkmFwW9F06eYcQm5GTUzNV+pc1Q5NVZ1qhWOGGx0=
+github.com/cloudfoundry/cf-test-helpers v1.0.1-0.20220603211108-d498b915ef74 h1:yr55FjD7Izo5FXR/jdQ1lKv/9y8xkwdwqmHN836iihM=
+github.com/cloudfoundry/cf-test-helpers v1.0.1-0.20220603211108-d498b915ef74/go.mod h1:bKEHPrQ6kVJs/JnG/nAtWwOEdNOenRFoEcmvsYsS5BQ=
 github.com/cloudfoundry/dropsonde v1.0.0/go.mod h1:6zwvrWK5TpxBVYi1cdkE5WDsIO8E0n7qAJg3wR9B67c=
 github.com/cloudfoundry/gosteno v0.0.0-20150423193413-0c8581caea35/go.mod h1:3YBPUR85RIrvaUTdA1dL38YSp6s3OHu1xrWLkGt2Mog=
 github.com/cloudfoundry/loggregatorlib v0.0.0-20170823162133-36eddf15ef12/go.mod h1:ucj7+svyACshmxV3Zze2NAcEcdbBf9scZYR+QKCX9/w=

--- a/tests/smoke/run-smoke-tests-kind.sh
+++ b/tests/smoke/run-smoke-tests-kind.sh
@@ -1,17 +1,14 @@
 #!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-pushd "${SCRIPT_DIR}"
-{
-  cf api https://localhost --skip-ssl-validation
-  cf login <<EOF
-2
-2
-2
-EOF
-  SMOKE_TEST_APP_ROUTE_PROTOCOL="https" SMOKE_TEST_APPS_DOMAIN="vcap.me" go test
-}
-popd
+export SMOKE_TEST_USER=cf-admin
+export SMOKE_TEST_APPS_DOMAIN=vcap.me
+export SMOKE_TEST_APP_ROUTE_PROTOCOL=https
+export SMOKE_TEST_API_ENDPOINT=https://localhost
+export SMOKE_TEST_SKIP_SSL=true
+
+cd "${SCRIPT_DIR}"
+ginkgo

--- a/tests/smoke/smoke_suite_test.go
+++ b/tests/smoke/smoke_suite_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -3,27 +3,27 @@ package smoke_test
 import (
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
-	. "github.com/onsi/ginkgo"
+	"github.com/cloudfoundry/cf-test-helpers/cf"
+	"github.com/cloudfoundry/cf-test-helpers/generator"
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2/types"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gbytes"
 	. "github.com/onsi/gomega/gexec"
-
-	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
-	"github.com/cloudfoundry-incubator/cf-test-helpers/generator"
 )
 
 const NamePrefix = "cf-on-k8s-smoke"
 
 func GetRequiredEnvVar(envVarName string) string {
 	value, ok := os.LookupEnv(envVarName)
-	if !ok {
-		panic(envVarName + " environment variable is required, but was not provided.")
-	}
+	Expect(ok).To(BeTrue(), envVarName+" environment variable is required, but was not provided.")
 	return value
 }
 
@@ -44,32 +44,19 @@ var _ = Describe("Smoke Tests", func() {
 		)
 
 		BeforeEach(func() {
-			doLogin := GetDefaultedEnvVar("SMOKE_TEST_LOGIN", "")
-
-			if doLogin != "" {
-				apiEndpoint := GetRequiredEnvVar("SMOKE_TEST_API_ENDPOINT")
-				// username := GetRequiredEnvVar("SMOKE_TEST_USERNAME")
-				// password := GetRequiredEnvVar("SMOKE_TEST_PASSWORD")
-
-				apiArguments := []string{"api", apiEndpoint}
-				skip_ssl, _ := os.LookupEnv("SMOKE_TEST_SKIP_SSL")
-				skip_ssl_bool := skip_ssl == "true"
-				if skip_ssl_bool {
-					apiArguments = append(apiArguments, "--skip-ssl-validation")
-				}
-				http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: skip_ssl_bool}
-
-				// Target CF and auth
-				cfAPI := cf.Cf(apiArguments...)
-				Eventually(cfAPI).Should(Exit(0))
-
-				// Authenticate - untested not sure if this works for cf-on-k8s
-				Eventually(cf.Cf("login").Wait()).Should(Exit(0))
+			apiArguments := []string{"api", GetRequiredEnvVar("SMOKE_TEST_API_ENDPOINT")}
+			skipSSL := os.Getenv("SMOKE_TEST_SKIP_SSL") == "true"
+			if skipSSL {
+				apiArguments = append(apiArguments, "--skip-ssl-validation")
 			}
+
+			cfAPI := cf.Cf(apiArguments...)
+			Eventually(cfAPI).Should(Exit(0))
+
+			loginAs(GetRequiredEnvVar("SMOKE_TEST_USER"))
 
 			appRouteProtocol = GetDefaultedEnvVar("SMOKE_TEST_APP_ROUTE_PROTOCOL", "https")
 			appsDomain = GetRequiredEnvVar("SMOKE_TEST_APPS_DOMAIN")
-			// Create an org and space and target
 			orgName = generator.PrefixedRandomName(NamePrefix, "org")
 			spaceName := generator.PrefixedRandomName(NamePrefix, "space")
 
@@ -79,12 +66,11 @@ var _ = Describe("Smoke Tests", func() {
 		})
 
 		AfterEach(func() {
-			if CurrentGinkgoTestDescription().Failed {
+			if CurrentSpecReport().State.Is(types.SpecStateFailed) {
 				printAppReport(appName)
 			}
 
 			if orgName != "" {
-				// Delete the test org
 				Eventually(func() *Session {
 					return cf.Cf("delete-org", orgName, "-f").Wait()
 				}, 2*time.Minute, 1*time.Second).Should(Exit(0))
@@ -94,31 +80,20 @@ var _ = Describe("Smoke Tests", func() {
 		It("creates a routable app pod in Kubernetes from a source-based app", func() {
 			appName = generator.PrefixedRandomName(NamePrefix, "app")
 
-			By("pushing an app and checking that the CF CLI command succeeds")
 			cfPush := cf.Cf("push", appName, "-p", "assets/test-node-app")
 			Eventually(cfPush).Should(Exit(0))
 
-			By("querying the app")
-			var resp *http.Response
+			var httpClient http.Client
+			httpClient.Transport = &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			}
 
-			Eventually(func() int {
-				var err error
-				http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-				resp, err = http.Get(fmt.Sprintf("%s://%s.%s", appRouteProtocol, appName, appsDomain))
-				Expect(err).NotTo(HaveOccurred())
-				return resp.StatusCode
-			}, 2*time.Minute, 30*time.Second).Should(Equal(200))
-
-			body, err := ioutil.ReadAll(resp.Body)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(string(body)).To(Equal("Hello World\n"))
-
-			// TODO: Log retrieval is not supported yet
-			//By("verifying that the application's logs are available.")
-			//Eventually(func() string {
-			//	cfLogs := cf.Cf("logs", appName, "--recent")
-			//	return string(cfLogs.Wait().Out.Contents())
-			//}, 2*time.Minute, 2*time.Second).Should(ContainSubstring("Console output from test-node-app"))
+			Eventually(func(g Gomega) {
+				resp, err := httpClient.Get(fmt.Sprintf("%s://%s.%s", appRouteProtocol, appName, appsDomain))
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(resp).To(HaveHTTPStatus(http.StatusOK))
+				g.Expect(resp).To(HaveHTTPBody(ContainSubstring("Hello World")))
+			}, 2*time.Minute, 30*time.Second).Should(Succeed())
 		})
 	})
 })
@@ -137,4 +112,20 @@ func printAppReport(appName string) {
 func printAppReportBanner(announcement string) {
 	sequence := strings.Repeat("*", len(announcement))
 	fmt.Fprintf(GinkgoWriter, "\n\n%s\n%s\n%s\n", sequence, announcement, sequence)
+}
+
+func loginAs(user string) {
+	r, w := io.Pipe()
+	loginSession := cf.CfWithStdin(r, "login")
+	Eventually(loginSession).Should(Say("Choose your Kubernetes"))
+
+	userEntryRegex, err := regexp.Compile(`(\d*). ` + user + `\s`)
+	Expect(err).NotTo(HaveOccurred())
+	matches := userEntryRegex.FindSubmatch(loginSession.Buffer().Contents())
+	Expect(matches).To(HaveLen(2))
+
+	Expect(fmt.Fprintf(w, "%s\n\n", matches[1])).To(BeNumerically(">=", 3))
+	Expect(w.Close()).To(Succeed())
+
+	Eventually(loginSession).Should(Exit(0))
 }


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
Loosely #1014

## What is this change about?
Main change is to rework the `cf login` so it will select the correct number for the given user.

Also bump cf-test-helpers to a recent version where is go.mod enabled and containing the 'with-stdin' runner.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Run the run-smoke-tests-kind.sh script and see it work.

## Tag your pair, your PM, and/or team
@gcapizzi 
