### PR TITLE
Fix a timer memory leak in task repository

### DIFF
--- a/api/repositories/task_repository.go
+++ b/api/repositories/task_repository.go
@@ -104,6 +104,9 @@ func (r *TaskRepo) awaitInitialization(ctx context.Context, userClient client.Wi
 	}
 	defer watch.Stop()
 
+	timer := time.NewTimer(r.timeout)
+	defer timer.Stop()
+
 	for {
 		select {
 		case e := <-watch.ResultChan():
@@ -115,7 +118,7 @@ func (r *TaskRepo) awaitInitialization(ctx context.Context, userClient client.Wi
 			if meta.IsStatusConditionTrue(updatedTask.Status.Conditions, korifiv1alpha1.TaskInitializedConditionType) {
 				return *updatedTask, nil
 			}
-		case <-time.After(r.timeout):
+		case <-timer.C:
 			return korifiv1alpha1.CFTask{}, fmt.Errorf("task did not get initialized within timeout period %d ms", r.timeout.Milliseconds())
 		}
 	}


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
* task initialised timeout timer is created before running the select
  loop which means it is going to be created just once rather than on
  every loop
* introduce a kill channel for the controller-like loop in the
  repositories test


## Does this PR introduce a breaking change?
No

## Acceptance Steps
Run repositories test while monitoring memory usage, the test process should not use anything abnormal

## Tag your pair, your PM, and/or team
@kieron-dev 

