### PR TITLE
Bump timeout to accommodate app push

### DIFF
--- a/tests/e2e/processes_test.go
+++ b/tests/e2e/processes_test.go
@@ -2,7 +2,6 @@ package e2e_test
 
 import (
 	"net/http"
-	"time"
 
 	"code.cloudfoundry.org/korifi/tests/e2e/helpers"
 
@@ -149,7 +148,7 @@ var _ = Describe("Processes", func() {
 					Expect(err).NotTo(HaveOccurred())
 
 					return processStats.Resources[0].Usage
-				}, 60*time.Second).ShouldNot(Equal(statsUsage{}))
+				}).ShouldNot(Equal(statsUsage{}))
 			})
 
 			It("succeeds", func() {


### PR DESCRIPTION
This test has flaked historically