### PR TITLE
Fix flaky cfprocess controller integration test

### DIFF
--- a/controllers/controllers/workloads/integration/suite_integration_test.go
+++ b/controllers/controllers/workloads/integration/suite_integration_test.go
@@ -284,7 +284,7 @@ func patchAppWithDroplet(ctx context.Context, k8sClient client.Client, appGUID, 
 	return baseCFApp
 }
 
-func getMapKeyValue(m map[string]string, k string) string {
+func valueForKey(m map[string]string, k string) string {
 	if m == nil {
 		return ""
 	}


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
Failed CI build: https://ci.korifi.cf-app.com/teams/main/pipelines/main/jobs/run-tests-periodic/builds/92

The test flakes because it expects an LRP for a process with certain
properties. Due to setting the VCAP_SERVICES env var asynchronously, the
LRP might not have its env set according to the expectations initially.
Therefore, this change puts all the LRP checks into `Eventually`

## Does this PR introduce a breaking change?
No

## Acceptance Steps
N/A

## Tag your pair, your PM, and/or team
@georgethebeatle 

