### PR TITLE
Bump Eventually timeout/polling interval

### DIFF
--- a/kpack-image-builder/controllers/suite_test.go
+++ b/kpack-image-builder/controllers/suite_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"path/filepath"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -60,6 +61,9 @@ var (
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
+
+	SetDefaultEventuallyTimeout(10 * time.Second)
+	SetDefaultEventuallyPollingInterval(200 * time.Millisecond)
 
 	RunSpecs(t, "Controller Suite")
 }


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
Bump Eventually timeout/polling interval
We suspect that the default timeout of 1 second causes flakes

## Does this PR introduce a breaking change?
No

## Acceptance Steps
N/A

## Tag your pair, your PM, and/or team
@georgethebeatle 
