### PR TITLE
Fix some CF Process flakes

### DIFF
--- a/api/repositories/process_repository.go
+++ b/api/repositories/process_repository.go
@@ -208,7 +208,7 @@ func (r *ProcessRepo) CreateProcess(ctx context.Context, authInfo authorization.
 			Ports:            []int32{},
 		},
 	}
-	process.SetRandomName()
+	process.SetStableName(message.AppGUID)
 	err = userClient.Create(ctx, process)
 	return apierrors.FromK8sError(err, ProcessResourceType)
 }

--- a/controllers/api/v1alpha1/cfprocess_types.go
+++ b/controllers/api/v1alpha1/cfprocess_types.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"github.com/google/uuid"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -105,8 +104,8 @@ type CFProcessList struct {
 	Items           []CFProcess `json:"items"`
 }
 
-func (r *CFProcess) SetRandomName() {
-	r.Name = processNamePrefix + uuid.NewString()
+func (r *CFProcess) SetStableName(appGUID string) {
+	r.Name = processNamePrefix + appGUID + r.Spec.ProcessType
 	if r.Labels == nil {
 		r.Labels = map[string]string{}
 	}

--- a/controllers/controllers/workloads/cfapp_controller.go
+++ b/controllers/controllers/workloads/cfapp_controller.go
@@ -166,7 +166,7 @@ func (r *CFAppReconciler) createCFProcess(ctx context.Context, process korifiv1a
 			Ports:            ports,
 		},
 	}
-	desiredCFProcess.SetRandomName()
+	desiredCFProcess.SetStableName(cfApp.Name)
 
 	err := controllerutil.SetOwnerReference(cfApp, desiredCFProcess, r.Scheme)
 	if err != nil {

--- a/controllers/controllers/workloads/integration/cfapp_controller_integration_test.go
+++ b/controllers/controllers/workloads/integration/cfapp_controller_integration_test.go
@@ -96,8 +96,8 @@ var _ = Describe("CFAppReconciler Integration Tests", func() {
 				return string(createdCFApp.Status.ObservedDesiredState)
 			}).Should(Equal(string(cfApp.Spec.DesiredState)))
 
-			runningConditionFalse := meta.IsStatusConditionFalse(createdCFApp.Status.Conditions, "Running")
-			Expect(runningConditionFalse).To(BeTrue())
+			runningConditionFalse := meta.IsStatusConditionTrue(createdCFApp.Status.Conditions, "Running")
+			Expect(runningConditionFalse).To(BeFalse())
 			Expect(createdCFApp.Status.ObservedDesiredState).To(Equal(createdCFApp.Spec.DesiredState))
 		})
 	})


### PR DESCRIPTION
## Is there a related GitHub Issue?
#1261

## What is this change about?
Allow running condition to be not present

IsStatusConditionFalse only returns `true` when the condition both
exists and is equal to "False". In this test, we need to accommodate the
condition not yet existing also. So the correct way to call this is to
check for the "True" condition, and assert that we don't get it.

Fixes flake at cfapp_controller_integration_test.go:100.

AND


Use a stable name for CFProcesses

Format is `cf-proc-<appGUID>-<processType>`

This allows optimistic locking as the name is now deterministic. It
prevents the bug described in the associated issue.


## Does this PR introduce a breaking change?
No

## Acceptance Steps
Flakes disappear in periodic tests.

## Tag your pair, your PM, and/or team
@georgethebeatle 

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
