### PR TITLE
Introduce the `Staged` condition for `CFApp`

### DIFF
--- a/controllers/controllers/workloads/cfapp_controller_test.go
+++ b/controllers/controllers/workloads/cfapp_controller_test.go
@@ -211,6 +211,7 @@ var _ = Describe("CFAppReconciler", func() {
 				_, updatedCFApp, _ := fakeStatusWriter.UpdateArgsForCall(0)
 				cast, ok := updatedCFApp.(*korifiv1alpha1.CFApp)
 				Expect(ok).To(BeTrue(), "Cast to korifiv1alpha1.CFApp failed")
+				Expect(meta.IsStatusConditionTrue(cast.Status.Conditions, StatusConditionStaged)).To(BeFalse())
 				Expect(meta.IsStatusConditionFalse(cast.Status.Conditions, StatusConditionRunning)).To(BeTrue(), "Status Condition "+StatusConditionRunning+" was not False as expected")
 				Expect(cast.Status.ObservedDesiredState).To(Equal(cast.Spec.DesiredState))
 			})
@@ -315,6 +316,7 @@ var _ = Describe("CFAppReconciler", func() {
 				_, updatedCFApp, _ := fakeStatusWriter.UpdateArgsForCall(0)
 				cast, ok := updatedCFApp.(*korifiv1alpha1.CFApp)
 				Expect(ok).To(BeTrue(), "Cast to korifiv1alpha1.CFApp failed")
+				Expect(meta.IsStatusConditionTrue(cast.Status.Conditions, StatusConditionStaged)).To(BeTrue())
 				Expect(meta.IsStatusConditionFalse(cast.Status.Conditions, StatusConditionRunning)).To(BeTrue(), "Status Condition "+StatusConditionRunning+" was not False as expected")
 			})
 		})
@@ -351,6 +353,14 @@ var _ = Describe("CFAppReconciler", func() {
 				It("should returns an error", func() {
 					Expect(reconcileErr).To(MatchError(failsOnPurposeErrorMessage))
 				})
+
+				It("should unset the staged condition", func() {
+					Expect(fakeStatusWriter.UpdateCallCount()).To(Equal(1))
+					_, updatedCFApp, _ := fakeStatusWriter.UpdateArgsForCall(0)
+					cast, ok := updatedCFApp.(*korifiv1alpha1.CFApp)
+					Expect(ok).To(BeTrue(), "Cast to korifiv1alpha1.CFApp failed")
+					Expect(meta.IsStatusConditionTrue(cast.Status.Conditions, StatusConditionStaged)).To(BeFalse())
+				})
 			})
 
 			When("Droplet status on CFBuild is nil", func() {
@@ -361,6 +371,14 @@ var _ = Describe("CFAppReconciler", func() {
 
 				It("should returns an error", func() {
 					Expect(reconcileErr).To(MatchError(ContainSubstring(buildDropletStatusErrorMessage)))
+				})
+
+				It("should unset the staged condition", func() {
+					Expect(fakeStatusWriter.UpdateCallCount()).To(Equal(1))
+					_, updatedCFApp, _ := fakeStatusWriter.UpdateArgsForCall(0)
+					cast, ok := updatedCFApp.(*korifiv1alpha1.CFApp)
+					Expect(ok).To(BeTrue(), "Cast to korifiv1alpha1.CFApp failed")
+					Expect(meta.IsStatusConditionTrue(cast.Status.Conditions, StatusConditionStaged)).To(BeFalse())
 				})
 			})
 


### PR DESCRIPTION
## Is there a related GitHub Issue?

#1266 

## What is this change about?

This adds a `Staged` condition to `CFApp` which will be set to true only if the app has a valid droplet reference. The condition will be unset back to false if the droplet referenced by the app disappears.

This will make it very easy for the task creation endpoint to identify apps that are not staged yet and return proper errors.

## Does this PR introduce a breaking change?

No.

## Tag your pair, your PM, and/or team

@danail-branekov 