### PR TITLE
Reject tasks on unstaged apps in the API shim

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -8,7 +8,10 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     go mod download
 
 COPY controllers/api controllers/api/
+COPY controllers/config controllers/config/
 COPY controllers/webhooks controllers/webhooks/
+COPY controllers/controllers/shared controllers/controllers/shared/
+COPY controllers/controllers/workloads controllers/controllers/workloads/
 COPY api/actions api/actions/
 COPY api/handlers api/handlers/
 COPY api/apierrors api/apierrors

--- a/api/handlers/task_handler.go
+++ b/api/handlers/task_handler.go
@@ -77,6 +77,11 @@ func (h *TaskHandler) taskCreateHandler(ctx context.Context, logger logr.Logger,
 		return nil, apierrors.ForbiddenAsNotFound(err)
 	}
 
+	if !appRecord.IsStaged {
+		logger.Info("App is not staged", "App GUID", appGUID)
+		return nil, apierrors.NewUnprocessableEntityError(nil, "Task must have a droplet. Assign current droplet to app.")
+	}
+
 	taskRecord, err := h.taskRepo.CreateTask(ctx, authInfo, payload.ToMessage(appRecord))
 	if err != nil {
 		logger.Error(err, "Failed to create task")

--- a/api/handlers/task_handler_test.go
+++ b/api/handlers/task_handler_test.go
@@ -30,6 +30,7 @@ var _ = Describe("TaskHandler", func() {
 		appRepo.GetAppReturns(repositories.AppRecord{
 			GUID:      "the-app-guid",
 			SpaceGUID: "the-space-guid",
+			IsStaged:  true,
 		}, nil)
 
 		taskHandler := handlers.NewTaskHandler(*serverURL, appRepo, taskRepo, decoderValidator)
@@ -144,6 +145,20 @@ var _ = Describe("TaskHandler", func() {
 
 			It("returns an Internal Server Error", func() {
 				expectUnknownError()
+			})
+		})
+
+		When("the app is not staged", func() {
+			BeforeEach(func() {
+				appRepo.GetAppReturns(repositories.AppRecord{
+					GUID:      "the-app-guid",
+					SpaceGUID: "the-space-guid",
+					IsStaged:  false,
+				}, nil)
+			})
+
+			It("returns an Unprocessable Entity error", func() {
+				expectUnprocessableEntityError("Task must have a droplet. Assign current droplet to app.")
 			})
 		})
 

--- a/api/repositories/app_repository.go
+++ b/api/repositories/app_repository.go
@@ -10,11 +10,13 @@ import (
 	"code.cloudfoundry.org/korifi/api/apierrors"
 	"code.cloudfoundry.org/korifi/api/authorization"
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
+	"code.cloudfoundry.org/korifi/controllers/controllers/workloads"
 	"code.cloudfoundry.org/korifi/controllers/webhooks"
 
 	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -61,6 +63,7 @@ type AppRecord struct {
 	Lifecycle     Lifecycle
 	CreatedAt     string
 	UpdatedAt     string
+	IsStaged      bool
 	envSecretName string
 }
 
@@ -532,6 +535,7 @@ func cfAppToAppRecord(cfApp korifiv1alpha1.CFApp) AppRecord {
 		},
 		CreatedAt:     cfApp.CreationTimestamp.UTC().Format(TimestampFormat),
 		UpdatedAt:     updatedAtTime,
+		IsStaged:      meta.IsStatusConditionTrue(cfApp.Status.Conditions, workloads.StatusConditionStaged),
 		envSecretName: cfApp.Spec.EnvSecretName,
 	}
 }


### PR DESCRIPTION
## Is there a related GitHub Issue?

#1266 

## What is this change about?

This changes the task creation endpoint so that it returns a `422 Unprocessable Entity` if the target app is not staged. The implementation leverages the `Staged` status condition introduced in #1269.

## Does this PR introduce a breaking change?

Not really. The error message has changed from a generic 500 to the correct one.

## Tag your pair, your PM, and/or team

@kieron-dev 