### PR TITLE
Configure Korifi with `restricted` pod-security

### DIFF
--- a/api/config/base/deployment.yaml
+++ b/api/config/base/deployment.yaml
@@ -38,6 +38,14 @@ spec:
         - name: &tlsname korifi-tls-config
           mountPath: /etc/korifi-tls-config
           readOnly: true
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
       volumes:
       - name: *configname
         configMap:

--- a/api/config/base/namespace.yaml
+++ b/api/config/base/namespace.yaml
@@ -2,3 +2,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: system
+  labels:
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/enforce: restricted

--- a/controllers/config/default/manager_auth_proxy_patch.yaml
+++ b/controllers/config/default/manager_auth_proxy_patch.yaml
@@ -19,3 +19,11 @@ spec:
         ports:
         - containerPort: 8443
           name: https
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault

--- a/controllers/config/manager/manager.yaml
+++ b/controllers/config/manager/manager.yaml
@@ -3,6 +3,8 @@ kind: Namespace
 metadata:
   labels:
     control-plane: controller-manager
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/enforce: restricted
   name: system
 ---
 apiVersion: apps/v1
@@ -35,6 +37,12 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
         livenessProbe:
           httpGet:
             path: /healthz

--- a/kpack-image-builder/config/default/project_namespace/manager_auth_proxy_patch.yaml
+++ b/kpack-image-builder/config/default/project_namespace/manager_auth_proxy_patch.yaml
@@ -27,6 +27,14 @@ spec:
           requests:
             cpu: 5m
             memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
       - name: manager
         args:
         - "--health-probe-bind-address=:8081"

--- a/kpack-image-builder/config/default/project_namespace/manager_config_patch.yaml
+++ b/kpack-image-builder/config/default/project_namespace/manager_config_patch.yaml
@@ -14,6 +14,14 @@ spec:
         - name: manager-config
           mountPath: /controller_manager_config.yaml
           subPath: controller_manager_config.yaml
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
       volumes:
       - name: manager-config
         configMap:

--- a/kpack-image-builder/config/manager/manager.yaml
+++ b/kpack-image-builder/config/manager/manager.yaml
@@ -3,6 +3,8 @@ kind: Namespace
 metadata:
   labels:
     control-plane: controller-manager
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/enforce: restricted
   name: system
 ---
 apiVersion: apps/v1
@@ -33,6 +35,12 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
## Is there a related GitHub Issue?
https://github.com/cloudfoundry/korifi/issues/1221

## What is this change about?
Enable `restricted` pod security on Korifi "core" namespaces and pods

As this is a change in the deployment ymls - which we do not test - this PR has no tests

## Does this PR introduce a breaking change?
No. Although it technically enables the restricted pod security policy, Korifi's implementation does not violate it so no further changes are needed

## Acceptance Steps
See the story for acceptance

