### PR TITLE
Processes that have a route mapped to them default to having PORT health check type

### DIFF
--- a/api/payloads/manifest.go
+++ b/api/payloads/manifest.go
@@ -10,7 +10,6 @@ import (
 const (
 	processTypeWeb         = "web"
 	processHealthCheckType = "process"
-	portHealthCheckType    = "port"
 )
 
 type Manifest struct {
@@ -57,7 +56,7 @@ func (a ManifestApplication) ToAppCreateMessage(spaceGUID string) repositories.C
 	}
 }
 
-func (p ManifestApplicationProcess) ToProcessCreateMessage(appGUID, spaceGUID string, hasRoutes bool) repositories.CreateProcessMessage {
+func (p ManifestApplicationProcess) ToProcessCreateMessage(appGUID, spaceGUID string) repositories.CreateProcessMessage {
 	var (
 		command                      string
 		healthCheckType              string
@@ -72,9 +71,6 @@ func (p ManifestApplicationProcess) ToProcessCreateMessage(appGUID, spaceGUID st
 	healthCheckType = processHealthCheckType
 	if p.Type == processTypeWeb {
 		instances = 1
-		if hasRoutes {
-			healthCheckType = portHealthCheckType
-		}
 	} else {
 		instances = 0
 	}

--- a/api/payloads/manifest_test.go
+++ b/api/payloads/manifest_test.go
@@ -99,7 +99,7 @@ var _ = Describe("ManifestApplicationProcess", func() {
 						Command:          "",
 						DiskQuotaMB:      1024,
 						HealthCheck: repositories.HealthCheck{
-							Type: "port",
+							Type: "process",
 							Data: repositories.HealthCheckData{
 								HTTPEndpoint:             "",
 								TimeoutSeconds:           0, // this isn't nullable

--- a/controllers/controllers/workloads/cfapp_controller.go
+++ b/controllers/controllers/workloads/cfapp_controller.go
@@ -151,18 +151,7 @@ func (r *CFAppReconciler) startApp(ctx context.Context, cfApp *korifiv1alpha1.CF
 		}
 
 		if !processExistsForType {
-			cfRoutes, err := r.getCFRoutes(ctx, cfApp.Name, cfApp.Namespace)
-			if err != nil {
-				return err
-			}
-			// TODO: Determine if there is a timing issue regarding routes being present
-			r.Log.Info(fmt.Sprintf("CFRoute count %d", len(cfRoutes)))
-			var healthCheckType korifiv1alpha1.HealthCheckType
-			healthCheckType = processHealthCheckType
-			if process.Type == processTypeWeb && len(cfRoutes) > 0 {
-				healthCheckType = portHealthCheckType
-			}
-			err = r.createCFProcess(ctx, process, droplet.Ports, cfApp, healthCheckType)
+			err = r.createCFProcess(ctx, process, droplet.Ports, cfApp)
 			if err != nil {
 				r.Log.Error(err, fmt.Sprintf("Error creating CFProcess for Type: %s", process.Type))
 				return err
@@ -182,7 +171,11 @@ func addWebIfMissing(processTypes []korifiv1alpha1.ProcessType) []korifiv1alpha1
 	return append([]korifiv1alpha1.ProcessType{{Type: processTypeWeb}}, processTypes...)
 }
 
-func (r *CFAppReconciler) createCFProcess(ctx context.Context, process korifiv1alpha1.ProcessType, ports []int32, cfApp *korifiv1alpha1.CFApp, healthCheckType korifiv1alpha1.HealthCheckType) error {
+func (r *CFAppReconciler) createCFProcess(ctx context.Context, process korifiv1alpha1.ProcessType, ports []int32, cfApp *korifiv1alpha1.CFApp) error {
+	healthCheckType, err := r.getHealthCheckType(ctx, process.Type, cfApp)
+	if err != nil {
+		return err
+	}
 	desiredCFProcess := &korifiv1alpha1.CFProcess{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: cfApp.Namespace,
@@ -196,7 +189,7 @@ func (r *CFAppReconciler) createCFProcess(ctx context.Context, process korifiv1a
 			ProcessType: process.Type,
 			Command:     process.Command,
 			HealthCheck: korifiv1alpha1.HealthCheck{
-				Type: healthCheckType,
+				Type: korifiv1alpha1.HealthCheckType(healthCheckType),
 				Data: korifiv1alpha1.HealthCheckData{
 					InvocationTimeoutSeconds: 0,
 					TimeoutSeconds:           0,
@@ -210,13 +203,27 @@ func (r *CFAppReconciler) createCFProcess(ctx context.Context, process korifiv1a
 	}
 	desiredCFProcess.SetStableName(cfApp.Name)
 
-	err := controllerutil.SetOwnerReference(cfApp, desiredCFProcess, r.Scheme)
+	err = controllerutil.SetOwnerReference(cfApp, desiredCFProcess, r.Scheme)
 	if err != nil {
 		r.Log.Error(err, "failed to set OwnerRef on CFProcess")
 		return err
 	}
 
 	return r.Client.Create(ctx, desiredCFProcess)
+}
+
+func (r *CFAppReconciler) getHealthCheckType(ctx context.Context, processType string, cfApp *korifiv1alpha1.CFApp) (string, error) {
+	if processType == processTypeWeb {
+		cfRoutes, err := r.getCFRoutes(ctx, cfApp.Name, cfApp.Namespace)
+		if err != nil {
+			return "", err
+		}
+		if len(cfRoutes) > 0 {
+			return portHealthCheckType, nil
+		}
+	}
+
+	return processHealthCheckType, nil
 }
 
 func (r *CFAppReconciler) checkCFProcessExistsForType(ctx context.Context, appGUID string, namespace string, processType string) (bool, error) {
@@ -320,6 +327,7 @@ func (r *CFAppReconciler) getCFRoutes(ctx context.Context, cfAppGUID string, cfA
 	matchingFields := client.MatchingFields{IndexRouteDestinationAppName: cfAppGUID}
 	err := r.Client.List(context.Background(), &foundRoutes, client.InNamespace(cfAppNamespace), matchingFields)
 	if err != nil {
+		r.Log.Error(err, fmt.Sprintf("failed to List CFRoutes for CFApp %s/%s", cfAppNamespace, cfAppGUID))
 		return []korifiv1alpha1.CFRoute{}, err
 	}
 

--- a/controllers/controllers/workloads/cfapp_controller_test.go
+++ b/controllers/controllers/workloads/cfapp_controller_test.go
@@ -278,7 +278,7 @@ var _ = Describe("CFAppReconciler", func() {
 		})
 	})
 
-	When("a CFApp is updated to set currentDropletRef and Reconcile function is called", func() {
+	When("a CFApp is updated to set currentDropletRef which has a web process and Reconcile function is called", func() {
 		BeforeEach(func() {
 			cfApp.Spec.CurrentDropletRef = v1.LocalObjectReference{Name: cfBuildGUID}
 		})
@@ -305,13 +305,16 @@ var _ = Describe("CFAppReconciler", func() {
 				Expect(testRequestNamespacedName.Namespace).To(Equal(defaultNamespace))
 				Expect(testRequestNamespacedName.Name).To(Equal(cfBuildGUID))
 
-				// Validate call count to fetch CFProcess
-				Expect(fakeClient.ListCallCount()).To(Equal(1))
+				// Validate call count to fetch CFProcess and CFRoutes
+				Expect(fakeClient.ListCallCount()).To(Equal(2))
 
 				// Validate call count to create CFProcess
 				Expect(fakeClient.CreateCallCount()).To(Equal(1))
 				_, desiredProcess, _ := fakeClient.CreateArgsForCall(0)
 				Expect(desiredProcess.GetName()).To(HavePrefix("cf-proc-"))
+				desiredProcessObject, ok := desiredProcess.(*korifiv1alpha1.CFProcess)
+				Expect(ok).To(BeTrue())
+				Expect(desiredProcessObject.Spec.HealthCheck.Type).To(Equal(korifiv1alpha1.HealthCheckType("port")))
 
 				// validate the inputs to Status.Update
 				Expect(fakeStatusWriter.UpdateCallCount()).To(Equal(1))


### PR DESCRIPTION
## Is there a related GitHub Issue?
#1207 

## What is this change about?
Processes that have a route mapped to them should default to having the PORT health check type

## Does this PR introduce a breaking change?
no

## Acceptance Steps
See issue

## Tag your pair, your PM, and/or team
@akrishna90 
