### PR TITLE
Allow using a container registry signed by a custom CA

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -108,6 +108,12 @@ Note: DockerHub does not support nested directories so `kpackImageTag` and `pack
 
 Note: GCR supports nested directories, so you can organize your images as desired.
 
+#### Registry with Custom CA
+
+- See instruction in [Using container registry signed by custom CA](docs/using-container-registry-signed-by-custom-ca.md) doc.
+
+
+
 ## Root namespace and admin role binding
 
 Create the root namespace:

--- a/api/main.go
+++ b/api/main.go
@@ -124,11 +124,17 @@ func main() {
 		config.RootNamespace,
 		config.RoleMappings,
 	)
+	registryCAPath, found := os.LookupEnv("REGISTRY_CA_FILE")
+	if !found {
+		registryCAPath = ""
+	}
+
 	imageRepo := repositories.NewImageRepository(
 		privilegedK8sClient,
 		userClientFactory,
 		config.RootNamespace,
 		config.PackageRegistrySecretName,
+		registryCAPath,
 		reporegistry.NewImageBuilder(),
 		reporegistry.NewImagePusher(remote.Write),
 	)

--- a/api/repositories/fake/image_pusher.go
+++ b/api/repositories/fake/image_pusher.go
@@ -2,7 +2,6 @@
 package fake
 
 import (
-	"context"
 	"sync"
 
 	"code.cloudfoundry.org/korifi/api/repositories"
@@ -11,12 +10,12 @@ import (
 )
 
 type ImagePusher struct {
-	PushStub        func(context.Context, string, v1.Image, remote.Option) (string, error)
+	PushStub        func(string, v1.Image, remote.Option, remote.Option) (string, error)
 	pushMutex       sync.RWMutex
 	pushArgsForCall []struct {
-		arg1 context.Context
-		arg2 string
-		arg3 v1.Image
+		arg1 string
+		arg2 v1.Image
+		arg3 remote.Option
 		arg4 remote.Option
 	}
 	pushReturns struct {
@@ -31,13 +30,13 @@ type ImagePusher struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *ImagePusher) Push(arg1 context.Context, arg2 string, arg3 v1.Image, arg4 remote.Option) (string, error) {
+func (fake *ImagePusher) Push(arg1 string, arg2 v1.Image, arg3 remote.Option, arg4 remote.Option) (string, error) {
 	fake.pushMutex.Lock()
 	ret, specificReturn := fake.pushReturnsOnCall[len(fake.pushArgsForCall)]
 	fake.pushArgsForCall = append(fake.pushArgsForCall, struct {
-		arg1 context.Context
-		arg2 string
-		arg3 v1.Image
+		arg1 string
+		arg2 v1.Image
+		arg3 remote.Option
 		arg4 remote.Option
 	}{arg1, arg2, arg3, arg4})
 	stub := fake.PushStub
@@ -59,13 +58,13 @@ func (fake *ImagePusher) PushCallCount() int {
 	return len(fake.pushArgsForCall)
 }
 
-func (fake *ImagePusher) PushCalls(stub func(context.Context, string, v1.Image, remote.Option) (string, error)) {
+func (fake *ImagePusher) PushCalls(stub func(string, v1.Image, remote.Option, remote.Option) (string, error)) {
 	fake.pushMutex.Lock()
 	defer fake.pushMutex.Unlock()
 	fake.PushStub = stub
 }
 
-func (fake *ImagePusher) PushArgsForCall(i int) (context.Context, string, v1.Image, remote.Option) {
+func (fake *ImagePusher) PushArgsForCall(i int) (string, v1.Image, remote.Option, remote.Option) {
 	fake.pushMutex.RLock()
 	defer fake.pushMutex.RUnlock()
 	argsForCall := fake.pushArgsForCall[i]

--- a/api/repositories/image_repository_test.go
+++ b/api/repositories/image_repository_test.go
@@ -23,6 +23,7 @@ import (
 var _ = Describe("ImageRepository", func() {
 	var (
 		registrySecretName  string
+		registryCAPath      string
 		imageBuilder        *fake.ImageBuilder
 		imagePusher         *fake.ImagePusher
 		image               v1.Image
@@ -93,11 +94,14 @@ var _ = Describe("ImageRepository", func() {
 			)
 		Expect(err).NotTo(HaveOccurred())
 
+		registryCAPath = ""
+
 		imageRepo = repositories.NewImageRepository(
 			privilegedK8sClient,
 			userClientFactory,
 			rootNamespace,
 			registrySecretName,
+			registryCAPath,
 			imageBuilder,
 			imagePusher,
 		)
@@ -123,7 +127,7 @@ var _ = Describe("ImageRepository", func() {
 
 		It("uploads the image to the registry", func() {
 			Expect(imagePusher.PushCallCount()).To(Equal(1))
-			_, actualRef, actualImage, credentials := imagePusher.PushArgsForCall(0)
+			actualRef, actualImage, credentials, _ := imagePusher.PushArgsForCall(0)
 			Expect(actualRef).To(Equal("my-image"))
 			Expect(actualImage).To(Equal(image))
 			Expect(credentials).NotTo(BeNil())

--- a/api/repositories/registry/image_pusher.go
+++ b/api/repositories/registry/image_pusher.go
@@ -1,7 +1,6 @@
 package registry
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/google/go-containerregistry/pkg/name"
@@ -25,8 +24,8 @@ func NewImagePusher(imageWriter ImageWriter) *ImagePusher {
 	}
 }
 
-func (r *ImagePusher) Push(ctx context.Context, imageRef string, image v1.Image, credentials remote.Option) (string, error) {
-	ref, err := r.uploadImage(image, imageRef, credentials)
+func (r *ImagePusher) Push(imageRef string, image v1.Image, credentials remote.Option, transport remote.Option) (string, error) {
+	ref, err := r.uploadImage(image, imageRef, credentials, transport)
 	if err != nil {
 		return "", err
 	}
@@ -34,13 +33,13 @@ func (r *ImagePusher) Push(ctx context.Context, imageRef string, image v1.Image,
 	return buildRefWithDigest(image, ref)
 }
 
-func (r *ImagePusher) uploadImage(image v1.Image, imageRef string, credentials remote.Option) (name.Reference, error) {
+func (r *ImagePusher) uploadImage(image v1.Image, imageRef string, credentials remote.Option, transport remote.Option) (name.Reference, error) {
 	ref, err := name.ParseReference(imageRef)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing reference %s: %w", imageRef, err)
 	}
 
-	err = r.imageWriter(ref, image, credentials)
+	err = r.imageWriter(ref, image, credentials, transport)
 	if err != nil {
 		return nil, fmt.Errorf("failed to upload image: %w", err)
 	}

--- a/api/repositories/registry/image_pusher_test.go
+++ b/api/repositories/registry/image_pusher_test.go
@@ -1,7 +1,6 @@
 package registry_test
 
 import (
-	"context"
 	"errors"
 	"fmt"
 
@@ -18,6 +17,7 @@ var _ = Describe("ImagePusher", func() {
 	var (
 		imageWriter *fake.ImageWriter
 		credentials remote.Option
+		transport   remote.Option
 		imageRef    string
 		image       v1.Image
 
@@ -31,6 +31,8 @@ var _ = Describe("ImagePusher", func() {
 
 		credentials = remote.WithAuth(nil)
 
+		transport = remote.WithTransport(nil)
+
 		imageWriter = new(fake.ImageWriter)
 
 		var err error
@@ -41,7 +43,7 @@ var _ = Describe("ImagePusher", func() {
 	})
 
 	JustBeforeEach(func() {
-		pushedImageRef, pushErr = imagePusher.Push(context.Background(), imageRef, image, credentials)
+		pushedImageRef, pushErr = imagePusher.Push(imageRef, image, credentials, transport)
 	})
 
 	It("pushes the image to the registry", func() {
@@ -51,8 +53,9 @@ var _ = Describe("ImagePusher", func() {
 		actualRef, actualImage, actualOptions := imageWriter.ArgsForCall(0)
 		Expect(actualRef.Name()).To(Equal("index.docker.io/library/my-image-ref:latest"))
 		Expect(actualImage).To(Equal(image))
-		Expect(actualOptions).To(HaveLen(1))
+		Expect(actualOptions).To(HaveLen(2))
 		Expect(fmt.Sprintf("%#v", actualOptions[0])).To(Equal(fmt.Sprintf("%#v", credentials)))
+		Expect(fmt.Sprintf("%#v", actualOptions[1])).To(Equal(fmt.Sprintf("%#v", transport)))
 
 		Expect(pushedImageRef).To(HavePrefix("index.docker.io/library/my-image-ref"))
 	})

--- a/docs/using-container-registry-signed-by-custom-ca.md
+++ b/docs/using-container-registry-signed-by-custom-ca.md
@@ -1,0 +1,16 @@
+# Use container registry signed by custom CAs
+Korifi can be configured to use a custom registry that has a self-signed certicate.
+Korifi accepts the `REGISTRY_CA_FILE` environment variable to point to a mounted secret containing the registry's CA cert.
+
+## Configure korifi-api
+
+- Create a secret containing the registry's CA cert in the `korifi-api-system` namespace. (see instructions)
+    For example: `kubectl -n korifi-api-system create secret generic registry-ca-cert --from-file=cacerts.pem=./ca-cert.pem`
+- Update [deployment definition](https://github.com/cloudfoundry/korifi/blob/main/api/config/base/deployment.yaml) to mount the secret (see [instructions](https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-files-from-a-pod))
+- Set `REGISTRY_CA_FILE` environment variable on the deployment to point to the path of the mounted ca.crt file.
+
+## Configure kpack-image-builder
+Use the same instructions as above, but create secret in the `korifi-kpack-build-system` namespace and use this [deployment definition](https://github.com/cloudfoundry/korifi/blob/main/kpack-image-builder/config/manager/manager.yaml) 
+
+## Kpack
+Kpack does not support self-signed/internal CA configuration out of the box [see: pivotal/kpack#207](https://github.com/pivotal/kpack/issues/207) and providing support for that is not something in scope for us to take on. Operators can modify the Kpack deployment, using something like the [cert-injection-webhook](https://github.com/vmware-tanzu/cert-injection-webhook) on the kpack Pods, or bring their own build reconciler in these cases.

--- a/kpack-image-builder/controllers/fake/image_process_fetcher.go
+++ b/kpack-image-builder/controllers/fake/image_process_fetcher.go
@@ -10,11 +10,12 @@ import (
 )
 
 type ImageProcessFetcher struct {
-	Stub        func(string, remote.Option) ([]v1alpha1.ProcessType, []int32, error)
+	Stub        func(string, remote.Option, remote.Option) ([]v1alpha1.ProcessType, []int32, error)
 	mutex       sync.RWMutex
 	argsForCall []struct {
 		arg1 string
 		arg2 remote.Option
+		arg3 remote.Option
 	}
 	returns struct {
 		result1 []v1alpha1.ProcessType
@@ -30,19 +31,20 @@ type ImageProcessFetcher struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *ImageProcessFetcher) Spy(arg1 string, arg2 remote.Option) ([]v1alpha1.ProcessType, []int32, error) {
+func (fake *ImageProcessFetcher) Spy(arg1 string, arg2 remote.Option, arg3 remote.Option) ([]v1alpha1.ProcessType, []int32, error) {
 	fake.mutex.Lock()
 	ret, specificReturn := fake.returnsOnCall[len(fake.argsForCall)]
 	fake.argsForCall = append(fake.argsForCall, struct {
 		arg1 string
 		arg2 remote.Option
-	}{arg1, arg2})
+		arg3 remote.Option
+	}{arg1, arg2, arg3})
 	stub := fake.Stub
 	returns := fake.returns
-	fake.recordInvocation("ImageProcessFetcher", []interface{}{arg1, arg2})
+	fake.recordInvocation("ImageProcessFetcher", []interface{}{arg1, arg2, arg3})
 	fake.mutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2)
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
@@ -56,16 +58,16 @@ func (fake *ImageProcessFetcher) CallCount() int {
 	return len(fake.argsForCall)
 }
 
-func (fake *ImageProcessFetcher) Calls(stub func(string, remote.Option) ([]v1alpha1.ProcessType, []int32, error)) {
+func (fake *ImageProcessFetcher) Calls(stub func(string, remote.Option, remote.Option) ([]v1alpha1.ProcessType, []int32, error)) {
 	fake.mutex.Lock()
 	defer fake.mutex.Unlock()
 	fake.Stub = stub
 }
 
-func (fake *ImageProcessFetcher) ArgsForCall(i int) (string, remote.Option) {
+func (fake *ImageProcessFetcher) ArgsForCall(i int) (string, remote.Option, remote.Option) {
 	fake.mutex.RLock()
 	defer fake.mutex.RUnlock()
-	return fake.argsForCall[i].arg1, fake.argsForCall[i].arg2
+	return fake.argsForCall[i].arg1, fake.argsForCall[i].arg2, fake.argsForCall[i].arg3
 }
 
 func (fake *ImageProcessFetcher) Returns(result1 []v1alpha1.ProcessType, result2 []int32, result3 error) {

--- a/kpack-image-builder/controllers/imageprocessfetcher/image_process_fetcher.go
+++ b/kpack-image-builder/controllers/imageprocessfetcher/image_process_fetcher.go
@@ -20,14 +20,14 @@ type ImageProcessFetcher struct {
 	Log logr.Logger
 }
 
-func (f *ImageProcessFetcher) Fetch(imageRef string, credsOption remote.Option) ([]korifiv1alpha1.ProcessType, []int32, error) {
+func (f *ImageProcessFetcher) Fetch(imageRef string, credsOption remote.Option, transport remote.Option) ([]korifiv1alpha1.ProcessType, []int32, error) {
 	ref, err := name.ParseReference(imageRef)
 	if err != nil {
 		f.Log.Info(fmt.Sprintf("Error fetching image config: %s\n", err))
 		return nil, nil, err
 	}
 
-	img, err := remote.Image(ref, credsOption)
+	img, err := remote.Image(ref, credsOption, transport)
 	if err != nil {
 		f.Log.Info(fmt.Sprintf("Error fetching image config: %s\n", err))
 		return nil, nil, err

--- a/kpack-image-builder/controllers/suite_test.go
+++ b/kpack-image-builder/controllers/suite_test.go
@@ -57,6 +57,7 @@ var (
 	fakeImageProcessFetcher *fake.ImageProcessFetcher
 	buildWorkloadReconciler *controllers.BuildWorkloadReconciler
 	rootNamespace           *v1.Namespace
+	registryCAPath          string
 )
 
 func TestAPIs(t *testing.T) {
@@ -118,12 +119,15 @@ var _ = BeforeSuite(func() {
 	registryAuthFetcherClient, err := k8sclient.NewForConfig(cfg)
 	Expect(err).NotTo(HaveOccurred())
 
+	registryCAPath = ""
+
 	buildWorkloadReconciler = controllers.NewBuildWorkloadReconciler(
 		k8sManager.GetClient(),
 		k8sManager.GetScheme(),
 		ctrl.Log.WithName("kpack-image-builder").WithName("BuildWorkload"),
 		controllerConfig,
 		controllers.NewRegistryAuthFetcher(registryAuthFetcherClient),
+		registryCAPath,
 		nil, // Overridden in a beforeEach below
 	)
 	err = (buildWorkloadReconciler).SetupWithManager(k8sManager)

--- a/kpack-image-builder/main.go
+++ b/kpack-image-builder/main.go
@@ -104,12 +104,18 @@ func main() {
 		Log: ctrl.Log.WithName("controllers").WithName("CFBuildImageProcessFetcher"),
 	}
 
+	registryCAPath, found := os.LookupEnv("REGISTRY_CA_FILE")
+	if !found {
+		registryCAPath = ""
+	}
+
 	if err = controllers.NewBuildWorkloadReconciler(
 		mgr.GetClient(),
 		mgr.GetScheme(),
 		ctrl.Log.WithName("controllers").WithName("BuildWorkloadReconciler"),
 		controllerConfig,
 		controllers.NewRegistryAuthFetcher(k8sClient),
+		registryCAPath,
 		cfBuildImageProcessFetcher.Fetch,
 	).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "BuildWorkload")


### PR DESCRIPTION
## Is there a related GitHub Issue?
#1192 

## What is this change about?
Allow platform operator to configure Korifi components to trust a self-signed/internal CA when interacting with the container registry

## Does this PR introduce a breaking change?
no

## Acceptance Steps
See Issue

## Tag your pair, your PM, and/or team
@akrishna90 @julian-hj 
