### PR TITLE
Rename KorifiControllerNamespace config param

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -112,8 +112,6 @@ Note: GCR supports nested directories, so you can organize your images as desire
 
 - See instruction in [Using container registry signed by custom CA](docs/using-container-registry-signed-by-custom-ca.md) doc.
 
-
-
 ## Root namespace and admin role binding
 
 Create the root namespace:
@@ -266,7 +264,7 @@ kubectl -n korifi-api-system create secret tls korifi-api-ingress-cert --cert=<y
 kubectl -n korifi-controllers-system create secret tls korifi-workloads-ingress-cert --cert=<your-workloads-tls-cert-file> --key=<your-workloads-tls-key-file>
 ```
 
-The [`create_tls_secret` function in `scripts/common.sh`](https://github.com/cloudfoundry/korifi/blob/fd1aed6a8f406cb8d67cb5c214280e55db59901e/scripts/common.sh#L48-L91) shows how we do this on our development environments.
+The [`create_tls_secret` function in `scripts/common.sh`](https://github.com/cloudfoundry/korifi/blob/fd1aed6a8f406cb8d67cb5c214280e55db59901e/scripts/common.sh#L48-L91) shows how we do this for our development environments.
 
 ## Default CF Domain
 

--- a/controllers/config/base/controllersconfig/korifi_controllers_config.yaml
+++ b/controllers/config/base/controllersconfig/korifi_controllers_config.yaml
@@ -2,6 +2,6 @@ cfProcessDefaults:
   memoryMB: 1024
   diskQuotaMB: 1024
 cfRootNamespace: cf
-korifi_controller_namespace: korifi-controllers-system
 packageRegistrySecretName: image-registry-credentials # Create this secret in the rootNamespace
 workloads_tls_secret_name: korifi-workloads-ingress-cert
+workloads_tls_secret_namespace: korifi-controllers-system

--- a/controllers/config/config.go
+++ b/controllers/config/config.go
@@ -11,11 +11,11 @@ import (
 )
 
 type ControllerConfig struct {
-	CFProcessDefaults         CFProcessDefaults `yaml:"cfProcessDefaults"`
-	CFRootNamespace           string            `yaml:"cfRootNamespace"`
-	KorifiControllerNamespace string            `yaml:"korifi_controller_namespace"`
-	PackageRegistrySecretName string            `yaml:"packageRegistrySecretName"`
-	WorkloadsTLSSecretName    string            `yaml:"workloads_tls_secret_name"`
+	CFProcessDefaults           CFProcessDefaults `yaml:"cfProcessDefaults"`
+	CFRootNamespace             string            `yaml:"cfRootNamespace"`
+	PackageRegistrySecretName   string            `yaml:"packageRegistrySecretName"`
+	WorkloadsTLSSecretName      string            `yaml:"workloads_tls_secret_name"`
+	WorkloadsTLSSecretNamespace string            `yaml:"workloads_tls_secret_namespace"`
 }
 
 type CFProcessDefaults struct {
@@ -56,5 +56,5 @@ func (c ControllerConfig) WorkloadsTLSSecretNameWithNamespace() string {
 	if c.WorkloadsTLSSecretName == "" {
 		return ""
 	}
-	return filepath.Join(c.KorifiControllerNamespace, c.WorkloadsTLSSecretName)
+	return filepath.Join(c.WorkloadsTLSSecretNamespace, c.WorkloadsTLSSecretName)
 }

--- a/controllers/config/overlays/kind-local-registry/controllersconfig/korifi_controllers_config.yaml
+++ b/controllers/config/overlays/kind-local-registry/controllersconfig/korifi_controllers_config.yaml
@@ -2,6 +2,6 @@ cfProcessDefaults:
   memoryMB: 1024
   diskQuotaMB: 1024
 cfRootNamespace: cf
-korifi_controller_namespace: korifi-controllers-system
 packageRegistrySecretName: image-registry-credentials # Create this secret in the rootNamespace
 workloads_tls_secret_name: korifi-workloads-ingress-cert
+workloads_tls_secret_namespace: korifi-controllers-system

--- a/controllers/config/overlays/pr-e2e/controllersconfig/korifi_controllers_config.yaml
+++ b/controllers/config/overlays/pr-e2e/controllersconfig/korifi_controllers_config.yaml
@@ -2,6 +2,6 @@ cfProcessDefaults:
   memoryMB: 1024
   diskQuotaMB: 1024
 cfRootNamespace: cf
-korifi_controller_namespace: korifi-controllers-system
 packageRegistrySecretName: image-registry-credentials # Create this secret in the rootNamespace
 workloads_tls_secret_name: korifi-workloads-ingress-cert
+workloads_tls_secret_namespace: korifi-controllers-system

--- a/controllers/controllers/networking/cfroute_controller_test.go
+++ b/controllers/controllers/networking/cfroute_controller_test.go
@@ -27,16 +27,16 @@ import (
 )
 
 const (
-	testNamespace             = "test-ns"
-	testDomainGUID            = "test-domain-guid"
-	testDomainName            = "test.domain.name"
-	testRouteGUID             = "test-route-guid"
-	testRouteHost             = "test-route-host"
-	testRouteDestinationGUID  = "test-route-destination-guid"
-	testFQDN                  = testRouteHost + "." + testDomainName
-	testServiceGUID           = "s-" + testRouteDestinationGUID
-	routeGUIDLabelKey         = "korifi.cloudfoundry.org/route-guid"
-	korifiControllerNamespace = "korifi-controllers-system"
+	testNamespace               = "test-ns"
+	testDomainGUID              = "test-domain-guid"
+	testDomainName              = "test.domain.name"
+	testRouteGUID               = "test-route-guid"
+	testRouteHost               = "test-route-host"
+	testRouteDestinationGUID    = "test-route-destination-guid"
+	testFQDN                    = testRouteHost + "." + testDomainName
+	testServiceGUID             = "s-" + testRouteDestinationGUID
+	routeGUIDLabelKey           = "korifi.cloudfoundry.org/route-guid"
+	workloadsTLSSecretNamespace = "korifi-controllers-system"
 )
 
 var _ = Describe("CFRouteReconciler.Reconcile", func() {
@@ -233,7 +233,7 @@ var _ = Describe("CFRouteReconciler.Reconcile", func() {
 			scheme.Scheme,
 			zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)),
 			&config.ControllerConfig{
-				KorifiControllerNamespace: korifiControllerNamespace,
+				WorkloadsTLSSecretNamespace: workloadsTLSSecretNamespace,
 			},
 		)
 
@@ -318,7 +318,7 @@ var _ = Describe("CFRouteReconciler.Reconcile", func() {
 					Expect(fqdnProxy).NotTo(BeNil())
 
 					Expect(fqdnProxy.Spec.VirtualHost.TLS).To(PointTo(Equal(contourv1.TLS{
-						SecretName: korifiControllerNamespace + "/the-tls-secret",
+						SecretName: workloadsTLSSecretNamespace + "/the-tls-secret",
 					})))
 				})
 			})

--- a/controllers/controllers/networking/integration/suite_integration_test.go
+++ b/controllers/controllers/networking/integration/suite_integration_test.go
@@ -90,8 +90,8 @@ var _ = BeforeSuite(func() {
 				MemoryMB:    500,
 				DiskQuotaMB: 512,
 			},
-			KorifiControllerNamespace: "korifi-controllers-system",
-			WorkloadsTLSSecretName:    "korifi-workloads-ingress-cert",
+			WorkloadsTLSSecretName:      "korifi-workloads-ingress-cert",
+			WorkloadsTLSSecretNamespace: "korifi-controllers-system",
 		},
 	)).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())

--- a/controllers/controllers/workloads/integration/suite_integration_test.go
+++ b/controllers/controllers/workloads/integration/suite_integration_test.go
@@ -100,10 +100,10 @@ var _ = BeforeSuite(func() {
 			MemoryMB:    500,
 			DiskQuotaMB: 512,
 		},
-		KorifiControllerNamespace: "korifi-controllers-system",
-		PackageRegistrySecretName: packageRegistrySecretName,
-		WorkloadsTLSSecretName:    "korifi-workloads-ingress-cert",
-		CFRootNamespace:           "cf",
+		CFRootNamespace:             "cf",
+		PackageRegistrySecretName:   packageRegistrySecretName,
+		WorkloadsTLSSecretName:      "korifi-workloads-ingress-cert",
+		WorkloadsTLSSecretNamespace: "korifi-controllers-system",
 	}
 
 	err = (NewCFAppReconciler(


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
This PR renames the KorifiControllerNamespace config parameter as it is only used for the workloads TLS secret namespace.

## Does this PR introduce a breaking change?
The configuration parameter name change will be a breaking change for existing deployments.

## Acceptance Steps
Deploy Korifi following the docs and push an app.

## Tag your pair, your PM, and/or team
@clintyoshimura 