### PR TITLE
Fix the image tags for the statefulset-runner

### DIFF
--- a/statefulset-runner/Makefile
+++ b/statefulset-runner/Makefile
@@ -1,6 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= controller:latest
+IMG ?= cloudfoundry/statefulset-runner:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.23
 

--- a/statefulset-runner/config/manager/kustomization.yaml
+++ b/statefulset-runner/config/manager/kustomization.yaml
@@ -11,6 +11,6 @@ configMapGenerator:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-- name: controller
-  newName: controller
+- name: cloudfoundry/statefulset-runner
+  newName: cloudfoundry/statefulset-runner
   newTag: latest

--- a/statefulset-runner/config/manager/manager.yaml
+++ b/statefulset-runner/config/manager/manager.yaml
@@ -31,7 +31,7 @@ spec:
         - /manager
         args:
         - --leader-elect
-        image: controller:latest
+        image: cloudfoundry/statefulset-runner:latest
         imagePullPolicy: IfNotPresent
         name: manager
         securityContext:


### PR DESCRIPTION
## Is there a related GitHub Issue?
no

## What is this change about?
The statefulset-runner's build configs were incorrectly pointing to controller:latest. This is to correct it to point to the statefulset-runner image.

## Does this PR introduce a breaking change?
no

## Acceptance Steps
All tests pass

## Tag your pair, your PM, and/or team
@julian-hj 
