### PR TITLE
Fix the statefulset-runner configs to remove non existent /manager command

### DIFF
--- a/statefulset-runner/Makefile
+++ b/statefulset-runner/Makefile
@@ -99,7 +99,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	cd config/manager && $(KUSTOMIZE) edit set image cloudfoundry/statefulset-runner=${IMG}
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
 
 .PHONY: undeploy

--- a/statefulset-runner/config/manager/manager.yaml
+++ b/statefulset-runner/config/manager/manager.yaml
@@ -27,9 +27,7 @@ spec:
       securityContext:
         runAsNonRoot: true
       containers:
-      - command:
-        - /manager
-        args:
+      - args:
         - --leader-elect
         image: cloudfoundry/statefulset-runner:latest
         imagePullPolicy: IfNotPresent


### PR DESCRIPTION
## Is there a related GitHub Issue?
no

## What is this change about?
Remove the command argument in the config for statefulset-runner because /manager does not exist

## Does this PR introduce a breaking change?
no

## Acceptance Steps
Tests pass

## Tag your pair, your PM, and/or team
@julian-hj 
