### PR TITLE
Expose task state in API get and create task responses

### DIFF
--- a/api/handlers/task_handler_test.go
+++ b/api/handlers/task_handler_test.go
@@ -57,6 +57,7 @@ var _ = Describe("TaskHandler", func() {
 				CreationTimestamp: time.Date(2022, 6, 14, 13, 22, 34, 0, time.UTC),
 				MemoryMB:          256,
 				DiskMB:            128,
+				State:             "task-created",
 			}, nil)
 		})
 
@@ -85,6 +86,7 @@ var _ = Describe("TaskHandler", func() {
               "memory_in_mb": 256,
               "disk_in_mb": 128,
               "droplet_guid": "the-droplet-guid",
+              "state": "task-created",
               "relationships": {
                 "app": {
                   "data": {
@@ -195,6 +197,7 @@ var _ = Describe("TaskHandler", func() {
 				CreationTimestamp: time.Date(2022, 6, 21, 11, 11, 55, 0, time.UTC),
 				MemoryMB:          123,
 				DiskMB:            234,
+				State:             "stateful",
 			}, nil)
 
 			var err error
@@ -221,6 +224,7 @@ var _ = Describe("TaskHandler", func() {
               "memory_in_mb": 123,
               "disk_in_mb": 234,
               "droplet_guid": "droplet-guid",
+              "state": "stateful",
               "relationships": {
                 "app": {
                   "data": {

--- a/api/presenter/task.go
+++ b/api/presenter/task.go
@@ -22,6 +22,7 @@ type TaskResponse struct {
 	UpdatedAt     string        `json:"updated_at"`
 	MemoryMB      int64         `json:"memory_in_mb"`
 	DiskMB        int64         `json:"disk_in_mb"`
+	State         string        `json:"state"`
 }
 
 type TaskLinks struct {
@@ -43,6 +44,7 @@ func ForTask(responseTask repositories.TaskRecord, baseURL url.URL) TaskResponse
 		UpdatedAt:   creationTimestamp,
 		MemoryMB:    responseTask.MemoryMB,
 		DiskMB:      responseTask.DiskMB,
+		State:       responseTask.State,
 		Relationships: Relationships{
 			"app": Relationship{
 				Data: &RelationshipData{

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -108,6 +108,7 @@ type appResource struct {
 type taskResource struct {
 	resource `json:",inline"`
 	Command  string `json:"command,omitempty"`
+	State    string `json:"state,omitempty"`
 }
 
 type typedResource struct {


### PR DESCRIPTION
## Is there a related GitHub Issue?
https://github.com/cloudfoundry/korifi/issues/1032

## What is this change about?
Expose task state into the API shim

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
See story
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@kieron-dev
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

