### PR TITLE
Introduce a template for flakes

### DIFF
--- a/.github/ISSUE_TEMPLATE/flake.yml
+++ b/.github/ISSUE_TEMPLATE/flake.yml
@@ -1,0 +1,19 @@
+name: Flake Chore
+description: Log a flake
+title: "[Chore]: "
+labels: [chore,flake]
+body:
+  - type: textarea
+    id: url
+    attributes:
+      label: Build URL
+      description: Paste one or more links to builds that flaked with the new symptom
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Paste test failure logs and/or other information that may help debug the issue.
+    validations:
+      required: true


### PR DESCRIPTION
It will make it a bit easier to log a flake chore, making sure we do not miss to label it with the `flake` label