### PR TITLE
Do not propagate roles between orgs and spaces

### DIFF
--- a/controllers/config/rbac/role.yaml
+++ b/controllers/config/rbac/role.yaml
@@ -529,17 +529,6 @@ rules:
   - patch
   - watch
 - apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
-  - roles
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - watch
-- apiGroups:
   - servicebinding.io
   resources:
   - servicebindings

--- a/controllers/controllers/workloads/cforg_controller.go
+++ b/controllers/controllers/workloads/cforg_controller.go
@@ -65,7 +65,6 @@ const (
 
 //+kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=roles,verbs=create;patch;delete;get;list;watch
 //+kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=create;patch;delete;get;list;watch
 
 /* These rbac annotations are not used directly by this controller.
@@ -141,12 +140,6 @@ func (r *CFOrgReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		return ctrl.Result{}, err
 	}
 
-	err = propagateRoles(ctx, r.client, r.log, cfOrg)
-	if err != nil {
-		r.log.Error(err, fmt.Sprintf("Error propagating roles into CFOrg %s/%s", req.Namespace, req.Name))
-		return ctrl.Result{}, err
-	}
-
 	err = reconcileRoleBindings(ctx, r.client, r.log, cfOrg)
 	if err != nil {
 		r.log.Error(err, fmt.Sprintf("Error propagating role-bindings into CFOrg %s/%s", req.Namespace, req.Name))
@@ -187,10 +180,6 @@ func (r *CFOrgReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&korifiv1alpha1.CFOrg{}).
 		Watches(
 			&source.Kind{Type: &corev1.Secret{}},
-			handler.EnqueueRequestsFromMapFunc(r.enqueueCFOrgRequests),
-		).
-		Watches(
-			&source.Kind{Type: &rbacv1.Role{}},
 			handler.EnqueueRequestsFromMapFunc(r.enqueueCFOrgRequests),
 		).
 		Watches(

--- a/controllers/controllers/workloads/cfspace_controller.go
+++ b/controllers/controllers/workloads/cfspace_controller.go
@@ -73,7 +73,6 @@ func NewCFSpaceReconciler(
 
 //+kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=roles,verbs=create;patch;delete;get;list;watch
 //+kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=create;patch;delete;get;list;watch
 //+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;create
 
@@ -127,12 +126,6 @@ func (r *CFSpaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	err = propagateSecrets(ctx, r.client, r.log, cfSpace, r.packageRegistrySecretName)
 	if err != nil {
 		r.log.Error(err, fmt.Sprintf("Error propagating secrets into CFSpace %s/%s", req.Namespace, req.Name))
-		return ctrl.Result{}, err
-	}
-
-	err = propagateRoles(ctx, r.client, r.log, cfSpace)
-	if err != nil {
-		r.log.Error(err, fmt.Sprintf("Error propagating roles into CFSpace %s/%s", req.Namespace, req.Name))
 		return ctrl.Result{}, err
 	}
 
@@ -222,10 +215,6 @@ func (r *CFSpaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&korifiv1alpha1.CFSpace{}).
 		Watches(
 			&source.Kind{Type: &corev1.Secret{}},
-			handler.EnqueueRequestsFromMapFunc(r.enqueueCFSpaceRequests),
-		).
-		Watches(
-			&source.Kind{Type: &rbacv1.Role{}},
 			handler.EnqueueRequestsFromMapFunc(r.enqueueCFSpaceRequests),
 		).
 		Watches(

--- a/controllers/controllers/workloads/integration/suite_integration_test.go
+++ b/controllers/controllers/workloads/integration/suite_integration_test.go
@@ -229,11 +229,10 @@ func createSecret(ctx context.Context, k8sClient client.Client, name string, nam
 	return secret
 }
 
-func createRole(ctx context.Context, k8sClient client.Client, name string, namespace string, rules []rbacv1.PolicyRule) *rbacv1.Role {
-	role := &rbacv1.Role{
+func createClusterRole(ctx context.Context, k8sClient client.Client, name string, rules []rbacv1.PolicyRule) *rbacv1.ClusterRole {
+	role := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
+			Name: name,
 		},
 		Rules: rules,
 	}
@@ -241,7 +240,7 @@ func createRole(ctx context.Context, k8sClient client.Client, name string, names
 	return role
 }
 
-func createRoleBinding(ctx context.Context, k8sClient client.Client, roleBindingName, subjectName, roleReference, namespace string, annotations map[string]string) rbacv1.RoleBinding {
+func createClusterRoleBinding(ctx context.Context, k8sClient client.Client, roleBindingName, subjectName, roleReference, namespace string, annotations map[string]string) rbacv1.RoleBinding {
 	roleBinding := rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        roleBindingName,
@@ -253,7 +252,7 @@ func createRoleBinding(ctx context.Context, k8sClient client.Client, roleBinding
 			Name: subjectName,
 		}},
 		RoleRef: rbacv1.RoleRef{
-			Kind: "Role",
+			Kind: "ClusterRole",
 			Name: roleReference,
 		},
 	}


### PR DESCRIPTION
## Is there a related GitHub Issue?
https://github.com/cloudfoundry/korifi/issues/1318
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
CFOrg/Space controllers do not propagate roles anymore

The only reason for orgs and spaces to propagate roles was the roles
needed by the `eirini-controller` in the workloads namespaces. As of
eirini-controller 0.5.0, that role has been promoted to `ClusterRole`,
i.e. there is no need to propagate it to workload namespaces anymore.

Still, CFOrg/Space controllers keep propagating role bindings (even
though to cluster roles) as role bindings are not cluster-wide resources
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No

## Acceptance Steps
N/A

