### PR TITLE
Fix statefulset-runner image and resource names

### DIFF
--- a/statefulset-runner/Makefile
+++ b/statefulset-runner/Makefile
@@ -1,6 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= cloudfoundry/statefulset-runner:latest
+IMG_SSR ?= cloudfoundry/korifi-statefulset-runner:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.23
 
@@ -76,12 +76,12 @@ run: manifests generate fmt vet ## Run a controller from your host.
 
 .PHONY: docker-build
 docker-build: test ## Build docker image with the manager.
-	docker buildx build --load -f ./Dockerfile -t ${IMG} ..
+	docker buildx build --load -f ./Dockerfile -t ${IMG_SSR} ..
 
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
-	docker push ${IMG}
+	docker push ${IMG_SSR}
 
 ##@ Deployment
 
@@ -99,7 +99,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd config/manager && $(KUSTOMIZE) edit set image cloudfoundry/statefulset-runner=${IMG}
+	cd config/manager && $(KUSTOMIZE) edit set image cloudfoundry/korifi-statefulset-runner=${IMG_SSR}
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
 
 .PHONY: undeploy

--- a/statefulset-runner/config/default/kustomization.yaml
+++ b/statefulset-runner/config/default/kustomization.yaml
@@ -1,14 +1,14 @@
 # TODO: Remove role bindings for Service Accounts used for PSP?
 
 # Adds namespace to all resources.
-namespace: statefulset-runner-system
+namespace: korifi-statefulset-runner-system
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named
 # "wordpress" becomes "alices-wordpress".
 # Note that it should also match with the prefix (text before '-') of the namespace
 # field above.
-namePrefix: statefulset-runner-
+namePrefix: korifi-statefulset-runner-
 
 # Labels to add to all resources and selectors.
 #commonLabels:

--- a/statefulset-runner/config/manager/kustomization.yaml
+++ b/statefulset-runner/config/manager/kustomization.yaml
@@ -11,6 +11,6 @@ configMapGenerator:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-- name: cloudfoundry/statefulset-runner
-  newName: cloudfoundry/statefulset-runner
+- name: cloudfoundry/korifi-statefulset-runner
+  newName: cloudfoundry/korifi-statefulset-runner
   newTag: latest

--- a/statefulset-runner/config/manager/manager.yaml
+++ b/statefulset-runner/config/manager/manager.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
       - args:
         - --leader-elect
-        image: cloudfoundry/statefulset-runner:latest
+        image: cloudfoundry/korifi-statefulset-runner:latest
         imagePullPolicy: IfNotPresent
         name: manager
         securityContext:


### PR DESCRIPTION

<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->
No.

## What is this change about?
This PR renames the image tag `cloudfoundry/statefulset-runner` as `cloudfoundry/korifi-statefulset-runner`.
The korifi prefix clarifies that this is a korifi image, and is consistent with all of our other korifi docker images.

It also adds the korifi prefix to namespace and resource names.

## Does this PR introduce a breaking change?
No. We don't yet deploy this image in any of our tests or scripts.

## Acceptance Steps
- in `statefulset-runner` invoke `make docker-build`
- observe the new image tag
- run `load docker-image cloudfoundry/korifi-statefulset-runner:latest`
- run `make deploy`
- observe that the deployment uses the new image and deploys successfully with korifi prefixed names and namespaces.

## Tag your pair, your PM, and/or team
@davewalter @acosta11 
