### PR TITLE
Pin the `go` packeto buildpack to 1.5.0

### DIFF
--- a/dependencies/kpack/cluster_store.yaml
+++ b/dependencies/kpack/cluster_store.yaml
@@ -8,4 +8,4 @@ spec:
   - image: gcr.io/paketo-buildpacks/nodejs:0.13
   - image: gcr.io/paketo-buildpacks/ruby
   - image: gcr.io/paketo-buildpacks/procfile
-  - image: gcr.io/paketo-buildpacks/go
+  - image: gcr.io/paketo-buildpacks/go:1.5.0


### PR DESCRIPTION
latest go buildpack (as of today 1.6.0) requires buildpack api 0.8. The
buildpack api coming with the kpack version we deploy (5.2) provides
buildpack api up to 0.7

We cannot bump kpack before PR https://github.com/pivotal/kpack/pull/977
is merged.

Co-authored-by: Georgi Sabev <georgethebeatle@gmail.com>

<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Pin go buildpack to `1.5.0`

latest go buildpack (as of today 1.6.0) requires buildpack api 0.8. The
buildpack api coming with the kpack version we deploy (5.2) provides
buildpack api up to 0.7

We cannot bump kpack before PR https://github.com/pivotal/kpack/pull/977
is merged.
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
Kpack works on the Korifi deployment
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@georgethebeatle
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

