### PR TITLE
Unpin go buildpack and bump kpack to 0.6.0

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -177,7 +177,7 @@ kubectl apply -f dependencies/cert-manager.yaml
 [kpack](https://github.com/pivotal/kpack) powers our source-to-image build process.
 
 ```sh
-kubectl apply -f dependencies/kpack-release-0.5.2.yaml
+kubectl apply -f dependencies/kpack-release-0.6.0.yaml
 ```
 
 Ensure the kpack CRDs are ready:

--- a/api/repositories/repositories_suite_test.go
+++ b/api/repositories/repositories_suite_test.go
@@ -71,7 +71,7 @@ var _ = BeforeSuite(func() {
 		},
 		CRDInstallOptions: envtest.CRDInstallOptions{
 			Paths: []string{
-				filepath.Join("..", "..", "dependencies", "kpack-release-0.5.2.yaml"),
+				filepath.Join("..", "..", "dependencies", "kpack-release-0.6.0.yaml"),
 			},
 		},
 		ErrorIfCRDPathMissing: true,

--- a/dependencies/kpack-release-0.6.0.yaml
+++ b/dependencies/kpack-release-0.6.0.yaml
@@ -1,4 +1,3 @@
-
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -268,10 +267,38 @@ spec:
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  name: config-logging
+  namespace: kpack
+data:
+  zap-logger-config: |
+    {
+      "level": "info",
+      "development": false,
+      "outputPaths": ["stdout"],
+      "errorOutputPaths": ["stderr"],
+      "encoding": "json",
+      "encoderConfig": {
+        "timeKey": "ts",
+        "levelKey": "level",
+        "nameKey": "logger",
+        "callerKey": "caller",
+        "messageKey": "msg",
+        "stacktraceKey": "stacktrace",
+        "lineEnding": "",
+        "levelEncoder": "",
+        "timeEncoder": "rfc3339nano",
+        "durationEncoder": "",
+        "callerEncoder": ""
+      }
+    }
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
   name: build-init-image
   namespace: kpack
 data:
-  image: gcr.io/cf-build-service-public/kpack/build-init@sha256:358f6c68cdff4df532f81e377f51eaf50bd2828dba6a2d3c2fdba0dbad353695
+  image: gcr.io/cf-build-service-public/kpack/build-init@sha256:a68ebf8e886b3e53c9b7920e5bf39b6b67a225e9f930bdc0533f3e33e1ccb15f
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -279,7 +306,7 @@ metadata:
   name: build-init-windows-image
   namespace: kpack
 data:
-  image: gcr.io/cf-build-service-public/kpack/build-init-windows@sha256:f989746a3eeefbd04c7e22569a9ac9bdfe4b254f98887c78417fe6f0ec99d352
+  image: gcr.io/cf-build-service-public/kpack/build-init-windows@sha256:8730d4c869056068737aefa32983534cafecfcaa37c3cbcaff59c38b2d449358
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -287,7 +314,7 @@ metadata:
   name: rebase-image
   namespace: kpack
 data:
-  image: gcr.io/cf-build-service-public/kpack/rebase@sha256:dd57a8492671ecde2b5fa5fbe6fbce3813c8588faf19606c76699dff3d1b8ab8
+  image: gcr.io/cf-build-service-public/kpack/rebase@sha256:2396d57dada6fb1b43f19f8f48de79e8d25f2d85fb8c1befb7dffe61a92df0e6
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -295,7 +322,7 @@ metadata:
   name: lifecycle-image
   namespace: kpack
 data:
-  image: gcr.io/cf-build-service-public/kpack/lifecycle@sha256:0a021eacdae3166f3f116948562cc6900138a80948345f8e9c240d7cb978289a
+  image: gcr.io/cf-build-service-public/kpack/lifecycle@sha256:c7e8d312f79f5cf9918fd5c60191da9d34b750cc4183a159149835b88bf42721
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -303,7 +330,7 @@ metadata:
   name: completion-image
   namespace: kpack
 data:
-  image: gcr.io/cf-build-service-public/kpack/completion@sha256:be91b1535d09ef73319470b9aab6ba17dc44a481b64b8150468f1fc65ab8d30c
+  image: gcr.io/cf-build-service-public/kpack/completion@sha256:835d36448547643750786279fdc389566e34c362dceb68aebeee9c22a0756734
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -311,7 +338,7 @@ metadata:
   name: completion-windows-image
   namespace: kpack
 data:
-  image: gcr.io/cf-build-service-public/kpack/completion-windows@sha256:282c9ae1b181940f663baedfa3b6aa9501efc4c364fc0f76bdebcbfb6d3fae41
+  image: gcr.io/cf-build-service-public/kpack/completion-windows@sha256:369dea344c63e7c82d5565e41ccc58230508578fe105bb0ba55fd91dcbead0ac
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -327,15 +354,18 @@ spec:
     metadata:
       labels:
         app: kpack-controller
-        version: 0.5.2-rc.9
+        version: 0.6.0-rc.7
     spec:
+      priorityClassName: kpack-control-plane
       serviceAccountName: controller
       nodeSelector:
         kubernetes.io/os: linux
       containers:
       - name: controller
-        image: gcr.io/cf-build-service-public/kpack/controller@sha256:79960bbd44100593ca3ee73b5f71f38949e17a081946509b45da4c7a3f2ca35e
+        image: gcr.io/cf-build-service-public/kpack/controller@sha256:9fdec102a140d75f5c322a8f01ebfa37b57f9faa3ff2d4520905207326d64d9d
         env:
+        - name: ENABLE_PRIORITY_CLASSES
+          value: "false"
         - name: CONFIG_LOGGING_NAME
           value: config-logging
         - name: CONFIG_OBSERVABILITY_NAME
@@ -577,6 +607,31 @@ spec:
     - kpack
   scope: Namespaced
 ---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: kpack-control-plane
+value: 10000
+globalDefault: false
+description: Super High priority class for kpack control plane components
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: kpack-build-high-priority
+value: 1000
+globalDefault: false
+description: High priority class for kpack builds triggered by user changes.
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: kpack-build-low-priority
+value: 1
+globalDefault: false
+preemptionPolicy: Never
+description: Low priority class for kpack builds triggered by operator changes.
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -695,14 +750,15 @@ spec:
       labels:
         app: kpack-webhook
         role: webhook
-        version: 0.5.2-rc.9
+        version: 0.6.0-rc.7
     spec:
+      priorityClassName: kpack-control-plane
       serviceAccountName: webhook
       nodeSelector:
         kubernetes.io/os: linux
       containers:
       - name: webhook
-        image: gcr.io/cf-build-service-public/kpack/webhook@sha256:4a03886a76e2d50455bef71951a0aa65fb5bca1521627f61d4428bba97d3e2da
+        image: gcr.io/cf-build-service-public/kpack/webhook@sha256:659e53454546e3a45226eae805c62994c77a0d08e716bde263f6947395a6cee4
         ports:
         - name: https-webhook
           containerPort: 8443

--- a/dependencies/kpack/cluster_store.yaml
+++ b/dependencies/kpack/cluster_store.yaml
@@ -8,4 +8,4 @@ spec:
   - image: gcr.io/paketo-buildpacks/nodejs:0.13
   - image: gcr.io/paketo-buildpacks/ruby
   - image: gcr.io/paketo-buildpacks/procfile
-  - image: gcr.io/paketo-buildpacks/go:1.5.0
+  - image: gcr.io/paketo-buildpacks/go

--- a/kpack-image-builder/controllers/suite_test.go
+++ b/kpack-image-builder/controllers/suite_test.go
@@ -83,7 +83,7 @@ var _ = BeforeSuite(func() {
 		ErrorIfCRDPathMissing: true,
 		CRDInstallOptions: envtest.CRDInstallOptions{
 			Paths: []string{
-				filepath.Join("..", "..", "dependencies", "kpack-release-0.5.2.yaml"),
+				filepath.Join("..", "..", "dependencies", "kpack-release-0.6.0.yaml"),
 			},
 		},
 	}

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -67,7 +67,7 @@ echo "*******************"
 echo "Installing Kpack"
 echo "*******************"
 
-kubectl apply -f "${DEP_DIR}/kpack-release-0.5.2.yaml"
+kubectl apply -f "${DEP_DIR}/kpack-release-0.6.0.yaml"
 
 echo "*******************"
 echo "Configuring Kpack"


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
No

## What is this change about?
Unpin go buildpack and bump kpack to 0.6.0


We only bump kpack in `dependencies` but not in `go.mod` (because of
https://github.com/pivotal/kpack/pull/977)
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
Pushing `cf-acceptance-tests/assets/golang` works

<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->


## Tag your pair, your PM, and/or team
@georgethebeatle
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->


