### PR TITLE
App developer can view `VCAP_SERVICES` env var

### DIFF
--- a/api/handlers/app_handler.go
+++ b/api/handlers/app_handler.go
@@ -47,7 +47,7 @@ type CFAppRepository interface {
 	SetCurrentDroplet(context.Context, authorization.Info, repositories.SetCurrentDropletMessage) (repositories.CurrentDropletRecord, error)
 	SetAppDesiredState(context.Context, authorization.Info, repositories.SetAppDesiredStateMessage) (repositories.AppRecord, error)
 	DeleteApp(context.Context, authorization.Info, repositories.DeleteAppMessage) error
-	GetAppEnv(context.Context, authorization.Info, string) (map[string]string, error)
+	GetAppEnv(context.Context, authorization.Info, string) (repositories.AppEnvRecord, error)
 }
 
 //counterfeiter:generate -o fake -fake-name AppProcessScaler . AppProcessScaler
@@ -460,13 +460,13 @@ func (h *AppHandler) appGetEnvHandler(ctx context.Context, logger logr.Logger, a
 	vars := mux.Vars(r)
 	appGUID := vars["guid"]
 
-	envVars, err := h.appRepo.GetAppEnv(ctx, authInfo, appGUID)
+	appEnvRecord, err := h.appRepo.GetAppEnv(ctx, authInfo, appGUID)
 	if err != nil {
 		logger.Error(err, "Failed to fetch app environment variables", "AppGUID", appGUID)
 		return nil, err
 	}
 
-	return NewHandlerResponse(http.StatusOK).WithBody(presenter.ForAppEnv(envVars)), nil
+	return NewHandlerResponse(http.StatusOK).WithBody(presenter.ForAppEnv(appEnvRecord)), nil
 }
 
 func (h *AppHandler) getProcessByTypeForAppHander(ctx context.Context, logger logr.Logger, authInfo authorization.Info, r *http.Request) (*HandlerResponse, error) {

--- a/api/handlers/app_handler_test.go
+++ b/api/handlers/app_handler_test.go
@@ -2723,7 +2723,13 @@ var _ = Describe("AppHandler", func() {
 
 	Describe("the GET /v3/apps/:guid/env endpoint", func() {
 		BeforeEach(func() {
-			appRepo.GetAppEnvReturns(map[string]string{"VAR": "VAL"}, nil)
+			appEnvRecord := repositories.AppEnvRecord{
+				AppGUID:              appGUID,
+				SpaceGUID:            spaceGUID,
+				EnvironmentVariables: map[string]string{"VAR": "VAL"},
+				SystemEnv:            map[string]interface{}{},
+			}
+			appRepo.GetAppEnvReturns(appEnvRecord, nil)
 
 			var err error
 			req, err = http.NewRequestWithContext(ctx, "GET", "/v3/apps/"+appGUID+"/env", nil)
@@ -2757,7 +2763,7 @@ var _ = Describe("AppHandler", func() {
 
 		When("there is an error fetching the app env", func() {
 			BeforeEach(func() {
-				appRepo.GetAppEnvReturns(nil, errors.New("unknown!"))
+				appRepo.GetAppEnvReturns(repositories.AppEnvRecord{}, errors.New("unknown!"))
 			})
 
 			It("returns an error", func() {

--- a/api/handlers/fake/cfapp_repository.go
+++ b/api/handlers/fake/cfapp_repository.go
@@ -54,7 +54,7 @@ type CFAppRepository struct {
 		result1 repositories.AppRecord
 		result2 error
 	}
-	GetAppEnvStub        func(context.Context, authorization.Info, string) (map[string]string, error)
+	GetAppEnvStub        func(context.Context, authorization.Info, string) (repositories.AppEnvRecord, error)
 	getAppEnvMutex       sync.RWMutex
 	getAppEnvArgsForCall []struct {
 		arg1 context.Context
@@ -62,11 +62,11 @@ type CFAppRepository struct {
 		arg3 string
 	}
 	getAppEnvReturns struct {
-		result1 map[string]string
+		result1 repositories.AppEnvRecord
 		result2 error
 	}
 	getAppEnvReturnsOnCall map[int]struct {
-		result1 map[string]string
+		result1 repositories.AppEnvRecord
 		result2 error
 	}
 	ListAppsStub        func(context.Context, authorization.Info, repositories.ListAppsMessage) ([]repositories.AppRecord, error)
@@ -328,7 +328,7 @@ func (fake *CFAppRepository) GetAppReturnsOnCall(i int, result1 repositories.App
 	}{result1, result2}
 }
 
-func (fake *CFAppRepository) GetAppEnv(arg1 context.Context, arg2 authorization.Info, arg3 string) (map[string]string, error) {
+func (fake *CFAppRepository) GetAppEnv(arg1 context.Context, arg2 authorization.Info, arg3 string) (repositories.AppEnvRecord, error) {
 	fake.getAppEnvMutex.Lock()
 	ret, specificReturn := fake.getAppEnvReturnsOnCall[len(fake.getAppEnvArgsForCall)]
 	fake.getAppEnvArgsForCall = append(fake.getAppEnvArgsForCall, struct {
@@ -355,7 +355,7 @@ func (fake *CFAppRepository) GetAppEnvCallCount() int {
 	return len(fake.getAppEnvArgsForCall)
 }
 
-func (fake *CFAppRepository) GetAppEnvCalls(stub func(context.Context, authorization.Info, string) (map[string]string, error)) {
+func (fake *CFAppRepository) GetAppEnvCalls(stub func(context.Context, authorization.Info, string) (repositories.AppEnvRecord, error)) {
 	fake.getAppEnvMutex.Lock()
 	defer fake.getAppEnvMutex.Unlock()
 	fake.GetAppEnvStub = stub
@@ -368,28 +368,28 @@ func (fake *CFAppRepository) GetAppEnvArgsForCall(i int) (context.Context, autho
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
-func (fake *CFAppRepository) GetAppEnvReturns(result1 map[string]string, result2 error) {
+func (fake *CFAppRepository) GetAppEnvReturns(result1 repositories.AppEnvRecord, result2 error) {
 	fake.getAppEnvMutex.Lock()
 	defer fake.getAppEnvMutex.Unlock()
 	fake.GetAppEnvStub = nil
 	fake.getAppEnvReturns = struct {
-		result1 map[string]string
+		result1 repositories.AppEnvRecord
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *CFAppRepository) GetAppEnvReturnsOnCall(i int, result1 map[string]string, result2 error) {
+func (fake *CFAppRepository) GetAppEnvReturnsOnCall(i int, result1 repositories.AppEnvRecord, result2 error) {
 	fake.getAppEnvMutex.Lock()
 	defer fake.getAppEnvMutex.Unlock()
 	fake.GetAppEnvStub = nil
 	if fake.getAppEnvReturnsOnCall == nil {
 		fake.getAppEnvReturnsOnCall = make(map[int]struct {
-			result1 map[string]string
+			result1 repositories.AppEnvRecord
 			result2 error
 		})
 	}
 	fake.getAppEnvReturnsOnCall[i] = struct {
-		result1 map[string]string
+		result1 repositories.AppEnvRecord
 		result2 error
 	}{result1, result2}
 }

--- a/api/presenter/app.go
+++ b/api/presenter/app.go
@@ -172,19 +172,19 @@ func ForAppEnvVars(record repositories.AppEnvVarsRecord, baseURL url.URL) AppEnv
 }
 
 type AppEnvResponse struct {
-	EnvironmentVariables map[string]string `json:"environment_variables"`
-	StagingEnvJSON       map[string]string `json:"staging_env_json"`
-	RunningEnvJSON       map[string]string `json:"running_env_json"`
-	SystemEnvJSON        map[string]string `json:"system_env_json"`
-	ApplicationEnvJSON   map[string]string `json:"application_env_json"`
+	EnvironmentVariables map[string]string      `json:"environment_variables"`
+	StagingEnvJSON       map[string]string      `json:"staging_env_json"`
+	RunningEnvJSON       map[string]string      `json:"running_env_json"`
+	SystemEnvJSON        map[string]interface{} `json:"system_env_json"`
+	ApplicationEnvJSON   map[string]string      `json:"application_env_json"`
 }
 
-func ForAppEnv(envVars map[string]string) AppEnvResponse {
+func ForAppEnv(envVarRecord repositories.AppEnvRecord) AppEnvResponse {
 	return AppEnvResponse{
-		EnvironmentVariables: envVars,
+		EnvironmentVariables: envVarRecord.EnvironmentVariables,
 		StagingEnvJSON:       map[string]string{},
 		RunningEnvJSON:       map[string]string{},
-		SystemEnvJSON:        map[string]string{},
+		SystemEnvJSON:        envVarRecord.SystemEnv,
 		ApplicationEnvJSON:   map[string]string{},
 	}
 }

--- a/controllers/controllers/workloads/env/builder.go
+++ b/controllers/controllers/workloads/env/builder.go
@@ -14,7 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-type vcapServicesPresenter struct {
+type VcapServicesPresenter struct {
 	UserProvided []ServiceDetails `json:"user-provided,omitempty"`
 }
 
@@ -85,7 +85,7 @@ func (b *Builder) BuildVCAPServicesEnvValue(ctx context.Context, cfApp *korifiv1
 		serviceEnvs = append(serviceEnvs, serviceEnv)
 	}
 
-	toReturn, err := json.Marshal(vcapServicesPresenter{
+	toReturn, err := json.Marshal(VcapServicesPresenter{
 		UserProvided: serviceEnvs,
 	})
 	if err != nil {

--- a/tests/e2e/apps_test.go
+++ b/tests/e2e/apps_test.go
@@ -398,4 +398,55 @@ var _ = Describe("Apps", func() {
 			})
 		})
 	})
+
+	Describe("Fetch app env", func() {
+		var (
+			result       map[string]interface{}
+			instanceGUID string
+			instanceName string
+			bindingGUID  string
+		)
+
+		BeforeEach(func() {
+			createSpaceRole("space_developer", certUserName, space1GUID)
+			appGUID = createApp(space1GUID, generateGUID("app1"))
+			setEnv(appGUID, map[string]interface{}{
+				"foo": "var",
+			})
+			instanceName = generateGUID("service-instance")
+			instanceGUID = createServiceInstance(space1GUID, instanceName)
+			bindingGUID = createServiceBinding(appGUID, instanceGUID)
+		})
+
+		JustBeforeEach(func() {
+			Eventually(func() (*resty.Response, error) {
+				return certClient.R().
+					SetResult(&result).
+					Get("/v3/apps/" + appGUID + "/env")
+			}).Should(HaveRestyStatusCode(http.StatusOK), BeNil())
+		})
+
+		It("returns the app environment", func() {
+			Expect(result).To(HaveKeyWithValue("environment_variables", HaveKeyWithValue("foo", "var")))
+			Expect(result).To(HaveKeyWithValue("system_env_json", HaveKeyWithValue("VCAP_SERVICES", map[string]interface{}{
+				"user-provided": []interface{}{
+					map[string]interface{}{
+						"syslog_drain_url": nil,
+						"tags":             []interface{}{},
+						"instance_name":    instanceName,
+						"binding_guid":     bindingGUID,
+						"credentials": map[string]interface{}{
+							"type": "user-provided",
+						},
+						"volume_mounts": []interface{}{},
+						"label":         "user-provided",
+						"name":          instanceName,
+						"instance_guid": instanceGUID,
+						"binding_name":  nil,
+					},
+				},
+			})))
+		})
+
+	})
 })


### PR DESCRIPTION


<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
#1270

## What is this change about?
App developer can view VCAP_SERVICES env var via `v3/apps/:guid/env` endpoint
- `VCAP_SERVICES` env variable is now part of `system_env_json`
- added missing e2e test for `v3/apps/:guid/env` endpoint

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->
No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->
See issue #1270

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->
@davewalter 

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
