### PR TITLE
Pin version of nodejs buildpack to v0.17.1

### DIFF
--- a/dependencies/kpack/cluster_store.yaml
+++ b/dependencies/kpack/cluster_store.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   sources:
   - image: gcr.io/paketo-buildpacks/java
-  - image: gcr.io/paketo-buildpacks/nodejs:0.13
+  - image: gcr.io/paketo-buildpacks/nodejs:0.17.1
   - image: gcr.io/paketo-buildpacks/ruby
   - image: gcr.io/paketo-buildpacks/procfile
   - image: gcr.io/paketo-buildpacks/go


### PR DESCRIPTION

<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->
No

## What is this change about?
<!-- _Please describe the change here._ -->
We had pinned the version for `nodejs` buildpack to `0.13` a while ago and hadn't reverted back.
In this PR, we initially tried to unpin the version

- unpinning the version was causing builds to fail with error
`chmod /workspace: operation not permitted`

- On looking further we found an [issue is opened](https://github.com/paketo-buildpacks/nodejs/issues/602) on paketo-buildpacks/nodejs repo to address the same.

- we decided to pin to the latest compatible v0.17.1 version 

- We should unpin the nodejs version once the issue has been addressed

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->
No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->
Tests should pass.

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->
@davewalter 

