### PR TITLE
Fix panics when logging with format strings

### DIFF
--- a/api/handlers/job_handler.go
+++ b/api/handlers/job_handler.go
@@ -58,7 +58,7 @@ func (h *JobHandler) jobGetHandler(ctx context.Context, logger logr.Logger, auth
 	case appDeletePrefix, orgDeletePrefix, spaceDeletePrefix, routeDeletePrefix:
 		jobResponse = presenter.ForDeleteJob(jobGUID, jobType, h.serverURL)
 	default:
-		logger.Info("Invalid Job type: %s", jobType)
+		logger.Info(fmt.Sprintf("Invalid Job type: %s", jobType))
 		return nil, apierrors.NewNotFoundError(fmt.Errorf("invalid job type: %s", jobType), JobResourceType)
 	}
 

--- a/api/handlers/service_binding_handler.go
+++ b/api/handlers/service_binding_handler.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/url"
 
@@ -57,13 +58,13 @@ func (h *ServiceBindingHandler) createHandler(ctx context.Context, logger logr.L
 
 	app, err := h.appRepo.GetApp(ctx, authInfo, payload.Relationships.App.Data.GUID)
 	if err != nil {
-		logger.Error(err, "failed to get %s", repositories.AppResourceType)
+		logger.Error(err, fmt.Sprintf("failed to get %s", repositories.AppResourceType))
 		return nil, err
 	}
 
 	serviceInstance, err := h.serviceInstanceRepo.GetServiceInstance(ctx, authInfo, payload.Relationships.ServiceInstance.Data.GUID)
 	if err != nil {
-		logger.Error(err, "failed to get %s", repositories.ServiceInstanceResourceType)
+		logger.Error(err, fmt.Sprintf("failed to get %s", repositories.ServiceInstanceResourceType))
 		return nil, err
 	}
 
@@ -114,7 +115,7 @@ func (h *ServiceBindingHandler) listHandler(ctx context.Context, logger logr.Log
 
 	serviceBindingList, err := h.serviceBindingRepo.ListServiceBindings(ctx, authInfo, listFilter.ToMessage())
 	if err != nil {
-		logger.Error(err, "failed to list %s", repositories.ServiceBindingResourceType)
+		logger.Error(err, fmt.Sprintf("failed to list %s", repositories.ServiceBindingResourceType))
 		return nil, err
 	}
 
@@ -128,7 +129,7 @@ func (h *ServiceBindingHandler) listHandler(ctx context.Context, logger logr.Log
 
 		appRecords, err = h.appRepo.ListApps(ctx, authInfo, listAppsMessage)
 		if err != nil {
-			logger.Error(err, "failed to list %s", repositories.AppResourceType)
+			logger.Error(err, fmt.Sprintf("failed to list %s", repositories.AppResourceType))
 			return nil, err
 		}
 	}

--- a/controllers/controllers/workloads/cfprocess_controller.go
+++ b/controllers/controllers/workloads/cfprocess_controller.go
@@ -129,7 +129,7 @@ func (r *CFProcessReconciler) createOrPatchLRP(ctx context.Context, cfApp *korif
 
 	envVars, err := r.EnvBuilder.BuildEnv(ctx, cfApp)
 	if err != nil {
-		r.Log.Error(err, "error when trying build the process environment for app: %s/%s", cfProcess.Namespace, cfApp.Spec.DisplayName)
+		r.Log.Error(err, fmt.Sprintf("error when trying build the process environment for app: %s/%s", cfProcess.Namespace, cfApp.Spec.DisplayName))
 		return err
 	}
 


### PR DESCRIPTION

## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->
No.

## What is this change about?
<!-- _Please describe the change here._ -->
- the logger requires Sprintf when formatting error strings and panics if we log with an odd number of trailing arguments.
- we *think* we found all of the offending log lines and fixed them here.
- see [this example](https://go.dev/play/p/yzVGHCN3_D-) to replicate the panic we were getting in the API logs.

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->
No.

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->
CI should pass e2e tests (The API shim was panicing)
Also look for gpanic in the API shim logs

## Tag your pair, your PM, and/or team
@acosta11 
