### PR TITLE
Fix service instance env flake

### DIFF
--- a/tests/e2e/apps_test.go
+++ b/tests/e2e/apps_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/go-resty/resty/v2"
 	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 )
@@ -446,6 +447,13 @@ var _ = Describe("Apps", func() {
 					SetResult(&result).
 					Get("/v3/apps/" + appGUID + "/env")
 			}).Should(HaveRestyStatusCode(http.StatusOK), BeNil())
+
+			Eventually(func(g gomega.Gomega) {
+				resp, err := certClient.R().SetResult(&result).Get("/v3/apps/" + appGUID + "/env")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(resp).To(HaveRestyStatusCode(http.StatusOK))
+				g.Expect(result).To(HaveKeyWithValue("system_env_json", HaveKey("VCAP_SERVICES")))
+			}).Should(Succeed())
 		})
 
 		It("returns the app environment", func() {
@@ -469,6 +477,5 @@ var _ = Describe("Apps", func() {
 				},
 			})))
 		})
-
 	})
 })


### PR DESCRIPTION
## Is there a related GitHub Issue?

No

## What is this change about?

This change fixes the following flake:

https://ci.korifi.cf-app.com/teams/main/pipelines/main/jobs/run-e2es-main/builds/109#L62c509cc:254:286

The VCAP_SERVICES env var is coming from a secret that might not have
been set at the time of query. This fix is waiting for the VCAP_SERVICES
key to appear before inspecting its value. While this fixes the flake is
this behaviour desired? This means that users will have to retry until
they finally see their service instance related env vars

## Does this PR introduce a breaking change?

No

## Acceptance Steps

Green tests

## Tag your pair, your PM, and/or team

@eirini
