### PR TITLE
Include body in create space error

### DIFF
--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -305,7 +305,7 @@ func createOrgRaw(orgName string) (string, error) {
 		return "", err
 	}
 	if resp.StatusCode() != http.StatusCreated {
-		return "", fmt.Errorf("expected status code %d, got %d\n%s", http.StatusCreated, resp.StatusCode(), string(resp.Body()))
+		return "", fmt.Errorf("expected status code %d, got %d, body: %s", http.StatusCreated, resp.StatusCode(), string(resp.Body()))
 	}
 
 	return org.GUID, nil
@@ -348,7 +348,7 @@ func createSpaceRaw(spaceName, orgGUID string) (string, error) {
 	}
 
 	if resp.StatusCode() != http.StatusCreated {
-		return "", fmt.Errorf("expected status code %d, got %d", http.StatusCreated, resp.StatusCode())
+		return "", fmt.Errorf("expected status code %d, got %d, body: %s", http.StatusCreated, resp.StatusCode(), string(resp.Body()))
 	}
 
 	return space.GUID, nil


### PR DESCRIPTION
## Is there a related GitHub Issue?
https://github.com/cloudfoundry/korifi/issues/1291

## What is this change about?
Improve error logging when create{Org,Space}Raw fails by including the body from the http response

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
