### PR TITLE
Introduce API endpoints to cancel tasks

### DIFF
--- a/api/handlers/fake/cftask_repository.go
+++ b/api/handlers/fake/cftask_repository.go
@@ -11,6 +11,21 @@ import (
 )
 
 type CFTaskRepository struct {
+	CancelTaskStub        func(context.Context, authorization.Info, string) (repositories.TaskRecord, error)
+	cancelTaskMutex       sync.RWMutex
+	cancelTaskArgsForCall []struct {
+		arg1 context.Context
+		arg2 authorization.Info
+		arg3 string
+	}
+	cancelTaskReturns struct {
+		result1 repositories.TaskRecord
+		result2 error
+	}
+	cancelTaskReturnsOnCall map[int]struct {
+		result1 repositories.TaskRecord
+		result2 error
+	}
 	CreateTaskStub        func(context.Context, authorization.Info, repositories.CreateTaskMessage) (repositories.TaskRecord, error)
 	createTaskMutex       sync.RWMutex
 	createTaskArgsForCall []struct {
@@ -58,6 +73,72 @@ type CFTaskRepository struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *CFTaskRepository) CancelTask(arg1 context.Context, arg2 authorization.Info, arg3 string) (repositories.TaskRecord, error) {
+	fake.cancelTaskMutex.Lock()
+	ret, specificReturn := fake.cancelTaskReturnsOnCall[len(fake.cancelTaskArgsForCall)]
+	fake.cancelTaskArgsForCall = append(fake.cancelTaskArgsForCall, struct {
+		arg1 context.Context
+		arg2 authorization.Info
+		arg3 string
+	}{arg1, arg2, arg3})
+	stub := fake.CancelTaskStub
+	fakeReturns := fake.cancelTaskReturns
+	fake.recordInvocation("CancelTask", []interface{}{arg1, arg2, arg3})
+	fake.cancelTaskMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *CFTaskRepository) CancelTaskCallCount() int {
+	fake.cancelTaskMutex.RLock()
+	defer fake.cancelTaskMutex.RUnlock()
+	return len(fake.cancelTaskArgsForCall)
+}
+
+func (fake *CFTaskRepository) CancelTaskCalls(stub func(context.Context, authorization.Info, string) (repositories.TaskRecord, error)) {
+	fake.cancelTaskMutex.Lock()
+	defer fake.cancelTaskMutex.Unlock()
+	fake.CancelTaskStub = stub
+}
+
+func (fake *CFTaskRepository) CancelTaskArgsForCall(i int) (context.Context, authorization.Info, string) {
+	fake.cancelTaskMutex.RLock()
+	defer fake.cancelTaskMutex.RUnlock()
+	argsForCall := fake.cancelTaskArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *CFTaskRepository) CancelTaskReturns(result1 repositories.TaskRecord, result2 error) {
+	fake.cancelTaskMutex.Lock()
+	defer fake.cancelTaskMutex.Unlock()
+	fake.CancelTaskStub = nil
+	fake.cancelTaskReturns = struct {
+		result1 repositories.TaskRecord
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *CFTaskRepository) CancelTaskReturnsOnCall(i int, result1 repositories.TaskRecord, result2 error) {
+	fake.cancelTaskMutex.Lock()
+	defer fake.cancelTaskMutex.Unlock()
+	fake.CancelTaskStub = nil
+	if fake.cancelTaskReturnsOnCall == nil {
+		fake.cancelTaskReturnsOnCall = make(map[int]struct {
+			result1 repositories.TaskRecord
+			result2 error
+		})
+	}
+	fake.cancelTaskReturnsOnCall[i] = struct {
+		result1 repositories.TaskRecord
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *CFTaskRepository) CreateTask(arg1 context.Context, arg2 authorization.Info, arg3 repositories.CreateTaskMessage) (repositories.TaskRecord, error) {
@@ -261,6 +342,8 @@ func (fake *CFTaskRepository) ListTasksReturnsOnCall(i int, result1 []repositori
 func (fake *CFTaskRepository) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.cancelTaskMutex.RLock()
+	defer fake.cancelTaskMutex.RUnlock()
 	fake.createTaskMutex.RLock()
 	defer fake.createTaskMutex.RUnlock()
 	fake.getTaskMutex.RLock()

--- a/api/presenter/task.go
+++ b/api/presenter/task.go
@@ -1,6 +1,7 @@
 package presenter
 
 import (
+	"net/http"
 	"net/url"
 	"time"
 
@@ -35,6 +36,7 @@ type TaskLinks struct {
 	Self    Link `json:"self"`
 	App     Link `json:"app"`
 	Droplet Link `json:"droplet"`
+	Cancel  Link `json:"cancel"`
 }
 
 func ForTask(responseTask repositories.TaskRecord, baseURL url.URL) TaskResponse {
@@ -65,6 +67,10 @@ func ForTask(responseTask repositories.TaskRecord, baseURL url.URL) TaskResponse
 			},
 			Droplet: Link{
 				HRef: buildURL(baseURL).appendPath(dropletsBase, responseTask.DropletGUID).build(),
+			},
+			Cancel: Link{
+				HRef:   buildURL(baseURL).appendPath(tasksBase, responseTask.GUID, "actions", "cancel").build(),
+				Method: http.MethodPost,
 			},
 		},
 	}

--- a/api/repositories/app_repository.go
+++ b/api/repositories/app_repository.go
@@ -1,7 +1,6 @@
 package repositories
 
 import (
-	"code.cloudfoundry.org/korifi/controllers/controllers/workloads/env"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -13,6 +12,7 @@ import (
 	"code.cloudfoundry.org/korifi/api/authorization"
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"code.cloudfoundry.org/korifi/controllers/controllers/workloads"
+	"code.cloudfoundry.org/korifi/controllers/controllers/workloads/env"
 	"code.cloudfoundry.org/korifi/controllers/webhooks"
 
 	"github.com/google/uuid"

--- a/controllers/webhooks/cf_validation_errors.go
+++ b/controllers/webhooks/cf_validation_errors.go
@@ -23,6 +23,10 @@ func (v ValidationError) Error() string {
 	return "ValidationError-" + v.Type + ": " + v.Message
 }
 
+func (v ValidationError) GetMessage() string {
+	return v.Message
+}
+
 func (v ValidationError) ExportJSONError() error {
 	bytes, err := json.Marshal(v)
 	if err != nil { // This (probably) can't fail, untested

--- a/controllers/webhooks/workloads/integration/cftask_validator_test.go
+++ b/controllers/webhooks/workloads/integration/cftask_validator_test.go
@@ -137,7 +137,7 @@ var _ = Describe("CFTask Update", func() {
 				Expect(ok).To(BeTrue())
 
 				Expect(validationErr.Type).To(Equal(workloads.CancelationNotPossibleErrorType))
-				Expect(validationErr.Message).To(ContainSubstring("it has already terminated"))
+				Expect(validationErr.Message).To(ContainSubstring("cannot be canceled"))
 			})
 		})
 
@@ -152,7 +152,7 @@ var _ = Describe("CFTask Update", func() {
 				Expect(ok).To(BeTrue())
 
 				Expect(validationErr.Type).To(Equal(workloads.CancelationNotPossibleErrorType))
-				Expect(validationErr.Message).To(ContainSubstring("it has already terminated"))
+				Expect(validationErr.Message).To(ContainSubstring("cannot be canceled"))
 			})
 		})
 


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?

https://github.com/cloudfoundry/korifi/issues/1041

<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?

Introduce API endpoints to cancel tasks

```
POST /v3/tasks/{taskGUID}/actions/cancel
PUT /v3/tasks/{taskGUID}/cancel
```

Also, add a `cancel` href to task responses

<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?

No

<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps

See story

<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team

@kieron-dev

<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->
