### PR TITLE
Add pod mutating webhook to apply indexes

### DIFF
--- a/statefulset-runner/Makefile
+++ b/statefulset-runner/Makefile
@@ -40,8 +40,15 @@ help: ## Display this help.
 ##@ Development
 
 .PHONY: manifests
-manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
+manifests: manifest-configs kustomize-webhook-config
+
+.PHONY: manifest-configs
+manifest-configs: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) rbac:roleName=runworkload-manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+
+.PHONY: kustomize-webhook-config
+kustomize-webhook-config: kustomize
+	$(KUSTOMIZE) build config/webhook -o config/webhook/generated/envtest-webhook-config.yaml
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.

--- a/statefulset-runner/PROJECT
+++ b/statefulset-runner/PROJECT
@@ -13,4 +13,11 @@ resources:
   kind: RunWorkload
   path: code.cloudfoundry.org/korifi/statefulset-runner/api/v1alpha1
   version: v1alpha1
+- group: ""
+  kind: Pod
+  path: k8s.io/api/core/v1
+  version: v1
+  webhooks:
+    defaulting: true
+    webhookVersion: v1
 version: "3"

--- a/statefulset-runner/api/v1/pod_webhook.go
+++ b/statefulset-runner/api/v1/pod_webhook.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	"code.cloudfoundry.org/korifi/statefulset-runner/controllers"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// log is for logging in this package.
+var podlog = logf.Log.WithName("pod-resource")
+
+type STSPodDefaulter struct{}
+
+func NewSTSPodDefaulter() *STSPodDefaulter {
+	return &STSPodDefaulter{}
+}
+
+func (r *STSPodDefaulter) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(&corev1.Pod{}).
+		WithDefaulter(r).
+		Complete()
+}
+
+// Mutate path is found here: https://github.com/kubernetes-sigs/controller-runtime/blob/15154aaa67679df320008ed45534f83ff3d6922d/pkg/builder/webhook.go#L201-L204
+//+kubebuilder:webhook:path=/mutate--v1-pod,mutating=true,failurePolicy=fail,sideEffects=None,groups="",resources=pods,verbs=create,versions=v1,name=mpod.korifi.cloudfoundry.org,admissionReviewVersions=v1
+
+var _ webhook.CustomDefaulter = &STSPodDefaulter{}
+
+// Default implements webhook.Defaulter so a webhook will be registered for the type
+func (r *STSPodDefaulter) Default(ctx context.Context, obj runtime.Object) error {
+	podlog.Info("default", "name", obj.DeepCopyObject().GetObjectKind())
+
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a Pod but got a %T", obj))
+	}
+
+	index, err := parseAppIndex(pod.Name)
+	if err != nil {
+		return err
+	}
+
+	for c := range pod.Spec.Containers {
+		container := &pod.Spec.Containers[c]
+		if container.Name == controllers.ApplicationContainerName {
+			cfInstanceVar := corev1.EnvVar{Name: controllers.EnvCFInstanceIndex, Value: index}
+			container.Env = append(container.Env, cfInstanceVar)
+
+			podlog.Info(fmt.Sprintf("patching-instance-index env-var - %s: %s", controllers.EnvCFInstanceIndex, index))
+
+			return nil
+		}
+	}
+
+	return nil
+}
+
+func parseAppIndex(podName string) (string, error) {
+	expression := `-(\d+)$`
+	r := regexp.MustCompile(expression)
+	match := r.FindStringSubmatch(podName)
+
+	if len(match) == 0 {
+		return "", fmt.Errorf("pod %s name does not contain an index", podName)
+	}
+
+	return match[1], nil
+}

--- a/statefulset-runner/api/v1/pod_webhook_test.go
+++ b/statefulset-runner/api/v1/pod_webhook_test.go
@@ -1,0 +1,78 @@
+package v1_test
+
+import (
+	"code.cloudfoundry.org/korifi/controllers/controllers/workloads/testutils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	// . "github.com/onsi/gomega/gstruct"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("StatefulSet Runner Pod Mutating Webhook", func() {
+	var (
+		namespace string
+		stsPod    *corev1.Pod
+	)
+
+	BeforeEach(func() {
+		namespace = testutils.PrefixedGUID("ns")
+		err := k8sClient.Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespace,
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		stsPod = &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testutils.PrefixedGUID("pod") + "-1",
+				Namespace: namespace,
+			},
+			Spec: corev1.PodSpec{
+				InitContainers: []corev1.Container{{
+					Name:    "init-1",
+					Image:   "alpine",
+					Command: []string{"sleep", "1234"},
+				}},
+				Containers: []corev1.Container{{
+					Name:    "application",
+					Image:   "alpine",
+					Command: []string{"sleep", "9876"},
+				}},
+			},
+		}
+	})
+
+	JustBeforeEach(func() {
+		Expect(k8sClient.Create(ctx, stsPod)).To(Succeed())
+		lookupKey := client.ObjectKeyFromObject(stsPod)
+		Eventually(func(g Gomega) {
+			g.Expect(k8sClient.Get(ctx, lookupKey, stsPod)).To(Succeed())
+		}).Should(Succeed())
+	})
+
+	When("the pod has the `korifi.cloudfoundry.org/add-stsr-index: \"true\"` label", func() {
+		BeforeEach(func() {
+			stsPod.Labels = map[string]string{
+				"korifi.cloudfoundry.org/add-stsr-index": "true",
+			}
+		})
+
+		It("the application container has a CF_INSTANCE_INDEX ENVVAR", func() {
+			Expect(stsPod.Labels).To(HaveKeyWithValue("korifi.cloudfoundry.org/add-stsr-index", "true"))
+			Expect(stsPod.Spec.Containers[0].Env).ToNot(BeEmpty())
+			Expect(stsPod.Spec.Containers[0].Env[0].Name).To(Equal("CF_INSTANCE_INDEX"))
+			Expect(stsPod.Spec.Containers[0].Env[0].Value).To(Equal("1"))
+		})
+	})
+
+	When("the pod does not have the `korifi.cloudfoundry.org/add-stsr-index: \"true\"` label", func() {
+		It("the application container has a CF_INSTANCE_INDEX ENVVAR", func() {
+			Expect(stsPod.Spec.Containers[0].Env).To(BeEmpty())
+		})
+	})
+})

--- a/statefulset-runner/api/v1/webhook_suite_test.go
+++ b/statefulset-runner/api/v1/webhook_suite_test.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1_test
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
+	v1 "code.cloudfoundry.org/korifi/statefulset-runner/api/v1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+
+	//+kubebuilder:scaffold:imports
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+var (
+	cfg       *rest.Config
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+	ctx       context.Context
+	cancel    context.CancelFunc
+)
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "Webhook Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	ctx, cancel = context.WithCancel(context.TODO())
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: false,
+		WebhookInstallOptions: envtest.WebhookInstallOptions{
+			Paths: []string{filepath.Join("..", "..", "config", "webhook", "generated")},
+		},
+	}
+
+	var err error
+	// cfg is defined in this file globally.
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	scheme := runtime.NewScheme()
+	err = v1alpha1.AddToScheme(scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = admissionv1beta1.AddToScheme(scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = corev1.AddToScheme(scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	//+kubebuilder:scaffold:scheme
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
+	// start webhook server using Manager
+	webhookInstallOptions := &testEnv.WebhookInstallOptions
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:             scheme,
+		Host:               webhookInstallOptions.LocalServingHost,
+		Port:               webhookInstallOptions.LocalServingPort,
+		CertDir:            webhookInstallOptions.LocalServingCertDir,
+		LeaderElection:     false,
+		MetricsBindAddress: "0",
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	err = (&v1.STSPodDefaulter{}).SetupWebhookWithManager(mgr)
+	Expect(err).NotTo(HaveOccurred())
+
+	//+kubebuilder:scaffold:webhook
+
+	go func() {
+		defer GinkgoRecover()
+		err = mgr.Start(ctx)
+		Expect(err).NotTo(HaveOccurred())
+	}()
+
+	// wait for the webhook server to get ready
+	dialer := &net.Dialer{Timeout: time.Second}
+	addrPort := fmt.Sprintf("%s:%d", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
+	Eventually(func() error {
+		conn, err := tls.DialWithDialer(dialer, "tcp", addrPort, &tls.Config{InsecureSkipVerify: true})
+		if err != nil {
+			return err
+		}
+		conn.Close()
+		return nil
+	}).Should(Succeed())
+})
+
+var _ = AfterSuite(func() {
+	cancel()
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/statefulset-runner/config/certmanager/certificate.yaml
+++ b/statefulset-runner/config/certmanager/certificate.yaml
@@ -1,0 +1,25 @@
+# The following manifests contain a self-signed issuer CR and a certificate CR.
+# More document can be found at https://docs.cert-manager.io
+# WARNING: Targets CertManager v1.0. Check https://cert-manager.io/docs/installation/upgrading/ for breaking changes.
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+  namespace: system
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
+  namespace: system
+spec:
+  # $(SERVICE_NAME) and $(SERVICE_NAMESPACE) will be substituted by kustomize
+  dnsNames:
+  - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
+  - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: webhook-server-cert # this secret will not be prefixed, since it's not managed by kustomize

--- a/statefulset-runner/config/certmanager/kustomization.yaml
+++ b/statefulset-runner/config/certmanager/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+- certificate.yaml
+
+configurations:
+- kustomizeconfig.yaml

--- a/statefulset-runner/config/certmanager/kustomizeconfig.yaml
+++ b/statefulset-runner/config/certmanager/kustomizeconfig.yaml
@@ -1,0 +1,16 @@
+# This configuration is for teaching kustomize how to update name ref and var substitution 
+nameReference:
+- kind: Issuer
+  group: cert-manager.io
+  fieldSpecs:
+  - kind: Certificate
+    group: cert-manager.io
+    path: spec/issuerRef/name
+
+varReference:
+- kind: Certificate
+  group: cert-manager.io
+  path: spec/commonName
+- kind: Certificate
+  group: cert-manager.io
+  path: spec/dnsNames

--- a/statefulset-runner/config/default/kustomization.yaml
+++ b/statefulset-runner/config/default/kustomization.yaml
@@ -20,9 +20,9 @@ bases:
 - ../manager
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-#- ../webhook
+- ../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
-#- ../certmanager
+- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
@@ -38,39 +38,39 @@ patchesStrategicMerge:
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-#- manager_webhook_patch.yaml
+- manager_webhook_patch.yaml
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
 # 'CERTMANAGER' needs to be enabled to use ca injection
-#- webhookcainjection_patch.yaml
+- webhookcainjection_patch.yaml
 
 # the following config is for teaching kustomize how to do var substitution
 vars:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
-#- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
-#  objref:
-#    kind: Certificate
-#    group: cert-manager.io
-#    version: v1
-#    name: serving-cert # this name should match the one in certificate.yaml
-#  fieldref:
-#    fieldpath: metadata.namespace
-#- name: CERTIFICATE_NAME
-#  objref:
-#    kind: Certificate
-#    group: cert-manager.io
-#    version: v1
-#    name: serving-cert # this name should match the one in certificate.yaml
-#- name: SERVICE_NAMESPACE # namespace of the service
-#  objref:
-#    kind: Service
-#    version: v1
-#    name: webhook-service
-#  fieldref:
-#    fieldpath: metadata.namespace
-#- name: SERVICE_NAME
-#  objref:
-#    kind: Service
-#    version: v1
-#    name: webhook-service
+- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
+  objref:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert # this name should match the one in certificate.yaml
+  fieldref:
+    fieldpath: metadata.namespace
+- name: CERTIFICATE_NAME
+  objref:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert # this name should match the one in certificate.yaml
+- name: SERVICE_NAMESPACE # namespace of the service
+  objref:
+    kind: Service
+    version: v1
+    name: webhook-service
+  fieldref:
+    fieldpath: metadata.namespace
+- name: SERVICE_NAME
+  objref:
+    kind: Service
+    version: v1
+    name: webhook-service

--- a/statefulset-runner/config/default/manager_webhook_patch.yaml
+++ b/statefulset-runner/config/default/manager_webhook_patch.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: webhook-server-cert

--- a/statefulset-runner/config/default/webhookcainjection_patch.yaml
+++ b/statefulset-runner/config/default/webhookcainjection_patch.yaml
@@ -1,0 +1,15 @@
+# This patch add annotation to admission webhook config and
+# the variables $(CERTIFICATE_NAMESPACE) and $(CERTIFICATE_NAME) will be substituted by kustomize.
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+# ---
+# apiVersion: admissionregistration.k8s.io/v1
+# kind: ValidatingWebhookConfiguration
+# metadata:
+#   name: validating-webhook-configuration
+#   annotations:
+#     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)

--- a/statefulset-runner/config/webhook/generated/envtest-webhook-config.yaml
+++ b/statefulset-runner/config/webhook/generated/envtest-webhook-config.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: webhook-service
+  namespace: system
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    control-plane: controller-manager
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate--v1-pod
+  failurePolicy: Fail
+  name: mpod.korifi.cloudfoundry.org
+  objectSelector:
+    matchLabels:
+      korifi.cloudfoundry.org/add-stsr-index: "true"
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+  sideEffects: None

--- a/statefulset-runner/config/webhook/kustomization.yaml
+++ b/statefulset-runner/config/webhook/kustomization.yaml
@@ -1,0 +1,9 @@
+resources:
+- manifests.yaml
+- service.yaml
+
+patchesStrategicMerge:
+- patches/object_selector_patch.yaml
+
+configurations:
+- kustomizeconfig.yaml

--- a/statefulset-runner/config/webhook/kustomizeconfig.yaml
+++ b/statefulset-runner/config/webhook/kustomizeconfig.yaml
@@ -1,0 +1,25 @@
+# the following config is for teaching kustomize where to look at when substituting vars.
+# It requires kustomize v2.1.0 or newer to work properly.
+nameReference:
+- kind: Service
+  version: v1
+  fieldSpecs:
+  - kind: MutatingWebhookConfiguration
+    group: admissionregistration.k8s.io
+    path: webhooks/clientConfig/service/name
+  # - kind: ValidatingWebhookConfiguration
+  #   group: admissionregistration.k8s.io
+  #   path: webhooks/clientConfig/service/name
+
+namespace:
+- kind: MutatingWebhookConfiguration
+  group: admissionregistration.k8s.io
+  path: webhooks/clientConfig/service/namespace
+  create: true
+# - kind: ValidatingWebhookConfiguration
+#   group: admissionregistration.k8s.io
+#   path: webhooks/clientConfig/service/namespace
+#   create: true
+
+varReference:
+- path: metadata/annotations

--- a/statefulset-runner/config/webhook/manifests.yaml
+++ b/statefulset-runner/config/webhook/manifests.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate--v1-pod
+  failurePolicy: Fail
+  name: mpod.korifi.cloudfoundry.org
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+  sideEffects: None

--- a/statefulset-runner/config/webhook/patches/object_selector_patch.yaml
+++ b/statefulset-runner/config/webhook/patches/object_selector_patch.yaml
@@ -1,0 +1,10 @@
+# This patch adds objectSelector to the webhook config
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+webhooks:
+- name: mpod.korifi.cloudfoundry.org
+  objectSelector:
+    matchLabels:
+      korifi.cloudfoundry.org/add-stsr-index: "true"

--- a/statefulset-runner/config/webhook/service.yaml
+++ b/statefulset-runner/config/webhook/service.yaml
@@ -1,0 +1,13 @@
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: webhook-service
+  namespace: system
+spec:
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 9443
+  selector:
+    control-plane: controller-manager

--- a/statefulset-runner/controllers/runworkload_controller.go
+++ b/statefulset-runner/controllers/runworkload_controller.go
@@ -52,6 +52,7 @@ const (
 	EnvCFInstanceIP         = "CF_INSTANCE_IP"
 	EnvCFInstanceGUID       = "CF_INSTANCE_GUID"
 	EnvCFInstanceInternalIP = "CF_INSTANCE_INTERNAL_IP"
+	EnvCFInstanceIndex      = "CF_INSTANCE_INDEX"
 
 	// StatefulSet Keys
 	AnnotationVersion     = "korifi.cloudfoundry.org/version"
@@ -64,7 +65,7 @@ const (
 	LabelRunWorkloadGUID = "korifi.cloudfoundry.org/run-workload-guid"
 	LabelProcessType     = "korifi.cloudfoundry.org/process-type"
 
-	ApplicationContainerName = "app"
+	ApplicationContainerName = "application"
 
 	LivenessFailureThreshold  = 4
 	ReadinessFailureThreshold = 1


### PR DESCRIPTION
## Is there a related GitHub Issue?
#1234 

## What is this change about?
Adds a mutating webhook to add CF_INSTANCE_INDEX env var to pods created by statefulsets that have a `"korifi.cloudfoundry.org/add-stsr-index": "true"` label

## Does this PR introduce a breaking change?
No.

## Acceptance Steps
* Run tests.
* Deploy statefulset-runner and apply a statefulset with `"korifi.cloudfoundry.org/add-stsr-index": "true"` in pod spec label

## Tag your pair, your PM, and/or team
@akrishna90 @matt-royal @tcdowney 
