### PR TITLE
Common handling of webhook validation errors

### DIFF
--- a/api/apierrors/errors.go
+++ b/api/apierrors/errors.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"strings"
 
+	"code.cloudfoundry.org/korifi/controllers/webhooks"
 	"github.com/go-logr/logr"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 )
@@ -253,6 +254,10 @@ func NewPackageBitsAlreadyUploadedError(cause error) PackageBitsAlreadyUploadedE
 }
 
 func FromK8sError(err error, resourceType string) error {
+	if webhookValidationError, ok := webhooks.WebhookErrorToValidationError(err); ok {
+		return NewUnprocessableEntityError(err, webhookValidationError.GetMessage())
+	}
+
 	switch {
 	case k8serrors.IsUnauthorized(err):
 		return NewInvalidAuthError(err)

--- a/api/repositories/app_repository.go
+++ b/api/repositories/app_repository.go
@@ -220,9 +220,8 @@ func (f *AppRepo) CreateApp(ctx context.Context, authInfo authorization.Info, ap
 	if err != nil {
 		if validationError, ok := webhooks.WebhookErrorToValidationError(err); ok {
 			if validationError.Type == webhooks.DuplicateNameErrorType {
-				return AppRecord{}, apierrors.NewUniquenessError(err, validationError.Error())
+				return AppRecord{}, apierrors.NewUniquenessError(err, validationError.GetMessage())
 			}
-			return AppRecord{}, apierrors.NewUnprocessableEntityError(err, validationError.Error())
 		}
 
 		return AppRecord{}, apierrors.FromK8sError(err, AppResourceType)

--- a/api/repositories/org_repository.go
+++ b/api/repositories/org_repository.go
@@ -8,7 +8,6 @@ import (
 	"code.cloudfoundry.org/korifi/api/apierrors"
 	"code.cloudfoundry.org/korifi/api/authorization"
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
-	"code.cloudfoundry.org/korifi/controllers/webhooks"
 
 	"github.com/google/uuid"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -88,10 +87,7 @@ func (r *OrgRepo) CreateOrg(ctx context.Context, info authorization.Info, messag
 	})
 
 	if err != nil {
-		if webhookError, ok := webhooks.WebhookErrorToValidationError(err); ok { // untested
-			return OrgRecord{}, apierrors.NewUnprocessableEntityError(err, webhookError.Error())
-		}
-		return OrgRecord{}, err
+		return OrgRecord{}, apierrors.FromK8sError(err, OrgResourceType)
 	}
 
 	return OrgRecord{

--- a/api/repositories/route_repository.go
+++ b/api/repositories/route_repository.go
@@ -7,7 +7,6 @@ import (
 	"code.cloudfoundry.org/korifi/api/apierrors"
 	"code.cloudfoundry.org/korifi/api/authorization"
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
-	"code.cloudfoundry.org/korifi/controllers/webhooks"
 
 	"github.com/google/uuid"
 	v1 "k8s.io/api/core/v1"
@@ -315,9 +314,6 @@ func (f *RouteRepo) CreateRoute(ctx context.Context, authInfo authorization.Info
 
 	err = userClient.Create(ctx, &cfRoute)
 	if err != nil {
-		if validationError, ok := webhooks.WebhookErrorToValidationError(err); ok {
-			return RouteRecord{}, apierrors.NewUnprocessableEntityError(err, validationError.Error())
-		}
 		return RouteRecord{}, apierrors.FromK8sError(err, RouteResourceType)
 	}
 
@@ -370,9 +366,6 @@ func (f *RouteRepo) AddDestinationsToRoute(ctx context.Context, authInfo authori
 
 	err = userClient.Patch(ctx, cfRoute, client.MergeFrom(baseCFRoute))
 	if err != nil {
-		if validationError, ok := webhooks.WebhookErrorToValidationError(err); ok {
-			return RouteRecord{}, apierrors.NewUnprocessableEntityError(err, validationError.Error())
-		}
 		return RouteRecord{}, fmt.Errorf("failed to add destination to route %q: %w", message.RouteGUID, apierrors.FromK8sError(err, RouteResourceType))
 	}
 
@@ -410,9 +403,6 @@ func (f *RouteRepo) RemoveDestinationFromRoute(ctx context.Context, authInfo aut
 
 	err = userClient.Patch(ctx, cfRoute, client.MergeFrom(baseCFRoute))
 	if err != nil {
-		if validationError, ok := webhooks.WebhookErrorToValidationError(err); ok {
-			return RouteRecord{}, apierrors.NewUnprocessableEntityError(err, validationError.Error())
-		}
 		return RouteRecord{}, fmt.Errorf("failed to remove destination from route %q: %w", message.RouteGUID, apierrors.FromK8sError(err, RouteResourceType))
 	}
 

--- a/api/repositories/service_binding_repository.go
+++ b/api/repositories/service_binding_repository.go
@@ -108,9 +108,8 @@ func (r *ServiceBindingRepo) CreateServiceBinding(ctx context.Context, authInfo 
 	if err != nil {
 		if validationError, ok := webhooks.WebhookErrorToValidationError(err); ok {
 			if validationError.Type == services.ServiceBindingErrorType {
-				return ServiceBindingRecord{}, apierrors.NewUniquenessError(err, validationError.Error())
+				return ServiceBindingRecord{}, apierrors.NewUniquenessError(err, validationError.GetMessage())
 			}
-			return ServiceBindingRecord{}, apierrors.NewUnprocessableEntityError(err, validationError.Error())
 		}
 
 		return ServiceBindingRecord{}, apierrors.FromK8sError(err, ServiceBindingResourceType)

--- a/api/repositories/service_instance_repository.go
+++ b/api/repositories/service_instance_repository.go
@@ -8,7 +8,6 @@ import (
 	"code.cloudfoundry.org/korifi/api/apierrors"
 	"code.cloudfoundry.org/korifi/api/authorization"
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
-	"code.cloudfoundry.org/korifi/controllers/webhooks"
 
 	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
@@ -89,9 +88,6 @@ func (r *ServiceInstanceRepo) CreateServiceInstance(ctx context.Context, authInf
 	cfServiceInstance := message.toCFServiceInstance()
 	err = userClient.Create(ctx, &cfServiceInstance)
 	if err != nil {
-		if webhookError, ok := webhooks.WebhookErrorToValidationError(err); ok {
-			return ServiceInstanceRecord{}, apierrors.NewUnprocessableEntityError(err, webhookError.Error())
-		}
 		return ServiceInstanceRecord{}, apierrors.FromK8sError(err, ServiceInstanceResourceType)
 	}
 

--- a/api/repositories/space_repository.go
+++ b/api/repositories/space_repository.go
@@ -8,7 +8,6 @@ import (
 	"code.cloudfoundry.org/korifi/api/apierrors"
 	"code.cloudfoundry.org/korifi/api/authorization"
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
-	"code.cloudfoundry.org/korifi/controllers/webhooks"
 
 	"github.com/google/uuid"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -94,10 +93,7 @@ func (r *SpaceRepo) CreateSpace(ctx context.Context, info authorization.Info, me
 		},
 	})
 	if err != nil {
-		if webhookError, ok := webhooks.WebhookErrorToValidationError(err); ok {
-			return SpaceRecord{}, apierrors.NewUnprocessableEntityError(err, webhookError.Error())
-		}
-		return SpaceRecord{}, err
+		return SpaceRecord{}, apierrors.FromK8sError(err, SpaceResourceType)
 	}
 
 	return SpaceRecord{

--- a/api/repositories/task_repository.go
+++ b/api/repositories/task_repository.go
@@ -11,7 +11,6 @@ import (
 	"code.cloudfoundry.org/korifi/api/authorization"
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"code.cloudfoundry.org/korifi/controllers/controllers/workloads"
-	"code.cloudfoundry.org/korifi/controllers/webhooks"
 	"github.com/google/uuid"
 	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -220,9 +219,6 @@ func (r *TaskRepo) CancelTask(ctx context.Context, authInfo authorization.Info, 
 
 	err = userClient.Patch(ctx, task, client.MergeFrom(originalTask))
 	if err != nil {
-		if validationError, ok := webhooks.WebhookErrorToValidationError(err); ok {
-			return TaskRecord{}, apierrors.NewUnprocessableEntityError(err, validationError.GetMessage())
-		}
 		return TaskRecord{}, apierrors.FromK8sError(err, TaskResourceType)
 	}
 

--- a/controllers/webhooks/cf_validation_errors_test.go
+++ b/controllers/webhooks/cf_validation_errors_test.go
@@ -24,9 +24,16 @@ var _ = Describe("CFWebhookValidationError", func() {
 			Message: validationErrorMessage,
 		}
 	})
+
 	Describe("Error", func() {
 		It("returns a formatted error string", func() {
 			Expect(validationErr.Error()).To(Equal("ValidationError-" + validationErr.Type + ": " + validationErr.Message))
+		})
+	})
+
+	Describe("GetMessage", func() {
+		It("returns the user-facing message", func() {
+			Expect(validationErr.GetMessage()).To(Equal("some validation error message"))
 		})
 	})
 

--- a/tests/e2e/orgs_test.go
+++ b/tests/e2e/orgs_test.go
@@ -73,7 +73,7 @@ var _ = Describe("Orgs", func() {
 			It("returns an unprocessable entity error", func() {
 				Expect(resp).To(HaveRestyStatusCode(http.StatusUnprocessableEntity))
 				Expect(resultErr.Errors).To(ConsistOf(cfErr{
-					Detail: fmt.Sprintf(`ValidationError-DuplicateNameError: Organization '%s' already exists.`, orgName),
+					Detail: fmt.Sprintf(`Organization '%s' already exists.`, orgName),
 					Title:  "CF-UnprocessableEntity",
 					Code:   10008,
 				}))

--- a/tests/e2e/routes_test.go
+++ b/tests/e2e/routes_test.go
@@ -222,7 +222,7 @@ var _ = Describe("Routes", func() {
 				It("fails with a duplicate error", func() {
 					Expect(resp).To(HaveRestyStatusCode(http.StatusUnprocessableEntity))
 					Expect(createErr.Errors).To(ConsistOf(cfErr{
-						Detail: fmt.Sprintf("ValidationError-DuplicateNameError: Route already exists with host '%s' and path '%s' for domain '%s'.", host, path, domainName),
+						Detail: fmt.Sprintf("Route already exists with host '%s' and path '%s' for domain '%s'.", host, path, domainName),
 						Title:  "CF-UnprocessableEntity",
 						Code:   10008,
 					}))
@@ -244,7 +244,7 @@ var _ = Describe("Routes", func() {
 				It("fails with a duplicate error", func() {
 					Expect(resp).To(HaveRestyStatusCode(http.StatusUnprocessableEntity))
 					Expect(createErr.Errors).To(ConsistOf(cfErr{
-						Detail: fmt.Sprintf("ValidationError-DuplicateNameError: Route already exists with host '%s' and path '%s' for domain '%s'.", host, path, domainName),
+						Detail: fmt.Sprintf("Route already exists with host '%s' and path '%s' for domain '%s'.", host, path, domainName),
 						Title:  "CF-UnprocessableEntity",
 						Code:   10008,
 					}))
@@ -260,7 +260,7 @@ var _ = Describe("Routes", func() {
 				It("fails with a duplicate error", func() {
 					Expect(resp).To(HaveRestyStatusCode(http.StatusUnprocessableEntity))
 					Expect(createErr.Errors).To(ConsistOf(cfErr{
-						Detail: fmt.Sprintf("ValidationError-DuplicateNameError: Route already exists with host '%s' for domain '%s'.", host, domainName),
+						Detail: fmt.Sprintf("Route already exists with host '%s' for domain '%s'.", host, domainName),
 						Title:  "CF-UnprocessableEntity",
 						Code:   10008,
 					}))
@@ -369,7 +369,7 @@ var _ = Describe("Routes", func() {
 				})
 
 				It("fails with an unprocessable entity error", func() {
-					expectUnprocessableEntityError(resp, errResp, "ValidationError-RouteDestinationNotInSpaceError: Route destination app not found in space")
+					expectUnprocessableEntityError(resp, errResp, "Route destination app not found in space")
 				})
 			})
 		})

--- a/tests/e2e/spaces_test.go
+++ b/tests/e2e/spaces_test.go
@@ -78,7 +78,7 @@ var _ = Describe("Spaces", func() {
 			It("returns an unprocessable entity error", func() {
 				Expect(resp).To(HaveRestyStatusCode(http.StatusUnprocessableEntity))
 				Expect(createErr.Errors).To(ConsistOf(cfErr{
-					Detail: fmt.Sprintf(`ValidationError-DuplicateNameError: Space '%s' already exists. Name must be unique per organization.`, spaceName),
+					Detail: fmt.Sprintf(`Space '%s' already exists. Name must be unique per organization.`, spaceName),
 					Title:  "CF-UnprocessableEntity",
 					Code:   10008,
 				}))


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
https://github.com/cloudfoundry/korifi/issues/1335
https://github.com/cloudfoundry/korifi/issues/1339
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Webhook validation errors are a special case of K8S errors. Those
validation errors are usually mapped to `UnprocessableEntityError` with
quite few exceptions. Therefore,
* implement the default mapping in `apierrors.FromK8sError`
* only check for validation errors if mapping to another apierror type

Also, use `validationError.GetMessage` for the apierror details (as it
does not contain the machine-friendly error type which is irrelevant to
the human user)
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
N/A
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

