### PR TITLE
Show the failure reason for failed/cancelled tasks

### DIFF
--- a/api/presenter/task.go
+++ b/api/presenter/task.go
@@ -40,6 +40,12 @@ type TaskLinks struct {
 }
 
 func ForTask(responseTask repositories.TaskRecord, baseURL url.URL) TaskResponse {
+	result := TaskResult{}
+
+	if responseTask.FailureReason != "" {
+		result.FailureReason = &responseTask.FailureReason
+	}
+
 	return TaskResponse{
 		Name:        responseTask.Name,
 		GUID:        responseTask.GUID,
@@ -51,6 +57,7 @@ func ForTask(responseTask repositories.TaskRecord, baseURL url.URL) TaskResponse
 		MemoryMB:    responseTask.MemoryMB,
 		DiskMB:      responseTask.DiskMB,
 		State:       responseTask.State,
+		Result:      result,
 		Relationships: Relationships{
 			"app": Relationship{
 				Data: &RelationshipData{

--- a/api/repositories/task_repository_test.go
+++ b/api/repositories/task_repository_test.go
@@ -273,6 +273,26 @@ var _ = Describe("TaskRepository", func() {
 				It("returns the failed task", func() {
 					Expect(getErr).NotTo(HaveOccurred())
 					Expect(taskRecord.State).To(Equal(repositories.TaskStateFailed))
+					Expect(taskRecord.FailureReason).To(Equal("bar"))
+				})
+			})
+
+			When("the task was canceled", func() {
+				BeforeEach(func() {
+					setStatusAndUpdate(cfTask, korifiv1alpha1.TaskInitializedConditionType, korifiv1alpha1.TaskStartedConditionType)
+					meta.SetStatusCondition(&(cfTask.Status.Conditions), metav1.Condition{
+						Type:    korifiv1alpha1.TaskFailedConditionType,
+						Status:  metav1.ConditionTrue,
+						Reason:  "Error",
+						Message: "taskCanceled",
+					})
+					Expect(k8sClient.Status().Update(ctx, cfTask)).To(Succeed())
+				})
+
+				It("returns the failed task", func() {
+					Expect(getErr).NotTo(HaveOccurred())
+					Expect(taskRecord.State).To(Equal(repositories.TaskStateFailed))
+					Expect(taskRecord.FailureReason).To(Equal("task was canceled"))
 				})
 			})
 		})

--- a/controllers/controllers/workloads/cftask_controller.go
+++ b/controllers/controllers/workloads/cftask_controller.go
@@ -37,6 +37,8 @@ import (
 	"code.cloudfoundry.org/korifi/controllers/config"
 )
 
+const TaskCanceledReason = "taskCanceled"
+
 //counterfeiter:generate -o fake -fake-name SeqIdGenerator . SeqIdGenerator
 type SeqIdGenerator interface {
 	Generate() (int64, error)
@@ -275,14 +277,14 @@ func (r *CFTaskReconciler) handleCancelation(ctx context.Context, cfTask *korifi
 	meta.SetStatusCondition(&cfTask.Status.Conditions, metav1.Condition{
 		Type:   korifiv1alpha1.TaskCanceledConditionType,
 		Status: metav1.ConditionTrue,
-		Reason: "task_canceled",
+		Reason: TaskCanceledReason,
 	})
 
 	if !meta.IsStatusConditionTrue(cfTask.Status.Conditions, korifiv1alpha1.TaskSucceededConditionType) {
 		meta.SetStatusCondition(&cfTask.Status.Conditions, metav1.Condition{
 			Type:   korifiv1alpha1.TaskFailedConditionType,
 			Status: metav1.ConditionTrue,
-			Reason: "task_canceled",
+			Reason: TaskCanceledReason,
 		})
 	}
 

--- a/controllers/controllers/workloads/cftask_controller_test.go
+++ b/controllers/controllers/workloads/cftask_controller_test.go
@@ -512,7 +512,7 @@ var _ = Describe("CFTask Controller", func() {
 			canceledCondition := meta.FindStatusCondition(taskWithPatchedStatus().Status.Conditions, korifiv1alpha1.TaskCanceledConditionType)
 			Expect(canceledCondition).NotTo(BeNil())
 			Expect(canceledCondition.Status).To(Equal(metav1.ConditionTrue))
-			Expect(canceledCondition.Reason).To(Equal("task_canceled"))
+			Expect(canceledCondition.Reason).To(Equal("taskCanceled"))
 		})
 
 		When("the task is not completed", func() {
@@ -529,7 +529,7 @@ var _ = Describe("CFTask Controller", func() {
 				failedCondition := meta.FindStatusCondition(taskWithPatchedStatus().Status.Conditions, korifiv1alpha1.TaskFailedConditionType)
 				Expect(failedCondition).NotTo(BeNil())
 				Expect(failedCondition.Status).To(Equal(metav1.ConditionTrue))
-				Expect(failedCondition.Reason).To(Equal("task_canceled"))
+				Expect(failedCondition.Reason).To(Equal("taskCanceled"))
 			})
 		})
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	code.cloudfoundry.org/bytefmt v0.0.0-20211005130812-5bb3c17173e5
-	code.cloudfoundry.org/eirini-controller v0.6.0
+	code.cloudfoundry.org/eirini-controller v0.7.0
 	code.cloudfoundry.org/go-loggregator/v8 v8.0.5
 	github.com/buildpacks/lifecycle v0.14.1
 	github.com/buildpacks/pack v0.27.0

--- a/go.sum
+++ b/go.sum
@@ -86,6 +86,8 @@ code.cloudfoundry.org/bytefmt v0.0.0-20211005130812-5bb3c17173e5 h1:tM5+dn2C9xZw
 code.cloudfoundry.org/bytefmt v0.0.0-20211005130812-5bb3c17173e5/go.mod h1:v4VVB6oBMz/c9fRY6vZrwr5xKRWOH5NPDjQZlPk0Gbs=
 code.cloudfoundry.org/eirini-controller v0.6.0 h1:uh8W5TZn1NT+uBXu2IzGRbjWgGa4nrsx3+CnxbUFXI4=
 code.cloudfoundry.org/eirini-controller v0.6.0/go.mod h1:RxVgcDNvS05UdAz6tD4pymh7tljjMcuztI6+y/rkoDA=
+code.cloudfoundry.org/eirini-controller v0.7.0 h1:mg0aFxTpD20JbJqoC79p3Ar8MJdQQLk3rxgd87C95G4=
+code.cloudfoundry.org/eirini-controller v0.7.0/go.mod h1:RxVgcDNvS05UdAz6tD4pymh7tljjMcuztI6+y/rkoDA=
 code.cloudfoundry.org/go-diodes v0.0.0-20180905200951-72629b5276e3/go.mod h1:Jzi+ccHgo/V/PLQUaQ6hnZcC1c4BS790gx21LRRui4g=
 code.cloudfoundry.org/go-loggregator/v8 v8.0.5 h1:p1rrGxTwUqLjlUVtbjTAvKOSGNmPuBja8LeQOQgRrBc=
 code.cloudfoundry.org/go-loggregator/v8 v8.0.5/go.mod h1:mLlJ1ZyG6gVvBEtYypvbztRvFeCtBsTxE9tt+85tS6Y=

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -115,7 +115,7 @@ echo "*******************"
 echo "Installing Eirini"
 echo "*******************"
 
-EIRINI_VERSION="${EIRINI_VERSION:-0.6.0}"
+EIRINI_VERSION="${EIRINI_VERSION:-0.7.0}"
 
 cat <<EOF | kubectl apply -f -
 apiVersion: v1


### PR DESCRIPTION
## Is there a related GitHub Issue?
#1048

## What is this change about?
We bumped eirini-controller to 0.7.0 to get exit code failure messages included in the failed status condition.

This is used to populate the failure message in the TaskRecord and is passed back to the user in the get task response.

Cancelled tasks get the cancelled failure reason 'hard-coded'.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
See #1048

## Tag your pair, your PM, and/or team
@kieron-dev

## Things to remember
<!-
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
