### PR TITLE
CFProcess generates RunWorkloads instead of LRPs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -251,6 +251,7 @@ Just apply the files in the release:
 kubectl apply -f korifi-api.yml
 kubectl apply -f korifi-controllers.yml
 kubectl apply -f korifi-kpack-image-builder.yml
+kubectl apply -f korifi-statefulset-runner.yml
 ```
 
 ## TLS certificates

--- a/api/repositories/pod_repository_test.go
+++ b/api/repositories/pod_repository_test.go
@@ -23,8 +23,8 @@ import (
 )
 
 const (
-	eiriniLabelVersionKey = "korifi.cloudfoundry.org/version"
-	cfProcessGuidKey      = "korifi.cloudfoundry.org/guid"
+	LabelVersionKey  = "korifi.cloudfoundry.org/version"
+	cfProcessGuidKey = "korifi.cloudfoundry.org/guid"
 )
 
 var _ = Describe("PodRepository", func() {
@@ -170,15 +170,15 @@ var _ = Describe("PodRepository", func() {
 				}))
 			})
 
-			When("the 'oci' container is missing in one of the Pods", func() {
+			When("the 'app' container is missing in one of the Pods", func() {
 				BeforeEach(func() {
 					podWrong := createPodDef("pod-wrong", spaceGUID, appGUID, processGUID, "0", "1")
-					podWrong.Spec.Containers[0].Name = "not-oci"
+					podWrong.Spec.Containers[0].Name = "not-app"
 					Expect(k8sClient.Create(ctx, podWrong)).To(Succeed())
 				})
 
 				It("fails", func() {
-					Expect(listStatsErr).To(MatchError("container \"opi\" not found"))
+					Expect(listStatsErr).To(MatchError("container \"application\" not found"))
 				})
 			})
 
@@ -370,14 +370,14 @@ func createPodDef(name, namespace, appGUID, processGUID, index, version string) 
 			Namespace: namespace,
 			Labels: map[string]string{
 				korifiv1alpha1.CFAppGUIDLabelKey: appGUID,
-				eiriniLabelVersionKey:            version,
+				LabelVersionKey:                  version,
 				cfProcessGuidKey:                 processGUID,
 			},
 		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
 				{
-					Name:  "opi",
+					Name:  "application",
 					Image: "some-image",
 					Env: []corev1.EnvVar{
 						{

--- a/controllers/config/rbac/role.yaml
+++ b/controllers/config/rbac/role.yaml
@@ -97,18 +97,6 @@ rules:
 - apiGroups:
   - eirini.cloudfoundry.org
   resources:
-  - lrps
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - eirini.cloudfoundry.org
-  resources:
   - lrps/status
   verbs:
   - patch
@@ -459,6 +447,24 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - runworkloads
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - runworkloads/status
+  verbs:
+  - patch
 - apiGroups:
   - kpack.io
   resources:

--- a/controllers/config/samples/cfprocess.yaml
+++ b/controllers/config/samples/cfprocess.yaml
@@ -1,5 +1,5 @@
 ---
-# Defines a CFProcess for a given app. Results in an Eirini LRP.
+# Defines a CFProcess for a given app. Results in a RunWorkload.
 apiVersion: korifi.cloudfoundry.org/v1alpha1
 kind: CFProcess
 metadata:  # korifi.cloudfoundry.org/ labels are all managed by a mutating webhook based on appRef and its droplet

--- a/controllers/controllers/workloads/cforg_controller.go
+++ b/controllers/controllers/workloads/cforg_controller.go
@@ -81,6 +81,7 @@ const (
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=create;delete
 //+kubebuilder:rbac:groups="apps",resources=statefulsets,verbs=create;patch
 //+kubebuilder:rbac:groups="batch",resources=jobs,verbs=create;delete;deletecollection
+//+kubebuilder:rbac:groups=korifi.cloudfoundry.org,resources=runworkloads/status,verbs=patch
 //+kubebuilder:rbac:groups="eirini.cloudfoundry.org",resources=lrps/status,verbs=patch
 //+kubebuilder:rbac:groups="eirini.cloudfoundry.org",resources=tasks/status,verbs=patch
 //+kubebuilder:rbac:groups="metrics.k8s.io",resources=pods,verbs=get;list;watch

--- a/controllers/controllers/workloads/integration/cforg_controller_integration_test.go
+++ b/controllers/controllers/workloads/integration/cforg_controller_integration_test.go
@@ -56,17 +56,17 @@ var _ = Describe("CFOrgReconciler Integration Tests", func() {
 			{
 				Verbs:     []string{"patch"},
 				APIGroups: []string{"eirini.cloudfoundry.org"},
-				Resources: []string{"lrps/status"},
+				Resources: []string{"tasks/status"},
 			},
 		}
 		role2 = createClusterRole(testCtx, k8sClient, PrefixedGUID("role"), rules2)
 
 		username = PrefixedGUID("user")
-		roleBinding = createClusterRoleBinding(testCtx, k8sClient, PrefixedGUID("role-binding"), username, role1.Name, rootNamespace.Name, map[string]string{})
+		roleBinding = createRoleBinding(testCtx, k8sClient, PrefixedGUID("role-binding"), username, role1.Name, rootNamespace.Name, map[string]string{})
 
 		username2 := PrefixedGUID("user2")
 		annotations := map[string]string{"cloudfoundry.org/propagate-cf-role": "false"}
-		roleBinding2 = createClusterRoleBinding(testCtx, k8sClient, PrefixedGUID("role-binding2"), username2, role1.Name, rootNamespace.Name, annotations)
+		roleBinding2 = createRoleBinding(testCtx, k8sClient, PrefixedGUID("role-binding2"), username2, role1.Name, rootNamespace.Name, annotations)
 
 		orgGUID = PrefixedGUID("cf-org")
 		cfOrg = korifiv1alpha1.CFOrg{
@@ -170,7 +170,7 @@ var _ = Describe("CFOrgReconciler Integration Tests", func() {
 				g.Expect(meta.IsStatusConditionTrue(createdOrg.Status.Conditions, "Ready")).To(BeTrue())
 			}, 20*time.Second).Should(Succeed())
 
-			roleBinding3 = createClusterRoleBinding(testCtx, k8sClient, PrefixedGUID("role-binding"), username, role2.Name, rootNamespace.Name, map[string]string{})
+			roleBinding3 = createRoleBinding(testCtx, k8sClient, PrefixedGUID("role-binding"), username, role2.Name, rootNamespace.Name, map[string]string{})
 		})
 
 		It("propagates the new role-binding to org namespace", func() {

--- a/controllers/controllers/workloads/integration/cfspace_controller_integration_test.go
+++ b/controllers/controllers/workloads/integration/cfspace_controller_integration_test.go
@@ -57,17 +57,17 @@ var _ = Describe("CFSpaceReconciler Integration Tests", func() {
 			{
 				Verbs:     []string{"patch"},
 				APIGroups: []string{"eirini.cloudfoundry.org"},
-				Resources: []string{"lrps/status"},
+				Resources: []string{"tasks/status"},
 			},
 		}
 		role2 = createClusterRole(ctx, k8sClient, PrefixedGUID("clusterrole"), rules2)
 
 		username = PrefixedGUID("user")
-		roleBinding = createClusterRoleBinding(ctx, k8sClient, PrefixedGUID("role-binding"), username, role1.Name, orgNamespace.Name, map[string]string{})
+		roleBinding = createRoleBinding(ctx, k8sClient, PrefixedGUID("role-binding"), username, role1.Name, orgNamespace.Name, map[string]string{})
 
 		username2 := PrefixedGUID("user2")
 		annotations := map[string]string{"cloudfoundry.org/propagate-cf-role": "false"}
-		roleBinding2 = createClusterRoleBinding(ctx, k8sClient, PrefixedGUID("role-binding2"), username2, role1.Name, orgNamespace.Name, annotations)
+		roleBinding2 = createRoleBinding(ctx, k8sClient, PrefixedGUID("role-binding2"), username2, role1.Name, orgNamespace.Name, annotations)
 
 		spaceGUID = PrefixedGUID("cf-space")
 		cfSpace = &korifiv1alpha1.CFSpace{
@@ -187,7 +187,7 @@ var _ = Describe("CFSpaceReconciler Integration Tests", func() {
 				g.Expect(meta.IsStatusConditionTrue(createdSpace.Status.Conditions, "Ready")).To(BeTrue())
 			}, 20*time.Second).Should(Succeed())
 
-			roleBinding3 = createClusterRoleBinding(ctx, k8sClient, PrefixedGUID("role-binding"), username, role2.Name, orgNamespace.Name, map[string]string{})
+			roleBinding3 = createRoleBinding(ctx, k8sClient, PrefixedGUID("role-binding"), username, role2.Name, orgNamespace.Name, map[string]string{})
 		})
 
 		It("propagates the new role-binding to CFSpace namespace", func() {

--- a/controllers/controllers/workloads/integration/suite_integration_test.go
+++ b/controllers/controllers/workloads/integration/suite_integration_test.go
@@ -240,7 +240,7 @@ func createClusterRole(ctx context.Context, k8sClient client.Client, name string
 	return role
 }
 
-func createClusterRoleBinding(ctx context.Context, k8sClient client.Client, roleBindingName, subjectName, roleReference, namespace string, annotations map[string]string) rbacv1.RoleBinding {
+func createRoleBinding(ctx context.Context, k8sClient client.Client, roleBindingName, subjectName, roleReference, namespace string, annotations map[string]string) rbacv1.RoleBinding {
 	roleBinding := rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        roleBindingName,

--- a/controllers/controllers/workloads/testutils/shared_test_utils.go
+++ b/controllers/controllers/workloads/testutils/shared_test_utils.go
@@ -159,7 +159,7 @@ func BuildCFBuildDropletStatusObject(dropletProcessTypeMap map[string]string, dr
 	return &korifiv1alpha1.BuildDropletStatus{
 		Registry: korifiv1alpha1.Registry{
 			Image:            "image/registry/url",
-			ImagePullSecrets: nil,
+			ImagePullSecrets: []corev1.LocalObjectReference{{Name: "some-image-pull-secret"}},
 		},
 		Stack:        "cflinuxfs3",
 		ProcessTypes: dropletProcessTypes,
@@ -240,7 +240,7 @@ func UpdateCFBuildWithDropletStatus(cfbuild *korifiv1alpha1.CFBuild) {
 	cfbuild.Status.Droplet = &korifiv1alpha1.BuildDropletStatus{
 		Registry: korifiv1alpha1.Registry{
 			Image:            "my-image",
-			ImagePullSecrets: nil,
+			ImagePullSecrets: []corev1.LocalObjectReference{{Name: "some-image-pull-secret"}},
 		},
 		Stack: "cflinuxfs3",
 		ProcessTypes: []korifiv1alpha1.ProcessType{

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -83,5 +83,5 @@ We typically use ADRs to record context about decisions that were already made o
 | Service Instance               | CFServiceInstance ([ProvisionedService](https://github.com/servicebinding/spec#provisioned-service))       |
 | Service Binding                | CFServiceBinding + [ServiceBinding for Kubernetes](https://github.com/servicebinding/spec#service-binding) |
 | Service credentials            | Kubernetes Secret                                                                                          |
-| Diego Desired LRP              | RunWorkload (and Eirini LRP) + StatefulSet                                                                 |
+| Diego Desired LRP              | RunWorkload + StatefulSet                                                                                  |
 | Diego Actual LRP               | Kubernetes Pod                                                                                             |

--- a/statefulset-runner/Makefile
+++ b/statefulset-runner/Makefile
@@ -82,9 +82,8 @@ run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
 .PHONY: docker-build
-docker-build: test ## Build docker image with the manager.
+docker-build: ## Build docker image with the manager.
 	docker buildx build --load -f ./Dockerfile -t ${IMG_SSR} ..
-
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
@@ -104,9 +103,12 @@ install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~
 uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	$(KUSTOMIZE) build config/crd | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 
-.PHONY: deploy
-deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
+.PHONY: set-image-ref
+set-image-ref: kustomize
 	cd config/manager && $(KUSTOMIZE) edit set image cloudfoundry/korifi-statefulset-runner=${IMG_SSR}
+
+.PHONY: deploy
+deploy: manifests set-image-ref ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
 
 .PHONY: undeploy

--- a/statefulset-runner/controllers/runworkload_controller.go
+++ b/statefulset-runner/controllers/runworkload_controller.go
@@ -59,11 +59,12 @@ const (
 	AnnotationAppID       = "korifi.cloudfoundry.org/application-id"
 	AnnotationProcessGUID = "korifi.cloudfoundry.org/process-guid"
 
-	LabelGUID            = "korifi.cloudfoundry.org/guid"
-	LabelVersion         = "korifi.cloudfoundry.org/version"
-	LabelAppGUID         = "korifi.cloudfoundry.org/app-guid"
-	LabelRunWorkloadGUID = "korifi.cloudfoundry.org/run-workload-guid"
-	LabelProcessType     = "korifi.cloudfoundry.org/process-type"
+	LabelGUID                   = "korifi.cloudfoundry.org/guid"
+	LabelVersion                = "korifi.cloudfoundry.org/version"
+	LabelAppGUID                = "korifi.cloudfoundry.org/app-guid"
+	LabelRunWorkloadGUID        = "korifi.cloudfoundry.org/run-workload-guid"
+	LabelProcessType            = "korifi.cloudfoundry.org/process-type"
+	LabelStatefulSetRunnerIndex = "korifi.cloudfoundry.org/add-stsr-index"
 
 	ApplicationContainerName = "application"
 
@@ -265,6 +266,12 @@ func (r *RunWorkloadReconciler) Convert(runWorkload korifiv1alpha1.RunWorkload) 
 			Ports:           ports,
 			SecurityContext: &corev1.SecurityContext{
 				AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+				Capabilities: &corev1.Capabilities{
+					Drop: []corev1.Capability{"ALL"},
+				},
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
 			},
 			Resources:      getContainerResources(runWorkload.Spec.CPUWeight, runWorkload.Spec.MemoryMiB, runWorkload.Spec.DiskMiB),
 			LivenessProbe:  livenessProbe,
@@ -319,11 +326,12 @@ func (r *RunWorkloadReconciler) Convert(runWorkload korifiv1alpha1.RunWorkload) 
 	}
 
 	labels := map[string]string{
-		LabelGUID:            runWorkload.Spec.GUID,
-		LabelProcessType:     runWorkload.Spec.ProcessType,
-		LabelVersion:         runWorkload.Spec.Version,
-		LabelAppGUID:         runWorkload.Spec.AppGUID,
-		LabelRunWorkloadGUID: runWorkload.Name,
+		LabelGUID:                   runWorkload.Spec.GUID,
+		LabelProcessType:            runWorkload.Spec.ProcessType,
+		LabelVersion:                runWorkload.Spec.Version,
+		LabelAppGUID:                runWorkload.Spec.AppGUID,
+		LabelRunWorkloadGUID:        runWorkload.Name,
+		LabelStatefulSetRunnerIndex: "true",
 	}
 
 	statefulSet.Spec.Template.Labels = labels

--- a/statefulset-runner/controllers/runworkload_controller_test.go
+++ b/statefulset-runner/controllers/runworkload_controller_test.go
@@ -82,7 +82,20 @@ var _ = Describe("RunWorkload to StatefulSet Converter", func() {
 	})
 
 	It("should deny privilegeEscalation", func() {
+		Expect(statefulSet.Spec.Template.Spec.Containers[0].SecurityContext.AllowPrivilegeEscalation).NotTo(BeNil())
 		Expect(*statefulSet.Spec.Template.Spec.Containers[0].SecurityContext.AllowPrivilegeEscalation).To(Equal(false))
+	})
+
+	It("should drop all capabilities", func() {
+		Expect(statefulSet.Spec.Template.Spec.Containers[0].SecurityContext.Capabilities).NotTo(BeNil())
+		Expect(*statefulSet.Spec.Template.Spec.Containers[0].SecurityContext.Capabilities).To(Equal(corev1.Capabilities{
+			Drop: []corev1.Capability{"ALL"},
+		}))
+	})
+
+	It("should set the seccomp profile", func() {
+		Expect(statefulSet.Spec.Template.Spec.Containers[0].SecurityContext.SeccompProfile).NotTo(BeNil())
+		Expect(*statefulSet.Spec.Template.Spec.Containers[0].SecurityContext.SeccompProfile).To(Equal(corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault}))
 	})
 
 	It("should set the liveness probe", func() {
@@ -144,6 +157,11 @@ var _ = Describe("RunWorkload to StatefulSet Converter", func() {
 	It("should set version as a label", func() {
 		Expect(statefulSet.Labels).To(HaveKeyWithValue(controllers.LabelVersion, "version_1234"))
 		Expect(statefulSet.Spec.Template.Labels).To(HaveKeyWithValue(controllers.LabelVersion, "version_1234"))
+	})
+
+	It("should set statefulset-runner-index as a label", func() {
+		Expect(statefulSet.Labels).To(HaveKeyWithValue(controllers.LabelStatefulSetRunnerIndex, "true"))
+		Expect(statefulSet.Spec.Template.Labels).To(HaveKeyWithValue(controllers.LabelStatefulSetRunnerIndex, "true"))
 	})
 
 	It("should set guid as a label selector", func() {


### PR DESCRIPTION
## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->
#1145

## What is this change about?
<!-- _Please describe the change here._ -->
Running processes is now managed via RunWorkload resources

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->
Yes, workloads managed using Eirini `LRPs` are no longer compatible. Please redeploy your workloads to use `RunWorkload` resources

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->
See issue #1145 

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->
@davewalter 

