### PR TITLE
Bump version of kube-rbac-proxy used by statefulset-runner

### DIFF
--- a/kpack-image-builder/config/default/project_namespace/manager_auth_proxy_patch.yaml
+++ b/kpack-image-builder/config/default/project_namespace/manager_auth_proxy_patch.yaml
@@ -31,7 +31,7 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
-              - ALL
+            - ALL
           runAsNonRoot: true
           seccompProfile:
             type: RuntimeDefault

--- a/statefulset-runner/config/default/manager_auth_proxy_patch.yaml
+++ b/statefulset-runner/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.12.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"
@@ -27,6 +27,14 @@ spec:
           requests:
             cpu: 5m
             memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
       - name: manager
         args:
         - "--health-probe-bind-address=:8081"


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
This PR bumps the version of `kube-rbac-proxy` used by the `statefulset-runner` to v0.12.0. It also copies the `securityContext` block from `kpack-image-builder`.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Everything still works.

## Tag your pair, your PM, and/or team
@Birdrock 