### PR TITLE
SpaceManager should be able to get and list tasks

### DIFF
--- a/controllers/config/cf_roles/cf_space_manager.yaml
+++ b/controllers/config/cf_roles/cf_space_manager.yaml
@@ -59,3 +59,11 @@ rules:
   verbs:
   - get
   - list
+
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - cftasks
+  verbs:
+  - get
+  - list


### PR DESCRIPTION
## Is there a related GitHub Issue?

This should have been part of #1022, #1037 and #1038.

## What is this change about?

This allows users who are space managers to get and list tasks in their spaces.

## Does this PR introduce a breaking change?

No.