### PR TITLE
Listing tasks for unaccessible apps should 404

### DIFF
--- a/api/handlers/task_handler.go
+++ b/api/handlers/task_handler.go
@@ -115,8 +115,13 @@ func (h *TaskHandler) appTaskListHandler(ctx context.Context, logger logr.Logger
 		return nil, err
 	}
 
+	_, err := h.appRepo.GetApp(ctx, authInfo, appGUID)
+	if err != nil {
+		return nil, apierrors.LogAndReturn(logger, apierrors.ForbiddenAsNotFound(err), "error finding app", "appGUID", appGUID)
+	}
+
 	taskListFilter := new(payloads.TaskList)
-	err := payloads.Decode(taskListFilter, r.Form)
+	err = payloads.Decode(taskListFilter, r.Form)
 	if err != nil {
 		logger.Error(err, "Unable to decode request query parameters")
 		return nil, err

--- a/api/handlers/task_handler_test.go
+++ b/api/handlers/task_handler_test.go
@@ -369,6 +369,36 @@ var _ = Describe("TaskHandler", func() {
 				Expect(listMsg.AppGUIDs).To(ConsistOf("the-app-guid"))
 			})
 
+			When("the app does not exist", func() {
+				BeforeEach(func() {
+					appRepo.GetAppReturns(repositories.AppRecord{}, apierrors.NewNotFoundError(nil, repositories.AppResourceType))
+				})
+
+				It("returns a Not Found Error", func() {
+					expectNotFoundError("App not found")
+				})
+			})
+
+			When("the user cannot see the app", func() {
+				BeforeEach(func() {
+					appRepo.GetAppReturns(repositories.AppRecord{}, apierrors.NewForbiddenError(nil, repositories.AppResourceType))
+				})
+
+				It("returns a Not Found error", func() {
+					expectNotFoundError("App not found")
+				})
+			})
+
+			When("getting the app fails", func() {
+				BeforeEach(func() {
+					appRepo.GetAppReturns(repositories.AppRecord{}, errors.New("boom"))
+				})
+
+				It("returns an Internal Server Error", func() {
+					expectUnknownError()
+				})
+			})
+
 			When("filtering tasks by sequence ID", func() {
 				BeforeEach(func() {
 					var err error


### PR DESCRIPTION
## Is there a related GitHub Issue?

Should have been part of #1038.

## What is this change about?

This changes the `GET /v3/apps/:guid/tasks` endpoint to return a `404 Not Found` error if the app does not exist, or is not visible by the user. This is the behaviour of CF-on-VMs. Currently we just return an empty list.