### PR TITLE
Consistent Logging Severity

### DIFF
--- a/api/actions/app_logs.go
+++ b/api/actions/app_logs.go
@@ -33,20 +33,17 @@ func (a *AppLogs) Read(ctx context.Context, logger logr.Logger, authInfo authori
 
 	app, err := a.appRepo.GetApp(ctx, authInfo, appGUID)
 	if err != nil {
-		logger.Error(err, "Failed to fetch app from Kubernetes", "AppGUID", appGUID)
-		return nil, apierrors.ForbiddenAsNotFound(err)
+		return nil, apierrors.LogAndReturn(logger, apierrors.ForbiddenAsNotFound(err), "Failed to fetch app from Kubernetes", "AppGUID", appGUID)
 	}
 
 	build, err := a.buildRepo.GetLatestBuildByAppGUID(ctx, authInfo, app.SpaceGUID, appGUID)
 	if err != nil {
-		logger.Error(err, "Failed to fetch latest app CFBuild from Kubernetes", "AppGUID", appGUID)
-		return nil, apierrors.ForbiddenAsNotFound(err)
+		return nil, apierrors.LogAndReturn(logger, apierrors.ForbiddenAsNotFound(err), "Failed to fetch latest app CFBuild from Kubernetes", "AppGUID", appGUID)
 	}
 
 	buildLogs, err := a.buildRepo.GetBuildLogs(ctx, authInfo, app.SpaceGUID, build.GUID)
 	if err != nil {
-		logger.Error(err, "Failed to fetch build logs", "AppGUID", appGUID, "BuildGUID", build.GUID)
-		return nil, err
+		return nil, apierrors.LogAndReturn(logger, err, "Failed to fetch build logs", "AppGUID", appGUID, "BuildGUID", build.GUID)
 	}
 
 	logLimit := int64(defaultLogLimit)
@@ -61,8 +58,7 @@ func (a *AppLogs) Read(ctx context.Context, logger logr.Logger, authInfo authori
 		Limit:       logLimit,
 	})
 	if err != nil {
-		logger.Error(err, "Failed to fetch app runtime logs from Kubernetes", "AppGUID", appGUID)
-		return nil, err
+		return nil, apierrors.LogAndReturn(logger, err, "Failed to fetch app runtime logs from Kubernetes", "AppGUID", appGUID)
 	}
 
 	logs := append(buildLogs, runtimeLogs...)

--- a/api/authorization/cert_inspector.go
+++ b/api/authorization/cert_inspector.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 
 	"code.cloudfoundry.org/korifi/api/apierrors"
@@ -25,17 +26,17 @@ func NewCertInspector(restConfig *rest.Config) *CertInspector {
 func (c *CertInspector) WhoAmI(ctx context.Context, certPEM []byte) (Identity, error) {
 	certBlock, rst := pem.Decode(certPEM)
 	if certBlock == nil {
-		return Identity{}, fmt.Errorf("failed to decode cert PEM")
+		return Identity{}, apierrors.NewInvalidAuthError(errors.New("failed to decode cert PEM"))
 	}
 
 	cert, err := x509.ParseCertificate(certBlock.Bytes)
 	if err != nil {
-		return Identity{}, fmt.Errorf("failed to parse certificate: %w", err)
+		return Identity{}, apierrors.NewInvalidAuthError(fmt.Errorf("failed to parse certificate: %w", err))
 	}
 
 	keyBlock, _ := pem.Decode(rst)
 	if keyBlock == nil {
-		return Identity{}, fmt.Errorf("failed to decode key PEM")
+		return Identity{}, apierrors.NewInvalidAuthError(errors.New("failed to decode key PEM"))
 	}
 
 	config := rest.AnonymousClientConfig(c.restConfig)

--- a/api/authorization/cert_inspector_test.go
+++ b/api/authorization/cert_inspector_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/pem"
+	"errors"
 
 	"code.cloudfoundry.org/korifi/api/apierrors"
 	"code.cloudfoundry.org/korifi/api/authorization"
@@ -57,7 +58,7 @@ var _ = Describe("CertInspector", func() {
 		})
 
 		It("returns an error", func() {
-			Expect(inspectorErr).To(MatchError("failed to decode cert PEM"))
+			Expect(inspectorErr).To(Equal(apierrors.NewInvalidAuthError(errors.New("failed to decode cert PEM"))))
 		})
 	})
 
@@ -78,7 +79,10 @@ var _ = Describe("CertInspector", func() {
 		})
 
 		It("returns an error", func() {
-			Expect(inspectorErr).To(MatchError(ContainSubstring("failed to parse certificate")))
+			Expect(inspectorErr).To(SatisfyAll(
+				matchers.WrapErrorAssignableToTypeOf(apierrors.InvalidAuthError{})),
+				MatchError(ContainSubstring("failed to parse certificate")),
+			)
 		})
 	})
 })

--- a/api/handlers/authentication_middleware.go
+++ b/api/handlers/authentication_middleware.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"net/http"
 
+	"code.cloudfoundry.org/korifi/api/apierrors"
 	"code.cloudfoundry.org/korifi/api/authorization"
 	"code.cloudfoundry.org/korifi/api/correlation"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -48,8 +49,8 @@ func (a *AuthenticationMiddleware) Middleware(next http.Handler) http.Handler {
 
 		authInfo, err := a.authInfoParser.Parse(r.Header.Get(headers.Authorization))
 		if err != nil {
-			logger.Error(err, "failed to parse auth info")
-			presentError(w, err)
+			logger.Info("failed to parse auth info", "err", err)
+			presentError(logger, w, err)
 			return
 		}
 
@@ -57,8 +58,7 @@ func (a *AuthenticationMiddleware) Middleware(next http.Handler) http.Handler {
 
 		_, err = a.identityProvider.GetIdentity(r.Context(), authInfo)
 		if err != nil {
-			logger.Error(err, "failed to get identity")
-			presentError(w, err)
+			presentError(logger, w, apierrors.LogAndReturn(logger, err, "failed to get identity"))
 			return
 		}
 

--- a/api/handlers/buildpack_handler.go
+++ b/api/handlers/buildpack_handler.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/url"
 
+	"code.cloudfoundry.org/korifi/api/apierrors"
 	"code.cloudfoundry.org/korifi/api/authorization"
 	"code.cloudfoundry.org/korifi/api/payloads"
 	"code.cloudfoundry.org/korifi/api/presenter"
@@ -43,21 +44,18 @@ func NewBuildpackHandler(
 
 func (h *BuildpackHandler) buildpackListHandler(ctx context.Context, logger logr.Logger, authInfo authorization.Info, r *http.Request) (*HandlerResponse, error) {
 	if err := r.ParseForm(); err != nil {
-		logger.Error(err, "Unable to parse request query parameters")
-		return nil, err
+		return nil, apierrors.LogAndReturn(logger, err, "Unable to parse request query parameters")
 	}
 
 	buildpackListFilter := new(payloads.BuildpackList)
 	err := payloads.Decode(buildpackListFilter, r.Form)
 	if err != nil {
-		logger.Error(err, "Unable to decode request query parameters")
-		return nil, err
+		return nil, apierrors.LogAndReturn(logger, err, "Unable to decode request query parameters")
 	}
 
 	buildpacks, err := h.buildpackRepo.ListBuildpacks(ctx, authInfo)
 	if err != nil {
-		logger.Error(err, "Failed to fetch buildpacks from Kubernetes")
-		return nil, err
+		return nil, apierrors.LogAndReturn(logger, err, "Failed to fetch buildpacks from Kubernetes")
 	}
 
 	return NewHandlerResponse(http.StatusOK).WithBody(presenter.ForBuildpackList(buildpacks, h.serverURL, *r.URL)), nil

--- a/api/handlers/droplet_handler.go
+++ b/api/handlers/droplet_handler.go
@@ -49,8 +49,12 @@ func (h *DropletHandler) dropletGetHandler(ctx context.Context, logger logr.Logg
 
 	droplet, err := h.dropletRepo.GetDroplet(ctx, authInfo, dropletGUID)
 	if err != nil {
-		logger.Error(err, fmt.Sprintf("Failed to fetch %s from Kubernetes", repositories.DropletResourceType), "guid", dropletGUID)
-		return nil, apierrors.ForbiddenAsNotFound(err)
+		return nil, apierrors.LogAndReturn(
+			logger,
+			apierrors.ForbiddenAsNotFound(err),
+			fmt.Sprintf("Failed to fetch %s from Kubernetes", repositories.DropletResourceType),
+			"guid", dropletGUID,
+		)
 	}
 
 	return NewHandlerResponse(http.StatusOK).WithBody(presenter.ForDroplet(droplet, h.serverURL)), nil

--- a/api/handlers/http_logging_middleware.go
+++ b/api/handlers/http_logging_middleware.go
@@ -1,0 +1,30 @@
+package handlers
+
+import (
+	"io"
+	"net/http"
+	"os"
+	"time"
+
+	"code.cloudfoundry.org/korifi/api/correlation"
+	"github.com/gorilla/handlers"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+type HTTPLogging struct{}
+
+func NewHTTPLogging() HTTPLogging {
+	return HTTPLogging{}
+}
+
+func (l HTTPLogging) Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t1 := time.Now()
+		logger := correlation.AddCorrelationIDToLogger(r.Context(), logf.Log.WithName("http-logger"))
+		logger.Info("request", "url", r.URL, "method", r.Method, "remoteAddr", r.RemoteAddr, "contentLength", r.ContentLength)
+
+		handlers.CustomLoggingHandler(os.Stdout, next, func(writer io.Writer, params handlers.LogFormatterParams) {
+			logger.Info("response", "status", params.StatusCode, "size", params.Size, "durationMillis", time.Since(t1).Milliseconds())
+		}).ServeHTTP(w, r)
+	})
+}

--- a/api/handlers/job_handler.go
+++ b/api/handlers/job_handler.go
@@ -46,8 +46,11 @@ func (h *JobHandler) jobGetHandler(ctx context.Context, logger logr.Logger, auth
 	jobType, resourceGUID, match := parseJobGUID(jobGUID)
 
 	if !match {
-		logger.Info("Invalid Job GUID")
-		return nil, apierrors.NewNotFoundError(fmt.Errorf("invalid job guid: %s", jobGUID), JobResourceType)
+		return nil, apierrors.LogAndReturn(
+			logger,
+			apierrors.NewNotFoundError(fmt.Errorf("invalid job guid: %s", jobGUID), JobResourceType),
+			"Invalid Job GUID",
+		)
 	}
 
 	var jobResponse presenter.JobResponse
@@ -58,8 +61,11 @@ func (h *JobHandler) jobGetHandler(ctx context.Context, logger logr.Logger, auth
 	case appDeletePrefix, orgDeletePrefix, spaceDeletePrefix, routeDeletePrefix:
 		jobResponse = presenter.ForDeleteJob(jobGUID, jobType, h.serverURL)
 	default:
-		logger.Info(fmt.Sprintf("Invalid Job type: %s", jobType))
-		return nil, apierrors.NewNotFoundError(fmt.Errorf("invalid job type: %s", jobType), JobResourceType)
+		return nil, apierrors.LogAndReturn(
+			logger,
+			apierrors.NewNotFoundError(fmt.Errorf("invalid job type: %s", jobType), JobResourceType),
+			fmt.Sprintf("Invalid Job type: %s", jobType),
+		)
 	}
 
 	return NewHandlerResponse(http.StatusOK).WithBody(jobResponse), nil

--- a/api/handlers/log_cache_handler.go
+++ b/api/handlers/log_cache_handler.go
@@ -60,21 +60,22 @@ func (h *LogCacheHandler) logCacheInfoHandler(ctx context.Context, logger logr.L
 
 func (h *LogCacheHandler) logCacheReadHandler(ctx context.Context, logger logr.Logger, authInfo authorization.Info, r *http.Request) (*HandlerResponse, error) {
 	if err := r.ParseForm(); err != nil {
-		logger.Error(err, "Unable to parse request query parameters")
-		return nil, err
+		return nil, apierrors.LogAndReturn(logger, err, "Unable to parse request query parameters")
 	}
 
 	logReadPayload := new(payloads.LogRead)
 	err := payloads.Decode(logReadPayload, r.Form)
 	if err != nil {
-		logger.Error(err, "Unable to decode request query parameters")
-		return nil, err
+		return nil, apierrors.LogAndReturn(logger, err, "Unable to decode request query parameters")
 	}
 
 	v := validator.New()
 	if logReadPayloadErr := v.Struct(logReadPayload); logReadPayloadErr != nil {
-		logger.Error(logReadPayloadErr, "Error validating log read request query parameters")
-		return nil, apierrors.NewUnprocessableEntityError(logReadPayloadErr, "error validating log read query parameters")
+		return nil, apierrors.LogAndReturn(
+			logger,
+			apierrors.NewUnprocessableEntityError(logReadPayloadErr, "error validating log read query parameters"),
+			"Error validating log read request query parameters",
+		)
 	}
 
 	vars := mux.Vars(r)

--- a/api/handlers/root_handler.go
+++ b/api/handlers/root_handler.go
@@ -1,10 +1,14 @@
 package handlers
 
 import (
+	"context"
 	"net/http"
 
+	"code.cloudfoundry.org/korifi/api/authorization"
 	"code.cloudfoundry.org/korifi/api/presenter"
+	"github.com/go-logr/logr"
 	"github.com/gorilla/mux"
+	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 const (
@@ -12,18 +16,21 @@ const (
 )
 
 type RootHandler struct {
-	serverURL string
+	serverURL                     string
+	unauthenticatedHandlerWrapper *AuthAwareHandlerFuncWrapper
 }
 
 func NewRootHandler(serverURL string) *RootHandler {
-	return &RootHandler{serverURL: serverURL}
+	return &RootHandler{
+		serverURL:                     serverURL,
+		unauthenticatedHandlerWrapper: NewUnauthenticatedHandlerFuncWrapper(ctrl.Log.WithName("RootHandler")),
+	}
 }
 
-func (h *RootHandler) rootGetHandler(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
-	writeResponse(w, http.StatusOK, presenter.GetRootResponse(h.serverURL))
+func (h *RootHandler) rootGetHandler(ctx context.Context, logger logr.Logger, _ authorization.Info, r *http.Request) (*HandlerResponse, error) {
+	return NewHandlerResponse(http.StatusOK).WithBody(presenter.GetRootResponse(h.serverURL)), nil
 }
 
 func (h *RootHandler) RegisterRoutes(router *mux.Router) {
-	router.Path(RootPath).Methods("GET").HandlerFunc(h.rootGetHandler)
+	router.Path(RootPath).Methods("GET").HandlerFunc(h.unauthenticatedHandlerWrapper.Wrap(h.rootGetHandler))
 }

--- a/api/handlers/root_v3_handler.go
+++ b/api/handlers/root_v3_handler.go
@@ -1,9 +1,13 @@
 package handlers
 
 import (
+	"context"
 	"net/http"
 
+	"code.cloudfoundry.org/korifi/api/authorization"
+	"github.com/go-logr/logr"
 	"github.com/gorilla/mux"
+	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 const (
@@ -11,23 +15,27 @@ const (
 )
 
 type RootV3Handler struct {
-	serverURL string
+	serverURL                     string
+	unauthenticatedHandlerWrapper *AuthAwareHandlerFuncWrapper
 }
 
 func NewRootV3Handler(serverURL string) *RootV3Handler {
-	return &RootV3Handler{serverURL: serverURL}
+	return &RootV3Handler{
+		serverURL:                     serverURL,
+		unauthenticatedHandlerWrapper: NewUnauthenticatedHandlerFuncWrapper(ctrl.Log.WithName("RootHandler")),
+	}
 }
 
-func (h *RootV3Handler) rootV3GetHandler(w http.ResponseWriter, r *http.Request) {
-	writeResponse(w, http.StatusOK, map[string]interface{}{
+func (h *RootV3Handler) rootV3GetHandler(ctx context.Context, logger logr.Logger, authInfo authorization.Info, r *http.Request) (*HandlerResponse, error) {
+	return NewHandlerResponse(http.StatusOK).WithBody(map[string]interface{}{
 		"links": map[string]interface{}{
 			"self": map[string]interface{}{
 				"href": h.serverURL + "/v3",
 			},
 		},
-	})
+	}), nil
 }
 
 func (h *RootV3Handler) RegisterRoutes(router *mux.Router) {
-	router.Path(RootV3Path).Methods("GET").HandlerFunc(h.rootV3GetHandler)
+	router.Path(RootV3Path).Methods("GET").HandlerFunc(h.unauthenticatedHandlerWrapper.Wrap(h.rootV3GetHandler))
 }

--- a/api/handlers/service_binding_handler.go
+++ b/api/handlers/service_binding_handler.go
@@ -91,7 +91,7 @@ func (h *ServiceBindingHandler) deleteHandler(ctx context.Context, logger logr.L
 		return nil, err
 	}
 
-	return NewHandlerResponse(http.StatusNoContent).WithBody(map[string]interface{}{}), nil
+	return NewHandlerResponse(http.StatusNoContent), nil
 }
 
 func (h *ServiceBindingHandler) listHandler(ctx context.Context, logger logr.Logger, authInfo authorization.Info, r *http.Request) (*HandlerResponse, error) {

--- a/api/handlers/service_binding_handler_test.go
+++ b/api/handlers/service_binding_handler_test.go
@@ -409,7 +409,7 @@ var _ = Describe("ServiceBindingHandler", func() {
 
 		It("returns a NoContent status", func() {
 			Expect(rr.Code).To(Equal(http.StatusNoContent))
-			Expect(rr.Body.String()).To(ContainSubstring(`{}`))
+			Expect(rr.Body.String()).To(BeEmpty())
 		})
 
 		It("invokes DeleteServiceBinding on the repository", func() {

--- a/api/handlers/shared.go
+++ b/api/handlers/shared.go
@@ -12,7 +12,6 @@ import (
 	"code.cloudfoundry.org/korifi/api/payloads"
 
 	"code.cloudfoundry.org/bytefmt"
-	"github.com/go-http-utils/headers"
 	"github.com/go-playground/locales/en"
 	ut "github.com/go-playground/universal-translator"
 	"github.com/go-playground/validator/v10"
@@ -223,20 +222,6 @@ func checkRoleTypeAndOrgSpace(sl validator.StructLevel) {
 	case RoleName(""):
 	default:
 		sl.ReportError(roleCreate.Type, "type", "Role type", "valid_role", "")
-	}
-}
-
-func writeResponse(w http.ResponseWriter, status int, responseBody interface{}) {
-	w.Header().Set(headers.ContentType, "application/json")
-	w.WriteHeader(status)
-
-	encoder := json.NewEncoder(w)
-	encoder.SetEscapeHTML(false)
-
-	err := encoder.Encode(responseBody)
-	if err != nil {
-		Logger.Error(err, "failed to encode and write response")
-		return
 	}
 }
 

--- a/api/handlers/space_manifest_handler.go
+++ b/api/handlers/space_manifest_handler.go
@@ -69,12 +69,11 @@ func (h *SpaceManifestHandler) applyManifestHandler(ctx context.Context, logger 
 	spaceGUID := vars["spaceGUID"]
 	var manifest payloads.Manifest
 	if err := h.decoderValidator.DecodeAndValidateYAMLPayload(r, &manifest); err != nil {
-		return nil, err
+		return nil, apierrors.LogAndReturn(logger, err, "failed to decode payload")
 	}
 
 	if err := h.manifestApplier.Apply(ctx, authInfo, spaceGUID, manifest); err != nil {
-		logger.Error(err, "Error applying manifest")
-		return nil, err
+		return nil, apierrors.LogAndReturn(logger, err, "Error applying manifest")
 	}
 
 	return NewHandlerResponse(http.StatusAccepted).
@@ -86,8 +85,7 @@ func (h *SpaceManifestHandler) diffManifestHandler(ctx context.Context, logger l
 	spaceGUID := vars["spaceGUID"]
 
 	if _, err := h.spaceRepo.GetSpace(r.Context(), authInfo, spaceGUID); err != nil {
-		logger.Error(err, "failed to get space", "guid", spaceGUID)
-		return nil, apierrors.ForbiddenAsNotFound(err)
+		return nil, apierrors.LogAndReturn(logger, apierrors.ForbiddenAsNotFound(err), "failed to get space", "guid", spaceGUID)
 	}
 
 	return NewHandlerResponse(http.StatusAccepted).WithBody(map[string]interface{}{"diff": []string{}}), nil

--- a/api/handlers/task_handler.go
+++ b/api/handlers/task_handler.go
@@ -61,7 +61,7 @@ func (h *TaskHandler) taskGetHandler(ctx context.Context, logger logr.Logger, au
 
 	taskRecord, err := h.taskRepo.GetTask(ctx, authInfo, taskGUID)
 	if err != nil {
-		return nil, apierrors.ForbiddenAsNotFound(err)
+		return nil, apierrors.LogAndReturn(logger, apierrors.ForbiddenAsNotFound(err), "failed to get task", "taskGUID", taskGUID)
 	}
 
 	return NewHandlerResponse(http.StatusOK).WithBody(presenter.ForTask(taskRecord, h.serverURL)), nil
@@ -82,7 +82,7 @@ func (h *TaskHandler) taskCreateHandler(ctx context.Context, logger logr.Logger,
 
 	var payload payloads.TaskCreate
 	if err := h.decoderValidator.DecodeAndValidateJSONPayload(r, &payload); err != nil {
-		return nil, err
+		return nil, apierrors.LogAndReturn(logger, err, "failed to decode payload")
 	}
 
 	appRecord, err := h.appRepo.GetApp(ctx, authInfo, appGUID)

--- a/api/handlers/whoami_handler.go
+++ b/api/handlers/whoami_handler.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/url"
 
+	"code.cloudfoundry.org/korifi/api/apierrors"
 	"code.cloudfoundry.org/korifi/api/authorization"
 	"code.cloudfoundry.org/korifi/api/presenter"
 	"github.com/go-logr/logr"
@@ -39,9 +40,7 @@ func NewWhoAmI(identityProvider IdentityProvider, apiBaseURL url.URL) *WhoAmIHan
 func (h *WhoAmIHandler) whoAmIHandler(ctx context.Context, logger logr.Logger, authInfo authorization.Info, r *http.Request) (*HandlerResponse, error) {
 	identity, err := h.identityProvider.GetIdentity(r.Context(), authInfo)
 	if err != nil {
-		logger.Info("failed to get identity", "err", err)
-
-		return nil, err
+		return nil, apierrors.LogAndReturn(logger, err, "failed to get identity")
 	}
 
 	return NewHandlerResponse(http.StatusOK).WithBody(presenter.ForWhoAmI(identity)), nil

--- a/api/main.go
+++ b/api/main.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
-
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
@@ -289,6 +288,7 @@ func main() {
 	authInfoParser := authorization.NewInfoParser()
 	router.Use(
 		handlers.NewCorrelationIDMiddleware().Middleware,
+		handlers.NewHTTPLogging().Middleware,
 		handlers.NewAuthenticationMiddleware(
 			authInfoParser,
 			cachingIdentityProvider,

--- a/api/repositories/build_repository.go
+++ b/api/repositories/build_repository.go
@@ -88,13 +88,13 @@ func (b *BuildRepo) GetBuild(ctx context.Context, authInfo authorization.Info, b
 func (b *BuildRepo) GetLatestBuildByAppGUID(ctx context.Context, authInfo authorization.Info, spaceGUID string, appGUID string) (BuildRecord, error) {
 	userClient, err := b.userClientFactory.BuildClient(authInfo)
 	if err != nil { // Untested
-		return BuildRecord{}, apierrors.NewUnknownError(err)
+		return BuildRecord{}, err
 	}
 	labelSelector, err := labels.ValidatedSelectorFromSet(map[string]string{
 		korifiv1alpha1.CFAppGUIDLabelKey: appGUID,
 	})
 	if err != nil { // Untested
-		return BuildRecord{}, apierrors.NewUnknownError(err)
+		return BuildRecord{}, err
 	}
 
 	listOpts := &client.ListOptions{Namespace: spaceGUID, LabelSelector: labelSelector}
@@ -124,7 +124,7 @@ func orderBuilds(builds []korifiv1alpha1.CFBuild) []korifiv1alpha1.CFBuild {
 func (b *BuildRepo) GetBuildLogs(ctx context.Context, authInfo authorization.Info, spaceGUID string, buildGUID string) ([]LogRecord, error) {
 	userClient, err := b.userClientFactory.BuildK8sClient(authInfo)
 	if err != nil { // Untested
-		return []LogRecord{}, apierrors.NewUnknownError(err)
+		return []LogRecord{}, err
 	}
 	logWriter := new(strings.Builder)
 	err = NewBuildLogsClient(userClient).GetImageLogs(ctx, logWriter, buildGUID, spaceGUID)

--- a/api/repositories/pod_repository.go
+++ b/api/repositories/pod_repository.go
@@ -365,7 +365,7 @@ func (r *PodRepo) GetRuntimeLogsForApp(ctx context.Context, logger logr.Logger, 
 		logReadCloser, err = k8sClient.CoreV1().Pods(message.SpaceGUID).GetLogs(pod.Name, &corev1.PodLogOptions{Timestamps: true, TailLines: &message.Limit}).Stream(ctx)
 		if err != nil {
 			// untested
-			logger.Error(err, fmt.Sprintf("failed to fetch logs for pod: %s", pod.Name))
+			logger.Info(fmt.Sprintf("failed to fetch logs for pod: %s", pod.Name), "err", err)
 			continue
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/google/go-containerregistry v0.10.0
 	github.com/google/uuid v1.3.0
+	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/schema v1.2.0
 	github.com/jonboulle/clockwork v0.3.0
@@ -43,6 +44,7 @@ require (
 require (
 	code.cloudfoundry.org/lager v2.0.0+incompatible // indirect
 	github.com/emicklei/go-restful/v3 v3.8.0 // indirect
+	github.com/felixge/httpsnoop v1.0.1 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.20.0 // indirect
 	github.com/go-openapi/swag v0.21.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -738,6 +738,7 @@ github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
+github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8SPQ=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/flowstack/go-jsonschema v0.1.1/go.mod h1:yL7fNggx1o8rm9RlgXv7hTBWxdBM0rVwpMwimd3F3N0=
 github.com/flynn/go-docopt v0.0.0-20140912013429-f6dd2ebbb31e/go.mod h1:HyVoz1Mz5Co8TFO8EupIdlcpwShBmY98dkT2xeHkvEI=
@@ -1217,6 +1218,8 @@ github.com/goreleaser/nfpm v1.2.1/go.mod h1:TtWrABZozuLOttX2uDlYyECfQX7x5XYkVxhj
 github.com/gorhill/cronexpr v0.0.0-20180427100037-88b0669f7d75/go.mod h1:g2644b03hfBX9Ov0ZBDgXXens4rxSxmqFBbhvKv2yVA=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/handlers v0.0.0-20150720190736-60c7bfde3e33/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
+github.com/gorilla/handlers v1.5.1 h1:9lRY6j8DEeeBT10CvO9hGW0gmky0BprnvDI5vfhUHH4=
+github.com/gorilla/handlers v1.5.1/go.mod h1:t8XrUpc4KVXb7HGyJ4/cEnwQiaxrX/hz1Zv/4g96P1Q=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.0/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=


### PR DESCRIPTION
## Is there a related GitHub Issue?
#1340

## What is this change about?
- Introduce HTTP request/response logging
- apierrors.LogAndReturn supports wrapped errors
- Introduce unauthenticatedHandlerWrapper
- Do not return apierrors.UnknownError from build repo
- CertInspector returns invalid auth errors on bad user input
- Do not send any body with 204 status code
- Use correct severity for logs by using apierrors.LogAndReturn

## Does this PR introduce a breaking change?
No

## Acceptance Steps
No logs at the error level after running e2e suite

## Tag your pair, your PM, and/or team
@kieron-dev

## Things to remember
