### PR TITLE
`CFTask.canceled` should not be a required field

### DIFF
--- a/controllers/api/v1alpha1/cftask_types.go
+++ b/controllers/api/v1alpha1/cftask_types.go
@@ -37,9 +37,10 @@ type CFTaskSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	Command  []string                    `json:"command,omitempty"`
-	AppRef   corev1.LocalObjectReference `json:"appRef,omitempty"`
-	Canceled bool                        `json:"canceled"`
+	Command []string                    `json:"command,omitempty"`
+	AppRef  corev1.LocalObjectReference `json:"appRef,omitempty"`
+	// +optional
+	Canceled bool `json:"canceled"`
 }
 
 // CFTaskStatus defines the observed state of CFTask

--- a/controllers/config/crd/bases/korifi.cloudfoundry.org_cftasks.yaml
+++ b/controllers/config/crd/bases/korifi.cloudfoundry.org_cftasks.yaml
@@ -50,8 +50,6 @@ spec:
                 items:
                   type: string
                 type: array
-            required:
-            - canceled
             type: object
           status:
             description: CFTaskStatus defines the observed state of CFTask


### PR DESCRIPTION
## Is there a related GitHub Issue?

Problem introduced in #1040 (PR #1327).

## What is this change about?

This removes the `required` constraint on the `canceled` field of `CFTask`, as a task should not be considered canceled by default and it shouldn't be necessary to specify `canceled: false` to create a `CFTask`.