### PR TITLE
Fix the failure message for canceled tasks

### DIFF
--- a/api/repositories/task_repository.go
+++ b/api/repositories/task_repository.go
@@ -295,7 +295,7 @@ func taskToRecord(task *korifiv1alpha1.CFTask) TaskRecord {
 	if failedCond != nil && failedCond.Status == metav1.ConditionTrue {
 		taskRecord.FailureReason = failedCond.Message
 
-		if failedCond.Message == workloads.TaskCanceledReason {
+		if failedCond.Reason == workloads.TaskCanceledReason {
 			taskRecord.FailureReason = "task was canceled"
 		}
 	}

--- a/api/repositories/task_repository_test.go
+++ b/api/repositories/task_repository_test.go
@@ -292,10 +292,9 @@ var _ = Describe("TaskRepository", func() {
 				BeforeEach(func() {
 					setStatusAndUpdate(cfTask, korifiv1alpha1.TaskInitializedConditionType, korifiv1alpha1.TaskStartedConditionType)
 					meta.SetStatusCondition(&(cfTask.Status.Conditions), metav1.Condition{
-						Type:    korifiv1alpha1.TaskFailedConditionType,
-						Status:  metav1.ConditionTrue,
-						Reason:  "Error",
-						Message: "taskCanceled",
+						Type:   korifiv1alpha1.TaskFailedConditionType,
+						Status: metav1.ConditionTrue,
+						Reason: "taskCanceled",
 					})
 					Expect(k8sClient.Status().Update(ctx, cfTask)).To(Succeed())
 				})


### PR DESCRIPTION
## Is there a related GitHub Issue?

Bug from #1048 (PR #1347).

## What is this change about?

This fixes the `TaskRepository` so that canceled tasks have a failure message saying `"task was canceled"`.