### PR TITLE
Make task status fields optional

### DIFF
--- a/controllers/api/v1alpha1/cftask_types.go
+++ b/controllers/api/v1alpha1/cftask_types.go
@@ -47,12 +47,17 @@ type CFTaskSpec struct {
 type CFTaskStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
+	// +optional
 	Conditions []metav1.Condition `json:"conditions"`
 
-	SequenceID  int64                       `json:"sequenceId"`
-	MemoryMB    int64                       `json:"memoryMB"`
-	DiskQuotaMB int64                       `json:"diskQuotaMB"`
-	DropletRef  corev1.LocalObjectReference `json:"dropletRef"`
+	// +optional
+	SequenceID int64 `json:"sequenceId"`
+	// +optional
+	MemoryMB int64 `json:"memoryMB"`
+	// +optional
+	DiskQuotaMB int64 `json:"diskQuotaMB"`
+	// +optional
+	DropletRef corev1.LocalObjectReference `json:"dropletRef"`
 }
 
 //+kubebuilder:object:root=true

--- a/controllers/config/crd/bases/korifi.cloudfoundry.org_cftasks.yaml
+++ b/controllers/config/crd/bases/korifi.cloudfoundry.org_cftasks.yaml
@@ -143,12 +143,6 @@ spec:
               sequenceId:
                 format: int64
                 type: integer
-            required:
-            - conditions
-            - diskQuotaMB
-            - dropletRef
-            - memoryMB
-            - sequenceId
             type: object
         type: object
     served: true

--- a/controllers/webhooks/workloads/integration/cftask_validator_test.go
+++ b/controllers/webhooks/workloads/integration/cftask_validator_test.go
@@ -176,10 +176,6 @@ func setStatusCondition(cftask *korifiv1alpha1.CFTask, conditionType string) {
 		Reason:  "foo",
 		Message: "bar",
 	})
-	cftask.Status.MemoryMB = 1
-	cftask.Status.DiskQuotaMB = 2
-	cftask.Status.DropletRef = corev1.LocalObjectReference{Name: "bob"}
-	cftask.Status.SequenceID = 3
 	Expect(k8sClient.Status().Patch(context.Background(), cftask, client.MergeFrom(clone))).To(Succeed())
 
 	// the status update clears any unapplied changes to the rest of the object, so reset spec changes:


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Make task status fields optional.
It was just the kubebuilder default to make them required, this was
never intended
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
no
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
N/A
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@kieron-dev
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

