### PR TITLE
Enforce the `restricted` pod security standard for `statefulset-runner`

### DIFF
--- a/statefulset-runner/config/manager/manager.yaml
+++ b/statefulset-runner/config/manager/manager.yaml
@@ -3,6 +3,8 @@ kind: Namespace
 metadata:
   labels:
     control-plane: controller-manager
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/enforce: restricted
   name: system
 ---
 apiVersion: apps/v1
@@ -34,6 +36,12 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
## Is there a related GitHub Issue?

This is related to #1221.

## What is this change about?

This does the same we did in #1221 on the new `statefulset-runner` `Namespace` and `Deployment`.