### PR TITLE
Tasks are deleted after their retention period

### DIFF
--- a/controllers/config/base/controllersconfig/korifi_controllers_config.yaml
+++ b/controllers/config/base/controllersconfig/korifi_controllers_config.yaml
@@ -3,5 +3,8 @@ cfProcessDefaults:
   diskQuotaMB: 1024
 cfRootNamespace: cf
 packageRegistrySecretName: image-registry-credentials # Create this secret in the rootNamespace
+# taskTTL should be series of numbers and units (d: days, h: hours, m: minutes, s: seconds)
+# with no spaces, e.g. 5d12h45m. Default is 30 days
+taskTTL: 30d
 workloads_tls_secret_name: korifi-workloads-ingress-cert
 workloads_tls_secret_namespace: korifi-controllers-system

--- a/controllers/config/config_suite_test.go
+++ b/controllers/config/config_suite_test.go
@@ -1,0 +1,13 @@
+package config_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Config Suite")
+}

--- a/controllers/config/config_test.go
+++ b/controllers/config/config_test.go
@@ -1,0 +1,97 @@
+package config_test
+
+import (
+	"time"
+
+	"code.cloudfoundry.org/korifi/controllers/config"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ParseTaskTTL", func() {
+	var (
+		taskTTLString string
+		taskTTL       time.Duration
+		parseErr      error
+	)
+
+	BeforeEach(func() {
+		taskTTLString = ""
+	})
+
+	JustBeforeEach(func() {
+		cfg := config.ControllerConfig{
+			TaskTTL: taskTTLString,
+		}
+
+		taskTTL, parseErr = cfg.ParseTaskTTL()
+	})
+
+	It("return 30 days by default", func() {
+		Expect(parseErr).NotTo(HaveOccurred())
+		Expect(taskTTL).To(Equal(30 * 24 * time.Hour))
+	})
+
+	When("entering something parseable by time.ParseDuration", func() {
+		BeforeEach(func() {
+			taskTTLString = "12h30m5s20ns"
+		})
+
+		It("parses ok", func() {
+			Expect(parseErr).NotTo(HaveOccurred())
+			Expect(taskTTL).To(Equal(12*time.Hour + 30*time.Minute + 5*time.Second + 20*time.Nanosecond))
+		})
+	})
+
+	When("entering something that cannot be parsed", func() {
+		BeforeEach(func() {
+			taskTTLString = "foreva"
+		})
+
+		It("returns an error", func() {
+			Expect(parseErr).To(HaveOccurred())
+		})
+	})
+
+	When("a simple day expression", func() {
+		BeforeEach(func() {
+			taskTTLString = "25d"
+		})
+
+		It("parses ok", func() {
+			Expect(parseErr).NotTo(HaveOccurred())
+			Expect(taskTTL).To(Equal(25 * 24 * time.Hour))
+		})
+	})
+
+	When("a compound day expression", func() {
+		BeforeEach(func() {
+			taskTTLString = "25d13h12m"
+		})
+
+		It("parses ok", func() {
+			Expect(parseErr).NotTo(HaveOccurred())
+			Expect(taskTTL).To(Equal(25*24*time.Hour + 13*time.Hour + 12*time.Minute))
+		})
+	})
+
+	When("a compound day erroneous expression", func() {
+		BeforeEach(func() {
+			taskTTLString = "25dlater"
+		})
+
+		It("parses ok", func() {
+			Expect(parseErr).To(HaveOccurred())
+		})
+	})
+
+	When("it contains more than 1 'd'", func() {
+		BeforeEach(func() {
+			taskTTLString = "1d2d"
+		})
+
+		It("returns an error", func() {
+			Expect(parseErr).To(HaveOccurred())
+		})
+	})
+})

--- a/controllers/config/overlays/kind-local-registry/controllersconfig/korifi_controllers_config.yaml
+++ b/controllers/config/overlays/kind-local-registry/controllersconfig/korifi_controllers_config.yaml
@@ -3,5 +3,6 @@ cfProcessDefaults:
   diskQuotaMB: 1024
 cfRootNamespace: cf
 packageRegistrySecretName: image-registry-credentials # Create this secret in the rootNamespace
+taskTTL: 5s
 workloads_tls_secret_name: korifi-workloads-ingress-cert
 workloads_tls_secret_namespace: korifi-controllers-system

--- a/controllers/config/overlays/pr-e2e/controllersconfig/korifi_controllers_config.yaml
+++ b/controllers/config/overlays/pr-e2e/controllersconfig/korifi_controllers_config.yaml
@@ -3,5 +3,6 @@ cfProcessDefaults:
   diskQuotaMB: 1024
 cfRootNamespace: cf
 packageRegistrySecretName: image-registry-credentials # Create this secret in the rootNamespace
+taskTTL: 5s
 workloads_tls_secret_name: korifi-workloads-ingress-cert
 workloads_tls_secret_namespace: korifi-controllers-system

--- a/controllers/controllers/workloads/integration/suite_integration_test.go
+++ b/controllers/controllers/workloads/integration/suite_integration_test.go
@@ -161,6 +161,7 @@ var _ = BeforeSuite(func() {
 		ctrl.Log.WithName("controllers").WithName("CFTask"),
 		NewSequenceId(clockwork.NewRealClock()),
 		cfProcessDefaults,
+		2*time.Second,
 	).SetupWithManager(k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -215,6 +215,12 @@ func main() {
 		os.Exit(1)
 	}
 
+	taskTTL, err := controllerConfig.ParseTaskTTL()
+	if err != nil {
+		setupLog.Error(err, "failed to parse task TTL", "controller", "CFTask", "taskTTL", controllerConfig.TaskTTL)
+		os.Exit(1)
+
+	}
 	if err = workloadscontrollers.NewCFTaskReconciler(
 		mgr.GetClient(),
 		mgr.GetScheme(),
@@ -222,6 +228,7 @@ func main() {
 		ctrl.Log.WithName("controllers").WithName("CFTask"),
 		workloadscontrollers.NewSequenceId(clockwork.NewRealClock()),
 		controllerConfig.CFProcessDefaults,
+		taskTTL,
 	).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "CFTask")
 		os.Exit(1)

--- a/tests/e2e/tasks_test.go
+++ b/tests/e2e/tasks_test.go
@@ -108,8 +108,18 @@ var _ = Describe("Tasks", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("succeeds", func() {
+		It("succeeds and is cleaned up after its TTL", func() {
 			eventuallyTaskShouldHaveState(createdTask.GUID, "SUCCEEDED")
+
+			Eventually(func(g Gomega) {
+				var task taskResource
+				getResp, err := certClient.R().
+					SetPathParam("taskGUID", createdTask.GUID).
+					SetResult(&task).
+					Get("/v3/tasks/{taskGUID}")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(getResp).To(HaveRestyStatusCode(http.StatusNotFound))
+			}).Should(Succeed())
 		})
 	})
 


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
#1049

<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Tasks are deleted after their retention period


* Introduce a controller config property `taskTTL` that has format that
  is parsable by time.ParseDuration, e.g. `12h30m6s`. In contrast to
  `time.ParseDuration`, `taskTTL` also accepts days, so `12d6h` means 12
  days and 6 hours
* The default `taskTTL` is 30 days (`30d`)
* On local kind and `pr-e2e` clusters `taskTTL` is set to `5s` in the
  corresponding overlay so that e2e test that verifies that the task is
  eventually deleted does not have to wait for 30 days
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
See story
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@kieron-dev
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

