### PR TITLE
Delete referencing tasks when deleting an app

### DIFF
--- a/controllers/controllers/shared/index.go
+++ b/controllers/controllers/shared/index.go
@@ -12,6 +12,7 @@ const (
 	IndexRouteDestinationAppName           = "destinationAppName"
 	IndexServiceBindingAppGUID             = "serviceBindingAppGUID"
 	IndexServiceBindingServiceInstanceGUID = "serviceBindingServiceInstanceGUID"
+	IndexAppTasks                          = "appTasks"
 )
 
 func SetupIndexWithManager(mgr manager.Manager) error {
@@ -29,6 +30,15 @@ func SetupIndexWithManager(mgr manager.Manager) error {
 	if err != nil {
 		return err
 	}
+
+	err = mgr.GetFieldIndexer().IndexField(context.Background(), &korifiv1alpha1.CFTask{}, IndexAppTasks, func(object client.Object) []string {
+		task := object.(*korifiv1alpha1.CFTask)
+		return []string{task.Spec.AppRef.Name}
+	})
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/controllers/controllers/workloads/fake/cfclient.go
+++ b/controllers/controllers/workloads/fake/cfclient.go
@@ -24,6 +24,19 @@ type CFClient struct {
 	createReturnsOnCall map[int]struct {
 		result1 error
 	}
+	DeleteStub        func(context.Context, client.Object, ...client.DeleteOption) error
+	deleteMutex       sync.RWMutex
+	deleteArgsForCall []struct {
+		arg1 context.Context
+		arg2 client.Object
+		arg3 []client.DeleteOption
+	}
+	deleteReturns struct {
+		result1 error
+	}
+	deleteReturnsOnCall map[int]struct {
+		result1 error
+	}
 	GetStub        func(context.Context, types.NamespacedName, client.Object) error
 	getMutex       sync.RWMutex
 	getArgsForCall []struct {
@@ -150,6 +163,69 @@ func (fake *CFClient) CreateReturnsOnCall(i int, result1 error) {
 		})
 	}
 	fake.createReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *CFClient) Delete(arg1 context.Context, arg2 client.Object, arg3 ...client.DeleteOption) error {
+	fake.deleteMutex.Lock()
+	ret, specificReturn := fake.deleteReturnsOnCall[len(fake.deleteArgsForCall)]
+	fake.deleteArgsForCall = append(fake.deleteArgsForCall, struct {
+		arg1 context.Context
+		arg2 client.Object
+		arg3 []client.DeleteOption
+	}{arg1, arg2, arg3})
+	stub := fake.DeleteStub
+	fakeReturns := fake.deleteReturns
+	fake.recordInvocation("Delete", []interface{}{arg1, arg2, arg3})
+	fake.deleteMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3...)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *CFClient) DeleteCallCount() int {
+	fake.deleteMutex.RLock()
+	defer fake.deleteMutex.RUnlock()
+	return len(fake.deleteArgsForCall)
+}
+
+func (fake *CFClient) DeleteCalls(stub func(context.Context, client.Object, ...client.DeleteOption) error) {
+	fake.deleteMutex.Lock()
+	defer fake.deleteMutex.Unlock()
+	fake.DeleteStub = stub
+}
+
+func (fake *CFClient) DeleteArgsForCall(i int) (context.Context, client.Object, []client.DeleteOption) {
+	fake.deleteMutex.RLock()
+	defer fake.deleteMutex.RUnlock()
+	argsForCall := fake.deleteArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *CFClient) DeleteReturns(result1 error) {
+	fake.deleteMutex.Lock()
+	defer fake.deleteMutex.Unlock()
+	fake.DeleteStub = nil
+	fake.deleteReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *CFClient) DeleteReturnsOnCall(i int, result1 error) {
+	fake.deleteMutex.Lock()
+	defer fake.deleteMutex.Unlock()
+	fake.DeleteStub = nil
+	if fake.deleteReturnsOnCall == nil {
+		fake.deleteReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.deleteReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
 }
@@ -465,6 +541,8 @@ func (fake *CFClient) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.createMutex.RLock()
 	defer fake.createMutex.RUnlock()
+	fake.deleteMutex.RLock()
+	defer fake.deleteMutex.RUnlock()
 	fake.getMutex.RLock()
 	defer fake.getMutex.RUnlock()
 	fake.listMutex.RLock()

--- a/controllers/controllers/workloads/shared.go
+++ b/controllers/controllers/workloads/shared.go
@@ -29,6 +29,7 @@ type CFClient interface {
 	Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error
 	Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error
 	Status() client.StatusWriter
+	Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error
 }
 
 // This is a helper function for updating local copy of status conditions


### PR DESCRIPTION
## Is there a related GitHub Issue?
https://github.com/cloudfoundry/korifi/issues/1241
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Delete tasks that reference the app when deleting the app
* Task deletion takes place in app's finalizer
* Introduce index on tasks on appref's name so that we could easily find tasks that reference the app

<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
See story
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@georgethebeatle

<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

