### PR TITLE
Set `source_type` tag on LogEnvelopes to `STG` for build logs.

### DIFF
--- a/api/handlers/log_cache_handler_test.go
+++ b/api/handlers/log_cache_handler_test.go
@@ -78,10 +78,16 @@ var _ = Describe("LogCacheHandler", func() {
 				{
 					Message:   "BuildMessage1",
 					Timestamp: time.Now().UnixNano(),
+					Tags: map[string]string{
+						"source_type": "STG",
+					},
 				},
 				{
 					Message:   "BuildMessage2",
 					Timestamp: time.Now().UnixNano(),
+					Tags: map[string]string{
+						"source_type": "STG",
+					},
 				},
 			}
 
@@ -118,6 +124,9 @@ var _ = Describe("LogCacheHandler", func() {
 							"log": {
 								"payload": "%[2]s",
 								"type": 0
+							},
+							"tags": {
+								"source_type": "STG"
 							}
 						},
 						{
@@ -125,6 +134,9 @@ var _ = Describe("LogCacheHandler", func() {
 							"log": {
 								"payload": "%[4]s",
 								"type": 0
+							},
+							"tags": {
+								"source_type": "STG"
 							}
 						},
 						{

--- a/api/presenter/log.go
+++ b/api/presenter/log.go
@@ -16,6 +16,7 @@ type LogCacheReadResponseEnvelopes struct {
 type LogCacheReadResponseBatch struct {
 	Timestamp int64                   `json:"timestamp"`
 	Log       LogCacheReadResponseLog `json:"log"`
+	Tags      map[string]string       `json:"tags,omitempty"`
 }
 
 type LogCacheReadResponseLog struct {
@@ -32,6 +33,7 @@ func ForLogs(logRecords []repositories.LogRecord) LogCacheReadResponse {
 				Payload: []byte(logRecord.Message),
 				Type:    loggregator_v2.Log_OUT,
 			},
+			Tags: logRecord.Tags,
 		}
 
 		envelopes = append(envelopes, batch)

--- a/api/repositories/build_repository.go
+++ b/api/repositories/build_repository.go
@@ -30,6 +30,7 @@ const (
 	SucceededConditionType = "Succeeded"
 
 	BuildResourceType = "Build"
+	stagingLog        = "STG"
 )
 
 type BuildRecord struct {
@@ -52,6 +53,7 @@ type LogRecord struct {
 	Message   string
 	Timestamp int64
 	Header    string
+	Tags      map[string]string
 }
 
 type BuildRepo struct {
@@ -140,6 +142,9 @@ func (b *BuildRepo) GetBuildLogs(ctx context.Context, authInfo authorization.Inf
 		toReturn = append(toReturn, LogRecord{
 			Message:   logLine,
 			Timestamp: logTime,
+			Tags: map[string]string{
+				"source_type": stagingLog,
+			},
 		})
 	}
 

--- a/tests/e2e/log_cache_test.go
+++ b/tests/e2e/log_cache_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/go-resty/resty/v2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
 )
 
 var _ = Describe("LogCache", func() {
@@ -36,6 +37,9 @@ var _ = Describe("LogCache", func() {
 			Expect(httpError).NotTo(HaveOccurred())
 			Expect(httpResp).To(HaveRestyStatusCode(http.StatusOK))
 			Expect(result.Envelopes.Batch).NotTo(BeEmpty())
+			Expect(result.Envelopes.Batch).To(ContainElements(MatchFields(IgnoreExtras, Fields{
+				"Tags": HaveKeyWithValue("source_type", "STG"),
+			})))
 		})
 	})
 })


### PR DESCRIPTION

<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->
#1298

## What is this change about?
<!-- _Please describe the change here._ -->
Sets "source_type" tag on LogEnvelopes to "STG" for build logs, enabling the CLI to output staging logs to console.

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->
No.

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->
Follow acceptance steps on issues

- DEV build for CF CLI is not required as the dummy `oauth/token` endpoint exists.

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->
@clintyoshimura 
