### PR TITLE
Wait for the ClusterBuilder before running e2e

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -57,6 +57,9 @@ else
   source "$SCRIPT_DIR/account-creation.sh" "$SCRIPT_DIR"
 
   extra_args+=("--slow-spec-threshold=30s")
+
+  echo "waiting for ClusterBuilder to be ready..."
+  kubectl wait --for=condition=ready clusterbuilder --all=true --timeout=15m
 fi
 
 if [[ -z "$NON_RECURSIVE_TEST" ]]; then


### PR DESCRIPTION
## Is there a related GitHub Issue?
[#1388]

## What is this change about?
- Wait for the Ready condition on all clusterbuilders before starting
  e2e tests.
- This will keep us from erroring out listing buildpacks in the case
  where we start tests before the ClusterBuilder is done reconciling.

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->
No.

## Acceptance Steps
[#1388]

## Tag your pair, your PM, and/or team
@matt-royal 
