### PR TITLE
Await `Staged` condition on setting the app droplet

### DIFF
--- a/api/handlers/integration/apply_manifest_test.go
+++ b/api/handlers/integration/apply_manifest_test.go
@@ -29,7 +29,7 @@ var _ = Describe("POST /v3/spaces/<space-guid>/actions/apply_manifest endpoint",
 	)
 
 	BeforeEach(func() {
-		appRepo := repositories.NewAppRepo(namespaceRetriever, clientFactory, nsPermissions, conditions.NewCFAppConditionAwaiter(2*time.Second))
+		appRepo := repositories.NewAppRepo(namespaceRetriever, clientFactory, nsPermissions, conditions.NewConditionAwaiter[*korifiv1alpha1.CFApp, korifiv1alpha1.CFAppList](2*time.Second))
 		domainRepo := repositories.NewDomainRepo(clientFactory, namespaceRetriever, rootNamespace)
 		processRepo := repositories.NewProcessRepo(namespaceRetriever, clientFactory, nsPermissions)
 		routeRepo := repositories.NewRouteRepo(namespaceRetriever, clientFactory, nsPermissions)

--- a/api/handlers/integration/apply_manifest_test.go
+++ b/api/handlers/integration/apply_manifest_test.go
@@ -11,6 +11,7 @@ import (
 	"code.cloudfoundry.org/korifi/api/actions"
 	. "code.cloudfoundry.org/korifi/api/handlers"
 	"code.cloudfoundry.org/korifi/api/repositories"
+	"code.cloudfoundry.org/korifi/api/repositories/conditions"
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -28,7 +29,7 @@ var _ = Describe("POST /v3/spaces/<space-guid>/actions/apply_manifest endpoint",
 	)
 
 	BeforeEach(func() {
-		appRepo := repositories.NewAppRepo(namespaceRetriever, clientFactory, nsPermissions)
+		appRepo := repositories.NewAppRepo(namespaceRetriever, clientFactory, nsPermissions, conditions.NewCFAppConditionAwaiter(2*time.Second))
 		domainRepo := repositories.NewDomainRepo(clientFactory, namespaceRetriever, rootNamespace)
 		processRepo := repositories.NewProcessRepo(namespaceRetriever, clientFactory, nsPermissions)
 		routeRepo := repositories.NewRouteRepo(namespaceRetriever, clientFactory, nsPermissions)

--- a/api/handlers/integration/get_app_env_test.go
+++ b/api/handlers/integration/get_app_env_test.go
@@ -23,7 +23,7 @@ var _ = Describe("GET /v3/apps/:guid/env", func() {
 	var namespace *corev1.Namespace
 
 	BeforeEach(func() {
-		appRepo := repositories.NewAppRepo(namespaceRetriever, clientFactory, nsPermissions, conditions.NewCFAppConditionAwaiter(2*time.Second))
+		appRepo := repositories.NewAppRepo(namespaceRetriever, clientFactory, nsPermissions, conditions.NewConditionAwaiter[*korifiv1alpha1.CFApp, korifiv1alpha1.CFAppList](2*time.Second))
 		domainRepo := repositories.NewDomainRepo(clientFactory, namespaceRetriever, rootNamespace)
 		processRepo := repositories.NewProcessRepo(namespaceRetriever, clientFactory, nsPermissions)
 		routeRepo := repositories.NewRouteRepo(namespaceRetriever, clientFactory, nsPermissions)

--- a/api/handlers/integration/get_app_env_test.go
+++ b/api/handlers/integration/get_app_env_test.go
@@ -9,6 +9,7 @@ import (
 	"code.cloudfoundry.org/korifi/api/actions"
 	. "code.cloudfoundry.org/korifi/api/handlers"
 	"code.cloudfoundry.org/korifi/api/repositories"
+	"code.cloudfoundry.org/korifi/api/repositories/conditions"
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -22,7 +23,7 @@ var _ = Describe("GET /v3/apps/:guid/env", func() {
 	var namespace *corev1.Namespace
 
 	BeforeEach(func() {
-		appRepo := repositories.NewAppRepo(namespaceRetriever, clientFactory, nsPermissions)
+		appRepo := repositories.NewAppRepo(namespaceRetriever, clientFactory, nsPermissions, conditions.NewCFAppConditionAwaiter(2*time.Second))
 		domainRepo := repositories.NewDomainRepo(clientFactory, namespaceRetriever, rootNamespace)
 		processRepo := repositories.NewProcessRepo(namespaceRetriever, clientFactory, nsPermissions)
 		routeRepo := repositories.NewRouteRepo(namespaceRetriever, clientFactory, nsPermissions)

--- a/api/handlers/integration/route_test.go
+++ b/api/handlers/integration/route_test.go
@@ -11,6 +11,7 @@ import (
 
 	. "code.cloudfoundry.org/korifi/api/handlers"
 	"code.cloudfoundry.org/korifi/api/repositories"
+	"code.cloudfoundry.org/korifi/api/repositories/conditions"
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -29,7 +30,7 @@ var _ = Describe("Route Handler", func() {
 	)
 
 	BeforeEach(func() {
-		appRepo := repositories.NewAppRepo(namespaceRetriever, clientFactory, nsPermissions)
+		appRepo := repositories.NewAppRepo(namespaceRetriever, clientFactory, nsPermissions, conditions.NewCFAppConditionAwaiter(2*time.Second))
 		orgRepo := repositories.NewOrgRepo(rootNamespace, k8sClient, clientFactory, nsPermissions, time.Minute)
 		spaceRepo := repositories.NewSpaceRepo(namespaceRetriever, orgRepo, clientFactory, nsPermissions, time.Minute)
 		routeRepo := repositories.NewRouteRepo(namespaceRetriever, clientFactory, nsPermissions)

--- a/api/handlers/integration/route_test.go
+++ b/api/handlers/integration/route_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Route Handler", func() {
 	)
 
 	BeforeEach(func() {
-		appRepo := repositories.NewAppRepo(namespaceRetriever, clientFactory, nsPermissions, conditions.NewCFAppConditionAwaiter(2*time.Second))
+		appRepo := repositories.NewAppRepo(namespaceRetriever, clientFactory, nsPermissions, conditions.NewConditionAwaiter[*korifiv1alpha1.CFApp, korifiv1alpha1.CFAppList](2*time.Second))
 		orgRepo := repositories.NewOrgRepo(rootNamespace, k8sClient, clientFactory, nsPermissions, time.Minute)
 		spaceRepo := repositories.NewSpaceRepo(namespaceRetriever, orgRepo, clientFactory, nsPermissions, time.Minute)
 		routeRepo := repositories.NewRouteRepo(namespaceRetriever, clientFactory, nsPermissions)

--- a/api/main.go
+++ b/api/main.go
@@ -15,6 +15,7 @@ import (
 	"code.cloudfoundry.org/korifi/api/handlers"
 	"code.cloudfoundry.org/korifi/api/payloads"
 	"code.cloudfoundry.org/korifi/api/repositories"
+	"code.cloudfoundry.org/korifi/api/repositories/conditions"
 	reporegistry "code.cloudfoundry.org/korifi/api/repositories/registry"
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 
@@ -137,7 +138,12 @@ func main() {
 		reporegistry.NewImageBuilder(),
 		reporegistry.NewImagePusher(remote.Write),
 	)
-	taskRepo := repositories.NewTaskRepo(userClientFactory, namespaceRetriever, nsPermissions, createTimeout)
+	taskRepo := repositories.NewTaskRepo(
+		userClientFactory,
+		namespaceRetriever,
+		nsPermissions,
+		conditions.NewCFTaskConditionAwaiter(createTimeout),
+	)
 
 	processScaler := actions.NewProcessScaler(appRepo, processRepo)
 	processStats := actions.NewProcessStats(processRepo, podRepo, appRepo)

--- a/api/main.go
+++ b/api/main.go
@@ -104,7 +104,8 @@ func main() {
 	spaceRepo := repositories.NewSpaceRepo(namespaceRetriever, orgRepo, userClientFactory, nsPermissions, createTimeout)
 	processRepo := repositories.NewProcessRepo(namespaceRetriever, userClientFactory, nsPermissions)
 	podRepo := repositories.NewPodRepo(userClientFactory, metricsFetcherFunction)
-	appRepo := repositories.NewAppRepo(namespaceRetriever, userClientFactory, nsPermissions, conditions.NewCFAppConditionAwaiter(createTimeout))
+	cfAppConditionAwaiter := conditions.NewConditionAwaiter[*korifiv1alpha1.CFApp, korifiv1alpha1.CFAppList](createTimeout)
+	appRepo := repositories.NewAppRepo(namespaceRetriever, userClientFactory, nsPermissions, cfAppConditionAwaiter)
 	dropletRepo := repositories.NewDropletRepo(userClientFactory, namespaceRetriever, nsPermissions)
 	routeRepo := repositories.NewRouteRepo(namespaceRetriever, userClientFactory, nsPermissions)
 	domainRepo := repositories.NewDomainRepo(userClientFactory, namespaceRetriever, config.RootNamespace)
@@ -142,7 +143,7 @@ func main() {
 		userClientFactory,
 		namespaceRetriever,
 		nsPermissions,
-		conditions.NewCFTaskConditionAwaiter(createTimeout),
+		conditions.NewConditionAwaiter[*korifiv1alpha1.CFTask, korifiv1alpha1.CFTaskList](createTimeout),
 	)
 
 	processScaler := actions.NewProcessScaler(appRepo, processRepo)

--- a/api/main.go
+++ b/api/main.go
@@ -104,7 +104,7 @@ func main() {
 	spaceRepo := repositories.NewSpaceRepo(namespaceRetriever, orgRepo, userClientFactory, nsPermissions, createTimeout)
 	processRepo := repositories.NewProcessRepo(namespaceRetriever, userClientFactory, nsPermissions)
 	podRepo := repositories.NewPodRepo(userClientFactory, metricsFetcherFunction)
-	appRepo := repositories.NewAppRepo(namespaceRetriever, userClientFactory, nsPermissions)
+	appRepo := repositories.NewAppRepo(namespaceRetriever, userClientFactory, nsPermissions, conditions.NewCFAppConditionAwaiter(createTimeout))
 	dropletRepo := repositories.NewDropletRepo(userClientFactory, namespaceRetriever, nsPermissions)
 	routeRepo := repositories.NewRouteRepo(namespaceRetriever, userClientFactory, nsPermissions)
 	domainRepo := repositories.NewDomainRepo(userClientFactory, namespaceRetriever, config.RootNamespace)

--- a/api/repositories/app_repository.go
+++ b/api/repositories/app_repository.go
@@ -41,14 +41,14 @@ type AppRepo struct {
 	namespaceRetriever   NamespaceRetriever
 	userClientFactory    authorization.UserK8sClientFactory
 	namespacePermissions *authorization.NamespacePermissions
-	appConditionAwaiter  ConditionAwaiter
+	appConditionAwaiter  ConditionAwaiter[*korifiv1alpha1.CFApp]
 }
 
 func NewAppRepo(
 	namespaceRetriever NamespaceRetriever,
 	userClientFactory authorization.UserK8sClientFactory,
 	authPerms *authorization.NamespacePermissions,
-	appConditionAwaiter ConditionAwaiter,
+	appConditionAwaiter ConditionAwaiter[*korifiv1alpha1.CFApp],
 ) *AppRepo {
 	return &AppRepo{
 		namespaceRetriever:   namespaceRetriever,

--- a/api/repositories/app_repository_test.go
+++ b/api/repositories/app_repository_test.go
@@ -43,7 +43,7 @@ var _ = Describe("AppRepository", func() {
 	BeforeEach(func() {
 		testCtx = context.Background()
 
-		appRepo = NewAppRepo(namespaceRetriever, userClientFactory, nsPerms, conditions.NewCFAppConditionAwaiter(2*time.Second))
+		appRepo = NewAppRepo(namespaceRetriever, userClientFactory, nsPerms, conditions.NewConditionAwaiter[*korifiv1alpha1.CFApp, korifiv1alpha1.CFAppList](2*time.Second))
 
 		org = createOrgWithCleanup(testCtx, prefixedGUID("org"))
 		space = createSpaceWithCleanup(testCtx, org.Name, prefixedGUID("space1"))

--- a/api/repositories/app_repository_test.go
+++ b/api/repositories/app_repository_test.go
@@ -5,10 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"sync"
 	"time"
 
 	"code.cloudfoundry.org/korifi/api/apierrors"
 	. "code.cloudfoundry.org/korifi/api/repositories"
+	"code.cloudfoundry.org/korifi/api/repositories/conditions"
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"code.cloudfoundry.org/korifi/controllers/controllers/workloads"
 	"code.cloudfoundry.org/korifi/controllers/controllers/workloads/env"
@@ -41,7 +43,7 @@ var _ = Describe("AppRepository", func() {
 	BeforeEach(func() {
 		testCtx = context.Background()
 
-		appRepo = NewAppRepo(namespaceRetriever, userClientFactory, nsPerms)
+		appRepo = NewAppRepo(namespaceRetriever, userClientFactory, nsPerms, conditions.NewCFAppConditionAwaiter(2*time.Second))
 
 		org = createOrgWithCleanup(testCtx, prefixedGUID("org"))
 		space = createSpaceWithCleanup(testCtx, org.Name, prefixedGUID("space1"))
@@ -87,23 +89,29 @@ var _ = Describe("AppRepository", func() {
 						Stack:      cfApp.Spec.Lifecycle.Data.Stack,
 					},
 				}))
-				Expect(app.IsStaged).To(BeTrue())
+				Expect(app.IsStaged).To(BeFalse())
 			})
 
-			When("the app has no staged condition", func() {
+			When("the app has staged condition true", func() {
 				BeforeEach(func() {
-					cfApp.Status.Conditions = []metav1.Condition{}
+					cfApp.Status.Conditions = []metav1.Condition{{
+						Type:               workloads.StatusConditionStaged,
+						Status:             metav1.ConditionTrue,
+						LastTransitionTime: metav1.Now(),
+						Reason:             "staged",
+						Message:            "staged",
+					}}
 					Expect(k8sClient.Status().Update(testCtx, cfApp)).To(Succeed())
 					Eventually(func(g Gomega) {
 						app := korifiv1alpha1.CFApp{}
 						g.Expect(k8sClient.Get(testCtx, client.ObjectKeyFromObject(cfApp), &app)).To(Succeed())
-						g.Expect(app.Status.Conditions).To(BeEmpty())
+						g.Expect(app.Status.Conditions).NotTo(BeEmpty())
 					}).Should(Succeed())
 				})
 
-				It("sets IsStaged to false", func() {
+				It("sets IsStaged to true", func() {
 					Expect(getErr).ToNot(HaveOccurred())
-					Expect(app.IsStaged).To(BeFalse())
+					Expect(app.IsStaged).To(BeTrue())
 				})
 			})
 
@@ -708,15 +716,48 @@ var _ = Describe("AppRepository", func() {
 
 			currentDropletRecord CurrentDropletRecord
 			setDropletErr        error
+			dummyAppController   func()
+			dummyControllerSync  sync.WaitGroup
 		)
 
 		BeforeEach(func() {
 			dropletGUID = generateGUID()
 			appGUID = cfApp.Name
 			createDropletCR(testCtx, k8sClient, dropletGUID, cfApp.Name, space.Name)
+
+			dummyControllerSync.Add(1)
+			dummyAppController = func() {
+				defer GinkgoRecover()
+				defer dummyControllerSync.Done()
+
+				Eventually(func(g Gomega) {
+					theApp := &korifiv1alpha1.CFApp{}
+					g.Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(cfApp), theApp)).To(Succeed())
+					g.Expect(theApp.Spec.CurrentDropletRef.Name).NotTo(BeEmpty())
+
+					theAppCopy := theApp.DeepCopy()
+					theAppCopy.Status = korifiv1alpha1.CFAppStatus{
+						Conditions: []metav1.Condition{{
+							Type:               workloads.StatusConditionStaged,
+							Status:             metav1.ConditionTrue,
+							LastTransitionTime: metav1.Now(),
+							Reason:             "staged",
+							Message:            "staged",
+						}},
+						ObservedDesiredState: "STOPPED",
+					}
+					g.Expect(k8sClient.Status().Patch(context.Background(), theAppCopy, client.MergeFrom(theApp))).To(Succeed())
+				}).Should(Succeed())
+			}
+		})
+
+		AfterEach(func() {
+			dummyControllerSync.Wait()
 		})
 
 		JustBeforeEach(func() {
+			go dummyAppController()
+
 			currentDropletRecord, setDropletErr = appRepo.SetCurrentDroplet(testCtx, authInfo, SetCurrentDropletMessage{
 				AppGUID:     appGUID,
 				DropletGUID: dropletGUID,
@@ -751,6 +792,19 @@ var _ = Describe("AppRepository", func() {
 
 				It("errors", func() {
 					Expect(setDropletErr).To(MatchError(ContainSubstring("not found")))
+				})
+			})
+
+			When("the app does not get the staged condition", func() {
+				BeforeEach(func() {
+					dummyAppController = func() {
+						defer GinkgoRecover()
+						defer dummyControllerSync.Done()
+					}
+				})
+
+				It("returns an error", func() {
+					Expect(setDropletErr).To(MatchError(ContainSubstring("did not get the Staged condition")))
 				})
 			})
 		})
@@ -929,8 +983,6 @@ var _ = Describe("AppRepository", func() {
 			}
 
 			Expect(k8sClient.Create(testCtx, secret)).To(Succeed())
-
-			appRepo = NewAppRepo(namespaceRetriever, userClientFactory, nsPerms)
 		})
 
 		JustBeforeEach(func() {
@@ -1131,12 +1183,7 @@ func createAppWithGUID(space, guid string) *korifiv1alpha1.CFApp {
 	}
 	Expect(k8sClient.Create(context.Background(), cfApp)).To(Succeed())
 
-	meta.SetStatusCondition(&cfApp.Status.Conditions, metav1.Condition{
-		Type:    workloads.StatusConditionStaged,
-		Status:  metav1.ConditionTrue,
-		Reason:  "appStaged",
-		Message: "",
-	})
+	cfApp.Status.Conditions = []metav1.Condition{}
 	cfApp.Status.ObservedDesiredState = "STOPPED"
 	Expect(k8sClient.Status().Update(context.Background(), cfApp)).To(Succeed())
 

--- a/api/repositories/conditions/await.go
+++ b/api/repositories/conditions/await.go
@@ -1,0 +1,81 @@
+package conditions
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type awaitConfig interface {
+	watchObjectList() client.ObjectList
+	conditions() func(runtime.Object) ([]metav1.Condition, bool)
+}
+
+type cfTaskAwaitConfig struct{}
+
+func (c cfTaskAwaitConfig) watchObjectList() client.ObjectList {
+	return &korifiv1alpha1.CFTaskList{}
+}
+
+func (c cfTaskAwaitConfig) conditions() func(runtime.Object) ([]metav1.Condition, bool) {
+	return func(obj runtime.Object) ([]metav1.Condition, bool) {
+		cfTask, ok := obj.(*korifiv1alpha1.CFTask)
+		if !ok {
+			return nil, false
+		}
+
+		return cfTask.Status.Conditions, true
+	}
+}
+
+type Awaiter struct {
+	timeout time.Duration
+	config  awaitConfig
+}
+
+func NewCFTaskConditionAwaiter(timeout time.Duration) *Awaiter {
+	return &Awaiter{
+		timeout: timeout,
+		config:  cfTaskAwaitConfig{},
+	}
+}
+
+func (a *Awaiter) AwaitCondition(ctx context.Context, k8sClient client.WithWatch, object client.Object, conditionType string) (runtime.Object, error) {
+	watch, err := k8sClient.Watch(ctx,
+		a.config.watchObjectList(),
+		client.InNamespace(object.GetNamespace()),
+		client.MatchingFields{"metadata.name": object.GetName()},
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer watch.Stop()
+
+	timer := time.NewTimer(a.timeout)
+	defer timer.Stop()
+
+	for {
+		select {
+		case e := <-watch.ResultChan():
+			conditions, ok := a.config.conditions()(e.Object)
+			if !ok {
+				continue
+			}
+
+			if meta.IsStatusConditionTrue(conditions, conditionType) {
+				return e.Object, nil
+			}
+		case <-timer.C:
+			return nil, fmt.Errorf(
+				"object %s:%s did not get the %s condition within timeout period %d ms",
+				object.GetNamespace(), object.GetName(), conditionType, a.timeout.Milliseconds(),
+			)
+		}
+	}
+}

--- a/api/repositories/conditions/await.go
+++ b/api/repositories/conditions/await.go
@@ -34,6 +34,23 @@ func (c cfTaskAwaitConfig) conditions() func(runtime.Object) ([]metav1.Condition
 	}
 }
 
+type cfAppAwaitConfig struct{}
+
+func (c cfAppAwaitConfig) watchObjectList() client.ObjectList {
+	return &korifiv1alpha1.CFAppList{}
+}
+
+func (c cfAppAwaitConfig) conditions() func(runtime.Object) ([]metav1.Condition, bool) {
+	return func(obj runtime.Object) ([]metav1.Condition, bool) {
+		cfApp, ok := obj.(*korifiv1alpha1.CFApp)
+		if !ok {
+			return nil, false
+		}
+
+		return cfApp.Status.Conditions, true
+	}
+}
+
 type Awaiter struct {
 	timeout time.Duration
 	config  awaitConfig
@@ -43,6 +60,13 @@ func NewCFTaskConditionAwaiter(timeout time.Duration) *Awaiter {
 	return &Awaiter{
 		timeout: timeout,
 		config:  cfTaskAwaitConfig{},
+	}
+}
+
+func NewCFAppConditionAwaiter(timeout time.Duration) *Awaiter {
+	return &Awaiter{
+		timeout: timeout,
+		config:  cfAppAwaitConfig{},
 	}
 }
 

--- a/api/repositories/conditions/await.go
+++ b/api/repositories/conditions/await.go
@@ -5,101 +5,60 @@ import (
 	"fmt"
 	"time"
 
-	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-type awaitConfig interface {
-	watchObjectList() client.ObjectList
-	conditions() func(runtime.Object) ([]metav1.Condition, bool)
+type RuntimeObjectWithStatusConditions interface {
+	client.Object
+	StatusConditions() []metav1.Condition
 }
 
-type cfTaskAwaitConfig struct{}
-
-func (c cfTaskAwaitConfig) watchObjectList() client.ObjectList {
-	return &korifiv1alpha1.CFTaskList{}
+type objectList[L any] interface {
+	*L
+	client.ObjectList
 }
 
-func (c cfTaskAwaitConfig) conditions() func(runtime.Object) ([]metav1.Condition, bool) {
-	return func(obj runtime.Object) ([]metav1.Condition, bool) {
-		cfTask, ok := obj.(*korifiv1alpha1.CFTask)
-		if !ok {
-			return nil, false
-		}
-
-		return cfTask.Status.Conditions, true
-	}
-}
-
-type cfAppAwaitConfig struct{}
-
-func (c cfAppAwaitConfig) watchObjectList() client.ObjectList {
-	return &korifiv1alpha1.CFAppList{}
-}
-
-func (c cfAppAwaitConfig) conditions() func(runtime.Object) ([]metav1.Condition, bool) {
-	return func(obj runtime.Object) ([]metav1.Condition, bool) {
-		cfApp, ok := obj.(*korifiv1alpha1.CFApp)
-		if !ok {
-			return nil, false
-		}
-
-		return cfApp.Status.Conditions, true
-	}
-}
-
-type Awaiter struct {
+type Awaiter[T RuntimeObjectWithStatusConditions, L any, PL objectList[L]] struct {
 	timeout time.Duration
-	config  awaitConfig
 }
 
-func NewCFTaskConditionAwaiter(timeout time.Duration) *Awaiter {
-	return &Awaiter{
+func NewConditionAwaiter[T RuntimeObjectWithStatusConditions, L any, PL objectList[L]](timeout time.Duration) *Awaiter[T, L, PL] {
+	return &Awaiter[T, L, PL]{
 		timeout: timeout,
-		config:  cfTaskAwaitConfig{},
 	}
 }
 
-func NewCFAppConditionAwaiter(timeout time.Duration) *Awaiter {
-	return &Awaiter{
-		timeout: timeout,
-		config:  cfAppAwaitConfig{},
-	}
-}
+func (a *Awaiter[T, L, PL]) AwaitCondition(ctx context.Context, k8sClient client.WithWatch, object client.Object, conditionType string) (T, error) {
+	var empty T
+	objList := PL(new(L))
 
-func (a *Awaiter) AwaitCondition(ctx context.Context, k8sClient client.WithWatch, object client.Object, conditionType string) (runtime.Object, error) {
-	watch, err := k8sClient.Watch(ctx,
-		a.config.watchObjectList(),
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, a.timeout)
+	defer cancel()
+
+	watch, err := k8sClient.Watch(ctxWithTimeout,
+		objList,
 		client.InNamespace(object.GetNamespace()),
 		client.MatchingFields{"metadata.name": object.GetName()},
 	)
 	if err != nil {
-		return nil, err
+		return empty, err
 	}
 	defer watch.Stop()
 
-	timer := time.NewTimer(a.timeout)
-	defer timer.Stop()
+	for e := range watch.ResultChan() {
+		obj, ok := e.Object.(T)
+		if !ok {
+			continue
+		}
 
-	for {
-		select {
-		case e := <-watch.ResultChan():
-			conditions, ok := a.config.conditions()(e.Object)
-			if !ok {
-				continue
-			}
-
-			if meta.IsStatusConditionTrue(conditions, conditionType) {
-				return e.Object, nil
-			}
-		case <-timer.C:
-			return nil, fmt.Errorf(
-				"object %s:%s did not get the %s condition within timeout period %d ms",
-				object.GetNamespace(), object.GetName(), conditionType, a.timeout.Milliseconds(),
-			)
+		if meta.IsStatusConditionTrue(obj.StatusConditions(), conditionType) {
+			return obj, nil
 		}
 	}
+
+	return empty, fmt.Errorf("object %s:%s did not get the %s condition within timeout period %d ms",
+		object.GetNamespace(), object.GetName(), conditionType, a.timeout.Milliseconds(),
+	)
 }

--- a/api/repositories/conditions/await_test.go
+++ b/api/repositories/conditions/await_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Await", func() {
 	)
 
 	BeforeEach(func() {
-		awaiter = conditions.NewCFTaskConditionAwaiter(time.Second)
+		awaiter = conditions.NewCFTaskConditionAwaiter(100 * time.Millisecond)
 		awaitedObject = nil
 		awaitErr = nil
 
@@ -58,7 +58,6 @@ var _ = Describe("Await", func() {
 				defer GinkgoRecover()
 				defer wg.Done()
 
-				time.Sleep(500 * time.Millisecond)
 				taskCopy := task.DeepCopy()
 				taskCopy.Status = korifiv1alpha1.CFTaskStatus{
 					Conditions: []metav1.Condition{{
@@ -79,15 +78,13 @@ var _ = Describe("Await", func() {
 		})
 
 		It("succeeds and returns the updated object", func() {
-			Eventually(func(g Gomega) {
-				g.Expect(awaitErr).NotTo(HaveOccurred())
-				g.Expect(awaitedObject).NotTo(BeNil())
+			Expect(awaitErr).NotTo(HaveOccurred())
+			Expect(awaitedObject).NotTo(BeNil())
 
-				awaitedTask, ok := awaitedObject.(*korifiv1alpha1.CFTask)
-				g.Expect(ok).To(BeTrue())
-				g.Expect(awaitedTask.Name).To(Equal(task.Name))
-				g.Expect(meta.IsStatusConditionTrue(awaitedTask.Status.Conditions, korifiv1alpha1.TaskInitializedConditionType)).To(BeTrue())
-			}).Should(Succeed())
+			awaitedTask, ok := awaitedObject.(*korifiv1alpha1.CFTask)
+			Expect(ok).To(BeTrue())
+			Expect(awaitedTask.Name).To(Equal(task.Name))
+			Expect(meta.IsStatusConditionTrue(awaitedTask.Status.Conditions, korifiv1alpha1.TaskInitializedConditionType)).To(BeTrue())
 		})
 	})
 })

--- a/api/repositories/conditions/await_test.go
+++ b/api/repositories/conditions/await_test.go
@@ -1,0 +1,93 @@
+package conditions_test
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"code.cloudfoundry.org/korifi/api/repositories/conditions"
+	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Await", func() {
+	var (
+		awaiter *conditions.Awaiter
+		task    *korifiv1alpha1.CFTask
+
+		awaitedObject runtime.Object
+		awaitErr      error
+	)
+
+	BeforeEach(func() {
+		awaiter = conditions.NewCFTaskConditionAwaiter(time.Second)
+		awaitedObject = nil
+		awaitErr = nil
+
+		task = &korifiv1alpha1.CFTask{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      "my-task",
+			},
+			Spec: korifiv1alpha1.CFTaskSpec{},
+		}
+
+		Expect(k8sClient.Create(context.Background(), task)).To(Succeed())
+	})
+
+	JustBeforeEach(func() {
+		awaitedObject, awaitErr = awaiter.AwaitCondition(context.Background(), k8sClient, task, korifiv1alpha1.TaskInitializedConditionType)
+	})
+
+	It("returns an error as the condition never becomes true", func() {
+		Expect(awaitErr).To(MatchError(ContainSubstring("did not get the Initialized condition")))
+	})
+
+	When("the condition becomes true", func() {
+		var wg sync.WaitGroup
+
+		BeforeEach(func() {
+			wg.Add(1)
+
+			go func() {
+				defer GinkgoRecover()
+				defer wg.Done()
+
+				time.Sleep(500 * time.Millisecond)
+				taskCopy := task.DeepCopy()
+				taskCopy.Status = korifiv1alpha1.CFTaskStatus{
+					Conditions: []metav1.Condition{{
+						Type:               korifiv1alpha1.TaskInitializedConditionType,
+						Status:             metav1.ConditionTrue,
+						Reason:             "initialized",
+						Message:            "initialized",
+						LastTransitionTime: metav1.Now(),
+					}},
+				}
+
+				Expect(k8sClient.Status().Patch(context.Background(), taskCopy, client.MergeFrom(task))).To(Succeed())
+			}()
+		})
+
+		AfterEach(func() {
+			wg.Wait()
+		})
+
+		It("succeeds and returns the updated object", func() {
+			Eventually(func(g Gomega) {
+				g.Expect(awaitErr).NotTo(HaveOccurred())
+				g.Expect(awaitedObject).NotTo(BeNil())
+
+				awaitedTask, ok := awaitedObject.(*korifiv1alpha1.CFTask)
+				g.Expect(ok).To(BeTrue())
+				g.Expect(awaitedTask.Name).To(Equal(task.Name))
+				g.Expect(meta.IsStatusConditionTrue(awaitedTask.Status.Conditions, korifiv1alpha1.TaskInitializedConditionType)).To(BeTrue())
+			}).Should(Succeed())
+		})
+	})
+})

--- a/api/repositories/conditions/conditions_suite_test.go
+++ b/api/repositories/conditions/conditions_suite_test.go
@@ -1,0 +1,66 @@
+package conditions_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+func TestConditions(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Conditions Suite")
+}
+
+var (
+	testEnv   *envtest.Environment
+	k8sClient client.WithWatch
+	namespace string
+)
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "..", "controllers", "config", "crd", "bases"),
+		},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	k8sConfig, err := testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sConfig).NotTo(BeNil())
+
+	err = korifiv1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	k8sClient, err = client.NewWithWatch(k8sConfig, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+})
+
+var _ = AfterSuite(func() {
+	Expect(testEnv.Stop()).To(Succeed())
+})
+
+var _ = BeforeEach(func() {
+	namespace = "test-ns-" + uuid.NewString()[:8]
+	Expect(k8sClient.Create(context.Background(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}})).To(Succeed())
+})
+
+var _ = AfterEach(func() {
+	Expect(k8sClient.Delete(context.Background(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}})).To(Succeed())
+})

--- a/api/repositories/shared.go
+++ b/api/repositories/shared.go
@@ -17,8 +17,8 @@ const (
 
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 
-type ConditionAwaiter interface {
-	AwaitCondition(ctx context.Context, userClient client.WithWatch, object client.Object, conditionType string) (runtime.Object, error)
+type ConditionAwaiter[T runtime.Object] interface {
+	AwaitCondition(ctx context.Context, userClient client.WithWatch, object client.Object, conditionType string) (T, error)
 }
 
 // getTimeLastUpdatedTimestamp takes the ObjectMeta from a CR and extracts the last updated time from its list of ManagedFields

--- a/api/repositories/shared.go
+++ b/api/repositories/shared.go
@@ -1,10 +1,13 @@
 package repositories
 
 import (
+	"context"
 	"errors"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -13,6 +16,10 @@ const (
 )
 
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
+
+type ConditionAwaiter interface {
+	AwaitCondition(ctx context.Context, userClient client.WithWatch, object client.Object, conditionType string) (runtime.Object, error)
+}
 
 // getTimeLastUpdatedTimestamp takes the ObjectMeta from a CR and extracts the last updated time from its list of ManagedFields
 // Returns an error if the list is empty or the time could not be extracted

--- a/api/repositories/task_repository_test.go
+++ b/api/repositories/task_repository_test.go
@@ -8,6 +8,7 @@ import (
 	"code.cloudfoundry.org/korifi/api/apierrors"
 	"code.cloudfoundry.org/korifi/api/authorization"
 	"code.cloudfoundry.org/korifi/api/repositories"
+	"code.cloudfoundry.org/korifi/api/repositories/conditions"
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"code.cloudfoundry.org/korifi/tests/matchers"
 	. "github.com/onsi/ginkgo/v2"
@@ -56,7 +57,7 @@ var _ = Describe("TaskRepository", func() {
 	}
 
 	BeforeEach(func() {
-		taskRepo = repositories.NewTaskRepo(userClientFactory, namespaceRetriever, nsPerms, 2*time.Second)
+		taskRepo = repositories.NewTaskRepo(userClientFactory, namespaceRetriever, nsPerms, conditions.NewCFTaskConditionAwaiter(2*time.Second))
 
 		org = createOrgWithCleanup(ctx, prefixedGUID("org"))
 		space = createSpaceWithCleanup(ctx, org.Name, prefixedGUID("space"))

--- a/api/repositories/task_repository_test.go
+++ b/api/repositories/task_repository_test.go
@@ -57,7 +57,7 @@ var _ = Describe("TaskRepository", func() {
 	}
 
 	BeforeEach(func() {
-		taskRepo = repositories.NewTaskRepo(userClientFactory, namespaceRetriever, nsPerms, conditions.NewCFTaskConditionAwaiter(2*time.Second))
+		taskRepo = repositories.NewTaskRepo(userClientFactory, namespaceRetriever, nsPerms, conditions.NewConditionAwaiter[*korifiv1alpha1.CFTask, korifiv1alpha1.CFTaskList](2*time.Second))
 
 		org = createOrgWithCleanup(ctx, prefixedGUID("org"))
 		space = createSpaceWithCleanup(ctx, org.Name, prefixedGUID("space"))

--- a/controllers/api/v1alpha1/cfapp_types.go
+++ b/controllers/api/v1alpha1/cfapp_types.go
@@ -85,3 +85,7 @@ type CFAppList struct {
 func init() {
 	SchemeBuilder.Register(&CFApp{}, &CFAppList{})
 }
+
+func (a CFApp) StatusConditions() []metav1.Condition {
+	return a.Status.Conditions
+}

--- a/controllers/api/v1alpha1/cftask_types.go
+++ b/controllers/api/v1alpha1/cftask_types.go
@@ -84,3 +84,7 @@ type CFTaskList struct {
 func init() {
 	SchemeBuilder.Register(&CFTask{}, &CFTaskList{})
 }
+
+func (t CFTask) StatusConditions() []metav1.Condition {
+	return t.Status.Conditions
+}

--- a/controllers/config/cf_roles/cf_admin.yaml
+++ b/controllers/config/cf_roles/cf_admin.yaml
@@ -63,6 +63,7 @@ rules:
   - patch
   - delete
   - list
+  - watch
 
 - apiGroups:
   - korifi.cloudfoundry.org

--- a/controllers/config/cf_roles/cf_space_developer.yaml
+++ b/controllers/config/cf_roles/cf_space_developer.yaml
@@ -37,6 +37,7 @@ rules:
   - patch
   - delete
   - list
+  - watch
 
 - apiGroups:
   - korifi.cloudfoundry.org


### PR DESCRIPTION
## Is there a related GitHub Issue?
https://github.com/cloudfoundry/korifi/issues/1385
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Await the `Staged` app condition on set app droplet

By doing that we ensure that the app controller has accepted the request
to set the app droplet and it is aware that the app is staged. Thus
subsequent creation of objects that depend on the app being staged (such
as tasks) would not fail.

Awaiting for a status condition of a task requires adding the `watch`
permission on apps for the `cf_admin` and `space-developer` roles

<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
n/a
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

