### PR TITLE
Bump Golang to 1.18.4 in Dockerfiles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,27 @@ updates:
     interval: "daily"
 
 - package-ecosystem: "docker"
+  directory: "/api/remote-debug"
+  schedule:
+    interval: "daily"
+
+- package-ecosystem: "docker"
   directory: "/controllers"
+  schedule:
+    interval: "daily"
+
+- package-ecosystem: "docker"
+  directory: "/controllers/remote-debug"
+  schedule:
+    interval: "daily"
+
+- package-ecosystem: "docker"
+  directory: "/kpack-image-builder"
+  schedule:
+    interval: "daily"
+
+- package-ecosystem: "docker"
+  directory: "/statefulset-runner"
   schedule:
     interval: "daily"
 

--- a/api/remote-debug/Dockerfile
+++ b/api/remote-debug/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:experimental
-FROM golang:1.18.1 as builder
+FROM golang:1.18.4 as builder
 
 WORKDIR /workspace
 

--- a/controllers/remote-debug/Dockerfile
+++ b/controllers/remote-debug/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:experimental
-FROM golang:1.18.1 as builder
+FROM golang:1.18.4 as builder
 
 WORKDIR /workspace
 

--- a/kpack-image-builder/Dockerfile
+++ b/kpack-image-builder/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.18.1 as builder
+FROM golang:1.18.4 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/statefulset-runner/Dockerfile
+++ b/statefulset-runner/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.18.1 as builder
+FROM golang:1.18.4 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
This PR bumps the version of Golang used to build component images to 1.18.4. It also configures dependabot to automatically bump the version in future.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Everything still works.

## Tag your pair, your PM, and/or team
