### PR TITLE
Cleanup finalizing checks

### DIFF
--- a/controllers/controllers/networking/cfroute_controller.go
+++ b/controllers/controllers/networking/cfroute_controller.go
@@ -73,7 +73,7 @@ func (r *CFRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	if isFinalizing(cfRoute) {
+	if !cfRoute.GetDeletionTimestamp().IsZero() {
 		return r.finalizeCFRoute(ctx, cfRoute)
 	}
 
@@ -459,10 +459,6 @@ func (r *CFRouteReconciler) fetchServicesByMatchingLabels(ctx context.Context, l
 	}
 
 	return &serviceList, nil
-}
-
-func isFinalizing(cfRoute *korifiv1alpha1.CFRoute) bool {
-	return cfRoute.ObjectMeta.DeletionTimestamp != nil && !cfRoute.ObjectMeta.DeletionTimestamp.IsZero()
 }
 
 func generateServiceName(destination *korifiv1alpha1.Destination) string {

--- a/controllers/controllers/services/cfserviceinstance_controller.go
+++ b/controllers/controllers/services/cfserviceinstance_controller.go
@@ -76,7 +76,7 @@ func (r *CFServiceInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, err
 	}
 
-	if isFinalizing(cfServiceInstance) {
+	if !cfServiceInstance.GetDeletionTimestamp().IsZero() {
 		return r.finalizeCFServiceInstance(ctx, cfServiceInstance)
 	}
 
@@ -174,8 +174,4 @@ func (r *CFServiceInstanceReconciler) finalizeCFServiceInstance(ctx context.Cont
 	}
 
 	return ctrl.Result{}, nil
-}
-
-func isFinalizing(cfServiceInstance *korifiv1alpha1.CFServiceInstance) bool {
-	return cfServiceInstance.ObjectMeta.DeletionTimestamp != nil && !cfServiceInstance.ObjectMeta.DeletionTimestamp.IsZero()
 }

--- a/controllers/controllers/workloads/cfapp_controller.go
+++ b/controllers/controllers/workloads/cfapp_controller.go
@@ -78,7 +78,7 @@ func (r *CFAppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		return ctrl.Result{}, err
 	}
 
-	if isFinalizing(cfApp) {
+	if !cfApp.GetDeletionTimestamp().IsZero() {
 		return r.finalizeCFApp(ctx, cfApp)
 	}
 

--- a/controllers/controllers/workloads/cforg_controller.go
+++ b/controllers/controllers/workloads/cforg_controller.go
@@ -119,7 +119,7 @@ func (r *CFOrgReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		return ctrl.Result{}, err
 	}
 
-	if isFinalizing(cfOrg) {
+	if !cfOrg.GetDeletionTimestamp().IsZero() {
 		return finalize(ctx, r.client, r.log, cfOrg, orgFinalizerName)
 	}
 

--- a/controllers/controllers/workloads/cfspace_controller.go
+++ b/controllers/controllers/workloads/cfspace_controller.go
@@ -107,7 +107,7 @@ func (r *CFSpaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, err
 	}
 
-	if isFinalizing(cfSpace) {
+	if !cfSpace.GetDeletionTimestamp().IsZero() {
 		return finalize(ctx, r.client, r.log, cfSpace, spaceFinalizerName)
 	}
 

--- a/controllers/controllers/workloads/shared.go
+++ b/controllers/controllers/workloads/shared.go
@@ -176,13 +176,6 @@ func reconcileRoleBindings(ctx context.Context, kClient client.Client, log logr.
 	return nil
 }
 
-func isFinalizing(orgOrSpace client.Object) bool {
-	if orgOrSpace.GetDeletionTimestamp() != nil && !orgOrSpace.GetDeletionTimestamp().IsZero() {
-		return true
-	}
-	return false
-}
-
 func finalize(ctx context.Context, kClient client.Client, log logr.Logger, orgOrSpace client.Object, finalizerName string) (ctrl.Result, error) {
 	log.Info(fmt.Sprintf("Reconciling deletion of %s", orgOrSpace.GetName()))
 

--- a/controllers/coordination/integration/name_registry_test.go
+++ b/controllers/coordination/integration/name_registry_test.go
@@ -82,6 +82,11 @@ var _ = Describe("Name Registry", func() {
 			Expect(nameRegistry.DeregisterName(ctx, ns1.Name, name)).To(Succeed())
 		})
 
+		It("can re-register a deleted name", func() {
+			Expect(nameRegistry.DeregisterName(ctx, ns1.Name, name)).To(Succeed())
+			Expect(nameRegistry.RegisterName(ctx, ns1.Name, name)).To(Succeed())
+		})
+
 		When("the name is locked", func() {
 			BeforeEach(func() {
 				Expect(nameRegistry.TryLockName(ctx, ns1.Name, name)).To(Succeed())
@@ -92,15 +97,10 @@ var _ = Describe("Name Registry", func() {
 			})
 		})
 
-		It("can re-register a deleted name", func() {
-			Expect(nameRegistry.DeregisterName(ctx, ns1.Name, name)).To(Succeed())
-			Expect(nameRegistry.RegisterName(ctx, ns1.Name, name)).To(Succeed())
-		})
-
 		When("the name doesn't exist", func() {
-			It("returns a not found error", func() {
+			It("does not return an error", func() {
 				err := nameRegistry.DeregisterName(ctx, ns1.Name, "nope")
-				Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+				Expect(k8serrors.IsNotFound(err)).To(BeFalse())
 			})
 		})
 	})

--- a/controllers/coordination/name_registry.go
+++ b/controllers/coordination/name_registry.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"code.cloudfoundry.org/korifi/controllers/webhooks"
+
 	coordinationv1 "k8s.io/api/coordination/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -69,7 +70,7 @@ func (r NameRegistry) DeregisterName(ctx context.Context, namespace, name string
 			Namespace: namespace,
 		},
 	}
-	if err := r.client.Delete(ctx, lease); err != nil {
+	if err := r.client.Delete(ctx, lease); client.IgnoreNotFound(err) != nil {
 		return fmt.Errorf("deleting a lease failed: %w", err)
 	}
 

--- a/controllers/coordination/name_registry_test.go
+++ b/controllers/coordination/name_registry_test.go
@@ -4,15 +4,15 @@ import (
 	"context"
 	"errors"
 
+	"code.cloudfoundry.org/korifi/controllers/coordination"
+	"code.cloudfoundry.org/korifi/controllers/coordination/fake"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-
-	"code.cloudfoundry.org/korifi/controllers/coordination"
-	"code.cloudfoundry.org/korifi/controllers/coordination/fake"
 )
 
 var _ = Describe("NameRegistry", func() {
@@ -95,6 +95,16 @@ var _ = Describe("NameRegistry", func() {
 			lease := obj.(*coordinationv1.Lease)
 			Expect(lease.Namespace).To(Equal(namespace))
 			Expect(lease.Name).To(HavePrefix("n-"))
+		})
+
+		When("the lease does not exist", func() {
+			BeforeEach(func() {
+				client.DeleteReturns(k8serrors.NewNotFound(schema.GroupResource{}, "some-name"))
+			})
+
+			It("does not return an error", func() {
+				Expect(err).NotTo(HaveOccurred())
+			})
 		})
 
 		When("deleting the lease fails", func() {

--- a/controllers/webhooks/networking/cfdomain_validator.go
+++ b/controllers/webhooks/networking/cfdomain_validator.go
@@ -88,12 +88,16 @@ func (v *CFDomainValidator) ValidateCreate(ctx context.Context, obj runtime.Obje
 }
 
 func (v *CFDomainValidator) ValidateUpdate(ctx context.Context, oldObj runtime.Object, obj runtime.Object) error {
-	oldDomain, ok := oldObj.(*korifiv1alpha1.CFDomain)
+	domain, ok := obj.(*korifiv1alpha1.CFDomain)
 	if !ok {
 		return apierrors.NewBadRequest(fmt.Sprintf("expected a CFDomain but got a %T", obj))
 	}
 
-	domain, ok := obj.(*korifiv1alpha1.CFDomain)
+	if !domain.GetDeletionTimestamp().IsZero() {
+		return nil
+	}
+
+	oldDomain, ok := oldObj.(*korifiv1alpha1.CFDomain)
 	if !ok {
 		return apierrors.NewBadRequest(fmt.Sprintf("expected a CFDomain but got a %T", obj))
 	}

--- a/controllers/webhooks/networking/cfroute_validator.go
+++ b/controllers/webhooks/networking/cfroute_validator.go
@@ -96,6 +96,10 @@ func (v *CFRouteValidator) ValidateUpdate(ctx context.Context, oldObj, obj runti
 		return apierrors.NewBadRequest(fmt.Sprintf("expected a CFRoute but got a %T", obj))
 	}
 
+	if !route.GetDeletionTimestamp().IsZero() {
+		return nil
+	}
+
 	oldRoute, ok := oldObj.(*korifiv1alpha1.CFRoute)
 	if !ok {
 		return apierrors.NewBadRequest(fmt.Sprintf("expected a CFRoute but got a %T", obj))

--- a/controllers/webhooks/networking/cfroute_validator_test.go
+++ b/controllers/webhooks/networking/cfroute_validator_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	controllerfake "code.cloudfoundry.org/korifi/controllers/fake"
@@ -353,6 +354,16 @@ var _ = Describe("CFRouteValidator", func() {
 			Expect(actualContext).To(Equal(ctx))
 			Expect(actualNamespace).To(Equal(rootNamespace))
 			Expect(oldName).To(Equal(testRouteHost + "::" + testDomainNamespace + "::" + testDomainGUID + "::" + testRoutePath))
+		})
+
+		When("the route is being deleted", func() {
+			BeforeEach(func() {
+				updatedCFRoute.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+			})
+
+			It("does not return an error", func() {
+				Expect(retErr).NotTo(HaveOccurred())
+			})
 		})
 
 		When("the hostname is updated", func() {

--- a/controllers/webhooks/services/cfservicebinding_validator.go
+++ b/controllers/webhooks/services/cfservicebinding_validator.go
@@ -62,14 +62,18 @@ func (v *CFServiceBindingValidator) ValidateCreate(ctx context.Context, obj runt
 }
 
 func (v *CFServiceBindingValidator) ValidateUpdate(ctx context.Context, oldObj, obj runtime.Object) error {
-	oldServiceBinding, ok := oldObj.(*korifiv1alpha1.CFServiceBinding)
-	if !ok {
-		return apierrors.NewBadRequest(fmt.Sprintf("expected a CFServiceBinding but got a %T", oldObj))
-	}
-
 	serviceBinding, ok := obj.(*korifiv1alpha1.CFServiceBinding)
 	if !ok {
 		return apierrors.NewBadRequest(fmt.Sprintf("expected a CFServiceBinding but got a %T", obj))
+	}
+
+	if !serviceBinding.GetDeletionTimestamp().IsZero() {
+		return nil
+	}
+
+	oldServiceBinding, ok := oldObj.(*korifiv1alpha1.CFServiceBinding)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a CFServiceBinding but got a %T", oldObj))
 	}
 
 	if oldServiceBinding.Spec.AppRef.Name != serviceBinding.Spec.AppRef.Name {

--- a/controllers/webhooks/services/cfservicebinding_validator_test.go
+++ b/controllers/webhooks/services/cfservicebinding_validator_test.go
@@ -3,6 +3,7 @@ package services_test
 import (
 	"context"
 	"fmt"
+	"time"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"code.cloudfoundry.org/korifi/controllers/webhooks"
@@ -127,6 +128,16 @@ var _ = Describe("CFServiceBindingValidatingWebhook", func() {
 
 		It("allows the DisplayName to change", func() {
 			Expect(retErr).NotTo(HaveOccurred())
+		})
+
+		When("the service binding is being deleted", func() {
+			BeforeEach(func() {
+				updatedServiceBinding.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+			})
+
+			It("does not return an error", func() {
+				Expect(retErr).NotTo(HaveOccurred())
+			})
 		})
 
 		When("the AppRef name changes", func() {

--- a/controllers/webhooks/services/cfserviceinstance_validator.go
+++ b/controllers/webhooks/services/cfserviceinstance_validator.go
@@ -59,14 +59,18 @@ func (v *CFServiceInstanceValidator) ValidateCreate(ctx context.Context, obj run
 }
 
 func (v *CFServiceInstanceValidator) ValidateUpdate(ctx context.Context, oldObj, obj runtime.Object) error {
-	oldServiceInstance, ok := oldObj.(*korifiv1alpha1.CFServiceInstance)
-	if !ok {
-		return apierrors.NewBadRequest(fmt.Sprintf("expected a CFServiceInstance but got a %T", oldObj))
-	}
-
 	serviceInstance, ok := obj.(*korifiv1alpha1.CFServiceInstance)
 	if !ok {
 		return apierrors.NewBadRequest(fmt.Sprintf("expected a CFServiceInstance but got a %T", obj))
+	}
+
+	if !serviceInstance.GetDeletionTimestamp().IsZero() {
+		return nil
+	}
+
+	oldServiceInstance, ok := oldObj.(*korifiv1alpha1.CFServiceInstance)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a CFServiceInstance but got a %T", oldObj))
 	}
 
 	duplicateErrorMessage := fmt.Sprintf(duplicateServiceInstanceNameErrorMessage, serviceInstance.Spec.DisplayName)

--- a/controllers/webhooks/services/cfserviceinstance_validator_test.go
+++ b/controllers/webhooks/services/cfserviceinstance_validator_test.go
@@ -2,6 +2,7 @@ package services_test
 
 import (
 	"context"
+	"time"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"code.cloudfoundry.org/korifi/controllers/webhooks"
@@ -127,6 +128,16 @@ var _ = Describe("CFServiceInstanceValidatingWebhook", func() {
 			Expect(actualNamespace).To(Equal(serviceInstance.Namespace))
 			Expect(oldName).To(Equal(serviceInstance.Spec.DisplayName))
 			Expect(newName).To(Equal(updatedServiceInstance.Spec.DisplayName))
+		})
+
+		When("the service instance is being deleted", func() {
+			BeforeEach(func() {
+				updatedServiceInstance.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+			})
+
+			It("does not return an error", func() {
+				Expect(retErr).NotTo(HaveOccurred())
+			})
 		})
 
 		When("the new serviceInstance name is a duplicate", func() {

--- a/controllers/webhooks/workloads/cfapp_validator.go
+++ b/controllers/webhooks/workloads/cfapp_validator.go
@@ -60,14 +60,18 @@ func (v *CFAppValidator) ValidateCreate(ctx context.Context, obj runtime.Object)
 }
 
 func (v *CFAppValidator) ValidateUpdate(ctx context.Context, oldObj, obj runtime.Object) error {
-	oldApp, ok := oldObj.(*korifiv1alpha1.CFApp)
-	if !ok {
-		return apierrors.NewBadRequest(fmt.Sprintf("expected a CFApp but got a %T", oldObj))
-	}
-
 	app, ok := obj.(*korifiv1alpha1.CFApp)
 	if !ok {
 		return apierrors.NewBadRequest(fmt.Sprintf("expected a CFApp but got a %T", obj))
+	}
+
+	if !app.GetDeletionTimestamp().IsZero() {
+		return nil
+	}
+
+	oldApp, ok := oldObj.(*korifiv1alpha1.CFApp)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a CFApp but got a %T", oldObj))
 	}
 
 	duplicateErrorMessage := fmt.Sprintf(duplicateAppNameErrorMessage, app.Spec.DisplayName)

--- a/controllers/webhooks/workloads/cfapp_validator_test.go
+++ b/controllers/webhooks/workloads/cfapp_validator_test.go
@@ -2,6 +2,7 @@ package workloads_test
 
 import (
 	"context"
+	"time"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"code.cloudfoundry.org/korifi/controllers/webhooks"
@@ -125,6 +126,16 @@ var _ = Describe("CFAppValidator", func() {
 			Expect(actualNamespace).To(Equal(cfApp.Namespace))
 			Expect(oldName).To(Equal(cfApp.Spec.DisplayName))
 			Expect(newName).To(Equal(updatedCFApp.Spec.DisplayName))
+		})
+
+		When("the app is being deleted", func() {
+			BeforeEach(func() {
+				updatedCFApp.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+			})
+
+			It("does not return an error", func() {
+				Expect(retErr).NotTo(HaveOccurred())
+			})
 		})
 
 		When("the new app name is a duplicate", func() {

--- a/controllers/webhooks/workloads/cforg_validator.go
+++ b/controllers/webhooks/workloads/cforg_validator.go
@@ -69,12 +69,16 @@ func (v *CFOrgValidator) ValidateCreate(ctx context.Context, obj runtime.Object)
 }
 
 func (v *CFOrgValidator) ValidateUpdate(ctx context.Context, oldObj, obj runtime.Object) error {
-	oldOrg, ok := oldObj.(*korifiv1alpha1.CFOrg)
+	org, ok := obj.(*korifiv1alpha1.CFOrg)
 	if !ok {
 		return apierrors.NewBadRequest(fmt.Sprintf("expected a CFOrg but got a %T", obj))
 	}
 
-	org, ok := obj.(*korifiv1alpha1.CFOrg)
+	if !org.GetDeletionTimestamp().IsZero() {
+		return nil
+	}
+
+	oldOrg, ok := oldObj.(*korifiv1alpha1.CFOrg)
 	if !ok {
 		return apierrors.NewBadRequest(fmt.Sprintf("expected a CFOrg but got a %T", obj))
 	}

--- a/controllers/webhooks/workloads/cforg_validator_test.go
+++ b/controllers/webhooks/workloads/cforg_validator_test.go
@@ -3,6 +3,7 @@ package workloads_test
 import (
 	"context"
 	"fmt"
+	"time"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"code.cloudfoundry.org/korifi/controllers/webhooks"
@@ -143,6 +144,16 @@ var _ = Describe("CFOrgValidator", func() {
 			Expect(actualNamespace).To(Equal(cfOrg.Namespace))
 			Expect(oldName).To(Equal(cfOrg.Spec.DisplayName))
 			Expect(newName).To(Equal(updatedCFOrg.Spec.DisplayName))
+		})
+
+		When("the org is being deleted", func() {
+			BeforeEach(func() {
+				updatedCFOrg.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+			})
+
+			It("does not return an error", func() {
+				Expect(retErr).NotTo(HaveOccurred())
+			})
 		})
 
 		When("the new org name is a duplicate", func() {

--- a/controllers/webhooks/workloads/cfspace_validator.go
+++ b/controllers/webhooks/workloads/cfspace_validator.go
@@ -67,12 +67,16 @@ func (v *CFSpaceValidator) ValidateCreate(ctx context.Context, obj runtime.Objec
 }
 
 func (v *CFSpaceValidator) ValidateUpdate(ctx context.Context, oldObj, obj runtime.Object) error {
-	oldSpace, ok := oldObj.(*korifiv1alpha1.CFSpace)
+	space, ok := obj.(*korifiv1alpha1.CFSpace)
 	if !ok {
 		return apierrors.NewBadRequest(fmt.Sprintf("expected a CFSpace but got a %T", obj))
 	}
 
-	space, ok := obj.(*korifiv1alpha1.CFSpace)
+	if !space.GetDeletionTimestamp().IsZero() {
+		return nil
+	}
+
+	oldSpace, ok := oldObj.(*korifiv1alpha1.CFSpace)
 	if !ok {
 		return apierrors.NewBadRequest(fmt.Sprintf("expected a CFSpace but got a %T", obj))
 	}

--- a/controllers/webhooks/workloads/cfspace_validator_test.go
+++ b/controllers/webhooks/workloads/cfspace_validator_test.go
@@ -2,6 +2,7 @@ package workloads_test
 
 import (
 	"context"
+	"time"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"code.cloudfoundry.org/korifi/controllers/webhooks"
@@ -12,6 +13,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -134,6 +136,16 @@ var _ = Describe("CFSpaceValidation", func() {
 			Expect(actualNamespace).To(Equal(cfSpace.Namespace))
 			Expect(oldName).To(Equal(cfSpace.Spec.DisplayName))
 			Expect(newName).To(Equal(updatedCFSpace.Spec.DisplayName))
+		})
+
+		When("the space is being deleted", func() {
+			BeforeEach(func() {
+				updatedCFSpace.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+			})
+
+			It("does not return an error", func() {
+				Expect(retErr).NotTo(HaveOccurred())
+			})
 		})
 
 		When("the new space name already exists in the namespace", func() {

--- a/controllers/webhooks/workloads/cftask_validator.go
+++ b/controllers/webhooks/workloads/cftask_validator.go
@@ -88,6 +88,10 @@ func (v *CFTaskValidator) ValidateUpdate(ctx context.Context, oldObj runtime.Obj
 		return apierrors.NewBadRequest(fmt.Sprintf("expected a CFTask but got a %T", obj))
 	}
 
+	if !newTask.GetDeletionTimestamp().IsZero() {
+		return nil
+	}
+
 	cftasklog.Info("validate task update", "namespace", newTask.Namespace, "name", newTask.Name)
 
 	oldTask, ok := oldObj.(*v1alpha1.CFTask)

--- a/controllers/webhooks/workloads/cftask_validator_test.go
+++ b/controllers/webhooks/workloads/cftask_validator_test.go
@@ -3,6 +3,7 @@ package workloads_test
 import (
 	"context"
 	"fmt"
+	"time"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"code.cloudfoundry.org/korifi/controllers/webhooks"
@@ -102,6 +103,16 @@ var _ = Describe("CFTaskValidator", func() {
 
 		It("allows the request", func() {
 			Expect(retErr).NotTo(HaveOccurred())
+		})
+
+		When("the task is being deleted", func() {
+			BeforeEach(func() {
+				updatedCFTask.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+			})
+
+			It("does not return an error", func() {
+				Expect(retErr).NotTo(HaveOccurred())
+			})
 		})
 	})
 


### PR DESCRIPTION
## Is there a related GitHub Issue?
#1420 

## What is this change about?
This PR cleans up the finalizing checks in the controllers and adds checks to all validating webhooks to allow the update if the resource is currently being deleted (non-zero deletion timestamp) as the change is likely the removal of the finalizer, which shouldn't be blocked.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
See #1420 

## Tag your pair, your PM, and/or team
@Birdrock 