### PR TITLE
Use the cnb lifecycle launcher for running tasks

### DIFF
--- a/tests/e2e/tasks_test.go
+++ b/tests/e2e/tasks_test.go
@@ -99,7 +99,7 @@ var _ = Describe("Tasks", func() {
 			createSpaceRole("space_developer", certUserName, spaceGUID)
 			resp, err = certClient.R().
 				SetBody(taskResource{
-					Command: "echo hello",
+					Command: "/bin/sh -c 'echo hello world'",
 				}).
 				SetPathParam("appGUID", appGUID).
 				SetResult(&createdTask).


### PR DESCRIPTION
## Is there a related GitHub Issue?
#1430

## What is this change about?
We must use the CNB lifecycle launcher to run task commands, else the environment will not be set up correctly. Also the complete command should be passed to the launcher without any string splitting.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Attempt to run a complex task that uses the buildpack environment, and it should succeed.

For example, deploy postfacto and attempt:
```
cf run-task postfacto -c 'ADMIN_EMAIL=user@example.com ADMIN_PASSWORD=pass bundle exec rake admin:create_user'
```

## Tag your pair, your PM, and/or team
@kieron-dev
