### PR TITLE
Allow korifi apps to use websockets

### DIFF
--- a/controllers/controllers/networking/cfroute_controller.go
+++ b/controllers/controllers/networking/cfroute_controller.go
@@ -298,7 +298,8 @@ func (r *CFRouteReconciler) createOrPatchRouteProxy(ctx context.Context, cfRoute
 					Conditions: []contourv1.MatchCondition{
 						{Prefix: cfRoute.Spec.Path},
 					},
-					Services: services,
+					Services:         services,
+					EnableWebsockets: true,
 				},
 			}
 		}

--- a/controllers/controllers/networking/integration/cfroute_controller_integration_test.go
+++ b/controllers/controllers/networking/integration/cfroute_controller_integration_test.go
@@ -278,6 +278,7 @@ var _ = Describe("CFRouteReconciler Integration Tests", func() {
 						Port: cfRoute.Spec.Destinations[0].Port,
 					},
 				},
+				EnableWebsockets: true,
 			}), "HTTPProxy route does not match destination")
 		})
 
@@ -473,6 +474,7 @@ var _ = Describe("CFRouteReconciler Integration Tests", func() {
 						Port: duplicateRoute.Spec.Destinations[0].Port,
 					},
 				},
+				EnableWebsockets: true,
 			}), "HTTPProxy route does not match destination")
 		})
 	})
@@ -561,6 +563,7 @@ var _ = Describe("CFRouteReconciler Integration Tests", func() {
 							Port: cfRoute.Spec.Destinations[1].Port,
 						},
 					},
+					EnableWebsockets: true,
 				},
 			}), "HTTPProxy routes mismatch")
 		})


### PR DESCRIPTION
## Is there a related GitHub Issue?
#1250


## What is this change about?
It turns out that Contour is disallowing websockets by default. This
breaks apps like postfacto. This commit allows all apps to use
websockets.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Deploy an app that uses websockets (e.g postfacto) and see it wokring. With postfacto working means that different browsers see live updates on the retro board.

## Tag your pair, your PM, and/or team
@kieron-dev

## Things to remember
