### PR TITLE
Unpin nodejs and pin ruby buildpack to 0.11

### DIFF
--- a/dependencies/kpack/cluster_store.yaml
+++ b/dependencies/kpack/cluster_store.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   sources:
   - image: gcr.io/paketo-buildpacks/java
-  - image: gcr.io/paketo-buildpacks/nodejs:0.17.1
-  - image: gcr.io/paketo-buildpacks/ruby
+  - image: gcr.io/paketo-buildpacks/nodejs
+  - image: gcr.io/paketo-buildpacks/ruby:0.11
   - image: gcr.io/paketo-buildpacks/procfile
   - image: gcr.io/paketo-buildpacks/go


### PR DESCRIPTION

<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->
#1329 

## What is this change about?
<!-- _Please describe the change here._ -->
Unpin nodejs and pin ruby buildpack to 0.11
- with ruby, the builds succeed but the pods fail to start with the latest version.
- we are extracting the start-command from the built image and setting it on the cf-process. This seems to work fine with ruby:0.11 but is broken on the latest version.
- removing the command from the cfprocess spec fixes the issue
- we decided to pin the version to 0.11 until we figure out how we want to fix this. See #1439 

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->
No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->
All tests should pass

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->
@Birdrock 

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
