### PR TITLE
Implement the spec reconcileName in BuildWorkload

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,3 @@
-export KUBEBUILDER_ASSETS=$PWD/testbin/bin
+source <(setup-envtest use -p env --bin-dir "$PWD/testbin")
 export APICONFIG=$PWD/config/base/apiconfig/
 export CONTROLLERSCONFIG=$PWD/config/base/controllersconfig/

--- a/controllers/api/v1alpha1/buildworkload_types.go
+++ b/controllers/api/v1alpha1/buildworkload_types.go
@@ -35,6 +35,8 @@ type BuildWorkloadSpec struct {
 	Env []v1.EnvVar `json:"env,omitempty"`
 
 	Services []v1.ObjectReference `json:"services,omitempty"`
+
+	ReconcilerName string `json:"reconcilerName"`
 }
 
 // BuildWorkloadStatus defines the observed state of BuildWorkload

--- a/controllers/config/base/controllersconfig/korifi_controllers_config.yaml
+++ b/controllers/config/base/controllersconfig/korifi_controllers_config.yaml
@@ -1,3 +1,4 @@
+buildReconciler: kpack-image-builder
 cfProcessDefaults:
   memoryMB: 1024
   diskQuotaMB: 1024

--- a/controllers/config/config.go
+++ b/controllers/config/config.go
@@ -19,6 +19,7 @@ type ControllerConfig struct {
 	TaskTTL                     string            `yaml:"taskTTL"`
 	WorkloadsTLSSecretName      string            `yaml:"workloads_tls_secret_name"`
 	WorkloadsTLSSecretNamespace string            `yaml:"workloads_tls_secret_namespace"`
+	BuildReconciler             string            `yaml:"buildReconciler"`
 }
 
 type CFProcessDefaults struct {

--- a/controllers/config/config_test.go
+++ b/controllers/config/config_test.go
@@ -1,12 +1,99 @@
 package config_test
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
 	"time"
 
+	"gopkg.in/yaml.v3"
+
 	"code.cloudfoundry.org/korifi/controllers/config"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+var _ = Describe("LoadFromPath", func() {
+	var (
+		configPath string
+		retConfig  *config.ControllerConfig
+		retErr     error
+	)
+
+	BeforeEach(func() {
+		// Setup filesystem
+		var err error
+		configPath, err = os.MkdirTemp("", "config")
+		Expect(err).NotTo(HaveOccurred())
+
+		config := config.ControllerConfig{
+			CFProcessDefaults: config.CFProcessDefaults{
+				MemoryMB:    1024,
+				DiskQuotaMB: 512,
+			},
+			CFRootNamespace:             "rootNamespace",
+			PackageRegistrySecretName:   "packageRegistrySecretName",
+			TaskTTL:                     "taskTTL",
+			WorkloadsTLSSecretName:      "workloadsTLSSecretName",
+			WorkloadsTLSSecretNamespace: "workloadsTLSSecretNamespace",
+			BuildReconciler:             "buildReconciler",
+		}
+		configYAML, err := yaml.Marshal(config)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = os.WriteFile(filepath.Join(configPath, "file1"), configYAML, 0o644)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = os.WriteFile(filepath.Join(configPath, "file2"), []byte(`buildReconciler: "newBuildReconciler"`), 0o644)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		Expect(os.RemoveAll(configPath)).To(Succeed())
+	})
+
+	JustBeforeEach(func() {
+		retConfig, retErr = config.LoadFromPath(configPath)
+	})
+
+	It("loads the configuration from all the files in the given directory", func() {
+		Expect(retErr).NotTo(HaveOccurred())
+		Expect(*retConfig).To(Equal(config.ControllerConfig{
+			CFProcessDefaults: config.CFProcessDefaults{
+				MemoryMB:    1024,
+				DiskQuotaMB: 512,
+			},
+			CFRootNamespace:             "rootNamespace",
+			PackageRegistrySecretName:   "packageRegistrySecretName",
+			TaskTTL:                     "taskTTL",
+			WorkloadsTLSSecretName:      "workloadsTLSSecretName",
+			WorkloadsTLSSecretNamespace: "workloadsTLSSecretNamespace",
+			BuildReconciler:             "newBuildReconciler",
+		}))
+	})
+
+	When("the path does not exist", func() {
+		BeforeEach(func() {
+			configPath = "notarealpath"
+		})
+
+		It("throws an error", func() {
+			Expect(retErr).To(MatchError(fmt.Sprintf("error reading config dir %q: open %s: no such file or directory", configPath, configPath)))
+		})
+	})
+
+	When("a file cannot be read", func() {
+		BeforeEach(func() {
+			err := os.WriteFile(filepath.Join(configPath, "file3"), []byte(`buildReconciler: "newBuildReconciler"`), 0o000)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("throws an error", func() {
+			Expect(retErr).To(MatchError(fmt.Sprintf("failed to open file: open %s: permission denied", filepath.Join(configPath, "file3"))))
+		})
+	})
+})
 
 var _ = Describe("ParseTaskTTL", func() {
 	var (

--- a/controllers/config/crd/bases/korifi.cloudfoundry.org_buildworkloads.yaml
+++ b/controllers/config/crd/bases/korifi.cloudfoundry.org_buildworkloads.yaml
@@ -152,6 +152,8 @@ spec:
                   - name
                   type: object
                 type: array
+              reconcilerName:
+                type: string
               services:
                 items:
                   description: 'ObjectReference contains enough information to let
@@ -248,6 +250,7 @@ spec:
                 type: object
             required:
             - buildRef
+            - reconcilerName
             type: object
           status:
             description: BuildWorkloadStatus defines the observed state of BuildWorkload

--- a/controllers/config/overlays/kind-local-registry/controllersconfig/korifi_controllers_config.yaml
+++ b/controllers/config/overlays/kind-local-registry/controllersconfig/korifi_controllers_config.yaml
@@ -1,3 +1,4 @@
+buildReconciler: kpack-image-builder
 cfProcessDefaults:
   memoryMB: 1024
   diskQuotaMB: 1024

--- a/controllers/config/samples/build_workload.yaml
+++ b/controllers/config/samples/build_workload.yaml
@@ -12,3 +12,4 @@ spec:
       image: gcr.io/cf-relint-greengrass/cf-crd-staging-spike/packages/665a78f8-ed97-47e6-85b2-60cbcc21d5e2
       imagePullSecrets:
         - name: image-registry-credentials
+  reconcilerName: kpack-image-builder

--- a/controllers/controllers/workloads/cfbuild_controller.go
+++ b/controllers/controllers/workloads/cfbuild_controller.go
@@ -160,6 +160,7 @@ func (r *CFBuildReconciler) createBuildWorkloadAndUpdateStatus(ctx context.Conte
 					ImagePullSecrets: cfPackage.Spec.Source.Registry.ImagePullSecrets,
 				},
 			},
+			ReconcilerName: r.ControllerConfig.BuildReconciler,
 		},
 	}
 

--- a/controllers/controllers/workloads/cfbuild_controller_test.go
+++ b/controllers/controllers/workloads/cfbuild_controller_test.go
@@ -110,7 +110,9 @@ var _ = Describe("CFBuildReconciler", func() {
 			fakeClient,
 			scheme.Scheme,
 			zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)),
-			&config.ControllerConfig{},
+			&config.ControllerConfig{
+				BuildReconciler: "myCustomBuildReconciler",
+			},
 			fakeEnvBuilder,
 		)
 		req = ctrl.Request{
@@ -169,6 +171,14 @@ var _ = Describe("CFBuildReconciler", func() {
 				Expect(actualApp).To(Equal(cfApp))
 
 				Expect(actualWorkload.Spec.Env).To(Equal(buildEnv))
+			})
+
+			It("sets the build reconciler from the controller config", func() {
+				Expect(fakeClient.CreateCallCount()).To(Equal(1), "fakeClient Create was not called 1 time")
+				_, obj, _ := fakeClient.CreateArgsForCall(0)
+				actualWorkload, ok := obj.(*korifiv1alpha1.BuildWorkload)
+				Expect(ok).To(BeTrue(), "create wasn't passed a buildWorkload")
+				Expect(actualWorkload.Spec.ReconcilerName).To(Equal("myCustomBuildReconciler"))
 			})
 		})
 

--- a/kpack-image-builder/controllers/buildworkload_controller.go
+++ b/kpack-image-builder/controllers/buildworkload_controller.go
@@ -58,6 +58,7 @@ const (
 	clusterBuilderAPIVersion = "kpack.io/v1alpha2"
 	kpackServiceAccount      = "kpack-service-account"
 	BuildWorkloadLabelKey    = "korifi.cloudfoundry.org/build-workload-name"
+	kpackReconcilerName      = "kpack-image-builder"
 )
 
 //counterfeiter:generate -o fake -fake-name RegistryAuthFetcher . RegistryAuthFetcher
@@ -202,6 +203,10 @@ func (r *BuildWorkloadReconciler) ensureKpackImageRequirements(ctx context.Conte
 }
 
 func (r *BuildWorkloadReconciler) createKpackImageAndUpdateStatus(ctx context.Context, buildWorkload *korifiv1alpha1.BuildWorkload) error {
+	if buildWorkload.Spec.ReconcilerName != kpackReconcilerName {
+		// Stop reconciling since the buildWorkload.Spec.ReconcilerName does not match this builder
+		return nil
+	}
 	serviceAccountName := kpackServiceAccount
 	kpackImageTag := path.Join(r.ControllerConfig.KpackImageTag, buildWorkload.Name)
 	kpackImageName := buildWorkload.Name

--- a/kpack-image-builder/controllers/suite_test.go
+++ b/kpack-image-builder/controllers/suite_test.go
@@ -65,6 +65,8 @@ func TestAPIs(t *testing.T) {
 
 	SetDefaultEventuallyTimeout(10 * time.Second)
 	SetDefaultEventuallyPollingInterval(200 * time.Millisecond)
+	SetDefaultConsistentlyDuration(10 * time.Second)
+	SetDefaultConsistentlyPollingInterval(200 * time.Millisecond)
 
 	RunSpecs(t, "Controller Suite")
 }


### PR DESCRIPTION
## Is there a related GitHub Issue?
#1427 

## What is this change about?
Implement the reconcileName in BuildWorkloads so builders will only produce images if the reconciler name matches

## Does this PR introduce a breaking change?
no

## Acceptance Steps
See issue

## Tag your pair, your PM, and/or team
@davewalter 
