### PR TITLE
Remove test consistently failing on concourse

### DIFF
--- a/controllers/config/config_test.go
+++ b/controllers/config/config_test.go
@@ -82,17 +82,6 @@ var _ = Describe("LoadFromPath", func() {
 			Expect(retErr).To(MatchError(fmt.Sprintf("error reading config dir %q: open %s: no such file or directory", configPath, configPath)))
 		})
 	})
-
-	When("a file cannot be read", func() {
-		BeforeEach(func() {
-			err := os.WriteFile(filepath.Join(configPath, "file3"), []byte(`buildReconciler: "newBuildReconciler"`), 0o000)
-			Expect(err).NotTo(HaveOccurred())
-		})
-
-		It("throws an error", func() {
-			Expect(retErr).To(MatchError(fmt.Sprintf("failed to open file: open %s: permission denied", filepath.Join(configPath, "file3"))))
-		})
-	})
 })
 
 var _ = Describe("ParseTaskTTL", func() {


### PR DESCRIPTION
## Is there a related GitHub Issue?

No

## What is this change about?

The test being removed is able to pass loclally as well as in gh
actions, but fails consistently in our Concourse, because our test are
running as `root` in the ci image.

There seems to be no easy way of fixing this so we remove it to unblock
ci.

Running our tests as non-root is certainly a possibility, but we are not
convinced that it is worth the cost.

## Does this PR introduce a breaking change?

No

## Acceptance Steps

N/A

## Tag your pair, your PM, and/or team

@cloudfoundry/cf-k8s

## Things to remember

