### PR TITLE
Fix bug reading stats for recently-scaled-down process

### DIFF
--- a/api/repositories/pod_repository.go
+++ b/api/repositories/pod_repository.go
@@ -117,6 +117,9 @@ func (r *PodRepo) ListPodStats(ctx context.Context, authInfo authorization.Info,
 		if podState == "DOWN" {
 			continue
 		}
+		if index >= len(records) {
+			continue
+		}
 		records[index].State = podState
 
 		podMetrics, err := r.metricsFetcher(ctx, p.Namespace, p.Name)


### PR DESCRIPTION
## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->
No
## What is this change about?
<!-- _Please describe the change here._ -->
This PR solves a bug when running `cf scale -i` to a scale an App down. Before this change, the following sequence would consistently lead to an error:

1. `cf scale -i 4`
2. Wait for all instances to come up (by polling `cf app`)
3. `cf scale -i 1`

The user would see output like this:
```
$ cf scale node -i 1
Scaling app node in org o / space s as cf-admin...


Error unmarshalling the following into a cloud controller error: upstream connect error or disconnect/reset before headers. reset reason: connection termination
FAILED
```

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->
No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->
Follow the steps in the "What is this change about?" section above. On this branch, there should be no error when scaling down the App.

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
