### PR TITLE
Require `staged` condition on app on task reconcile

### DIFF
--- a/controllers/controllers/workloads/cftask_controller.go
+++ b/controllers/controllers/workloads/cftask_controller.go
@@ -201,6 +201,12 @@ func (r *CFTaskReconciler) getApp(ctx context.Context, cfTask *korifiv1alpha1.CF
 		return nil, err
 	}
 
+	if !meta.IsStatusConditionTrue(cfApp.Status.Conditions, StatusConditionStaged) {
+		r.logger.Info("cfapp not staged", "app-namespace", cfApp.Namespace, "app-name", cfApp.Name)
+		r.recorder.Eventf(cfTask, "Warning", "appNotStaged", "App %s:%s is not staged", cfApp.Namespace, cfApp.Name)
+		return nil, errors.New("app not staged")
+	}
+
 	if cfApp.Spec.CurrentDropletRef.Name == "" {
 		r.recorder.Eventf(cfTask, "Warning", "appCurrentDropletRefNotSet", "App %s does not have a current droplet", cfTask.Spec.AppRef.Name)
 		return nil, errors.New("app droplet ref not set")


### PR DESCRIPTION

## Is there a related GitHub Issue?
https://github.com/cloudfoundry/korifi/issues/1464
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
The task reconciler now returns an error when the app does not have the
`staged` status condition. The `staged=true` condition indicates that
the app's status has its droplet and `VCAP_SERVICES` secret set.

The task controller also explicitly checks for the droplet reference
being not empty to make sure that the task can transition into
`initialized` state.

Also, reorder objects creation on integartion tests to mitigate
https://github.com/cloudfoundry/korifi/issues/954
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
The flake is fixed
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@kieron-dev
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

