### PR TITLE
Clarify "long cert expiry" warning message

### DIFF
--- a/api/handlers/org_handler.go
+++ b/api/handlers/org_handler.go
@@ -96,7 +96,8 @@ func (h *OrgHandler) orgListHandler(ctx context.Context, logger logr.Logger, aut
 	notAfter, certParsed := decodePEMNotAfter(authInfo.CertData)
 
 	if !isExpirationValid(notAfter, h.userCertificateExpirationWarningDuration, certParsed) {
-		resp = resp.WithHeader("X-Cf-Warnings", fmt.Sprintf("Warning: Client certificate has an unsafe expiry date (%s). Please use a short-lived certificate that expires in less than %s.", notAfter.Format(time.RFC3339), h.userCertificateExpirationWarningDuration))
+		certWarningMsg := "Warning: The client certificate you provided for user authentication expires at %s, which exceeds the recommended validity duration of %s. Ask your platform provider to issue you a short-lived certificate credential or to configure your authentication to generate short-lived credentials automatically."
+		resp = resp.WithHeader("X-Cf-Warnings", fmt.Sprintf(certWarningMsg, notAfter.Format(time.RFC3339), h.userCertificateExpirationWarningDuration))
 	}
 	return resp, nil
 }

--- a/tests/e2e/orgs_test.go
+++ b/tests/e2e/orgs_test.go
@@ -191,7 +191,10 @@ var _ = Describe("Orgs", func() {
 			})
 			It("returns orgs that the client has a role in and sets an HTTP warning header", func() {
 				Expect(resp).To(HaveRestyStatusCode(http.StatusOK))
-				Expect(resp).To(HaveRestyHeaderWithValue("X-Cf-Warnings", HavePrefix("Warning: Client certificate has an unsafe expiry date")))
+				Expect(resp).To(HaveRestyHeaderWithValue("X-Cf-Warnings", HavePrefix("Warning: The client certificate you provided for user authentication expires at")))
+				Expect(resp).To(HaveRestyHeaderWithValue("X-Cf-Warnings", MatchRegexp("\\d{4}-\\d{2}-\\d{2}")))
+				Expect(resp).To(HaveRestyHeaderWithValue("X-Cf-Warnings", MatchRegexp("\\d{3}h\\d{1}m\\d{1}s")))
+				Expect(resp).To(HaveRestyHeaderWithValue("X-Cf-Warnings", HaveSuffix("to configure your authentication to generate short-lived credentials automatically.")))
 				Expect(result.Resources).To(ContainElements(
 					MatchFields(IgnoreExtras, Fields{"Name": Equal(org3Name)}),
 				))


### PR DESCRIPTION
## Is there a related GitHub Issue?
Not specifically, but these two are related:
* https://github.com/cloudfoundry/korifi/issues/1090
* https://github.com/cloudfoundry/korifi/issues/1236

## What is this change about?
- Users have reported confusion regarding what certificate this message
was referring to. This clarifies that it is the client cert used for
authentication and not any of the ingress certs.
- Also directs the user to the Platform Operator who is more likely to
be the one who can solve the problem for them.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Follow the A/C on https://github.com/cloudfoundry/korifi/issues/1090 to set up the scenarios that trigger this warning. By default just authenticate with a client certificate that has an expiration of over a week.

## Tag your pair, your PM, and/or team
@emalm 