### PR TITLE
Increase timeout for smoke tests to reduce flakes

### DIFF
--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -91,7 +91,7 @@ var _ = Describe("Smoke Tests", func() {
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(resp).To(HaveHTTPStatus(http.StatusOK))
 				g.Expect(resp).To(HaveHTTPBody(ContainSubstring("Hello World")))
-			}, 2*time.Minute, 30*time.Second).Should(Succeed())
+			}, 5*time.Minute, 30*time.Second).Should(Succeed())
 		})
 	})
 })


### PR DESCRIPTION
## Is there a related GitHub Issue?
#1394 

## What is this change about?
Increase the timeout for smoke tests to 5 minutes to reduce flakes. After analysis over several days worth of runs, it was determined that the errors that occur are due to timeouts and the apps become available after a longer wait period. After characterization, it was determined that in 97% of test runs, the apps are available in under 3 minutes. There were a few outliers where they took up to 4 minutes that seem to coincide with system load so 5 minutes seems like a safe value.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Smoke tests pass
