### PR TITLE
Make assertion order independent

### DIFF
--- a/tests/e2e/apps_test.go
+++ b/tests/e2e/apps_test.go
@@ -465,38 +465,42 @@ var _ = Describe("Apps", func() {
 
 		It("returns the app environment", func() {
 			Expect(result).To(HaveKeyWithValue("environment_variables", HaveKeyWithValue("foo", "var")))
-			Expect(result).To(HaveKeyWithValue("system_env_json", HaveKeyWithValue("VCAP_SERVICES", map[string]interface{}{
-				"user-provided": []interface{}{
-					map[string]interface{}{
-						"syslog_drain_url": nil,
-						"tags":             []interface{}{},
-						"instance_name":    instanceName,
-						"binding_guid":     bindingGUID,
-						"credentials": map[string]interface{}{
-							"type": "user-provided",
-						},
-						"volume_mounts": []interface{}{},
-						"label":         "user-provided",
-						"name":          instanceName,
-						"instance_guid": instanceGUID,
-						"binding_name":  nil,
-					},
-					map[string]interface{}{
-						"syslog_drain_url": nil,
-						"tags":             []interface{}{},
-						"instance_name":    instanceName2,
-						"binding_guid":     bindingGUID2,
-						"credentials": map[string]interface{}{
-							"type": "user-provided",
-						},
-						"volume_mounts": []interface{}{},
-						"label":         "user-provided",
-						"name":          instanceName2,
-						"instance_guid": instanceGUID2,
-						"binding_name":  nil,
-					},
-				},
-			})))
+			Expect(result).To(
+				HaveKeyWithValue("system_env_json",
+					HaveKeyWithValue("VCAP_SERVICES",
+						HaveKeyWithValue("user-provided", ConsistOf(
+							map[string]interface{}{
+								"syslog_drain_url": nil,
+								"tags":             []interface{}{},
+								"instance_name":    instanceName,
+								"binding_guid":     bindingGUID,
+								"credentials": map[string]interface{}{
+									"type": "user-provided",
+								},
+								"volume_mounts": []interface{}{},
+								"label":         "user-provided",
+								"name":          instanceName,
+								"instance_guid": instanceGUID,
+								"binding_name":  nil,
+							},
+							map[string]interface{}{
+								"syslog_drain_url": nil,
+								"tags":             []interface{}{},
+								"instance_name":    instanceName2,
+								"binding_guid":     bindingGUID2,
+								"credentials": map[string]interface{}{
+									"type": "user-provided",
+								},
+								"volume_mounts": []interface{}{},
+								"label":         "user-provided",
+								"name":          instanceName2,
+								"instance_guid": instanceGUID2,
+								"binding_name":  nil,
+							}),
+						),
+					),
+				),
+			)
 		})
 
 		When("a deleted service binding changes the app env", func() {


### PR DESCRIPTION

<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
No

## What is this change about?
Thie e2e app env test has been flaking like this recently:
https://ci.korifi.cf-app.com/teams/main/pipelines/main/jobs/run-e2es-periodic/builds/953

Looks like the two valuse under the  "user-provided" key can be returned
in any order. This commit makes the assertion order independent

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Green tests

## Tag your pair, your PM, and/or team
@eirini

