### PR TITLE
Use `Patch` in service instance controller

### DIFF
--- a/controllers/api/v1alpha1/cfserviceinstance_types.go
+++ b/controllers/api/v1alpha1/cfserviceinstance_types.go
@@ -17,7 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -51,7 +51,8 @@ type InstanceType string
 type CFServiceInstanceStatus struct {
 	// A reference to the Secret containing the credentials (same as spec.secretName).
 	// This is required to conform to the Kubernetes Service Bindings spec
-	Binding v1.LocalObjectReference `json:"binding"`
+	// +optional
+	Binding corev1.LocalObjectReference `json:"binding"`
 
 	// Conditions capture the current status of the CFServiceInstance
 	Conditions []metav1.Condition `json:"conditions"`

--- a/controllers/config/crd/bases/korifi.cloudfoundry.org_cfserviceinstances.yaml
+++ b/controllers/config/crd/bases/korifi.cloudfoundry.org_cfserviceinstances.yaml
@@ -147,7 +147,6 @@ spec:
                   type: object
                 type: array
             required:
-            - binding
             - conditions
             type: object
         type: object

--- a/controllers/controllers/services/integration/cfserviceinstance_integration_test.go
+++ b/controllers/controllers/services/integration/cfserviceinstance_integration_test.go
@@ -2,7 +2,6 @@ package integration_test
 
 import (
 	"context"
-	"time"
 
 	. "github.com/onsi/gomega/gstruct"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -18,272 +17,180 @@ import (
 )
 
 var _ = Describe("CFServiceInstance", func() {
-	var namespace *corev1.Namespace
+	var (
+		namespace         *corev1.Namespace
+		secret            *corev1.Secret
+		cfServiceInstance *korifiv1alpha1.CFServiceInstance
+	)
 
 	BeforeEach(func() {
 		namespace = BuildNamespaceObject(GenerateGUID())
 		Expect(
 			k8sClient.Create(context.Background(), namespace),
 		).To(Succeed())
+
+		secret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "secret-name",
+				Namespace: namespace.Name,
+			},
+			StringData: map[string]string{"foo": "bar"},
+		}
+
+		Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+
+		cfServiceInstance = &korifiv1alpha1.CFServiceInstance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "service-instance-guid",
+				Namespace: namespace.Name,
+			},
+			Spec: korifiv1alpha1.CFServiceInstanceSpec{
+				DisplayName: "service-instance-name",
+				Type:        "user-provided",
+				Tags:        []string{},
+			},
+		}
 	})
 
 	AfterEach(func() {
 		Expect(k8sClient.Delete(context.Background(), namespace)).To(Succeed())
 	})
 
-	When("a new CFServiceInstance is Created", func() {
-		var (
-			secretData        map[string]string
-			secret            *corev1.Secret
-			cfServiceInstance *korifiv1alpha1.CFServiceInstance
-		)
-		BeforeEach(func() {
-			ctx := context.Background()
-
-			secretData = map[string]string{
-				"foo": "bar",
-			}
-			secret = &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "secret-name",
-					Namespace: namespace.Name,
-				},
-				StringData: secretData,
-			}
-			Expect(
-				k8sClient.Create(ctx, secret),
-			).To(Succeed())
-
-			cfServiceInstance = &korifiv1alpha1.CFServiceInstance{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "service-instance-guid",
-					Namespace: namespace.Name,
-				},
-				Spec: korifiv1alpha1.CFServiceInstanceSpec{
-					DisplayName: "service-instance-name",
-					SecretName:  secret.Name,
-					Type:        "user-provided",
-					Tags:        []string{},
-				},
-			}
-		})
-
+	Describe("Create", func() {
 		JustBeforeEach(func() {
-			Expect(
-				k8sClient.Create(context.Background(), cfServiceInstance),
-			).To(Succeed())
+			Expect(k8sClient.Create(context.Background(), cfServiceInstance)).To(Succeed())
 		})
 
-		It("eventually adds a finalizer", func() {
-			Eventually(func() []string {
+		It("adds a finalizer", func() {
+			Eventually(func(g Gomega) {
 				updatedCFServiceInstance := new(korifiv1alpha1.CFServiceInstance)
-				Expect(
-					k8sClient.Get(context.Background(), types.NamespacedName{Name: cfServiceInstance.Name, Namespace: cfServiceInstance.Namespace}, updatedCFServiceInstance),
-				).To(Succeed())
-				return updatedCFServiceInstance.ObjectMeta.Finalizers
-			}).Should(ConsistOf([]string{
-				"cfServiceInstance.korifi.cloudfoundry.org",
-			}))
+				serviceInstanceNamespacedName := types.NamespacedName{Name: cfServiceInstance.Name, Namespace: cfServiceInstance.Namespace}
+				err := k8sClient.Get(context.Background(), serviceInstanceNamespacedName, updatedCFServiceInstance)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				g.Expect(updatedCFServiceInstance.ObjectMeta.Finalizers).To(ConsistOf("cfServiceInstance.korifi.cloudfoundry.org"))
+			}).Should(Succeed())
 		})
 
-		When("and the secret exists", func() {
+		When("the secret exists", func() {
 			BeforeEach(func() {
 				cfServiceInstance.Spec.SecretName = secret.Name
 			})
 
-			It("eventually resolves the secretName and updates the CFServiceInstance status", func() {
-				updatedCFServiceInstance := new(korifiv1alpha1.CFServiceInstance)
-				Eventually(func() string {
-					Expect(
-						k8sClient.Get(context.Background(), types.NamespacedName{Name: cfServiceInstance.Name, Namespace: cfServiceInstance.Namespace}, updatedCFServiceInstance),
-					).To(Succeed())
-
-					return updatedCFServiceInstance.Status.Binding.Name
-				}).ShouldNot(BeEmpty())
-
-				Expect(updatedCFServiceInstance.Status.Binding.Name).To(Equal(updatedCFServiceInstance.Spec.SecretName))
-				Expect(updatedCFServiceInstance.Status.Conditions).To(ContainElement(MatchFields(IgnoreExtras, Fields{
-					"Type":    Equal("BindingSecretAvailable"),
-					"Status":  Equal(metav1.ConditionTrue),
-					"Reason":  Equal("SecretFound"),
-					"Message": Equal(""),
-				})))
-			})
-		})
-
-		When("and the referenced secret does not exist", func() {
-			var otherSecret *corev1.Secret
-
-			BeforeEach(func() {
-				otherSecret = &corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "other-secret-name",
-						Namespace: namespace.Name,
-					},
-				}
-				cfServiceInstance.Spec.SecretName = otherSecret.Name
-			})
-
-			It("updates the CFServiceInstance status", func() {
-				updatedCFServiceInstance := new(korifiv1alpha1.CFServiceInstance)
-				Eventually(func() korifiv1alpha1.CFServiceInstanceStatus {
-					Expect(
-						k8sClient.Get(context.Background(), types.NamespacedName{Name: cfServiceInstance.Name, Namespace: cfServiceInstance.Namespace}, updatedCFServiceInstance),
-					).To(Succeed())
-
-					return updatedCFServiceInstance.Status
-				}).ShouldNot(Equal(korifiv1alpha1.CFServiceInstanceStatus{}))
-
-				Expect(updatedCFServiceInstance.Status.Binding.Name).To(Equal(""))
-				Expect(updatedCFServiceInstance.Status.Conditions).To(ContainElement(MatchFields(IgnoreExtras, Fields{
-					"Type":    Equal("BindingSecretAvailable"),
-					"Status":  Equal(metav1.ConditionFalse),
-					"Reason":  Equal("SecretNotFound"),
-					"Message": Equal("Binding secret does not exist"),
-				})))
-			})
-
-			When("the referenced secret is created afterwards", func() {
-				JustBeforeEach(func() {
-					time.Sleep(100 * time.Millisecond)
-					Expect(
-						k8sClient.Create(context.Background(), otherSecret),
-					).To(Succeed())
-				})
-
-				It("eventually resolves the secretName and updates the CFServiceInstance status", func() {
+			It("sets the BindingSecretAvailable condition to true in the CFServiceInstance status", func() {
+				Eventually(func(g Gomega) {
 					updatedCFServiceInstance := new(korifiv1alpha1.CFServiceInstance)
-					Eventually(func() string {
-						Expect(
-							k8sClient.Get(context.Background(), types.NamespacedName{Name: cfServiceInstance.Name, Namespace: cfServiceInstance.Namespace}, updatedCFServiceInstance),
-						).To(Succeed())
+					serviceInstanceNamespacedName := types.NamespacedName{Name: cfServiceInstance.Name, Namespace: cfServiceInstance.Namespace}
+					err := k8sClient.Get(context.Background(), serviceInstanceNamespacedName, updatedCFServiceInstance)
+					g.Expect(err).NotTo(HaveOccurred())
 
-						return updatedCFServiceInstance.Status.Binding.Name
-					}).ShouldNot(BeEmpty())
-
-					Expect(updatedCFServiceInstance.Status.Binding.Name).To(Equal(updatedCFServiceInstance.Spec.SecretName))
-					Expect(updatedCFServiceInstance.Status.Conditions).To(ContainElement(MatchFields(IgnoreExtras, Fields{
+					g.Expect(updatedCFServiceInstance.Status.Binding.Name).To(Equal("secret-name"))
+					g.Expect(updatedCFServiceInstance.Status.Conditions).To(ContainElement(MatchFields(IgnoreExtras, Fields{
 						"Type":    Equal("BindingSecretAvailable"),
 						"Status":  Equal(metav1.ConditionTrue),
 						"Reason":  Equal("SecretFound"),
 						"Message": Equal(""),
 					})))
+				}).Should(Succeed())
+			})
+		})
+
+		When("the referenced secret does not exist", func() {
+			BeforeEach(func() {
+				cfServiceInstance.Spec.SecretName = "other-secret-name"
+			})
+
+			It("sets the BindingSecretAvailable condition to false in the CFServiceInstance status", func() {
+				Eventually(func(g Gomega) {
+					updatedCFServiceInstance := new(korifiv1alpha1.CFServiceInstance)
+					serviceInstanceNamespacedName := types.NamespacedName{Name: cfServiceInstance.Name, Namespace: cfServiceInstance.Namespace}
+					err := k8sClient.Get(context.Background(), serviceInstanceNamespacedName, updatedCFServiceInstance)
+					g.Expect(err).NotTo(HaveOccurred())
+
+					g.Expect(updatedCFServiceInstance.Status.Binding).To(BeZero())
+					g.Expect(updatedCFServiceInstance.Status.Conditions).To(ContainElement(MatchFields(IgnoreExtras, Fields{
+						"Type":    Equal("BindingSecretAvailable"),
+						"Status":  Equal(metav1.ConditionFalse),
+						"Reason":  Equal("SecretNotFound"),
+						"Message": Equal("Binding secret does not exist"),
+					})))
+				}).Should(Succeed())
+			})
+
+			When("the referenced secret is created afterwards", func() {
+				BeforeEach(func() {
+					Expect(k8sClient.Create(context.Background(), &corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "other-secret-name",
+							Namespace: namespace.Name,
+						},
+					})).To(Succeed())
+				})
+
+				It("sets the BindingSecretAvailable condition to true in the CFServiceInstance status", func() {
+					Eventually(func(g Gomega) {
+						updatedCFServiceInstance := new(korifiv1alpha1.CFServiceInstance)
+						serviceInstanceNamespacedName := types.NamespacedName{Name: cfServiceInstance.Name, Namespace: cfServiceInstance.Namespace}
+						err := k8sClient.Get(context.Background(), serviceInstanceNamespacedName, updatedCFServiceInstance)
+						g.Expect(err).NotTo(HaveOccurred())
+
+						g.Expect(updatedCFServiceInstance.Status.Binding.Name).To(Equal("other-secret-name"))
+						g.Expect(updatedCFServiceInstance.Status.Conditions).To(ContainElement(MatchFields(IgnoreExtras, Fields{
+							"Type":    Equal("BindingSecretAvailable"),
+							"Status":  Equal(metav1.ConditionTrue),
+							"Reason":  Equal("SecretFound"),
+							"Message": Equal(""),
+						})))
+					}).Should(Succeed())
 				})
 			})
 		})
 	})
 
-	When(" a CFServiceInstance is Deleted", func() {
-		var cfServiceInstance *korifiv1alpha1.CFServiceInstance
-
+	Describe("Delete", func() {
 		BeforeEach(func() {
-			ctx := context.Background()
+			cfServiceInstance.Spec.SecretName = secret.Name
+			Expect(k8sClient.Create(context.Background(), cfServiceInstance)).To(Succeed())
 
-			secretData := map[string]string{
-				"foo": "bar",
-			}
-			secret := &corev1.Secret{
+			Eventually(func(g Gomega) {
+				updatedCFServiceInstance := new(korifiv1alpha1.CFServiceInstance)
+				serviceInstanceNamespacedName := types.NamespacedName{Name: cfServiceInstance.Name, Namespace: cfServiceInstance.Namespace}
+				err := k8sClient.Get(context.Background(), serviceInstanceNamespacedName, updatedCFServiceInstance)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				g.Expect(updatedCFServiceInstance.ObjectMeta.Finalizers).To(ConsistOf("cfServiceInstance.korifi.cloudfoundry.org"))
+			}).Should(Succeed())
+
+			cfServiceBinding := &korifiv1alpha1.CFServiceBinding{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "secret-name",
+					Name:      GenerateGUID(),
 					Namespace: namespace.Name,
 				},
-				StringData: secretData,
-			}
-			Expect(
-				k8sClient.Create(ctx, secret),
-			).To(Succeed())
-
-			cfServiceInstance = &korifiv1alpha1.CFServiceInstance{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "service-instance-guid",
-					Namespace: namespace.Name,
-				},
-				Spec: korifiv1alpha1.CFServiceInstanceSpec{
-					DisplayName: "service-instance-name",
-					SecretName:  secret.Name,
-					Type:        "user-provided",
-					Tags:        []string{},
+				Spec: korifiv1alpha1.CFServiceBindingSpec{
+					Service: corev1.ObjectReference{
+						Kind:       "ServiceInstance",
+						Name:       cfServiceInstance.Name,
+						APIVersion: "korifi.cloudfoundry.org/v1alpha1",
+					},
+					AppRef: corev1.LocalObjectReference{
+						Name: "",
+					},
 				},
 			}
-			Expect(
-				k8sClient.Create(context.Background(), cfServiceInstance),
-			).To(Succeed())
+			Expect(k8sClient.Create(context.Background(), cfServiceBinding)).To(Succeed())
 		})
 
 		JustBeforeEach(func() {
-			Expect(
-				k8sClient.Delete(context.Background(), cfServiceInstance),
-			).To(Succeed())
+			Expect(k8sClient.Delete(context.Background(), cfServiceInstance)).To(Succeed())
 		})
 
-		When("a ServiceBinding exists for the CFServiceInstance", func() {
-			var cfServiceBinding *korifiv1alpha1.CFServiceBinding
+		It("deletes associated ServiceBindings", func() {
+			Eventually(func(g Gomega) {
+				cfServiceBindingList := new(korifiv1alpha1.CFServiceBindingList)
+				g.Expect(k8sClient.List(context.Background(), cfServiceBindingList, client.InNamespace(namespace.Name))).To(Succeed())
 
-			BeforeEach(func() {
-				cfServiceBinding = &korifiv1alpha1.CFServiceBinding{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      GenerateGUID(),
-						Namespace: namespace.Name,
-					},
-					Spec: korifiv1alpha1.CFServiceBindingSpec{
-						Service: corev1.ObjectReference{
-							Kind:       "ServiceInstance",
-							Name:       cfServiceInstance.Name,
-							APIVersion: "korifi.cloudfoundry.org/v1alpha1",
-						},
-						AppRef: corev1.LocalObjectReference{
-							Name: "",
-						},
-					},
-				}
-				Expect(
-					k8sClient.Create(context.Background(), cfServiceBinding),
-				).To(Succeed())
-
-				cfServiceBinding2 := &korifiv1alpha1.CFServiceBinding{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      GenerateGUID(),
-						Namespace: namespace.Name,
-					},
-					Spec: korifiv1alpha1.CFServiceBindingSpec{
-						Service: corev1.ObjectReference{
-							Kind:       "ServiceInstance",
-							Name:       cfServiceInstance.Name,
-							APIVersion: "korifi.cloudfoundry.org/v1alpha1",
-						},
-						AppRef: corev1.LocalObjectReference{
-							Name: "",
-						},
-					},
-				}
-				Expect(
-					k8sClient.Create(context.Background(), cfServiceBinding2),
-				).To(Succeed())
-
-				Eventually(func() []korifiv1alpha1.CFServiceBinding {
-					cfServiceBindingList := new(korifiv1alpha1.CFServiceBindingList)
-					Expect(k8sClient.List(context.Background(), cfServiceBindingList, client.InNamespace(namespace.Name))).To(Succeed())
-					return cfServiceBindingList.Items
-				}).Should(HaveLen(2))
-
-				Eventually(func() []string {
-					updatedCFServiceInstance := new(korifiv1alpha1.CFServiceInstance)
-					Expect(
-						k8sClient.Get(context.Background(), types.NamespacedName{Name: cfServiceInstance.Name, Namespace: cfServiceInstance.Namespace}, updatedCFServiceInstance),
-					).To(Succeed())
-					return updatedCFServiceInstance.ObjectMeta.Finalizers
-				}).Should(ConsistOf([]string{
-					"cfServiceInstance.korifi.cloudfoundry.org",
-				}))
-			})
-
-			It("eventually deletes associated ServiceBindings", func() {
-				Eventually(func() []korifiv1alpha1.CFServiceBinding {
-					cfServiceBindingList := new(korifiv1alpha1.CFServiceBindingList)
-					Expect(k8sClient.List(context.Background(), cfServiceBindingList, client.InNamespace(namespace.Name))).To(Succeed())
-					return cfServiceBindingList.Items
-				}).Should(HaveLen(0))
-			})
+				g.Expect(cfServiceBindingList.Items).To(BeEmpty())
+			}).Should(Succeed())
 		})
 	})
 })

--- a/controllers/controllers/services/integration/suite_integration_test.go
+++ b/controllers/controllers/services/integration/suite_integration_test.go
@@ -43,6 +43,7 @@ import (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
+	ctx       context.Context
 	cancel    context.CancelFunc
 	testEnv   *envtest.Environment
 	k8sClient client.Client
@@ -59,8 +60,7 @@ func TestAPIs(t *testing.T) {
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
-	ctx, cancelFunc := context.WithCancel(context.TODO())
-	cancel = cancelFunc
+	ctx, cancel = context.WithCancel(context.TODO())
 
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths: []string{


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
https://github.com/cloudfoundry/korifi/issues/714
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
* Use `Patch` in service instance controller
* Remove the redundant `CfServiceInstance.Status.Binding` field - it has
  been only referenced in tests
* Improve the controller integration test
* Simplify the controller implementation
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
No conflict errors caused by updating service instance status by the controller
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@danail-branekov
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

