### PR TITLE
Use the newer os functions rather than ioutil

### DIFF
--- a/api/config/config.go
+++ b/api/config/config.go
@@ -3,7 +3,6 @@ package config
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -54,7 +53,7 @@ type DefaultLifecycleConfig struct {
 func LoadFromPath(path string) (*APIConfig, error) {
 	var config APIConfig
 
-	items, err := ioutil.ReadDir(path)
+	items, err := os.ReadDir(path)
 	if err != nil {
 		return nil, fmt.Errorf("error reading config dir %q: %w", path, err)
 	}

--- a/api/repositories/registry/image_builder.go
+++ b/api/repositories/registry/image_builder.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/buildpacks/pack/pkg/archive"
@@ -30,7 +29,7 @@ func (r *ImageBuilder) Build(ctx context.Context, srcReader io.Reader) (v1.Image
 }
 
 func copyIntoTempFile(srcReader io.Reader) (string, error) {
-	tmpFile, err := ioutil.TempFile(os.TempDir(), "sourceimg-%s")
+	tmpFile, err := os.CreateTemp(os.TempDir(), "sourceimg-%s")
 	if err != nil {
 		return "", fmt.Errorf("failed to create a temp file for image: %w", err)
 	}

--- a/controllers/config/config.go
+++ b/controllers/config/config.go
@@ -3,7 +3,6 @@ package config
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -32,7 +31,7 @@ const defaultTaskTTL = 30 * 24 * time.Hour
 func LoadFromPath(path string) (*ControllerConfig, error) {
 	var config ControllerConfig
 
-	items, err := ioutil.ReadDir(path)
+	items, err := os.ReadDir(path)
 	if err != nil {
 		return nil, fmt.Errorf("error reading config dir %q: %w", path, err)
 	}


### PR DESCRIPTION

<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
`ioutil.ReadDir` docs say use `os.ReadDir` instead. And similarly with `ioutil.TempFile` -> `os.CreateTemp`.

This fixes linter errors, e.g. https://ci.korifi.cf-app.com/teams/main/pipelines/main/jobs/run-tests-main/builds/220

## Does this PR introduce a breaking change?
No

## Acceptance Steps
There should be no material difference, but the golangci-lint task will pass.

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
