### PR TITLE
Delete 'VCAP_SERVICES' Secret when App is deleted

### DIFF
--- a/controllers/controllers/workloads/cfapp_controller.go
+++ b/controllers/controllers/workloads/cfapp_controller.go
@@ -401,7 +401,7 @@ func (r *CFAppReconciler) createVCAPServicesSecretForApp(ctx context.Context, cf
 	err := r.Client.Get(ctx, vcapServicesSecretLookupKey, vcapServicesSecret)
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
-			r.Log.Error(err, "unable to fetch vcap services Secret")
+			r.Log.Error(err, "unable to fetch 'VCAP_SERVICES' Secret")
 			return err
 		}
 
@@ -417,9 +417,16 @@ func (r *CFAppReconciler) createVCAPServicesSecretForApp(ctx context.Context, cf
 			},
 			Type: "",
 		}
+
+		err = controllerutil.SetOwnerReference(cfApp, vcapServicesSecret, r.Scheme)
+		if err != nil {
+			r.Log.Error(err, "failed to set OwnerRef on 'VCAP_SERVICES' Secret")
+			return err
+		}
+
 		err = r.Client.Create(ctx, vcapServicesSecret)
 		if err != nil {
-			r.Log.Error(err, "unable to create vcap services Secret")
+			r.Log.Error(err, "unable to create 'VCAP_SERVICES' Secret")
 			return err
 		}
 	}

--- a/controllers/controllers/workloads/integration/cfapp_controller_integration_test.go
+++ b/controllers/controllers/workloads/integration/cfapp_controller_integration_test.go
@@ -80,6 +80,14 @@ var _ = Describe("CFAppReconciler Integration Tests", func() {
 			createdSecret := new(corev1.Secret)
 			Expect(k8sClient.Get(ctx, vcapServicesSecretLookupKey, createdSecret)).To(Succeed())
 			Expect(createdSecret.Data).To(HaveKeyWithValue("VCAP_SERVICES", []byte("{}")))
+			Expect(createdSecret.ObjectMeta.OwnerReferences).To(ConsistOf([]metav1.OwnerReference{
+				{
+					APIVersion: "korifi.cloudfoundry.org/v1alpha1",
+					Kind:       "CFApp",
+					Name:       cfApp.Name,
+					UID:        cfApp.GetUID(),
+				},
+			}))
 		})
 
 		It("sets its status.conditions", func() {

--- a/go.mod
+++ b/go.mod
@@ -103,7 +103,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.3-0.20220114050600-8b9d41f48198 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.2 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect


### PR DESCRIPTION
## Is there a related GitHub Issue?
Issue: https://github.com/cloudfoundry/korifi/issues/1498

## What is this change about?
Sets an ownerReference on this Secret to the CFApp that it belongs to so that it gets cleaned up when the app is deleted.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
1. `cf push` an app
2. Verify that it has a Secret containing `VCAP_SERVICES`: `kubectl -n $(cf space s --guid) get secrets`
  There will be one with a `-vcap-services` suffix corresponding for the app
3. `cf delete APP_NAME -f`
4. Verify that the Secret is deleted
