### PR TITLE
Remove usages of the deprecated `ioutil` package

### DIFF
--- a/api/authorization/testhelpers/auth_provider.go
+++ b/api/authorization/testhelpers/auth_provider.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"net/http"
 	"os"
@@ -70,7 +69,7 @@ func (p *AuthProvider) GenerateJWTToken(subject string, groups ...string) string
 func writeCAToTempFile(server *ghttp.Server) string {
 	caDerBytes := server.HTTPTestServer.TLS.Certificates[0].Certificate[0]
 
-	certOut, err := ioutil.TempFile("", "test-oidc-ca")
+	certOut, err := os.CreateTemp("", "test-oidc-ca")
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	err = pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: caDerBytes})

--- a/api/handlers/integration/apply_manifest_test.go
+++ b/api/handlers/integration/apply_manifest_test.go
@@ -3,7 +3,7 @@ package integration_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -144,7 +144,7 @@ var _ = Describe("POST /v3/spaces/<space-guid>/actions/apply_manifest endpoint",
 			It("creates the applications in the manifest, the env var secret, the processes, and the route, then returns 202 and a job URI", func() {
 				Expect(rr.Code).To(Equal(202))
 
-				body, err := ioutil.ReadAll(rr.Body)
+				body, err := io.ReadAll(rr.Body)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(body).To(BeEmpty())
 
@@ -601,7 +601,7 @@ var _ = Describe("POST /v3/spaces/<space-guid>/actions/apply_manifest endpoint",
 			It("updates the app with the manifest changes and returns a 202", func() {
 				Expect(rr.Code).To(Equal(202))
 
-				body, err := ioutil.ReadAll(rr.Body)
+				body, err := io.ReadAll(rr.Body)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(body).To(BeEmpty())
 

--- a/api/handlers/integration/integration_suite_test.go
+++ b/api/handlers/integration/integration_suite_test.go
@@ -3,11 +3,11 @@ package integration_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -253,7 +253,7 @@ func createSpaceWithCleanup(ctx context.Context, orgGUID, name string) *korifiv1
 
 func createClusterRole(ctx context.Context, filename string) *rbacv1.ClusterRole {
 	filepath := filepath.Join("..", "..", "..", "controllers", "config", "cf_roles", filename+".yaml")
-	content, err := ioutil.ReadFile(filepath)
+	content, err := os.ReadFile(filepath)
 	Expect(err).NotTo(HaveOccurred())
 
 	decoder := serializer.NewCodecFactory(scheme.Scheme).UniversalDecoder()

--- a/api/repositories/repositories_suite_test.go
+++ b/api/repositories/repositories_suite_test.go
@@ -2,7 +2,7 @@ package repositories_test
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -226,7 +226,7 @@ func createNamespace(ctx context.Context, orgName, name string, labels map[strin
 
 func createClusterRole(ctx context.Context, filename string) *rbacv1.ClusterRole {
 	filepath := filepath.Join("..", "..", "controllers", "config", "cf_roles", filename+".yaml")
-	content, err := ioutil.ReadFile(filepath)
+	content, err := os.ReadFile(filepath)
 	Expect(err).NotTo(HaveOccurred())
 
 	decoder := serializer.NewCodecFactory(scheme.Scheme).UniversalDecoder()

--- a/kpack-image-builder/config/config.go
+++ b/kpack-image-builder/config/config.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -19,7 +18,7 @@ type ControllerConfig struct {
 func LoadFromPath(path string) (*ControllerConfig, error) {
 	var config ControllerConfig
 
-	items, err := ioutil.ReadDir(path)
+	items, err := os.ReadDir(path)
 	if err != nil {
 		return nil, fmt.Errorf("error reading config dir %q: %w", path, err)
 	}


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Remove usages of the `ioutil` package, those were causing linter errors
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
`make lint` succeeds

<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@kieron-dev
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

