### PR TITLE
Update kube-rbac-proxy image ref in job-task-runner

### DIFF
--- a/job-task-runner/config/default/manager_auth_proxy_patch.yaml
+++ b/job-task-runner/config/default/manager_auth_proxy_patch.yaml
@@ -15,7 +15,7 @@ spec:
           capabilities:
             drop:
               - "ALL"
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.12.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.12.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
This PR updates the job-task-runner config to use the same image reference for kube-rbac-proxy as the other components.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Everything still works.

## Tag your pair, your PM, and/or team
@matt-royal 