### PR TITLE
Update job-task-runner security context

### DIFF
--- a/job-task-runner/config/default/manager_auth_proxy_patch.yaml
+++ b/job-task-runner/config/default/manager_auth_proxy_patch.yaml
@@ -10,11 +10,6 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-              - "ALL"
         image: quay.io/brancz/kube-rbac-proxy:v0.12.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
@@ -32,6 +27,14 @@ spec:
           requests:
             cpu: 5m
             memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
       - name: manager
         args:
         - "--health-probe-bind-address=:8081"

--- a/job-task-runner/config/manager/manager.yaml
+++ b/job-task-runner/config/manager/manager.yaml
@@ -3,6 +3,8 @@ kind: Namespace
 metadata:
   labels:
     control-plane: controller-manager
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/enforce: restricted
   name: system
 ---
 apiVersion: apps/v1
@@ -44,7 +46,7 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
-              - "ALL"
+              - ALL
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
This PR updates job-task-runner security context to add the pod-security labels to the namespace and set `seccompProfile` and `runAsNonRoot`.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Everything deploys successfully.

## Tag your pair, your PM, and/or team
@matt-royal 