### PR TITLE
Remove hard-coded job-task-runner command

### DIFF
--- a/job-task-runner/config/manager/manager.yaml
+++ b/job-task-runner/config/manager/manager.yaml
@@ -28,25 +28,20 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
-        # TODO(user): For common cases that do not require escalating privileges
-        # it is recommended to ensure that all your Pods/Containers are restrictive.
-        # More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
-        # Please uncomment the following code if your project does NOT have to work on old Kubernetes
-        # versions < 1.19 or on vendors versions which do NOT support this field by default (i.e. Openshift < 4.11 ).
-        # seccompProfile:
-        #   type: RuntimeDefault
       containers:
-      - command:
-        - /manager
-        args:
+      - args:
         - --leader-elect
         image: cloudfoundry/korifi-job-task-runner:latest
+        imagePullPolicy: IfNotPresent
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
               - ALL
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
This PR removes the hard-coded `job-task-runner` command from the deployment in favour of the image's entrypoint. It also adds more security context values.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Everything deploys and tests pass.

## Tag your pair, your PM, and/or team
@matt-royal 