### PR TITLE
Set job parallelism and completions

### DIFF
--- a/job-task-runner/controllers/integration/taskworkload_controller_test.go
+++ b/job-task-runner/controllers/integration/taskworkload_controller_test.go
@@ -65,7 +65,9 @@ var _ = Describe("Job TaskWorkload Controller Integration Test", func() {
 		Expect(job.OwnerReferences).To(HaveLen(1))
 		Expect(job.OwnerReferences[0].Name).To(Equal(taskWorkload.Name))
 		Expect(*job.OwnerReferences[0].Controller).To(BeTrue())
-		Expect(*job.Spec.BackoffLimit).To(BeZero())
+		Expect(job.Spec.Parallelism).To(Equal(tools.PtrTo(int32(1))))
+		Expect(job.Spec.Completions).To(Equal(tools.PtrTo(int32(1))))
+		Expect(job.Spec.BackoffLimit).To(Equal(tools.PtrTo(int32(0))))
 
 		podSpec := job.Spec.Template.Spec
 		Expect(podSpec.RestartPolicy).To(Equal(corev1.RestartPolicyNever))

--- a/job-task-runner/controllers/taskworkload_controller.go
+++ b/job-task-runner/controllers/taskworkload_controller.go
@@ -146,6 +146,8 @@ func (r *TaskWorkloadReconciler) workloadToJob(taskWorkload *korifiv1alpha1.Task
 		},
 		Spec: batchv1.JobSpec{
 			BackoffLimit: tools.PtrTo(int32(0)),
+			Parallelism:  tools.PtrTo(int32(1)),
+			Completions:  tools.PtrTo(int32(1)),
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					RestartPolicy: corev1.RestartPolicyNever,


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
#1491

## What is this change about?
Set `Parallelism` and `Completions` on the Job resource both to 1

## Does this PR introduce a breaking change?
No

## Acceptance Steps
See a task runs once and once only

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
