### PR TITLE
Set the `AutomountServiceAccountToken` property to false on job pods

### DIFF
--- a/job-task-runner/controllers/integration/taskworkload_controller_test.go
+++ b/job-task-runner/controllers/integration/taskworkload_controller_test.go
@@ -74,6 +74,7 @@ var _ = Describe("Job TaskWorkload Controller Integration Test", func() {
 		Expect(podSpec.SecurityContext).To(Equal(&corev1.PodSecurityContext{
 			RunAsNonRoot: tools.PtrTo(true),
 		}))
+		Expect(podSpec.AutomountServiceAccountToken).To(Equal(tools.PtrTo(false)))
 		Expect(podSpec.Containers).To(HaveLen(1))
 		Expect(podSpec.Containers[0].Name).To(Equal("workload"))
 		Expect(podSpec.Containers[0].Image).To(Equal("my-image"))

--- a/job-task-runner/controllers/taskworkload_controller.go
+++ b/job-task-runner/controllers/taskworkload_controller.go
@@ -154,6 +154,7 @@ func (r *TaskWorkloadReconciler) workloadToJob(taskWorkload *korifiv1alpha1.Task
 					SecurityContext: &corev1.PodSecurityContext{
 						RunAsNonRoot: tools.PtrTo(true),
 					},
+					AutomountServiceAccountToken: tools.PtrTo(false),
 					Containers: []corev1.Container{{
 						Name:      workloadContainerName,
 						Image:     taskWorkload.Spec.Image,


### PR DESCRIPTION
## Is there a related GitHub Issue?

<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?

This means that whatever the value of the same property on the service account
used to run the jobs, the service account token will not be mounted in the job
containers.

## Does this PR introduce a breaking change?

No

## Acceptance Steps

See #1492

## Tag your pair, your PM, and/or team

@kieron-dev

## Things to remember

<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
