### PR TITLE
Remove the -a flag from go build in dockerfile

### DIFF
--- a/job-task-runner/Dockerfile
+++ b/job-task-runner/Dockerfile
@@ -18,7 +18,7 @@ COPY job-task-runner/controllers/ job-task-runner/controllers/
 
 # Build
 RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg/mod \
-     CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager job-task-runner/main.go
+     CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o manager job-task-runner/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
This means the docker build can use the go cache for building. No reason not to.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
n/a

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
