### PR TITLE
Set the task workloads image pull secrets on the job's pod

### DIFF
--- a/job-task-runner/controllers/integration/taskworkload_controller_test.go
+++ b/job-task-runner/controllers/integration/taskworkload_controller_test.go
@@ -43,6 +43,9 @@ var _ = Describe("Job TaskWorkload Controller Integration Test", func() {
 						corev1.ResourceEphemeralStorage: *resource.NewScaledQuantity(512, resource.Mega),
 					},
 				},
+				ImagePullSecrets: []corev1.LocalObjectReference{{
+					Name: "my-image-secret",
+				}},
 			},
 		}
 	})
@@ -75,6 +78,7 @@ var _ = Describe("Job TaskWorkload Controller Integration Test", func() {
 			RunAsNonRoot: tools.PtrTo(true),
 		}))
 		Expect(podSpec.AutomountServiceAccountToken).To(Equal(tools.PtrTo(false)))
+		Expect(podSpec.ImagePullSecrets).To(ConsistOf(corev1.LocalObjectReference{Name: "my-image-secret"}))
 		Expect(podSpec.Containers).To(HaveLen(1))
 		Expect(podSpec.Containers[0].Name).To(Equal("workload"))
 		Expect(podSpec.Containers[0].Image).To(Equal("my-image"))

--- a/job-task-runner/controllers/taskworkload_controller.go
+++ b/job-task-runner/controllers/taskworkload_controller.go
@@ -155,6 +155,7 @@ func (r *TaskWorkloadReconciler) workloadToJob(taskWorkload *korifiv1alpha1.Task
 						RunAsNonRoot: tools.PtrTo(true),
 					},
 					AutomountServiceAccountToken: tools.PtrTo(false),
+					ImagePullSecrets:             taskWorkload.Spec.ImagePullSecrets,
 					Containers: []corev1.Container{{
 						Name:      workloadContainerName,
 						Image:     taskWorkload.Spec.Image,


### PR DESCRIPTION
## Is there a related GitHub Issue?
#1463

## What is this change about?
Set the image pull secrets from the workload task onto the job's pod

## Does this PR introduce a breaking change?
No

## Acceptance Steps
See #1463 in the κορυφή github

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
