### PR TITLE
Operators can switch to other AppWorkload Reconciler

### DIFF
--- a/controllers/api/v1alpha1/appworkload_types.go
+++ b/controllers/api/v1alpha1/appworkload_types.go
@@ -47,6 +47,8 @@ type AppWorkloadSpec struct {
 	// +kubebuilder:validation:Required
 	DiskMiB       int64 `json:"diskMiB"`
 	CPUMillicores int64 `json:"cpuMillicores"`
+	// +kubebuilder:validation:Required
+	ReconcilerName string `json:"reconcilerName"`
 }
 
 type Healthcheck struct {

--- a/controllers/config/base/controllersconfig/korifi_controllers_config.yaml
+++ b/controllers/config/base/controllersconfig/korifi_controllers_config.yaml
@@ -1,4 +1,5 @@
 buildReconciler: kpack-image-builder
+appReconciler: statefulset-runner
 cfProcessDefaults:
   memoryMB: 1024
   diskQuotaMB: 1024

--- a/controllers/config/config.go
+++ b/controllers/config/config.go
@@ -15,6 +15,7 @@ type ControllerConfig struct {
 	WorkloadsTLSSecretName      string            `yaml:"workloads_tls_secret_name"`
 	WorkloadsTLSSecretNamespace string            `yaml:"workloads_tls_secret_namespace"`
 	BuildReconciler             string            `yaml:"buildReconciler"`
+	AppReconciler               string            `yaml:"appReconciler"`
 }
 
 type CFProcessDefaults struct {

--- a/controllers/config/config_test.go
+++ b/controllers/config/config_test.go
@@ -37,12 +37,12 @@ var _ = Describe("LoadFromPath", func() {
 			WorkloadsTLSSecretName:      "workloadsTLSSecretName",
 			WorkloadsTLSSecretNamespace: "workloadsTLSSecretNamespace",
 			BuildReconciler:             "buildReconciler",
+			AppReconciler:               "statefulset-runner",
 		}
 		configYAML, err := yaml.Marshal(config)
 		Expect(err).NotTo(HaveOccurred())
 
-		err = os.WriteFile(filepath.Join(configPath, "file1"), configYAML, 0o644)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(os.WriteFile(filepath.Join(configPath, "file1"), configYAML, 0o644)).To(Succeed())
 	})
 
 	AfterEach(func() {
@@ -66,6 +66,7 @@ var _ = Describe("LoadFromPath", func() {
 			WorkloadsTLSSecretName:      "workloadsTLSSecretName",
 			WorkloadsTLSSecretNamespace: "workloadsTLSSecretNamespace",
 			BuildReconciler:             "buildReconciler",
+			AppReconciler:               "statefulset-runner",
 		}))
 	})
 })

--- a/controllers/config/crd/bases/korifi.cloudfoundry.org_appworkloads.yaml
+++ b/controllers/config/crd/bases/korifi.cloudfoundry.org_appworkloads.yaml
@@ -204,6 +204,8 @@ spec:
                 type: array
               processType:
                 type: string
+              reconcilerName:
+                type: string
               version:
                 type: string
             required:
@@ -217,6 +219,7 @@ spec:
             - instances
             - memoryMiB
             - processType
+            - reconcilerName
             - version
             type: object
           status:

--- a/controllers/config/overlays/kind-local-registry/controllersconfig/korifi_controllers_config.yaml
+++ b/controllers/config/overlays/kind-local-registry/controllersconfig/korifi_controllers_config.yaml
@@ -1,4 +1,5 @@
 buildReconciler: kpack-image-builder
+appReconciler: statefulset-runner
 cfProcessDefaults:
   memoryMB: 1024
   diskQuotaMB: 1024

--- a/controllers/controllers/workloads/integration/suite_integration_test.go
+++ b/controllers/controllers/workloads/integration/suite_integration_test.go
@@ -124,6 +124,7 @@ var _ = BeforeSuite(func() {
 		k8sManager.GetClient(),
 		k8sManager.GetScheme(),
 		ctrl.Log.WithName("controllers").WithName("CFProcess"),
+		controllerConfig,
 		env.NewBuilder(k8sManager.GetClient()),
 	)).SetupWithManager(k8sManager)
 	Expect(err).NotTo(HaveOccurred())

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -160,6 +160,7 @@ func main() {
 			mgr.GetClient(),
 			mgr.GetScheme(),
 			ctrl.Log.WithName("controllers").WithName("CFProcess"),
+			controllerConfig,
 			env.NewBuilder(mgr.GetClient()),
 		)).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "CFProcess")

--- a/kpack-image-builder/controllers/buildworkload_controller_test.go
+++ b/kpack-image-builder/controllers/buildworkload_controller_test.go
@@ -179,7 +179,7 @@ var _ = Describe("BuildWorkloadReconciler", func() {
 			})
 		})
 
-		When("The build workload reconciler name is not kpack-image-builder", func() {
+		When("reconciler name on BuildWorkload is not kpack-image-builder", func() {
 			BeforeEach(func() {
 				reconcilerName = "notkpackreconciler"
 			})

--- a/statefulset-runner/controllers/appworkload_controller.go
+++ b/statefulset-runner/controllers/appworkload_controller.go
@@ -66,7 +66,8 @@ const (
 	LabelProcessType            = "korifi.cloudfoundry.org/process-type"
 	LabelStatefulSetRunnerIndex = "korifi.cloudfoundry.org/add-stsr-index"
 
-	ApplicationContainerName = "application"
+	ApplicationContainerName  = "application"
+	AppWorkloadReconcilerName = "statefulset-runner"
 
 	LivenessFailureThreshold  = 4
 	ReadinessFailureThreshold = 1
@@ -109,6 +110,10 @@ func (r *AppWorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	if err != nil {
 		r.Log.Error(err, "Error when fetching AppWorkload", "AppWorkload.Name", req.Name, "AppWorkload.Namespace", req.Namespace)
 		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	if appWorkload.Spec.ReconcilerName != AppWorkloadReconcilerName {
+		return ctrl.Result{}, nil
 	}
 
 	statefulSet, err := r.Convert(appWorkload)

--- a/statefulset-runner/controllers/appworkload_controller_test.go
+++ b/statefulset-runner/controllers/appworkload_controller_test.go
@@ -387,6 +387,17 @@ var _ = Describe("AppWorkload Reconcile", func() {
 				Expect(reconcileErr).To(MatchError("big sad"))
 			})
 		})
+
+		When("reconciler name on the AppWorkload is not statefulset-runner", func() {
+			BeforeEach(func() {
+				appWorkload.Spec.ReconcilerName = "MyCustomReconciler"
+			})
+
+			It("does not create/patch statefulset", func() {
+				Expect(fakeClient.CreateCallCount()).To(Equal(0), "Client.Create call count mismatch")
+				Expect(fakeClient.PatchCallCount()).To(Equal(0), "Client.Patch call count mismatch")
+			})
+		})
 	})
 
 	When("the appworkload is being deleted", func() {
@@ -419,12 +430,13 @@ var _ = Describe("AppWorkload Reconcile", func() {
 					Namespace: testNamespace,
 				},
 				Spec: korifiv1alpha1.AppWorkloadSpec{
-					GUID:          "test-sts",
-					Version:       "1",
-					Instances:     2,
-					MemoryMiB:     10,
-					DiskMiB:       10,
-					CPUMillicores: 10,
+					GUID:           "test-sts",
+					Version:        "1",
+					Instances:      2,
+					MemoryMiB:      10,
+					DiskMiB:        10,
+					CPUMillicores:  10,
+					ReconcilerName: "statefulset-runner",
 				},
 			}
 

--- a/statefulset-runner/controllers/integration/appworkload_controller_test.go
+++ b/statefulset-runner/controllers/integration/appworkload_controller_test.go
@@ -50,6 +50,7 @@ var _ = Describe("AppWorkloadsController", func() {
 				MemoryMiB:        5,
 				DiskMiB:          100,
 				CPUMillicores:    5,
+				ReconcilerName:   "statefulset-runner",
 			},
 		}
 	})

--- a/statefulset-runner/controllers/suite_test.go
+++ b/statefulset-runner/controllers/suite_test.go
@@ -41,11 +41,12 @@ func createAppWorkload(namespace, name string) *korifiv1alpha1.AppWorkload {
 				Endpoint:  "/healthz",
 				TimeoutMs: uint(60000),
 			},
-			Ports:         []int32{8888, 9999},
-			Instances:     1,
-			MemoryMiB:     1024,
-			DiskMiB:       2048,
-			CPUMillicores: 5,
+			Ports:          []int32{8888, 9999},
+			Instances:      1,
+			MemoryMiB:      1024,
+			DiskMiB:        2048,
+			CPUMillicores:  5,
+			ReconcilerName: "statefulset-runner",
 		},
 	}
 }


### PR DESCRIPTION
## Is there a related GitHub Issue?
#1428

## What is this change about?
Operators can switch to other AppWorkload Reconciler
- added a required `ReconcilerName` field to `AppWorkloads.Spec` and regenerated manifests.
- sets `statefulset-runner` as default value for `AppReconciler` in controllers config yaml.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
see issue #1428 

## Tag your pair, your PM, and/or team
