### PR TITLE
Remove unused rootNamespace property from NamespacePermissions

### DIFF
--- a/api/authorization/namespace_permissions.go
+++ b/api/authorization/namespace_permissions.go
@@ -24,14 +24,12 @@ type IdentityProvider interface {
 type NamespacePermissions struct {
 	privilegedClient client.Client
 	identityProvider IdentityProvider
-	rootNamespace    string
 }
 
-func NewNamespacePermissions(privilegedClient client.Client, identityProvider IdentityProvider, rootNamespace string) *NamespacePermissions {
+func NewNamespacePermissions(privilegedClient client.Client, identityProvider IdentityProvider) *NamespacePermissions {
 	return &NamespacePermissions{
 		privilegedClient: privilegedClient,
 		identityProvider: identityProvider,
-		rootNamespace:    rootNamespace,
 	}
 }
 

--- a/api/authorization/namespace_permissions_test.go
+++ b/api/authorization/namespace_permissions_test.go
@@ -28,9 +28,8 @@ var _ = Describe("Namespace Permissions", func() {
 		identity         authorization.Identity
 		identityProvider *fake.IdentityProvider
 
-		rootNamespace        string
-		org1NS, org2NS       string
 		space1NS, space2NS   string
+		org1NS, org2NS       string
 		nonCFNS              string
 		userName             string
 		roleName1, roleName2 string
@@ -85,7 +84,6 @@ var _ = Describe("Namespace Permissions", func() {
 	}
 
 	BeforeEach(func() {
-		rootNamespace = generateGUID("root-ns")
 		userName = generateGUID("alice")
 		ctx = context.Background()
 
@@ -99,7 +97,7 @@ var _ = Describe("Namespace Permissions", func() {
 		identityProvider = new(fake.IdentityProvider)
 		identityProvider.GetIdentityReturns(identity, nil)
 
-		nsPerms = authorization.NewNamespacePermissions(k8sClient, identityProvider, rootNamespace)
+		nsPerms = authorization.NewNamespacePermissions(k8sClient, identityProvider)
 
 		nonCFNS = createNamespace("non-cf", nil)
 

--- a/api/handlers/integration/integration_suite_test.go
+++ b/api/handlers/integration/integration_suite_test.go
@@ -123,7 +123,7 @@ var _ = BeforeEach(func() {
 	tokenInspector := authorization.NewTokenReviewer(k8sClient)
 	certInspector := authorization.NewCertInspector(k8sConfig)
 	identityProvider := authorization.NewCertTokenIdentityProvider(tokenInspector, certInspector)
-	nsPermissions = authorization.NewNamespacePermissions(k8sClient, identityProvider, rootNamespace)
+	nsPermissions = authorization.NewNamespacePermissions(k8sClient, identityProvider)
 
 	userName = generateGUID()
 

--- a/api/main.go
+++ b/api/main.go
@@ -89,7 +89,7 @@ func main() {
 
 	identityProvider := wireIdentityProvider(privilegedCRClient, k8sClientConfig)
 	cachingIdentityProvider := authorization.NewCachingIdentityProvider(identityProvider, cache.NewExpiring())
-	nsPermissions := authorization.NewNamespacePermissions(privilegedCRClient, cachingIdentityProvider, config.RootNamespace)
+	nsPermissions := authorization.NewNamespacePermissions(privilegedCRClient, cachingIdentityProvider)
 
 	serverURL, err := url.Parse(config.ServerURL)
 	if err != nil {
@@ -117,11 +117,7 @@ func main() {
 	roleRepo := repositories.NewRoleRepo(
 		userClientFactory,
 		spaceRepo,
-		authorization.NewNamespacePermissions(
-			privilegedCRClient,
-			cachingIdentityProvider,
-			config.RootNamespace,
-		),
+		authorization.NewNamespacePermissions(privilegedCRClient, cachingIdentityProvider),
 		config.RootNamespace,
 		config.RoleMappings,
 	)

--- a/api/repositories/repositories_suite_test.go
+++ b/api/repositories/repositories_suite_test.go
@@ -120,7 +120,7 @@ var _ = BeforeEach(func() {
 	certInspector := authorization.NewCertInspector(k8sConfig)
 	baseIDProvider := authorization.NewCertTokenIdentityProvider(tokenInspector, certInspector)
 	idProvider = authorization.NewCachingIdentityProvider(baseIDProvider, cache.NewExpiring())
-	nsPerms = authorization.NewNamespacePermissions(k8sClient, idProvider, rootNamespace)
+	nsPerms = authorization.NewNamespacePermissions(k8sClient, idProvider)
 
 	mapper, err := apiutil.NewDynamicRESTMapper(k8sConfig)
 	Expect(err).NotTo(HaveOccurred())

--- a/go.mod
+++ b/go.mod
@@ -131,7 +131,7 @@ require (
 	google.golang.org/grpc v1.47.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/apiextensions-apiserver v0.24.3 // indirect
 	k8s.io/component-base v0.24.3 // indirect
 	k8s.io/klog/v2 v2.70.1 // indirect


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
When looking at usages of rootNamespace throughout korifi, we noticed the NamePermissions helper received it but didn't use it.

This PR removes that property and fixes usages.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
All tests green

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
