### PR TITLE
Fix kpack builder check for reconcilerName

### DIFF
--- a/kpack-image-builder/controllers/buildworkload_controller.go
+++ b/kpack-image-builder/controllers/buildworkload_controller.go
@@ -134,6 +134,11 @@ func (r *BuildWorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
+	if buildWorkload.Spec.ReconcilerName != kpackReconcilerName {
+		// Stop reconciling since the buildWorkload.Spec.ReconcilerName does not match this builder
+		return ctrl.Result{}, nil
+	}
+
 	succeededStatus := meta.FindStatusCondition(buildWorkload.Status.Conditions, korifiv1alpha1.SucceededConditionType)
 
 	if succeededStatus != nil && succeededStatus.Status != metav1.ConditionUnknown {
@@ -205,10 +210,6 @@ func (r *BuildWorkloadReconciler) ensureKpackImageRequirements(ctx context.Conte
 }
 
 func (r *BuildWorkloadReconciler) createKpackImageAndUpdateStatus(ctx context.Context, buildWorkload *korifiv1alpha1.BuildWorkload) error {
-	if buildWorkload.Spec.ReconcilerName != kpackReconcilerName {
-		// Stop reconciling since the buildWorkload.Spec.ReconcilerName does not match this builder
-		return nil
-	}
 	serviceAccountName := kpackServiceAccount
 	kpackImageTag := path.Join(r.ControllerConfig.KpackImageTag, buildWorkload.Name)
 	kpackImageName := buildWorkload.Name


### PR DESCRIPTION
## Is there a related GitHub Issue?
related to #1427

## What is this change about?
- Previously, the check to ignore BuildWorkload objects intended for
  other reconcilers was nested in an if block so that it would only
  apply to new objects.
- This resulted in the kpack reconciler failing to ignore objects that
  were partially reconciled by another reconciler.
- In an unrelated change, this commit also makes a bunch of test helper
  methods private, since they were not used anywhere outside the
  package.

## Does this PR introduce a breaking change?
No. <!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
There's a new envtest that tests the previously failing case. That's probably the easiest way to reproduce this. Otherwise you would have to manually make the BuildWorkload and update the status and make the corresponding Image with all the right fields.

## Tag your pair, your PM, and/or team
cc @matt-royal @clintyoshimura 
