### PR TITLE
Use the build-workload-name label to find build logs

### DIFF
--- a/api/repositories/build_repository.go
+++ b/api/repositories/build_repository.go
@@ -275,12 +275,12 @@ func NewBuildLogsClient(k8sClient k8sclient.Interface) *BuildLogsClient {
 	}
 }
 
-const ImageLabel = "image.kpack.io/image"
+const BuildWorkloadLabelKey = "korifi.cloudfoundry.org/build-workload-name"
 
-func (c *BuildLogsClient) GetImageLogs(ctx context.Context, writer io.Writer, image, namespace string) error {
+func (c *BuildLogsClient) GetImageLogs(ctx context.Context, writer io.Writer, buildGUID, namespace string) error {
 	return c.getPodLogs(ctx, writer, namespace, metav1.ListOptions{
 		Watch:         false,
-		LabelSelector: fmt.Sprintf("%s=%s", ImageLabel, image),
+		LabelSelector: fmt.Sprintf("%s=%s", BuildWorkloadLabelKey, buildGUID),
 	}, false)
 }
 

--- a/api/repositories/build_repository_test.go
+++ b/api/repositories/build_repository_test.go
@@ -18,9 +18,7 @@ import (
 )
 
 var _ = Describe("BuildRepository", func() {
-	var (
-		buildRepo *repositories.BuildRepo
-	)
+	var buildRepo *repositories.BuildRepo
 
 	BeforeEach(func() {
 		buildRepo = repositories.NewBuildRepo(namespaceRetriever, userClientFactory)

--- a/api/repositories/buildpack_repository_test.go
+++ b/api/repositories/buildpack_repository_test.go
@@ -16,9 +16,7 @@ import (
 )
 
 var _ = Describe("BuildpackRepository", func() {
-	var (
-		buildpackRepo *BuildpackRepository
-	)
+	var buildpackRepo *BuildpackRepository
 
 	BeforeEach(func() {
 		buildpackRepo = NewBuildpackRepository(userClientFactory, rootNamespace)

--- a/api/repositories/org_repository_test.go
+++ b/api/repositories/org_repository_test.go
@@ -20,9 +20,7 @@ import (
 )
 
 var _ = Describe("OrgRepository", func() {
-	var (
-		orgRepo *repositories.OrgRepo
-	)
+	var orgRepo *repositories.OrgRepo
 
 	BeforeEach(func() {
 		orgRepo = repositories.NewOrgRepo(rootNamespace, k8sClient, userClientFactory, nsPerms, time.Millisecond*2000)

--- a/controllers/controllers/workloads/cfprocess_controller_test.go
+++ b/controllers/controllers/workloads/cfprocess_controller_test.go
@@ -3,9 +3,10 @@ package workloads_test
 import (
 	"context"
 	"errors"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"strconv"
 	"time"
+
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"code.cloudfoundry.org/korifi/controllers/config"

--- a/kpack-image-builder/controllers/buildworkload_controller_test.go
+++ b/kpack-image-builder/controllers/buildworkload_controller_test.go
@@ -238,7 +238,6 @@ var _ = Describe("BuildWorkloadReconciler", func() {
 						g.Expect(fakeImageProcessFetcher.CallCount()).To(BeZero())
 					}).Should(Succeed())
 				})
-
 			})
 		})
 	})
@@ -378,7 +377,6 @@ func PrefixedGUID(prefix string) string {
 func buildWorkloadObject(cfBuildGUID string, namespace string, source korifiv1alpha1.PackageSource, env []corev1.EnvVar, services []corev1.ObjectReference, reconcilerName string) *korifiv1alpha1.BuildWorkload {
 	return &korifiv1alpha1.BuildWorkload{
 		ObjectMeta: metav1.ObjectMeta{
-
 			Name:      cfBuildGUID,
 			Namespace: namespace,
 		},

--- a/statefulset-runner/controllers/integration/appworkload_controller_test.go
+++ b/statefulset-runner/controllers/integration/appworkload_controller_test.go
@@ -2,7 +2,6 @@ package integration_test
 
 import (
 	"context"
-	"k8s.io/apimachinery/pkg/api/resource"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"code.cloudfoundry.org/korifi/statefulset-runner/controllers"
@@ -12,6 +11,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"

--- a/tests/matchers/represents_resource_quantity.go
+++ b/tests/matchers/represents_resource_quantity.go
@@ -2,10 +2,10 @@ package matchers
 
 import (
 	"fmt"
-	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/onsi/gomega/format"
 	"github.com/onsi/gomega/types"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 type representsResourceQuantityMatcher struct {


### PR DESCRIPTION
## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->No

## What is this change about?
<!-- _Please describe the change here._ -->This PR changes how we fetch build logs, so that we use the `korifi.cloudfoundry.org/build-workload-name` label instead of `image.kpack.io/image`. Both labels have the same value. Without this change, an alternative builder implementation would need to set a kpack-specific label on their build pods to make logs available. As we want to support non-kpack builders, this requirement doesn't make sense.

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->Tests passing should be sufficient. There is no user-visible change

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
