### PR TITLE
Update dev scripts to use community version of servicebindings

### DIFF
--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -116,12 +116,14 @@ echo "*******************"
 
 kubectl apply -f https://projectcontour.io/quickstart/contour.yaml
 
-sbr_version=$(curl --silent "https://api.github.com/repos/vmware-tanzu/servicebinding/releases/latest" | jq -r '.tag_name')
+sbr_version=$(curl --silent "https://api.github.com/repos/servicebinding/runtime/releases/latest" | jq -r '.tag_name')
 echo "**************************************"
 echo "Installing Service Binding Runtime ${sbr_version}"
 echo "**************************************"
 
-kubectl apply -f https://github.com/vmware-tanzu/servicebinding/releases/download/${sbr_version}/service-bindings-${sbr_version:1}.yaml
+kubectl apply -f https://github.com/servicebinding/runtime/releases/download/${sbr_version}/servicebinding-runtime-${sbr_version}.yaml
+kubectl -n servicebinding-system rollout status deployment/servicebinding-controller-manager --watch=true
+kubectl apply -f https://github.com/servicebinding/runtime/releases/download/${sbr_version}/servicebinding-workloadresourcemappings-${sbr_version}.yaml
 
 if ! kubectl get apiservice v1beta1.metrics.k8s.io >/dev/null 2>&1; then
   if [[ -v INSECURE_TLS_METRICS_SERVER ]]; then


### PR DESCRIPTION
## Is there a related GitHub Issue?
Related to #1137

## What is this change about?
The instructions were changed to use the community version of servicebindings, however there was an issue preventing us from using it in our dev scripts. That issue has been fixed in the latest release and so dev scripts can now be updated.

## Does this PR introduce a breaking change?
no

## Acceptance Steps
All tests pass

## Tag your pair, your PM, and/or team
@davewalter @Birdrock 
