### PR TITLE
Removes duplicate declaration of k8s.io/apimachinery/pkg/api/resource.

### DIFF
--- a/controllers/controllers/workloads/cfprocess_controller_test.go
+++ b/controllers/controllers/workloads/cfprocess_controller_test.go
@@ -19,7 +19,6 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"


### PR DESCRIPTION
## Is there a related GitHub Issue?
PR #1553 sorta

## What is this change about?
PR introduced a duplicate declaration which this removes.

## Does this PR introduce a breaking change?
Nope

## Acceptance Steps
Run tests.