### PR TITLE
Improve error handling when source upload fails

### DIFF
--- a/api/apierrors/errors.go
+++ b/api/apierrors/errors.go
@@ -264,6 +264,22 @@ func NewPackageBitsAlreadyUploadedError(cause error) PackageBitsAlreadyUploadedE
 	}
 }
 
+type BlobstoreUnavailableError struct {
+	apiError
+}
+
+func NewBlobstoreUnavailableError(cause error) BlobstoreUnavailableError {
+	return BlobstoreUnavailableError{
+		apiError: apiError{
+			cause:      cause,
+			title:      "CF-BlobstoreUnavailable",
+			detail:     "Error uploading source package to the container registry",
+			code:       150006,
+			httpStatus: http.StatusBadGateway,
+		},
+	}
+}
+
 func FromK8sError(err error, resourceType string) error {
 	if webhookValidationError, ok := webhooks.WebhookErrorToValidationError(err); ok {
 		return NewUnprocessableEntityError(err, webhookValidationError.GetMessage())

--- a/api/handlers/apis_suite_test.go
+++ b/api/handlers/apis_suite_test.go
@@ -131,6 +131,18 @@ func expectBadRequestError() {
     }`)
 }
 
+func expectBlobstoreUnavailableError() {
+	expectJSONResponse(http.StatusBadGateway, `{
+        "errors": [
+            {
+                "title": "CF-BlobstoreUnavailable",
+                "detail": "Error uploading source package to the container registry",
+                "code": 150006
+            }
+        ]
+    }`)
+}
+
 func expectUnknownKeyError(detail string) {
 	expectJSONResponse(http.StatusBadRequest, fmt.Sprintf(`{
 		"errors": [

--- a/api/handlers/package_handler_test.go
+++ b/api/handlers/package_handler_test.go
@@ -887,13 +887,24 @@ var _ = Describe("PackageHandler", func() {
 			itDoesntUpdateAnyPackages()
 		})
 
-		When("uploading the source image errors", func() {
+		When("preparing to upload the source image errors", func() {
 			BeforeEach(func() {
 				imageRepo.UploadSourceImageReturns("", errors.New("boom"))
 			})
 
 			It("returns an error", func() {
 				expectUnknownError()
+			})
+			itDoesntUpdateAnyPackages()
+		})
+
+		When("uploading the source image errors", func() {
+			BeforeEach(func() {
+				imageRepo.UploadSourceImageReturns("", apierrors.NewBlobstoreUnavailableError(errors.New("boom")))
+			})
+
+			It("returns an error", func() {
+				expectBlobstoreUnavailableError()
 			})
 			itDoesntUpdateAnyPackages()
 		})

--- a/api/repositories/image_repository.go
+++ b/api/repositories/image_repository.go
@@ -97,7 +97,7 @@ func (r *ImageRepository) UploadSourceImage(ctx context.Context, authInfo author
 
 	pushedRef, err := r.pusher.Push(imageRef, image, credentials, transport)
 	if err != nil {
-		return "", fmt.Errorf("pushing image ref '%s' failed: %w", imageRef, err)
+		return "", apierrors.NewBlobstoreUnavailableError(fmt.Errorf("pushing image ref '%s' failed: %w", imageRef, err))
 	}
 
 	return pushedRef, nil

--- a/api/repositories/image_repository_test.go
+++ b/api/repositories/image_repository_test.go
@@ -145,8 +145,11 @@ var _ = Describe("ImageRepository", func() {
 				imagePusher.PushReturns("", errors.New("push-error"))
 			})
 
-			It("errors", func() {
+			It("fails with a blobstore unavailable error", func() {
 				Expect(uploadErr).To(MatchError(ContainSubstring("push-error")))
+				var apiError apierrors.BlobstoreUnavailableError
+				Expect(errors.As(uploadErr, &apiError)).To(BeTrue())
+				Expect(apiError.Detail()).To(Equal("Error uploading source package to the container registry"))
 			})
 		})
 


### PR DESCRIPTION
## Is there a related GitHub Issue?
[#1474]

## What is this change about?
- Instead of returning a generic 500 unknown error, application source
  when source upload to the container registry fails, use 502 and
  CF-BlobstoreUnavailable with a more helpful description.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
[#1474]


## Tag your pair, your PM, and/or team
@matt-royal (who *will* be my pair later today)
