### PR TITLE
CFSpace controller propagates service accounts

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -182,6 +182,8 @@ kind: ServiceAccount
 metadata:
   name: kpack-service-account
   namespace: cf
+  annotations:
+    cloudfoundry.org/propagate-service-account: "true"
 secrets:
 - name: image-registry-credentials
 imagePullSecrets:

--- a/controllers/api/v1alpha1/shared_types.go
+++ b/controllers/api/v1alpha1/shared_types.go
@@ -20,8 +20,9 @@ const (
 	ReadyConditionType     = "Ready"
 	SucceededConditionType = "Succeeded"
 
-	PropagateRoleBindingAnnotation = "cloudfoundry.org/propagate-cf-role"
-	PropagatedFromLabel            = "cloudfoundry.org/propagated-from"
+	PropagateRoleBindingAnnotation    = "cloudfoundry.org/propagate-cf-role"
+	PropagateServiceAccountAnnotation = "cloudfoundry.org/propagate-service-account"
+	PropagatedFromLabel               = "cloudfoundry.org/propagated-from"
 )
 
 type Lifecycle struct {

--- a/controllers/config/rbac/role.yaml
+++ b/controllers/config/rbac/role.yaml
@@ -57,8 +57,11 @@ rules:
   - serviceaccounts
   verbs:
   - create
+  - delete
   - get
   - list
+  - patch
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/controllers/controllers/workloads/integration/cfspace_controller_integration_test.go
+++ b/controllers/controllers/workloads/integration/cfspace_controller_integration_test.go
@@ -151,6 +151,21 @@ var _ = Describe("CFSpaceReconciler Integration Tests", func() {
 			}).Should(Succeed())
 		})
 
+		It("removes service account tokens from the propagated secret", func() {
+			Eventually(func(g Gomega) {
+				var createdServiceAccounts corev1.ServiceAccountList
+				g.Expect(k8sClient.List(ctx, &createdServiceAccounts, client.InNamespace(cfSpace.Name))).To(Succeed())
+				g.Expect(createdServiceAccounts.Items).To(ContainElements(
+					MatchFields(IgnoreExtras, Fields{
+						"ObjectMeta": MatchFields(IgnoreExtras, Fields{
+							"Name": Equal(serviceAccount.Name),
+						}),
+						"Secrets": ConsistOf(MatchFields(IgnoreExtras, Fields{"Name": Equal("a-secret-i-like")})),
+					}),
+				))
+			}).Should(Succeed())
+		})
+
 		It("does not propagate service accounts with annotation \"cloudfoundry.org/propagate-service-account\" set to \"false\" ", func() {
 			Consistently(func(g Gomega) bool {
 				var newServiceAccount corev1.ServiceAccount

--- a/controllers/controllers/workloads/integration/suite_integration_test.go
+++ b/controllers/controllers/workloads/integration/suite_integration_test.go
@@ -269,6 +269,10 @@ func createServiceAccount(ctx context.Context, k8sclient client.Client, serviceA
 			Namespace:   namespace,
 			Annotations: annotations,
 		},
+		Secrets: []corev1.ObjectReference{
+			{Name: serviceAccountName + "-token-someguid"},
+			{Name: "a-secret-i-like"},
+		},
 	}
 	Expect(k8sClient.Create(ctx, &serviceAccount)).To(Succeed())
 	return serviceAccount

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -211,6 +211,7 @@ func main() {
 			mgr.GetScheme(),
 			ctrl.Log.WithName("controllers").WithName("CFSpace"),
 			controllerConfig.PackageRegistrySecretName,
+			controllerConfig.CFRootNamespace,
 		).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "CFSpace")
 			os.Exit(1)

--- a/tests/dependencies/kpack/service_account.yaml
+++ b/tests/dependencies/kpack/service_account.yaml
@@ -4,6 +4,8 @@ kind: ServiceAccount
 metadata:
   name: kpack-service-account
   namespace: cf
+  annotations:
+    cloudfoundry.org/propagate-service-account: "true"
 secrets:
 - name: image-registry-credentials
 imagePullSecrets:


### PR DESCRIPTION
## Is there a related GitHub Issue?
[#1510]
## What is this change about?
- previously we had hard-coded logic to create a `kpack-service-account`
  in each space.
- this commit looks for service accounts in the root namespace with a
  specific annotation, and copies them instead.
- the contoller manager role is extended to watch/patch/delete service accounts in order to keep spaces
  in sync with any changes in the root namespace.

## Does this PR introduce a breaking change?
no

## Acceptance Steps
[#1510]

## Tag your pair, your PM, and/or team
@matt-royal 
