### PR TITLE
Tasks are "cancelled", not "canceled"

### DIFF
--- a/api/repositories/task_repository.go
+++ b/api/repositories/task_repository.go
@@ -270,7 +270,7 @@ func taskToRecord(task *korifiv1alpha1.CFTask) TaskRecord {
 		taskRecord.FailureReason = failedCond.Message
 
 		if failedCond.Reason == workloads.TaskCanceledReason {
-			taskRecord.FailureReason = "task was canceled"
+			taskRecord.FailureReason = "task was cancelled"
 		}
 	}
 

--- a/api/repositories/task_repository_test.go
+++ b/api/repositories/task_repository_test.go
@@ -277,7 +277,7 @@ var _ = Describe("TaskRepository", func() {
 				})
 			})
 
-			When("the task was canceled", func() {
+			When("the task was cancelled", func() {
 				BeforeEach(func() {
 					setStatusAndUpdate(cfTask, korifiv1alpha1.TaskInitializedConditionType, korifiv1alpha1.TaskStartedConditionType)
 					meta.SetStatusCondition(&(cfTask.Status.Conditions), metav1.Condition{
@@ -291,7 +291,7 @@ var _ = Describe("TaskRepository", func() {
 				It("returns the failed task", func() {
 					Expect(getErr).NotTo(HaveOccurred())
 					Expect(taskRecord.State).To(Equal(repositories.TaskStateFailed))
-					Expect(taskRecord.FailureReason).To(Equal("task was canceled"))
+					Expect(taskRecord.FailureReason).To(Equal("task was cancelled"))
 				})
 			})
 		})


### PR DESCRIPTION
This changes the failure reason for cancelled tasks to use the same spelling as traditional CF. It might look silly, but it makes a [CAT](https://github.com/cloudfoundry/cf-acceptance-tests/blob/a2262f3ce3129ec4f7f7b7f24455d610b8f9a509/tasks/task.go#L227) fail! 😅 
