### PR TITLE
Fix kind load targets to specify cluster name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 IMG_CONTROLLERS ?= cloudfoundry/korifi-controllers:latest
 IMG_API ?= cloudfoundry/korifi-api:latest
 CRD_OPTIONS ?= "crd"
+CLUSTER_NAME ?= "e2e"
 
 # Run controllers tests with two nodes by default to (potentially) minimise
 # flakes.
@@ -181,10 +182,10 @@ docker-push-statefulset-runner:
 kind-load-images: kind-load-api-image kind-load-controllers-image kind-load-job-task-runner-image kind-load-kpack-image-builder-image kind-load-statefulset-runner-image
 
 kind-load-api-image:
-	kind load docker-image ${IMG_API}
+	kind load docker-image --name ${CLUSTER_NAME} ${IMG_API}
 
 kind-load-controllers-image:
-	kind load docker-image ${IMG_CONTROLLERS}
+	kind load docker-image --name ${CLUSTER_NAME} ${IMG_CONTROLLERS}
 
 kind-load-job-task-runner-image:
 	make -C job-task-runner kind-load-image

--- a/job-task-runner/Makefile
+++ b/job-task-runner/Makefile
@@ -3,6 +3,7 @@
 IMG_JTR ?= cloudfoundry/korifi-job-task-runner:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.24.1
+CLUSTER_NAME ?= "e2e"
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -87,7 +88,7 @@ docker-push: ## Push docker image with the manager.
 	docker push ${IMG_JTR}
 
 kind-load-image:
-	kind load docker-image ${IMG_JTR}
+	kind load docker-image --name ${CLUSTER_NAME} ${IMG_JTR}
 
 ##@ Deployment
 

--- a/kpack-image-builder/Makefile
+++ b/kpack-image-builder/Makefile
@@ -2,6 +2,7 @@
 IMG_KIB ?= cloudfoundry/korifi-kpack-image-builder:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.23
+CLUSTER_NAME ?= "e2e"
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -82,7 +83,7 @@ docker-push: ## Push docker image with the manager.
 	docker push ${IMG_KIB}
 
 kind-load-image:
-	kind load docker-image ${IMG_KIB}
+	kind load docker-image --name ${CLUSTER_NAME} ${IMG_KIB}
 
 ##@ Deployment
 

--- a/statefulset-runner/Makefile
+++ b/statefulset-runner/Makefile
@@ -3,6 +3,7 @@
 IMG_SSR ?= cloudfoundry/korifi-statefulset-runner:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.23
+CLUSTER_NAME ?= "e2e"
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -94,7 +95,7 @@ docker-push: ## Push docker image with the manager.
 	docker push ${IMG_SSR}
 
 kind-load-image:
-	kind load docker-image ${IMG_SSR}
+	kind load docker-image --name ${CLUSTER_NAME} ${IMG_SSR}
 
 ##@ Deployment
 


### PR DESCRIPTION
## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Fix kind load targets to specify cluster name

Otherwise `kind load docker-image` is trying to use a cluster named `kind`
which does not exist in the context of `make test-e2e`
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
`make test-e2e` succeeds when there is no kind cluster
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@danail-branekov
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

