### PR TITLE
Make BuildReconciler configurable

### DIFF
--- a/api/config/base/apiconfig/korifi_api_config.yaml
+++ b/api/config/base/apiconfig/korifi_api_config.yaml
@@ -2,6 +2,7 @@ externalFQDN: "api.example.org"
 internalPort: 9000
 
 rootNamespace: cf
+buildReconciler: kpack-image-builder
 defaultLifecycleConfig:
   type: buildpack
   stack: cflinuxfs3

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -22,6 +22,7 @@ type APIConfig struct {
 	ServerURL string
 
 	RootNamespace                            string                 `yaml:"rootNamespace"`
+	BuildReconciler                          string                 `yaml:"buildReconciler"`
 	PackageRegistryBase                      string                 `yaml:"packageRegistryBase"`
 	PackageRegistrySecretName                string                 `yaml:"packageRegistrySecretName"`
 	DefaultDomainName                        string                 `yaml:"defaultDomainName"`
@@ -84,6 +85,10 @@ func (c *APIConfig) validate() error {
 		if _, err := time.ParseDuration(c.UserCertificateExpirationWarningDuration); err != nil {
 			return errors.New(`Invalid duration format for userCertificateExpirationWarningDuration. Use a format like "48h"`)
 		}
+	}
+
+	if c.BuildReconciler == "" {
+		return errors.New("BuildReconciler must have a value")
 	}
 
 	return nil

--- a/api/config/overlays/kind-local-registry/apiconfig/korifi_api_config.yaml
+++ b/api/config/overlays/kind-local-registry/apiconfig/korifi_api_config.yaml
@@ -2,6 +2,7 @@ externalFQDN: localhost
 internalPort: 9000
 
 rootNamespace: cf
+buildReconciler: kpack-image-builder
 defaultLifecycleConfig:
   type: buildpack
   stack: cflinuxfs3

--- a/api/config/overlays/kind/apiconfig/korifi_api_config.yaml
+++ b/api/config/overlays/kind/apiconfig/korifi_api_config.yaml
@@ -2,6 +2,7 @@ externalFQDN: localhost
 internalPort: 9000
 
 rootNamespace: cf
+buildReconciler: kpack-image-builder
 defaultLifecycleConfig:
   type: buildpack
   stack: cflinuxfs3

--- a/api/handlers/integration/integration_suite_test.go
+++ b/api/handlers/integration/integration_suite_test.go
@@ -96,7 +96,7 @@ var _ = BeforeSuite(func() {
 	dynamicClient, err := dynamic.NewForConfig(k8sConfig)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(dynamicClient).NotTo(BeNil())
-	namespaceRetriever = repositories.NewNamespaceRetriver(dynamicClient)
+	namespaceRetriever = repositories.NewNamespaceRetriever(dynamicClient)
 	Expect(namespaceRetriever).NotTo(BeNil())
 
 	rand.Seed(time.Now().UnixNano())

--- a/api/main.go
+++ b/api/main.go
@@ -78,7 +78,7 @@ func main() {
 	if err != nil {
 		panic(fmt.Sprintf("could not create dynamic k8s client: %v", err))
 	}
-	namespaceRetriever := repositories.NewNamespaceRetriver(dynamicClient)
+	namespaceRetriever := repositories.NewNamespaceRetriever(dynamicClient)
 
 	mapper, err := apiutil.NewDynamicRESTMapper(k8sClientConfig)
 	if err != nil {
@@ -113,7 +113,7 @@ func main() {
 	packageRepo := repositories.NewPackageRepo(userClientFactory, namespaceRetriever, nsPermissions)
 	serviceInstanceRepo := repositories.NewServiceInstanceRepo(namespaceRetriever, userClientFactory, nsPermissions)
 	serviceBindingRepo := repositories.NewServiceBindingRepo(namespaceRetriever, userClientFactory, nsPermissions, createTimeout)
-	buildpackRepo := repositories.NewBuildpackRepository(userClientFactory, config.RootNamespace)
+	buildpackRepo := repositories.NewBuildpackRepository(config.BuildReconciler, userClientFactory, config.RootNamespace)
 	roleRepo := repositories.NewRoleRepo(
 		userClientFactory,
 		spaceRepo,

--- a/api/repositories/namespace_retriever.go
+++ b/api/repositories/namespace_retriever.go
@@ -101,7 +101,7 @@ type NamespaceRetriever struct {
 	client dynamic.Interface
 }
 
-func NewNamespaceRetriver(client dynamic.Interface) NamespaceRetriever {
+func NewNamespaceRetriever(client dynamic.Interface) NamespaceRetriever {
 	return NamespaceRetriever{
 		client: client,
 	}

--- a/api/repositories/repositories_suite_test.go
+++ b/api/repositories/repositories_suite_test.go
@@ -51,6 +51,7 @@ var (
 	userName              string
 	authInfo              authorization.Info
 	rootNamespace         string
+	buildReconciler       string
 	idProvider            authorization.IdentityProvider
 	nsPerms               *authorization.NamespacePermissions
 	adminRole             *rbacv1.ClusterRole
@@ -90,7 +91,7 @@ var _ = BeforeSuite(func() {
 	dynamicClient, err := dynamic.NewForConfig(k8sConfig)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(dynamicClient).NotTo(BeNil())
-	namespaceRetriever = repositories.NewNamespaceRetriver(dynamicClient)
+	namespaceRetriever = repositories.NewNamespaceRetriever(dynamicClient)
 	Expect(namespaceRetriever).NotTo(BeNil())
 
 	adminRole = createClusterRole(context.Background(), "cf_admin")
@@ -112,6 +113,7 @@ var _ = BeforeEach(func() {
 	cert, key := testhelpers.ObtainClientCert(testEnv, userName)
 	authInfo.CertData = testhelpers.JoinCertAndKey(cert, key)
 	rootNamespace = prefixedGUID("root-ns")
+	buildReconciler = "kpack-image-builder"
 	tokenInspector := authorization.NewTokenReviewer(k8sClient)
 	certInspector := authorization.NewCertInspector(k8sConfig)
 	baseIDProvider := authorization.NewCertTokenIdentityProvider(tokenInspector, certInspector)


### PR DESCRIPTION
## Is there a related GitHub Issue?
#1529 

## What is this change about?
User can see accurate list of buildpacks when multiple build reconcilers are installed

## Does this PR introduce a breaking change?
Yes - `korifi_api_config.yaml` must have a populated `buildReconciler` top level field.

## Acceptance Steps
Run all tests. See acceptance steps in #1529 

## Tag your pair, your PM, and/or team
@matt-royal
