### PR TITLE
Fix flaky org repo test

### DIFF
--- a/api/repositories/org_repository_test.go
+++ b/api/repositories/org_repository_test.go
@@ -191,24 +191,18 @@ var _ = Describe("OrgRepository", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(orgs).To(ContainElements(
-				repositories.OrgRecord{
-					Name:      cfOrg1.Spec.DisplayName,
-					CreatedAt: cfOrg1.CreationTimestamp.Time.UTC().Format(time.RFC3339),
-					UpdatedAt: cfOrg1.CreationTimestamp.Time.UTC().Format(time.RFC3339),
-					GUID:      cfOrg1.Name,
-				},
-				repositories.OrgRecord{
-					Name:      cfOrg2.Spec.DisplayName,
-					CreatedAt: cfOrg2.CreationTimestamp.Time.UTC().Format(time.RFC3339),
-					UpdatedAt: cfOrg2.CreationTimestamp.Time.UTC().Format(time.RFC3339),
-					GUID:      cfOrg2.Name,
-				},
-				repositories.OrgRecord{
-					Name:      cfOrg3.Spec.DisplayName,
-					CreatedAt: cfOrg3.CreationTimestamp.Time.UTC().Format(time.RFC3339),
-					UpdatedAt: cfOrg3.CreationTimestamp.Time.UTC().Format(time.RFC3339),
-					GUID:      cfOrg3.Name,
-				},
+				MatchFields(IgnoreExtras, Fields{
+					"Name": Equal(cfOrg1.Spec.DisplayName),
+					"GUID": Equal(cfOrg1.Name),
+				}),
+				MatchFields(IgnoreExtras, Fields{
+					"Name": Equal(cfOrg2.Spec.DisplayName),
+					"GUID": Equal(cfOrg2.Name),
+				}),
+				MatchFields(IgnoreExtras, Fields{
+					"Name": Equal(cfOrg3.Spec.DisplayName),
+					"GUID": Equal(cfOrg3.Name),
+				}),
 			))
 		})
 
@@ -259,40 +253,32 @@ var _ = Describe("OrgRepository", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(orgs).To(ConsistOf(
-					repositories.OrgRecord{
-						Name:      cfOrg1.Spec.DisplayName,
-						CreatedAt: cfOrg1.CreationTimestamp.Time.UTC().Format(time.RFC3339),
-						UpdatedAt: cfOrg1.CreationTimestamp.Time.UTC().Format(time.RFC3339),
-						GUID:      cfOrg1.Name,
-					},
-					repositories.OrgRecord{
-						Name:      cfOrg3.Spec.DisplayName,
-						CreatedAt: cfOrg3.CreationTimestamp.Time.UTC().Format(time.RFC3339),
-						UpdatedAt: cfOrg3.CreationTimestamp.Time.UTC().Format(time.RFC3339),
-						GUID:      cfOrg3.Name,
-					},
+					MatchFields(IgnoreExtras, Fields{
+						"Name": Equal(cfOrg1.Spec.DisplayName),
+						"GUID": Equal(cfOrg1.Name),
+					}),
+					MatchFields(IgnoreExtras, Fields{
+						"Name": Equal(cfOrg3.Spec.DisplayName),
+						"GUID": Equal(cfOrg3.Name),
+					}),
 				))
 			})
 		})
 
-		When("we filter for guids org1 and org3", func() {
+		When("we filter for guids org1 and org2", func() {
 			It("returns just those", func() {
 				orgs, err := orgRepo.ListOrgs(ctx, authInfo, repositories.ListOrgsMessage{GUIDs: []string{cfOrg1.Name, cfOrg2.Name}})
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(orgs).To(ConsistOf(
-					repositories.OrgRecord{
-						Name:      cfOrg1.Spec.DisplayName,
-						CreatedAt: cfOrg1.CreationTimestamp.Time.UTC().Format(time.RFC3339),
-						UpdatedAt: cfOrg1.CreationTimestamp.Time.UTC().Format(time.RFC3339),
-						GUID:      cfOrg1.Name,
-					},
-					repositories.OrgRecord{
-						Name:      cfOrg2.Spec.DisplayName,
-						CreatedAt: cfOrg2.CreationTimestamp.Time.UTC().Format(time.RFC3339),
-						UpdatedAt: cfOrg2.CreationTimestamp.Time.UTC().Format(time.RFC3339),
-						GUID:      cfOrg2.Name,
-					},
+					MatchFields(IgnoreExtras, Fields{
+						"Name": Equal(cfOrg1.Spec.DisplayName),
+						"GUID": Equal(cfOrg1.Name),
+					}),
+					MatchFields(IgnoreExtras, Fields{
+						"Name": Equal(cfOrg2.Spec.DisplayName),
+						"GUID": Equal(cfOrg2.Name),
+					}),
 				))
 			})
 		})


### PR DESCRIPTION
## Is there a related GitHub Issue?
No, but related to this test run:
https://ci.korifi.cf-app.com/builds/5246001

## What is this change about?
The previous test checked for absolute timestamps for `CreatedAt`/`UpdatedAt` which was flaky since they could vary by a second or two, This change updates the assertion to check that we have the correct orgs/guids and ignore the exact values of the timestamps. Truncated failing test below:

```
• [FAILED] [0.175 seconds]
OrgRepository ListOrgs [It] returns the 3 orgs
/tmp/build/e45b3164/root/api/repositories/org_repository_test.go:189

  Expected
      <[]repositories.OrgRecord | len:3, cap:4>: [
...
          {
              Name: "org3-10063931",
              GUID: "92ae51cc-8dc1-42eb-9f7f-d9b778d1f1dd",
              Suspended: false,
              Labels: nil,
              Annotations: nil,
              CreatedAt: "2022-09-02T17:20:28Z",
              UpdatedAt: "2022-09-02T17:20:29Z",
          },
      ]
  to contain elements
      <[]repositories.OrgRecord | len:3, cap:3>: [
...
          {
              Name: "org3-10063931",
              GUID: "92ae51cc-8dc1-42eb-9f7f-d9b778d1f1dd",
              Suspended: false,
              Labels: nil,
              Annotations: nil,
              CreatedAt: "2022-09-02T17:20:28Z",
              UpdatedAt: "2022-09-02T17:20:28Z",
          },
      ]
```

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Tests should continue to pass.

I've been running with `--until-it-fails` with this change and at the time of submitting this PR it has made it to over 25 successful runs. 

```
[1662158053] Repositories Suite - 5/372 specs SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•••••SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS SUCCESS! 7.623553303s PASS | FOCUSED
[1662158053] Conditions Suite - 2/2 specs •• SUCCESS! 7.345689792s PASS
[1662158053] Registry Suite - 7/7 specs ••••••• SUCCESS! 4.870462ms PASS

All tests passed...
Will keep running them until they fail.
This was attempt #25
Dave, this conversation can serve no purpose anymore. Goodbye.
```