### PR TITLE
Fix the deploy-on-kind script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@
 IMG_CONTROLLERS ?= cloudfoundry/korifi-controllers:latest
 IMG_API ?= cloudfoundry/korifi-api:latest
 CRD_OPTIONS ?= "crd"
-CLUSTER_NAME ?= "e2e"
 
 # Run controllers tests with two nodes by default to (potentially) minimise
 # flakes.

--- a/scripts/deploy-on-kind.sh
+++ b/scripts/deploy-on-kind.sh
@@ -235,7 +235,7 @@ function deploy_korifi_controllers() {
       fi
     fi
 
-    make kind-load-controllers-image
+    CLUSTER_NAME="$cluster" make kind-load-controllers-image
 
     if [[ -n "${use_local_registry}" ]]; then
       if [[ -z "${debug}" ]]; then
@@ -274,7 +274,7 @@ function deploy_korifi_api() {
       fi
     fi
 
-    make kind-load-api-image
+    CLUSTER_NAME="$cluster" make kind-load-api-image
 
     if [[ -n "${use_local_registry}" ]]; then
       if [[ -z "${debug}" ]]; then
@@ -312,7 +312,7 @@ function deploy_job_task_runner() {
       fi
     fi
 
-    make kind-load-image
+    CLUSTER_NAME="$cluster" make kind-load-image
 
     if [[ -n "${debug}" ]]; then
       make deploy-kind-local-debug
@@ -344,7 +344,7 @@ function deploy_kpack_image_builder() {
       fi
     fi
 
-    make kind-load-image
+    CLUSTER_NAME="$cluster" make kind-load-image
 
     if [[ -n "${use_local_registry}" ]]; then
       if [[ -z "${debug}" ]]; then
@@ -380,7 +380,7 @@ function deploy_statefulset_runner() {
       fi
     fi
 
-    make kind-load-image
+    CLUSTER_NAME="$cluster" make kind-load-image
 
     if [[ -n "${debug}" ]]; then
       make deploy-kind-local-debug

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -74,6 +74,10 @@ echo " Installing Kpack"
 echo "******************"
 
 kubectl apply -f "$VENDOR_DIR/kpack"
+# Increase the CPU limit on the kpack-controller. Without this change the ClusterBuilder takes 10+ minutes to
+# become ready on M1 Macs. With this change the ClusterBuilder becomes ready in the time it takes this script to run.
+kubectl patch -n kpack deployment kpack-controller -p \
+  '{"spec": {"template": {"spec": {"containers": [{"name": "controller", "resources": {"limits": {"cpu": "500m"}}}]}}}}'
 
 if [[ -n "${GCP_SERVICE_ACCOUNT_JSON_FILE:=}" ]]; then
   DOCKER_SERVER="gcr.io"


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ --> No

## What is this change about?
<!-- _Please describe the change here._ --> Fixes a bug introduced in commit 42e44ce4, which caused `scripts/deploy-on-kind.sh` to fail consistently unless the name `e2e` was used.

Also increases the CPU limit on the kpack-controller so that ClusterBuilder becomes ready quickly instead of the 10+ minutes it's been taking on some machines

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ --> 
`make test-e2e` passes
`./scripts/deploy-on-kind.sh` succeeds with a name besides e2e

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
