### PR TITLE
Improve the reason and message on BuildWorkload conditions

### DIFF
--- a/api/repositories/build_repository.go
+++ b/api/repositories/build_repository.go
@@ -191,7 +191,7 @@ func cfBuildToBuildRecord(cfBuild korifiv1alpha1.CFBuild) BuildRecord {
 		case metav1.ConditionFalse:
 			toReturn.State = BuildStateFailed
 			conditionStatus := meta.FindStatusCondition(cfBuild.Status.Conditions, SucceededConditionType)
-			toReturn.StagingErrorMsg = fmt.Sprintf("%v: %v", conditionStatus.Reason, conditionStatus.Message)
+			toReturn.StagingErrorMsg = conditionStatus.Message
 		}
 	}
 

--- a/api/repositories/build_repository_test.go
+++ b/api/repositories/build_repository_test.go
@@ -222,7 +222,7 @@ var _ = Describe("BuildRepository", func() {
 						Expect(err).NotTo(HaveOccurred())
 						Expect(buildRecord.State).To(Equal("FAILED"))
 						Expect(buildRecord.DropletGUID).To(BeEmpty())
-						Expect(buildRecord.StagingErrorMsg).To(Equal(StagingError + ": " + StagingErrorMessage))
+						Expect(buildRecord.StagingErrorMsg).To(Equal(StagingErrorMessage))
 					})
 				})
 			})

--- a/controllers/controllers/workloads/cfbuild_controller.go
+++ b/controllers/controllers/workloads/cfbuild_controller.go
@@ -124,7 +124,7 @@ func (r *CFBuildReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	switch workloadSucceededStatus.Status {
 	case metav1.ConditionFalse:
-		failureStatusConditionMessage := fmt.Sprintf("%s:%s", workloadSucceededStatus.Reason, workloadSucceededStatus.Message)
+		failureStatusConditionMessage := fmt.Sprintf("%s: %s", workloadSucceededStatus.Reason, workloadSucceededStatus.Message)
 		setStatusConditionOnLocalCopy(&cfBuild.Status.Conditions, korifiv1alpha1.StagingConditionType, metav1.ConditionFalse, "BuildWorkload", "BuildWorkload")
 		setStatusConditionOnLocalCopy(&cfBuild.Status.Conditions, korifiv1alpha1.SucceededConditionType, metav1.ConditionFalse, "BuildWorkload", failureStatusConditionMessage)
 	case metav1.ConditionTrue:

--- a/kpack-image-builder/controllers/buildworkload_controller.go
+++ b/kpack-image-builder/controllers/buildworkload_controller.go
@@ -176,14 +176,13 @@ func (r *BuildWorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	kpackReadyStatusCondition := kpackImage.Status.GetCondition(kpackReadyConditionType)
 	if kpackReadyStatusCondition.IsFalse() {
-		failureStatusConditionMessage := kpackReadyStatusCondition.Reason + ":" + kpackReadyStatusCondition.Message
-		setSucceededConditionOnLocalCopy(&buildWorkload.Status.Conditions, metav1.ConditionFalse, "kpack", failureStatusConditionMessage)
+		setSucceededConditionOnLocalCopy(&buildWorkload.Status.Conditions, metav1.ConditionFalse, "BuildFailed", "Check build log output")
 		if err = r.Client.Status().Update(ctx, buildWorkload); err != nil {
 			r.Log.Error(err, "Error when updating buildWorkload status")
 			return ctrl.Result{}, err
 		}
 	} else if kpackReadyStatusCondition.IsTrue() {
-		setSucceededConditionOnLocalCopy(&buildWorkload.Status.Conditions, metav1.ConditionTrue, "kpack", "kpack")
+		setSucceededConditionOnLocalCopy(&buildWorkload.Status.Conditions, metav1.ConditionTrue, "BuildSucceeded", "Image built successfully")
 
 		serviceAccountName := kpackServiceAccount
 		serviceAccountLookupKey := types.NamespacedName{Name: serviceAccountName, Namespace: req.Namespace}
@@ -265,7 +264,7 @@ func (r *BuildWorkloadReconciler) createKpackImageAndUpdateStatus(ctx context.Co
 		return err
 	}
 
-	setSucceededConditionOnLocalCopy(&buildWorkload.Status.Conditions, metav1.ConditionUnknown, "Unknown", "Unknown")
+	setSucceededConditionOnLocalCopy(&buildWorkload.Status.Conditions, metav1.ConditionUnknown, "BuildRunning", "Waiting for image build to complete")
 	if err := r.Client.Status().Update(ctx, buildWorkload); err != nil {
 		r.Log.Error(err, "Error when updating buildWorkload status")
 		return err


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ --> No

## What is this change about?
<!-- _Please describe the change here._ --> Improve the reason and message fields on the BuildWorkload `Succeeded` condition. These are eventually shown to the user upon failure, and the old messages were not clear or helpful.

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ --> Only if clients were depending on the old `reason` values we were using, which is unlikely

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ --> `cf push` an app that you know will fail to stage and observe that the error message is now clearer.

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
