### PR TITLE
Unify object updates in reconcilers

### DIFF
--- a/controllers/api/v1alpha1/cfservicebinding_types.go
+++ b/controllers/api/v1alpha1/cfservicebinding_types.go
@@ -40,6 +40,7 @@ type CFServiceBindingSpec struct {
 type CFServiceBindingStatus struct {
 	// A reference to the Secret containing the credentials (same as spec.secretName).
 	// This is required to conform to the Kubernetes Service Bindings spec
+	// +optional
 	Binding v1.LocalObjectReference `json:"binding"`
 
 	// Conditions capture the current status of the CFServiceBinding

--- a/controllers/config/crd/bases/korifi.cloudfoundry.org_cfservicebindings.yaml
+++ b/controllers/config/crd/bases/korifi.cloudfoundry.org_cfservicebindings.yaml
@@ -179,7 +179,6 @@ spec:
                   type: object
                 type: array
             required:
-            - binding
             - conditions
             type: object
         type: object

--- a/controllers/controllers/services/cfservicebinding_controller.go
+++ b/controllers/controllers/services/cfservicebinding_controller.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
+	"code.cloudfoundry.org/korifi/tools/k8s"
 	"github.com/go-logr/logr"
 	servicebindingv1beta1 "github.com/servicebinding/service-binding-controller/apis/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -32,9 +33,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const (
@@ -49,14 +50,20 @@ type VCAPServicesSecretBuilder interface {
 
 // CFServiceBindingReconciler reconciles a CFServiceBinding object
 type CFServiceBindingReconciler struct {
-	client.Client
-	scheme  *runtime.Scheme
-	log     logr.Logger
-	builder VCAPServicesSecretBuilder
+	k8sClient client.Client
+	scheme    *runtime.Scheme
+	log       logr.Logger
+	builder   VCAPServicesSecretBuilder
 }
 
-func NewCFServiceBindingReconciler(client client.Client, scheme *runtime.Scheme, log logr.Logger, builder VCAPServicesSecretBuilder) *CFServiceBindingReconciler {
-	return &CFServiceBindingReconciler{Client: client, scheme: scheme, log: log, builder: builder}
+func NewCFServiceBindingReconciler(
+	k8sClient client.Client,
+	scheme *runtime.Scheme,
+	log logr.Logger,
+	builder VCAPServicesSecretBuilder,
+) *k8s.PatchingReconciler[korifiv1alpha1.CFServiceBinding, *korifiv1alpha1.CFServiceBinding] {
+	cfBindingReconciler := &CFServiceBindingReconciler{k8sClient: k8sClient, scheme: scheme, log: log, builder: builder}
+	return k8s.NewPatchingReconciler[korifiv1alpha1.CFServiceBinding, *korifiv1alpha1.CFServiceBinding](log, k8sClient, cfBindingReconciler)
 }
 
 const (
@@ -71,52 +78,29 @@ const (
 //+kubebuilder:rbac:groups=korifi.cloudfoundry.org,resources=cfservicebindings/finalizers,verbs=update
 //+kubebuilder:rbac:groups=servicebinding.io,resources=servicebindings,verbs=get;list;create;update;patch;watch
 
-func (r *CFServiceBindingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	_ = log.FromContext(ctx)
-	cfServiceBinding := new(korifiv1alpha1.CFServiceBinding)
-	err := r.Client.Get(ctx, types.NamespacedName{Name: req.Name, Namespace: req.Namespace}, cfServiceBinding)
-	if err != nil {
-		if !apierrors.IsNotFound(err) {
-			r.log.Error(err, "unable to fetch CFServiceBinding", req.Name, req.Namespace)
-		}
-		return ctrl.Result{}, client.IgnoreNotFound(err)
-	}
-
-	err = r.addFinalizer(ctx, cfServiceBinding)
-	if err != nil {
-		r.log.Error(err, "Error adding finalizer")
-		return ctrl.Result{}, err
-	}
+func (r *CFServiceBindingReconciler) ReconcileResource(ctx context.Context, cfServiceBinding *korifiv1alpha1.CFServiceBinding) (ctrl.Result, error) {
+	r.addFinalizer(ctx, cfServiceBinding)
 
 	cfApp := new(korifiv1alpha1.CFApp)
-	err = r.Client.Get(ctx, types.NamespacedName{Name: cfServiceBinding.Spec.AppRef.Name, Namespace: cfServiceBinding.Namespace}, cfApp)
+	err := r.k8sClient.Get(ctx, types.NamespacedName{Name: cfServiceBinding.Spec.AppRef.Name, Namespace: cfServiceBinding.Namespace}, cfApp)
 	if err != nil {
-		r.log.Error(err, "Error when fetching CFApp")
-
-		// If CFApp is missing due to the use of background cascading delete, we expect CFServiceBinding delete to
-		// proceed without further vcap services secret cleanup
-		if apierrors.IsNotFound(err) && !cfServiceBinding.ObjectMeta.DeletionTimestamp.IsZero() {
-			return r.finalizeCFServiceBinding(ctx, cfServiceBinding)
+		if apierrors.IsNotFound(err) {
+			r.finalizeCFServiceBinding(ctx, cfServiceBinding)
+			return ctrl.Result{}, nil
 		}
 
+		r.log.Error(err, "Error when fetching CFApp")
 		return ctrl.Result{}, err
 	}
 
-	originalCfServiceBinding := cfServiceBinding.DeepCopy()
 	err = controllerutil.SetOwnerReference(cfApp, cfServiceBinding, r.scheme)
 	if err != nil {
 		r.log.Error(err, "Unable to set owner reference on CfServiceBinding")
 		return ctrl.Result{}, err
 	}
 
-	err = r.Client.Patch(ctx, cfServiceBinding, client.MergeFrom(originalCfServiceBinding))
-	if err != nil {
-		r.log.Error(err, fmt.Sprintf("Error setting owner reference on the CFServiceBinding %s/%s", req.Namespace, cfServiceBinding.Name))
-		return ctrl.Result{}, err
-	}
-
 	instance := new(korifiv1alpha1.CFServiceInstance)
-	err = r.Client.Get(ctx, types.NamespacedName{Name: cfServiceBinding.Spec.Service.Name, Namespace: req.Namespace}, instance)
+	err = r.k8sClient.Get(ctx, types.NamespacedName{Name: cfServiceBinding.Spec.Service.Name, Namespace: cfServiceBinding.Namespace}, instance)
 	if err != nil {
 		// Unlike with CFApp cascading delete, CFServiceInstance delete cleans up CFServiceBindings itself as part of finalizing,
 		// so we do not check for deletion timestamp before returning here.
@@ -125,7 +109,7 @@ func (r *CFServiceBindingReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	secret := new(corev1.Secret)
 	// Note: is there a reason to fetch the secret name from the service instance spec?
-	err = r.Client.Get(ctx, types.NamespacedName{Name: instance.Spec.SecretName, Namespace: req.Namespace}, secret)
+	err = r.k8sClient.Get(ctx, types.NamespacedName{Name: instance.Spec.SecretName, Namespace: cfServiceBinding.Namespace}, secret)
 	if err != nil {
 		return r.handleGetError(ctx, err, cfServiceBinding, BindingSecretAvailableCondition, "SecretNotFound", "Binding secret")
 	}
@@ -138,11 +122,6 @@ func (r *CFServiceBindingReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		Message: "",
 	})
 
-	err = r.setStatus(ctx, cfServiceBinding)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
 	if cfApp.Status.VCAPServicesSecretName == "" {
 		r.log.Info("Did not find VCAPServiceSecret name on status of CFApp", "CFServiceBinding", cfServiceBinding.Name)
 		meta.SetStatusCondition(&cfServiceBinding.Status.Conditions, metav1.Condition{
@@ -152,21 +131,17 @@ func (r *CFServiceBindingReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			Message: "VCAPServicesSecret name absent from status of CFApp",
 		})
 
-		err = r.setStatus(ctx, cfServiceBinding)
-		if err != nil {
-			return ctrl.Result{}, err
-		}
-
 		return ctrl.Result{RequeueAfter: 2 * time.Second}, nil
 	}
 
 	vcapServicesData, err := r.builder.BuildVCAPServicesEnvValue(ctx, cfApp)
 	if err != nil {
 		r.log.Error(err, "failed to build vcap services secret", "CFServiceBinding", cfServiceBinding)
+		return ctrl.Result{}, err
 	}
 
 	vcapServicesSecret := new(corev1.Secret)
-	err = r.Client.Get(ctx, types.NamespacedName{Name: cfApp.Status.VCAPServicesSecretName, Namespace: req.Namespace}, vcapServicesSecret)
+	err = r.k8sClient.Get(ctx, types.NamespacedName{Name: cfApp.Status.VCAPServicesSecretName, Namespace: cfServiceBinding.Namespace}, vcapServicesSecret)
 	if err != nil {
 		return r.handleGetError(ctx, err, cfServiceBinding, VCAPServicesSecretAvailableCondition, "SecretNotFound", "Secret")
 	}
@@ -175,13 +150,15 @@ func (r *CFServiceBindingReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	secretData := map[string][]byte{}
 	secretData["VCAP_SERVICES"] = []byte(vcapServicesData)
 	updatedVcapServicesSecret.Data = secretData
-	err = r.Client.Patch(ctx, updatedVcapServicesSecret, client.MergeFrom(vcapServicesSecret))
+	err = r.k8sClient.Patch(ctx, updatedVcapServicesSecret, client.MergeFrom(vcapServicesSecret))
 	if err != nil {
 		r.log.Error(err, "failed to patch vcap services secret", "CFServiceBinding", cfServiceBinding)
+		return ctrl.Result{}, err
 	}
 
-	if !cfServiceBinding.ObjectMeta.DeletionTimestamp.IsZero() {
-		return r.finalizeCFServiceBinding(ctx, cfServiceBinding)
+	if !cfServiceBinding.DeletionTimestamp.IsZero() {
+		r.finalizeCFServiceBinding(ctx, cfServiceBinding)
+		return ctrl.Result{}, nil
 	}
 
 	meta.SetStatusCondition(&cfServiceBinding.Status.Conditions, metav1.Condition{
@@ -190,11 +167,6 @@ func (r *CFServiceBindingReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		Reason:  "SecretFound",
 		Message: "",
 	})
-
-	err = r.setStatus(ctx, cfServiceBinding)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
 
 	actualSBServiceBinding := servicebindingv1beta1.ServiceBinding{
 		ObjectMeta: metav1.ObjectMeta{
@@ -205,7 +177,7 @@ func (r *CFServiceBindingReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	desiredSBServiceBinding := generateDesiredServiceBinding(&actualSBServiceBinding, cfServiceBinding, cfApp, secret)
 
-	_, err = controllerutil.CreateOrPatch(ctx, r.Client, &actualSBServiceBinding, sbServiceBindingMutateFn(&actualSBServiceBinding, desiredSBServiceBinding))
+	_, err = controllerutil.CreateOrPatch(ctx, r.k8sClient, &actualSBServiceBinding, sbServiceBindingMutateFn(&actualSBServiceBinding, desiredSBServiceBinding))
 	if err != nil {
 		r.log.Error(err, "Error calling Create on servicebinding.io ServiceBinding")
 		return ctrl.Result{}, err
@@ -214,72 +186,48 @@ func (r *CFServiceBindingReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	return ctrl.Result{}, nil
 }
 
-func (r *CFServiceBindingReconciler) addFinalizer(ctx context.Context, cfServiceBinding *korifiv1alpha1.CFServiceBinding) error {
+func (r *CFServiceBindingReconciler) addFinalizer(ctx context.Context, cfServiceBinding *korifiv1alpha1.CFServiceBinding) {
 	if controllerutil.ContainsFinalizer(cfServiceBinding, CFServiceBindingFinalizerName) {
-		return nil
+		return
 	}
 
-	originalCFServiceBinding := cfServiceBinding.DeepCopy()
 	controllerutil.AddFinalizer(cfServiceBinding, CFServiceBindingFinalizerName)
-
-	err := r.Client.Patch(ctx, cfServiceBinding, client.MergeFrom(originalCFServiceBinding))
-	if err != nil {
-		r.log.Error(err, fmt.Sprintf("Error adding finalizer to CFServiceBinding/%s", cfServiceBinding.Name))
-		return err
-	}
-
 	r.log.Info(fmt.Sprintf("Finalizer added to CFServiceBinding/%s", cfServiceBinding.Name))
-	return nil
 }
 
-func (r *CFServiceBindingReconciler) finalizeCFServiceBinding(ctx context.Context, cfServiceBinding *korifiv1alpha1.CFServiceBinding) (ctrl.Result, error) {
+func (r *CFServiceBindingReconciler) finalizeCFServiceBinding(ctx context.Context, cfServiceBinding *korifiv1alpha1.CFServiceBinding) {
 	r.log.Info(fmt.Sprintf("Reconciling deletion of CFServiceBinding/%s", cfServiceBinding.Name))
 
 	if controllerutil.ContainsFinalizer(cfServiceBinding, CFServiceBindingFinalizerName) {
-		originalCFServiceBinding := cfServiceBinding.DeepCopy()
 		controllerutil.RemoveFinalizer(cfServiceBinding, CFServiceBindingFinalizerName)
-
-		if err := r.Client.Patch(ctx, cfServiceBinding, client.MergeFrom(originalCFServiceBinding)); err != nil {
-			r.log.Error(err, "Failed to remove finalizer")
-			return ctrl.Result{}, err
-		}
 	}
-
-	return ctrl.Result{}, nil
 }
 
 func (r *CFServiceBindingReconciler) handleGetError(ctx context.Context, err error, cfServiceBinding *korifiv1alpha1.CFServiceBinding, conditionType, notFoundReason, objectType string) (ctrl.Result, error) {
-	var result ctrl.Result
+	cfServiceBinding.Status.Binding = corev1.LocalObjectReference{}
 	if apierrors.IsNotFound(err) {
-		cfServiceBinding.Status.Binding.Name = ""
 		meta.SetStatusCondition(&cfServiceBinding.Status.Conditions, metav1.Condition{
 			Type:    conditionType,
 			Status:  metav1.ConditionFalse,
 			Reason:  notFoundReason,
 			Message: objectType + " does not exist",
 		})
-		result = ctrl.Result{RequeueAfter: 2 * time.Second}
-		err = nil
-	} else {
-		meta.SetStatusCondition(&cfServiceBinding.Status.Conditions, metav1.Condition{
-			Type:    conditionType,
-			Status:  metav1.ConditionFalse,
-			Reason:  "UnknownError",
-			Message: "Error occurred while fetching " + strings.ToLower(objectType) + ": " + err.Error(),
-		})
-		result = ctrl.Result{}
+		return ctrl.Result{RequeueAfter: 2 * time.Second}, nil
 	}
-	statusErr := r.setStatus(ctx, cfServiceBinding)
-	if statusErr != nil {
-		return ctrl.Result{}, statusErr
-	}
-	return result, err
+
+	meta.SetStatusCondition(&cfServiceBinding.Status.Conditions, metav1.Condition{
+		Type:    conditionType,
+		Status:  metav1.ConditionFalse,
+		Reason:  "UnknownError",
+		Message: "Error occurred while fetching " + strings.ToLower(objectType) + ": " + err.Error(),
+	})
+	return ctrl.Result{}, err
 }
 
 func sbServiceBindingMutateFn(actualSBServiceBinding, desiredSBServiceBinding *servicebindingv1beta1.ServiceBinding) controllerutil.MutateFn {
 	return func() error {
-		actualSBServiceBinding.ObjectMeta.Labels = desiredSBServiceBinding.ObjectMeta.Labels
-		actualSBServiceBinding.ObjectMeta.OwnerReferences = desiredSBServiceBinding.ObjectMeta.OwnerReferences
+		actualSBServiceBinding.Labels = desiredSBServiceBinding.Labels
+		actualSBServiceBinding.OwnerReferences = desiredSBServiceBinding.OwnerReferences
 		actualSBServiceBinding.Spec = desiredSBServiceBinding.Spec
 		return nil
 	}
@@ -288,7 +236,7 @@ func sbServiceBindingMutateFn(actualSBServiceBinding, desiredSBServiceBinding *s
 func generateDesiredServiceBinding(actualServiceBinding *servicebindingv1beta1.ServiceBinding, cfServiceBinding *korifiv1alpha1.CFServiceBinding, cfApp *korifiv1alpha1.CFApp, secret *corev1.Secret) *servicebindingv1beta1.ServiceBinding {
 	var desiredServiceBinding servicebindingv1beta1.ServiceBinding
 	actualServiceBinding.DeepCopyInto(&desiredServiceBinding)
-	desiredServiceBinding.ObjectMeta.Labels = map[string]string{
+	desiredServiceBinding.Labels = map[string]string{
 		ServiceBindingGUIDLabel:           cfServiceBinding.Name,
 		korifiv1alpha1.CFAppGUIDLabelKey:  cfApp.Name,
 		ServiceCredentialBindingTypeLabel: "app",
@@ -330,17 +278,8 @@ func generateDesiredServiceBinding(actualServiceBinding *servicebindingv1beta1.S
 	return &desiredServiceBinding
 }
 
-func (r *CFServiceBindingReconciler) setStatus(ctx context.Context, cfServiceBinding *korifiv1alpha1.CFServiceBinding) error {
-	if statusErr := r.Client.Status().Update(ctx, cfServiceBinding); statusErr != nil {
-		r.log.Error(statusErr, "unable to update CFServiceBinding status")
-		return statusErr
-	}
-	return nil
-}
-
 // SetupWithManager sets up the controller with the Manager.
-func (r *CFServiceBindingReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *CFServiceBindingReconciler) SetupWithManager(mgr ctrl.Manager) *builder.Builder {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&korifiv1alpha1.CFServiceBinding{}).
-		Complete(r)
+		For(&korifiv1alpha1.CFServiceBinding{})
 }

--- a/controllers/controllers/workloads/cfapp_controller_test.go
+++ b/controllers/controllers/workloads/cfapp_controller_test.go
@@ -9,6 +9,7 @@ import (
 	. "code.cloudfoundry.org/korifi/controllers/controllers/workloads"
 	. "code.cloudfoundry.org/korifi/controllers/controllers/workloads/testutils"
 	"code.cloudfoundry.org/korifi/controllers/fake"
+	"code.cloudfoundry.org/korifi/tools/k8s"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -55,7 +56,7 @@ var _ = Describe("CFAppReconciler", func() {
 		secret    *v1.Secret
 		secretErr error
 
-		cfAppReconciler *CFAppReconciler
+		cfAppReconciler *k8s.PatchingReconciler[korifiv1alpha1.CFApp, *korifiv1alpha1.CFApp]
 		ctx             context.Context
 		req             ctrl.Request
 
@@ -100,7 +101,6 @@ var _ = Describe("CFAppReconciler", func() {
 			}
 		}
 
-		// Configure mock status update to succeed
 		fakeStatusWriter = &fake.StatusWriter{}
 		fakeClient.StatusReturns(fakeStatusWriter)
 
@@ -224,9 +224,8 @@ var _ = Describe("CFAppReconciler", func() {
 				Expect(testRequestNamespacedName.Namespace).To(Equal(defaultNamespace))
 				Expect(testRequestNamespacedName.Name).To(Equal(cfAppGUID))
 
-				// validate the inputs to Status.Update
-				Expect(fakeStatusWriter.UpdateCallCount()).To(Equal(1))
-				_, updatedCFApp, _ := fakeStatusWriter.UpdateArgsForCall(0)
+				Expect(fakeStatusWriter.PatchCallCount()).To(Equal(1))
+				_, updatedCFApp, _, _ := fakeStatusWriter.PatchArgsForCall(0)
 				cast, ok := updatedCFApp.(*korifiv1alpha1.CFApp)
 				Expect(ok).To(BeTrue(), "Cast to korifiv1alpha1.CFApp failed")
 				Expect(meta.IsStatusConditionTrue(cast.Status.Conditions, StatusConditionStaged)).To(BeFalse())
@@ -256,9 +255,9 @@ var _ = Describe("CFAppReconciler", func() {
 				})
 			})
 
-			When("update status conditions returns an error", func() {
+			When("patch status conditions returns an error", func() {
 				BeforeEach(func() {
-					fakeStatusWriter.UpdateReturns(errors.New(failsOnPurposeErrorMessage))
+					fakeStatusWriter.PatchReturns(errors.New(failsOnPurposeErrorMessage))
 				})
 
 				It("should returns an error", func() {
@@ -320,9 +319,8 @@ var _ = Describe("CFAppReconciler", func() {
 				_, desiredProcess, _ := fakeClient.CreateArgsForCall(0)
 				Expect(desiredProcess.GetName()).To(Equal("cf-proc-cf-app-guid-web"))
 
-				// validate the inputs to Status.Update
-				Expect(fakeStatusWriter.UpdateCallCount()).To(Equal(1))
-				_, updatedCFApp, _ := fakeStatusWriter.UpdateArgsForCall(0)
+				Expect(fakeStatusWriter.PatchCallCount()).To(Equal(1))
+				_, updatedCFApp, _, _ := fakeStatusWriter.PatchArgsForCall(0)
 				cast, ok := updatedCFApp.(*korifiv1alpha1.CFApp)
 				Expect(ok).To(BeTrue(), "Cast to korifiv1alpha1.CFApp failed")
 				Expect(meta.IsStatusConditionTrue(cast.Status.Conditions, StatusConditionStaged)).To(BeTrue())
@@ -361,8 +359,8 @@ var _ = Describe("CFAppReconciler", func() {
 				})
 
 				It("should unset the staged condition", func() {
-					Expect(fakeStatusWriter.UpdateCallCount()).To(Equal(1))
-					_, updatedCFApp, _ := fakeStatusWriter.UpdateArgsForCall(0)
+					Expect(fakeStatusWriter.PatchCallCount()).To(Equal(1))
+					_, updatedCFApp, _, _ := fakeStatusWriter.PatchArgsForCall(0)
 					cast, ok := updatedCFApp.(*korifiv1alpha1.CFApp)
 					Expect(ok).To(BeTrue(), "Cast to korifiv1alpha1.CFApp failed")
 					Expect(meta.IsStatusConditionTrue(cast.Status.Conditions, StatusConditionStaged)).To(BeFalse())
@@ -379,8 +377,8 @@ var _ = Describe("CFAppReconciler", func() {
 				})
 
 				It("should unset the staged condition", func() {
-					Expect(fakeStatusWriter.UpdateCallCount()).To(Equal(1))
-					_, updatedCFApp, _ := fakeStatusWriter.UpdateArgsForCall(0)
+					Expect(fakeStatusWriter.PatchCallCount()).To(Equal(1))
+					_, updatedCFApp, _, _ := fakeStatusWriter.PatchArgsForCall(0)
 					cast, ok := updatedCFApp.(*korifiv1alpha1.CFApp)
 					Expect(ok).To(BeTrue(), "Cast to korifiv1alpha1.CFApp failed")
 					Expect(meta.IsStatusConditionTrue(cast.Status.Conditions, StatusConditionStaged)).To(BeFalse())
@@ -407,8 +405,8 @@ var _ = Describe("CFAppReconciler", func() {
 				})
 
 				It("has a staged true condition", func() {
-					Expect(fakeStatusWriter.UpdateCallCount()).To(Equal(1))
-					_, updatedCFApp, _ := fakeStatusWriter.UpdateArgsForCall(0)
+					Expect(fakeStatusWriter.PatchCallCount()).To(Equal(1))
+					_, updatedCFApp, _, _ := fakeStatusWriter.PatchArgsForCall(0)
 					cast, ok := updatedCFApp.(*korifiv1alpha1.CFApp)
 					Expect(ok).To(BeTrue())
 					Expect(meta.IsStatusConditionTrue(cast.Status.Conditions, StatusConditionStaged)).To(BeTrue())
@@ -425,17 +423,17 @@ var _ = Describe("CFAppReconciler", func() {
 				})
 
 				It("has a staged true condition", func() {
-					Expect(fakeStatusWriter.UpdateCallCount()).To(Equal(1))
-					_, updatedCFApp, _ := fakeStatusWriter.UpdateArgsForCall(0)
+					Expect(fakeStatusWriter.PatchCallCount()).To(Equal(1))
+					_, updatedCFApp, _, _ := fakeStatusWriter.PatchArgsForCall(0)
 					cast, ok := updatedCFApp.(*korifiv1alpha1.CFApp)
 					Expect(ok).To(BeTrue())
 					Expect(meta.IsStatusConditionTrue(cast.Status.Conditions, StatusConditionStaged)).To(BeTrue())
 				})
 			})
 
-			When("update status conditions returns an error", func() {
+			When("patch status conditions returns an error", func() {
 				BeforeEach(func() {
-					fakeStatusWriter.UpdateReturns(errors.New(failsOnPurposeErrorMessage))
+					fakeStatusWriter.PatchReturns(errors.New(failsOnPurposeErrorMessage))
 				})
 
 				It("should returns an error", func() {

--- a/controllers/controllers/workloads/env/builder.go
+++ b/controllers/controllers/workloads/env/builder.go
@@ -76,7 +76,7 @@ func (b *Builder) BuildVCAPServicesEnvValue(ctx context.Context, cfApp *korifiv1
 	serviceEnvs := []ServiceDetails{}
 	for _, currentServiceBinding := range serviceBindings.Items {
 		// If finalizing do not append
-		if !currentServiceBinding.ObjectMeta.DeletionTimestamp.IsZero() {
+		if !currentServiceBinding.DeletionTimestamp.IsZero() {
 			continue
 		}
 

--- a/tests/e2e/apps_test.go
+++ b/tests/e2e/apps_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/go-resty/resty/v2"
 	. "github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 )
@@ -503,7 +502,7 @@ var _ = Describe("Apps", func() {
 		})
 
 		JustBeforeEach(func() {
-			Eventually(func(g gomega.Gomega) {
+			Eventually(func(g Gomega) {
 				resp, err := certClient.R().
 					SetResult(&result).
 					Get("/v3/apps/" + appGUID + "/env")

--- a/tools/k8s/k8s_suite_test.go
+++ b/tools/k8s/k8s_suite_test.go
@@ -1,0 +1,13 @@
+package k8s_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestK8s(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "K8s Suite")
+}

--- a/tools/k8s/reconcile.go
+++ b/tools/k8s/reconcile.go
@@ -1,0 +1,77 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type ObjectWithDeepCopy[T any] interface {
+	*T
+
+	client.Object
+	DeepCopy() *T
+}
+
+type ObjectReconciler[T any, PT ObjectWithDeepCopy[T]] interface {
+	ReconcileResource(ctx context.Context, obj PT) (ctrl.Result, error)
+	SetupWithManager(mgr ctrl.Manager) *builder.Builder
+}
+
+type PatchingReconciler[T any, PT ObjectWithDeepCopy[T]] struct {
+	log              logr.Logger
+	k8sClient        client.Client
+	objectReconciler ObjectReconciler[T, PT]
+}
+
+func NewPatchingReconciler[T any, PT ObjectWithDeepCopy[T]](log logr.Logger, k8sClient client.Client, objectReconciler ObjectReconciler[T, PT]) *PatchingReconciler[T, PT] {
+	return &PatchingReconciler[T, PT]{
+		log:              log.WithName("patching-reconciler"),
+		k8sClient:        k8sClient,
+		objectReconciler: objectReconciler,
+	}
+}
+
+func (r *PatchingReconciler[T, PT]) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := r.log.WithValues("namespace", req.Namespace, "name", req.Name)
+
+	obj := PT(new(T))
+	err := r.k8sClient.Get(ctx, req.NamespacedName, obj)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		log.Error(err, fmt.Sprintf("unable to fetch %T", obj))
+		return ctrl.Result{}, err
+	}
+
+	originalObj := obj.DeepCopy()
+
+	result, delegateErr := r.objectReconciler.ReconcileResource(ctx, obj)
+	// copy obj as next update will reset the status
+	reconciledObjCopy := obj.DeepCopy()
+
+	err = r.k8sClient.Patch(ctx, obj, client.MergeFrom(PT(originalObj)))
+
+	if err != nil {
+		log.Error(err, "patch main object failed")
+		return ctrl.Result{}, err
+	}
+
+	err = r.k8sClient.Status().Patch(ctx, PT(reconciledObjCopy), client.MergeFrom(PT(originalObj)))
+	if err != nil {
+		log.Error(err, "patch object status failed")
+		return ctrl.Result{}, err
+	}
+
+	return result, delegateErr
+}
+
+func (r *PatchingReconciler[T, PT]) SetupWithManager(mgr ctrl.Manager) error {
+	return r.objectReconciler.SetupWithManager(mgr).Complete(r)
+}

--- a/tools/k8s/reconcile_test.go
+++ b/tools/k8s/reconcile_test.go
@@ -1,0 +1,192 @@
+package k8s_test
+
+import (
+	"context"
+	"errors"
+
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"code.cloudfoundry.org/korifi/controllers/fake"
+	"code.cloudfoundry.org/korifi/tools/k8s"
+)
+
+type fakeObjectReconciler struct {
+	reconcileResourceError     error
+	reconcileResourceCallCount int
+	reconcileResourceObj       *corev1.Pod
+}
+
+func (f *fakeObjectReconciler) ReconcileResource(ctx context.Context, obj *corev1.Pod) (ctrl.Result, error) {
+	f.reconcileResourceCallCount++
+	f.reconcileResourceObj = obj
+
+	obj.Spec.RestartPolicy = corev1.RestartPolicyOnFailure
+	obj.Status.Message = "hello"
+
+	return ctrl.Result{
+		RequeueAfter: 1,
+	}, f.reconcileResourceError
+}
+
+func (f *fakeObjectReconciler) SetupWithManager(mgr ctrl.Manager) *builder.Builder {
+	return nil
+}
+
+var _ = Describe("Reconcile", func() {
+	var (
+		ctx                context.Context
+		fakeClient         *fake.Client
+		fakeStatusWriter   *fake.StatusWriter
+		patchingReconciler *k8s.PatchingReconciler[corev1.Pod, *corev1.Pod]
+		objectReconciler   *fakeObjectReconciler
+		pod                *corev1.Pod
+		result             ctrl.Result
+		err                error
+	)
+
+	BeforeEach(func() {
+		objectReconciler = new(fakeObjectReconciler)
+		fakeClient = new(fake.Client)
+		fakeStatusWriter = new(fake.StatusWriter)
+		fakeClient.StatusReturns(fakeStatusWriter)
+
+		ctx = context.Background()
+		pod = &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: uuid.NewString(),
+				Name:      uuid.NewString(),
+			},
+			Spec:   corev1.PodSpec{},
+			Status: corev1.PodStatus{},
+		}
+
+		fakeClient.PatchStub = func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) error {
+			o, ok := obj.(*corev1.Pod)
+			Expect(ok).To(BeTrue())
+			o.Status = corev1.PodStatus{}
+			return nil
+		}
+
+		fakeClient.GetStub = func(_ context.Context, _ types.NamespacedName, obj client.Object, _ ...client.GetOption) error {
+			o, ok := obj.(*corev1.Pod)
+			Expect(ok).To(BeTrue())
+			*o = *pod
+
+			return nil
+		}
+
+		patchingReconciler = k8s.NewPatchingReconciler[corev1.Pod, *corev1.Pod](ctrl.Log, fakeClient, objectReconciler)
+	})
+
+	JustBeforeEach(func() {
+		result, err = patchingReconciler.Reconcile(ctx, ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: pod.Namespace,
+				Name:      pod.Name,
+			},
+		})
+	})
+
+	It("fetches the object", func() {
+		Expect(fakeClient.GetCallCount()).To(Equal(1))
+		_, namespacedName, obj, _ := fakeClient.GetArgsForCall(0)
+		Expect(namespacedName.Namespace).To(Equal(pod.Namespace))
+		Expect(namespacedName.Name).To(Equal(pod.Name))
+		Expect(obj).To(BeAssignableToTypeOf(&corev1.Pod{}))
+	})
+
+	When("the object does not exist", func() {
+		BeforeEach(func() {
+			fakeClient.GetReturns(apierrors.NewNotFound(schema.GroupResource{}, "pod"))
+		})
+
+		It("does not call the object reconciler and succeeds", func() {
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(objectReconciler.reconcileResourceCallCount).To(Equal(0))
+		})
+	})
+
+	When("the getting the object fails", func() {
+		BeforeEach(func() {
+			fakeClient.GetReturns(errors.New("get-error"))
+		})
+
+		It("fails without calling the reconciler", func() {
+			Expect(err).To(MatchError(ContainSubstring("get-error")))
+			Expect(objectReconciler.reconcileResourceCallCount).To(Equal(0))
+		})
+	})
+
+	It("calls the object reconciler", func() {
+		Expect(objectReconciler.reconcileResourceCallCount).To(Equal(1))
+		Expect(objectReconciler.reconcileResourceObj.Namespace).To(Equal(pod.Namespace))
+		Expect(objectReconciler.reconcileResourceObj.Name).To(Equal(pod.Name))
+	})
+
+	It("patches the object via the k8s client", func() {
+		Expect(fakeClient.PatchCallCount()).To(Equal(1))
+		_, updatedObject, _, _ := fakeClient.PatchArgsForCall(0)
+		updatedPod, ok := updatedObject.(*corev1.Pod)
+		Expect(ok).To(BeTrue())
+		Expect(updatedPod.Spec.RestartPolicy).To(Equal(corev1.RestartPolicyOnFailure))
+	})
+
+	When("patching the object fails", func() {
+		BeforeEach(func() {
+			fakeClient.PatchReturns(errors.New("patch-object-error"))
+		})
+
+		It("returns the error", func() {
+			Expect(err).To(MatchError("patch-object-error"))
+		})
+	})
+
+	It("patches the object status via the k8s client", func() {
+		Expect(fakeStatusWriter.PatchCallCount()).To(Equal(1))
+		_, updatedObject, _, _ := fakeStatusWriter.PatchArgsForCall(0)
+		updatedPod, ok := updatedObject.(*corev1.Pod)
+		Expect(ok).To(BeTrue())
+		Expect(updatedPod.Status.Message).To(Equal("hello"))
+	})
+
+	When("patching the object status fails", func() {
+		BeforeEach(func() {
+			fakeStatusWriter.PatchReturns(errors.New("patch-status-error"))
+		})
+
+		It("returns the error", func() {
+			Expect(err).To(MatchError("patch-status-error"))
+		})
+	})
+
+	It("succeeds and returns the result from the object reconciler", func() {
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(ctrl.Result{RequeueAfter: 1}))
+	})
+
+	When("the object reconciliation fails", func() {
+		BeforeEach(func() {
+			objectReconciler.reconcileResourceError = errors.New("reconcile-error")
+		})
+
+		It("returns the error", func() {
+			Expect(err).To(MatchError("reconcile-error"))
+		})
+
+		It("updates the object and its status nevertheless", func() {
+			Expect(fakeClient.PatchCallCount()).To(Equal(1))
+			Expect(fakeStatusWriter.PatchCallCount()).To(Equal(1))
+		})
+	})
+})


### PR DESCRIPTION
## Is there a related GitHub Issue?

https://github.com/cloudfoundry/korifi/issues/714

## What is this change about?

Reconcilers can get quite messy provided that they return on various conditions and should update the reconciled object to reflect the current state of the system. These are two separate concerns and it is a smell to address them both in a single type.

-   Introduce PatchingReconciler
    -   wraps the concrete reconciler logic
    -   it uses generics to abstract the concrete type of the runtime object
    -   if found, delegates to the concrete reconciler. The delegate reconciler interfaces also uses generics so that implementors receive the correct type, e.g. `*korifiv1alpha1.CFApp`
    -   regardless of the result from the delegate reconciler, the patching reconciler patches the object and its status. Therefore, delegate reconcilers do not have to do that themselves, instead they should focus on mutating the object correctly.

We have showcased this for the CFApp and CFServiceBindings reconcilers. The remaining reconcilers will be updated if this PR is accepted.

## Does this PR introduce a breaking change?

No

## Acceptance Steps

No functional change. All tests to remain green

## Tag your pair, your PM, and/or team

@kieron-dev

## Things to remember

<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
