### PR TITLE
Never fail when fetching Pod metrics fails

### DIFF
--- a/api/repositories/pod_repository.go
+++ b/api/repositories/pod_repository.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"strconv"
-	"strings"
 	"time"
 
 	"code.cloudfoundry.org/korifi/api/apierrors"
@@ -125,12 +124,7 @@ func (r *PodRepo) ListPodStats(ctx context.Context, authInfo authorization.Info,
 
 		podMetrics, err := r.metricsFetcher(ctx, p.Namespace, p.Name)
 		if err != nil {
-			errorMsg := err.Error()
-			if strings.Contains(errorMsg, "not found") ||
-				strings.Contains(errorMsg, "the server could not find the requested resource") {
-				continue
-			}
-			return nil, err
+			continue
 		}
 		metricsMap := aggregateContainerMetrics(podMetrics.Containers)
 		if len(metricsMap) == 0 {

--- a/api/repositories/pod_repository_test.go
+++ b/api/repositories/pod_repository_test.go
@@ -308,40 +308,17 @@ var _ = Describe("PodRepository", func() {
 
 			When("MetricFetcherFunction return an metrics resource not found error", func() {
 				BeforeEach(func() {
-					metricFetcherFn.Returns(nil, errors.New("the server could not find the requested resource"))
-				})
-				It("fetches all the pods and sets the usage stats with empty values", func() {
-					Expect(listStatsErr).NotTo(HaveOccurred())
-					Expect(records).To(ConsistOf(
-						[]PodStatsRecord{
-							{Type: "web", Index: 0, State: "RUNNING"},
-							{Type: "web", Index: 1, State: "DOWN"},
-						},
-					))
-				})
-			})
-
-			When("MetricsFetcherFunction returns a not found error for the PodMetrics", func() {
-				BeforeEach(func() {
-					metricFetcherFn.Returns(nil, errors.New("podmetrics.metrics.k8s.io \\\"Blah\\\" not found"))
-				})
-				It("fetches all the pods and sets the usage stats with empty values", func() {
-					Expect(listStatsErr).NotTo(HaveOccurred())
-					Expect(records).To(ConsistOf(
-						[]PodStatsRecord{
-							{Type: "web", Index: 0, State: "RUNNING"},
-							{Type: "web", Index: 1, State: "DOWN"},
-						},
-					))
-				})
-			})
-
-			When("MetricFetcherFunction return some other error", func() {
-				BeforeEach(func() {
 					metricFetcherFn.Returns(nil, errors.New("boom"))
 				})
-				It("returns the error", func() {
-					Expect(listStatsErr.Error()).To(ContainSubstring("boom"))
+
+				It("fetches all the pods and sets the usage stats with empty values", func() {
+					Expect(listStatsErr).NotTo(HaveOccurred())
+					Expect(records).To(ConsistOf(
+						[]PodStatsRecord{
+							{Type: "web", Index: 0, State: "RUNNING"},
+							{Type: "web", Index: 1, State: "DOWN"},
+						},
+					))
 				})
 			})
 


### PR DESCRIPTION
## Is there a related GitHub Issue?

No.

## What is this change about?

This makes `PodRepo.ListPodStats` always `continue` when its `metricsFetcher` errors.

## Does this PR introduce a breaking change?

Yes: the `/v3/processes/{guid}/stats` endpoint won't fail anymore when fetching metrics fails for any reason.
