### PR TITLE
Use `authn.Keychain` from `go-containerregistry`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -96,7 +96,7 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/gnostic v0.6.9 // indirect
 	github.com/google/go-cmp v0.5.8 // indirect
-	github.com/google/go-containerregistry/pkg/authn/k8schain v0.0.0-20210610160139-c086c7f16d4e // indirect
+	github.com/google/go-containerregistry/pkg/authn/k8schain v0.0.0-20210610160139-c086c7f16d4e
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 // indirect
 	github.com/heroku/color v0.0.6 // indirect


### PR DESCRIPTION
## Is there a related GitHub Issue?

No.

## What is this change about?

This replaces the `authn.Keychain` implementation coming from Kpack with the one coming from `go-containerregistry`. This reduces our coupling with Kpack: we're now only using their resource types.

## Does this PR introduce a breaking change?

No.
