### PR TITLE
Fix a panic in the build controller integration tests

### DIFF
--- a/controllers/controllers/workloads/integration/cfbuild_controller_integration_test.go
+++ b/controllers/controllers/workloads/integration/cfbuild_controller_integration_test.go
@@ -454,10 +454,10 @@ var _ = Describe("CFBuildReconciler Integration Tests", func() {
 			It("sets the CFBuild status condition Succeeded = False", func() {
 				lookupKey := types.NamespacedName{Name: cfBuildGUID, Namespace: namespaceGUID}
 				createdCFBuild := new(korifiv1alpha1.CFBuild)
-				Eventually(func(g Gomega) metav1.ConditionStatus {
+				Eventually(func(g Gomega) {
 					g.Expect(k8sClient.Get(context.Background(), lookupKey, createdCFBuild)).To(Succeed())
-					return meta.FindStatusCondition(createdCFBuild.Status.Conditions, succeededConditionType).Status
-				}).Should(Equal(metav1.ConditionFalse))
+					g.Expect(meta.IsStatusConditionFalse(createdCFBuild.Status.Conditions, succeededConditionType)).To(BeTrue())
+				}).Should(Succeed())
 			})
 		})
 


### PR DESCRIPTION
## Is there a related GitHub Issue?
CI build: https://ci.korifi.cf-app.com/teams/main/pipelines/main/jobs/run-tests-periodic/builds/2605

## What is this change about?
`FindStatusCondition` can return nil, thus the panic. Use the
`IsStatusConditionFalse` utility instead

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Green tests

## Tag your pair, your PM, and/or team
@georgethebeatle
