### PR TITLE
Add kind-specific install instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,31 +1,33 @@
 > **Warning**
 > Make sure you are using the correct version of these instructions by using the link in the release notes for the version you're trying to install. If you're not sure, check our [latest release](https://github.com/cloudfoundry/korifi/releases/latest).
 
-# Introduction
+# Korifi installation guide
 
 The following lines will guide you through the process of deploying a [released version](https://github.com/cloudfoundry/korifi/releases) of [Korifi](https://github.com/cloudfoundry/korifi). This document is written with the intent to act both as a runbook as well as a starting point in understanding basic concepts of Korifi and its dependencies.
 
-# Prerequisites
+## Prerequisites
 
--   Tools
-    -   [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl)
-    -   [cf](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html) CLI version 8.1 or greater
-    -   [Helm](https://helm.sh/docs/intro/install/)
--   Resources
-    -   Kubernetes cluster of one of the [upstream releases](https://kubernetes.io/releases/)
-    -   Container Registry on which you have write permissions
+- Tools:
+  - [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl);
+  - [cf](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html) CLI version 8.1 or greater;
+  - [Helm](https://helm.sh/docs/intro/install/).
+- Resources:
+  - Kubernetes cluster of one of the [upstream releases](https://kubernetes.io/releases/);
+  - Container Registry on which you have write permissions.
 
-This document was tested on both [EKS](https://aws.amazon.com/eks/) and [GKE](https://cloud.google.com/kubernetes-engine) using GCP's [Artifact Registry](https://cloud.google.com/artifact-registry).
+This document was tested on:
 
-# Initial setup
+- [EKS](https://aws.amazon.com/eks/), using GCP's [Artifact Registry](https://cloud.google.com/artifact-registry);
+- [GKE](https://cloud.google.com/kubernetes-engine), using GCP's [Artifact Registry](https://cloud.google.com/artifact-registry);
+- [kind](https://kind.sigs.k8s.io/), using [DockerHub](https://hub.docker.com/).
 
-## Environment Variables
+## Initial setup
 
 The following environment variables will be needed throughout this guide:
 
--   `ROOT_NAMESPACE`: the namespace at the root of the Korifi org and space hierarchy. The default value is `cf`.
--   `ADMIN_USERNAME`: the name of the Kubernetes user who will have CF admin privileges on the Korifi installation. For security reasons, you should choose or create a user that is different from your cluster admin user. To provision new users, follow the user management instructions specific for your cluster's [authentication configuration](https://kubernetes.io/docs/reference/access-authn-authz/authentication/) or create a [new (short-lived) client certificate for user authentication](https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/#normal-user).
--   `BASE_DOMAIN`: the base domain used by both the Korifi API and, by default, all apps running on Korifi.
+- `ROOT_NAMESPACE`: the namespace at the root of the Korifi org and space hierarchy. The default value is `cf`.
+- `ADMIN_USERNAME`: the name of the Kubernetes user who will have CF admin privileges on the Korifi installation. For security reasons, you should choose or create a user that is different from your cluster admin user. To provision new users, follow the user management instructions specific for your cluster's [authentication configuration](https://kubernetes.io/docs/reference/access-authn-authz/authentication/) or create a [new (short-lived) client certificate for user authentication](https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/#normal-user).
+- `BASE_DOMAIN`: the base domain used by both the Korifi API and, by default, all apps running on Korifi.
 
 Here are the example values we'll use in this guide:
 
@@ -39,71 +41,73 @@ export BASE_DOMAIN="korifi.example.org"
 
 You will need to update the following configuration files:
 
--   `korifi-kpack-image-builder.yml`
+- `korifi-kpack-image-builder.yml`
 
-    Change the value of `kpackImageTag` in the `korifi-kpack-build-config` `ConfigMap`. `kpackImageTag` specifies the tag prefix used for the images built by Korifi. Its hostname should point to your container registry and its path should be [valid for the registry](#image-registry-configuration).
+  Change the value of `kpackImageTag` in the `korifi-kpack-build-config` `ConfigMap`. `kpackImageTag` specifies the tag prefix used for the images built by Korifi. Its hostname should point to your container registry and its path should be [valid for the registry](#image-registry-configuration).
+
+  ```yaml
+  kpackImageTag: us-east4-docker.pkg.dev/vigilant-card-347116/korifi/droplets
+  ```
+
+- `korifi-api.yml`
+
+  - Change the following values in the `korifi-api-config-*` `ConfigMap`.
+
+    - `packageRegistryBase` specifies the tag prefix used for the source packages uploaded to Korifi. Its hostname should point to your container registry and its path should be [valid for the registry](#image-registry-configuration).
+    - `externalFQDN` is the domain name that will be used by the Korifi API, and is usually of the format `api.$BASE_DOMAIN`.
+    - `defaultDomainName` is the default base domain name for the apps deployed by Korifi, and is usually of the format `apps.$BASE_DOMAIN`.
 
     ```yaml
-    kpackImageTag: us-east4-docker.pkg.dev/vigilant-card-347116/korifi/droplets
+    packageRegistryBase: us-east4-docker.pkg.dev/vigilant-card-347116/korifi/packages
+    externalFQDN: api.korifi.example.org
+    defaultDomainName: apps.korifi.example.org
     ```
 
--   `korifi-api.yml`
+  - Change `spec.virtualhost.fqdn` in the `korifi-api-proxy` `HTTPProxy`. It should be the same as `externalFQDN` above.
 
-    -   Change the following values in the `korifi-api-config-*` `ConfigMap`.
-
-        -   `packageRegistryBase` specifies the tag prefix used for the source packages uploaded to Korifi. Its hostname should point to your container registry and its path should be [valid for the registry](#image-registry-configuration).
-        -   `externalFQDN` is the domain name that will be used by the Korifi API, and is usually of the format `api.$BASE_DOMAIN`.
-        -   `defaultDomainName` is the default base domain name for the apps deployed by Korifi, and is usually of the format `apps.$BASE_DOMAIN`.
-
-        ```yaml
-        packageRegistryBase: us-east4-docker.pkg.dev/vigilant-card-347116/korifi/packages
-        externalFQDN: api.korifi.example.org
-        defaultDomainName: apps.korifi.example.org
-        ```
-
-    -   Change `spec.virtualhost.fqdn` in the `korifi-api-proxy` `HTTPProxy`. It should be the same as `externalFQDN` above.
-
-        ```yaml
-        apiVersion: projectcontour.io/v1
-        kind: HTTPProxy
-        metadata:
-            # ...
-            name: korifi-api-proxy
-            namespace: korifi-api-system
-        spec:
-            # ...
-            virtualhost:
-                fqdn: api.korifi.example.org
-                # ...
-        ```
+    ```yaml
+    apiVersion: projectcontour.io/v1
+    kind: HTTPProxy
+    metadata:
+      # ...
+      name: korifi-api-proxy
+      namespace: korifi-api-system
+    spec:
+      # ...
+      virtualhost:
+        fqdn: api.korifi.example.org
+        # ...
+    ```
 
 ### Image Registry Configuration
 
 #### DockerHub
 
--   The cluster_builder.yaml `spec.tag` should be in the format `index.docker.io/<Username>/korifi-cluster-builder`.
--   The korifi-kpack-image-builder.yml `kpackImageTag` should be in the format `index.docker.io/<Username>`.
-    -   It will be combined with the GUID of the Kpack Image resource to create the full URI of the droplet image for an application.
--   The korifi-api.yml `packageRegistryBase` should be in the format `index.docker.io/<Username>`.
-    -   It will be combined with the GUID of the CFPackage resource to create the full URI of the package image for an application.
+- The `cluster_builder.yaml` `spec.tag` should be in the format `index.docker.io/<username>/korifi-cluster-builder`.
+- The `korifi-kpack-image-builder.yml` `kpackImageTag` should be in the format `index.docker.io/<username>`.
+  - It will be combined with the GUID of the Kpack Image resource to create the full URI of the droplet image for an application.
+- The `korifi-api.yml` `packageRegistryBase` should be in the format `index.docker.io/<username>`.
+  - It will be combined with the GUID of the CFPackage resource to create the full URI of the package image for an application.
 
-Note: DockerHub does not support nested directories so `kpackImageTag` and `packageRegistryBase` must point to the user's directory
+> **Note**
+> DockerHub does not support nested directories so `kpackImageTag` and `packageRegistryBase` must point to the user's directory
 
 #### GCR
 
--   The cluster_builder.yaml `spec.tag` should be in the format `gcr.io/<project-id>/korifi-cluster-builder`.
--   The korifi-kpack-image-builder.yml `kpackImageTag` should be in the format `gcr.io/<project-id>/droplets`.
-    -   It will be combined with the GUID of the Kpack Image resource to create the full URI of the droplet image for an application.
--   The korifi-api.yml `packageRegistryBase` should be in the format `gcr.io/<project-id>/packages`.
-    -   It will be combined with the GUID of the CFPackage resource to create the full URI of the package image for an application.
+- The `cluster_builder.yaml` `spec.tag` should be in the format `gcr.io/<project-id>/korifi-cluster-builder`.
+- The `korifi-kpack-image-builder.yml` `kpackImageTag` should be in the format `gcr.io/<project-id>/droplets`.
+  - It will be combined with the GUID of the Kpack Image resource to create the full URI of the droplet image for an application.
+- The korifi-api.yml `packageRegistryBase` should be in the format `gcr.io/<project-id>/packages`.
+  - It will be combined with the GUID of the CFPackage resource to create the full URI of the package image for an application.
 
-Note: GCR supports nested directories, so you can organize your images as desired.
+> **Note**
+> GCR supports nested directories, so you can organize your images as desired.
 
-#### Registry with Custom CA
+#### Registries with Custom CA
 
--   See instruction in [Using container registry signed by custom CA](docs/using-container-registry-signed-by-custom-ca.md) doc.
+See [_Using container registry signed by custom CA_](docs/using-container-registry-signed-by-custom-ca.md).
 
-## Root namespace and admin role binding
+## Root namespace setup
 
 Create the following resources:
 
@@ -130,9 +134,9 @@ roleRef:
   kind: ClusterRole
   name: korifi-controllers-admin
 subjects:
-- apiGroup: rbac.authorization.k8s.io
-  kind: User
-  name: $ADMIN_USERNAME
+  - apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: $ADMIN_USERNAME
 ```
 
 ### Container registry credentials
@@ -151,29 +155,29 @@ Make sure the value of `--docker-server` is a valid [URI authority](https://data
 
 #### DockerHub
 
-When using DockerHub,
+When using DockerHub:
 
--   the docker-server should be https://index.docker.io/v1/
--   the docker-username should be your DockerHub user
--   the docker-password can be either your DockerHub password or a generated personal access token
+- the `docker-server` should be `https://index.docker.io/v1/`;
+- the `docker-username` should be your DockerHub user;
+- the `docker-password` can be either your DockerHub password or a generated personal access token.
 
 #### GCR
 
-When using GCR,
+When using GCR:
 
--   the docker-server should be gcr.io
--   the docker-username should be `"_json_key"`
--   the docker-password should be the JSON-formatted access token for a service account that has permission to manage images in GCR
+- the `docker-server` should be `gcr.io`;
+- the `docker-username` should be `_json_key`;
+- the `docker-password` should be the JSON-formatted access token for a service account that has permission to manage images in GCR.
 
-# Dependencies
+## Dependencies
 
-## Cert-Manager
+### Cert-Manager
 
-Cert-Manager allows us to create internal automatically certificates within the cluster. Follow the [instructions](https://cert-manager.io/docs/installation/) to install the latest version.
+[Cert-Manager](https://cert-manager.io) allows us to create internal automatically certificates within the cluster. Follow the [instructions](https://cert-manager.io/docs/installation/) to install the latest version.
 
-## Kpack
+### Kpack
 
-[Kpack](https://github.com/pivotal/kpack) powers our source-to-image build process. Follow the [tutorial](https://github.com/pivotal/kpack/blob/main/docs/tutorial.md) to install the latest version and configure a stack, store and builder. Ensure that the name of the builder matches the value of the `clusterBuilderName` configuration from the `korifi-kpack-image-builder.yml` config file.  For the service account, use the following definition:
+[Kpack](https://github.com/pivotal/kpack) powers our source-to-image build process. Follow the [tutorial](https://github.com/pivotal/kpack/blob/main/docs/tutorial.md) to install the latest version and configure a stack, store and builder. Ensure that the name of the builder matches the value of the `clusterBuilderName` configuration from the `korifi-kpack-image-builder.yml` config file. For the service account, use the following definition:
 
 ```yaml
 ---
@@ -185,30 +189,30 @@ metadata:
   annotations:
     cloudfoundry.org/propagate-service-account: "true"
 secrets:
-- name: image-registry-credentials
+  - name: image-registry-credentials
 imagePullSecrets:
   - name: image-registry-credentials
 ```
 
-## Contour
+### Contour
 
 [Contour](https://projectcontour.io/) is our [ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) controller. Follow the [instructions](https://projectcontour.io/getting-started/#install-contour-and-envoy) from the getting started guide to install the latest version.
 
-## Metrics Server
+### Metrics Server
 
 We use the [Kubernetes Metrics Server](https://github.com/kubernetes-sigs/metrics-server) to implement [process stats](https://v3-apidocs.cloudfoundry.org/#get-stats-for-a-process).
 Most Kubernetes distributions will come with `metrics-server` already installed. If yours does not, you should follow the [instructions](https://github.com/kubernetes-sigs/metrics-server#installation) to install it.
 
-## Optional: Service Bindings Controller
+### Optional: Service Bindings Controller
 
 We use the [Service Binding Specification for Kubernetes](https://github.com/servicebinding/spec) and its [controller reference implementation](https://github.com/servicebinding/runtime) to implement [Cloud Foundry service bindings](https://docs.cloudfoundry.org/devguide/services/application-binding.html) ([see this issue](https://github.com/cloudfoundry/cf-k8s-controllers/issues/462)). Follow the [instructions](https://github.com/servicebinding/runtime/releases/latest) to install the latest version.
 
-# DNS
+## DNS
 
 Create DNS entries for the Korifi API and for the apps running on Korifi. They should match the [configuration](#configuration):
 
--   The Korifi API entry should match `externalFQDN`. In our example, that would be `api.korifi.example.org`.
--   The apps entry should be a wildcard matching `defaultDomainName`: In our example, `\*.apps.korifi.example.org`.
+- The Korifi API entry should match `externalFQDN`. In our example, that would be `api.korifi.example.org`.
+- The apps entry should be a wildcard matching `defaultDomainName`: In our example, `\*.apps.korifi.example.org`.
 
 The DNS entries should point to the load balancer endpoint created by Contour when installed. To discover your endpoint, run:
 
@@ -218,9 +222,9 @@ kubectl get service envoy -n projectcontour -ojsonpath='{.status.loadBalancer.in
 
 It may take some time before the address is available. Retry this until you see a result.
 
-The type of DNS records to create will differ based on the type of the endpoint: `ip` endpoints (e.g. the ones created by GKE) will need an A record, while `hostname` endpoints (e.g. on EKS) a CNAME record.
+The type of DNS records to create will differ based on the type of the endpoint: `ip` endpoints (e.g. the ones created by GKE) will need an `A` record, while `hostname` endpoints (e.g. on EKS) a `CNAME` record.
 
-# Deploy Korifi
+## Deploy Korifi
 
 Just apply the files in the release:
 
@@ -261,9 +265,9 @@ spec:
 EOF
 ```
 
-# Test Korifi
+## Test Korifi
 
-```
+```sh
 cf api https://api.$BASE_DOMAIN --skip-ssl-validation
 cf login # select the $ADMIN_USERNAME entry
 cf create-org org1

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -19,7 +19,7 @@ This document was tested on:
 
 - [EKS](https://aws.amazon.com/eks/), using GCP's [Artifact Registry](https://cloud.google.com/artifact-registry);
 - [GKE](https://cloud.google.com/kubernetes-engine), using GCP's [Artifact Registry](https://cloud.google.com/artifact-registry);
-- [kind](https://kind.sigs.k8s.io/), using [DockerHub](https://hub.docker.com/).
+- [kind](https://kind.sigs.k8s.io/), using [DockerHub](https://hub.docker.com/) (see [_Install Korifi on kind_](./INSTALL_kind.md)).
 
 ## Initial setup
 

--- a/INSTALL_kind.md
+++ b/INSTALL_kind.md
@@ -1,0 +1,161 @@
+> **Warning**
+> Make sure you are using the correct version of these instructions by using the link in the release notes for the version you're trying to install. If you're not sure, check our [latest release](https://github.com/cloudfoundry/korifi/releases/latest).
+
+# Install Korifi on kind
+
+This document integrates our [install instructions](./INSTALL.md) with specific tips to install Korifi locally using [kind](https://kind.sigs.k8s.io/).
+
+## Cluster creation
+
+In order to access the Korifi API, we'll need to [expose the cluster ingress locally](https://kind.sigs.k8s.io/docs/user/ingress/). To do it, create your kind cluster using a command like this:
+
+```sh
+cat <<EOF | kind create cluster --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  extraPortMappings:
+  - containerPort: 80
+    hostPort: 80
+    protocol: TCP
+  - containerPort: 443
+    hostPort: 443
+    protocol: TCP
+EOF
+```
+
+## Initial setup
+
+You don't need to export the environment variables. We wil use the following values:
+
+- `cf` as our root namespace;
+- `cf-admin` as our admin username: you will need to create this (check [`scripts/create-new-user.sh`](./scripts/create-new-user.sh) for an example of how we do this in our development environments);
+- `vcap.me` as our base domain: it will conveniently [resolve to `127.0.0.1`](https://www.nslookup.io/domains/vcap.me/dns-records), which is exactly what we need.
+
+## Configuration
+
+We recommend you use [DockerHub](https://hub.docker.com/) as your image registry. As specified by the instructions, you should use the following values in the configuration files:
+
+- `korifi-kpack-image-builder.yml`
+
+  ```yaml
+  kpackImageTag: index.docker.io/<username>
+  ```
+
+- `korifi-api.yml`
+
+  - `korifi-api-config-*` `ConfigMap`
+
+    ```yaml
+    packageRegistryBase: index.docker.io/<username>
+    externalFQDN: api.vcap.me
+    defaultDomainName: apps.vcap.me
+    ```
+
+  - `korifi-api-proxy` `HTTPProxy`
+
+    ```yaml
+    apiVersion: projectcontour.io/v1
+    kind: HTTPProxy
+    metadata:
+      # ...
+      name: korifi-api-proxy
+      namespace: korifi-api-system
+    spec:
+      # ...
+      virtualhost:
+        fqdn: api.vcap.me
+        # ...
+    ```
+
+## Root namespace setup
+
+As per the instructions, create the following:
+
+```yaml
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cf
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/audit: restricted
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: default-admin-binding
+  namespace: cf
+  annotations:
+    cloudfoundry.org/propagate-cf-role: "true"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: korifi-controllers-admin
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: cf-admin
+```
+
+### Container registry credentials
+
+We recommend you [create an access token](https://hub.docker.com/settings/security?generateToken=true) on DockerHub. Then run the following command, as described in the instructions:
+
+```sh
+kubectl create secret docker-registry image-registry-credentials \
+    --docker-username="<your-dockerhub-username>" \
+    --docker-password="<your-dockerhub-access-token>" \
+    --docker-server="https://index.docker.io/v1/" \
+    --namespace cf
+```
+
+## Dependencies
+
+No changes here, follow the instructions.
+
+## DNS
+
+You can skip this section.
+
+## Deploy Korifi
+
+No changes here, follow the instructions.
+
+## TLS certificates
+
+Given you don't have any DNS records, you want to use the following values for `CN`/`SAN`:
+
+- for the API, use `localhost`;
+- for the apps, use `*.vcap.me`.
+
+## Default CF Domain
+
+As per the instructions:
+
+```sh
+cat <<EOF | kubectl apply --namespace cf -f -
+apiVersion: korifi.cloudfoundry.org/v1alpha1
+kind: CFDomain
+metadata:
+  name: default-domain
+  namespace: cf
+spec:
+  name: apps.vcap.me
+EOF
+```
+
+## Test Korifi
+
+```sh
+cf api https://api.vcap.me --skip-ssl-validation
+cf login # select the cf-admin entry
+cf create-org org1
+cf create-space -o org1 space1
+cf target -o org1
+cd <directory of a test cf app>
+cf push test-app
+```


### PR DESCRIPTION
## Is there a related GitHub Issue?

Yes, #1552.

## What is this change about?

This introduces the new `INSTALL_kind.md` document, containing kind-specific install instructions to integrate `INSTALL.md`.

## Does this PR introduce a breaking change?

No.

## Acceptance Steps

Install Korifi on kind following `INSTALL.md` and `INSTALL_kind.md`.
