### PR TITLE
Remove unused `ingress-ready` label on kind nodes

### DIFF
--- a/scripts/deploy-on-kind.sh
+++ b/scripts/deploy-on-kind.sh
@@ -145,12 +145,6 @@ featureGates:
   EphemeralContainers: true
 nodes:
 - role: control-plane
-  kubeadmConfigPatches:
-  - |
-    kind: InitConfiguration
-    nodeRegistration:
-      kubeletExtraArgs:
-        node-labels: "ingress-ready=true"
   extraPortMappings:
   - containerPort: 80
     hostPort: 80

--- a/scripts/samples/deploy-release.sh
+++ b/scripts/samples/deploy-release.sh
@@ -31,12 +31,6 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  kubeadmConfigPatches:
-  - |
-    kind: InitConfiguration
-    nodeRegistration:
-      kubeletExtraArgs:
-        node-labels: "ingress-ready=true"
   extraPortMappings:
   - containerPort: 80
     hostPort: 80


### PR DESCRIPTION

<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?

No.

## What is this change about?

This removes the `ingress-ready` label from our kind nodes. The label probably came from copy-and-pasting [this example](https://kind.sigs.k8s.io/docs/user/ingress/) which uses it to filter nodes using Contour's `spec.nodeSelector`. We never do this, so we shouldn't need to label our nodes.

## Does this PR introduce a breaking change?

No. This passed `make test-e2e` on my machine.