### PR TITLE
Update serviceaccount propagation for spaces

### DIFF
--- a/controllers/controllers/workloads/integration/cfspace_controller_integration_test.go
+++ b/controllers/controllers/workloads/integration/cfspace_controller_integration_test.go
@@ -160,7 +160,7 @@ var _ = Describe("CFSpaceReconciler Integration Tests", func() {
 						"ObjectMeta": MatchFields(IgnoreExtras, Fields{
 							"Name": Equal(serviceAccount.Name),
 						}),
-						"Secrets": ConsistOf(MatchFields(IgnoreExtras, Fields{"Name": Equal("a-secret-i-like")})),
+						"Secrets": ConsistOf(MatchFields(IgnoreExtras, Fields{"Name": Equal(packageRegistrySecretName)})),
 					}),
 				))
 			}).Should(Succeed())

--- a/controllers/controllers/workloads/integration/suite_integration_test.go
+++ b/controllers/controllers/workloads/integration/suite_integration_test.go
@@ -270,7 +270,8 @@ func createServiceAccount(ctx context.Context, k8sclient client.Client, serviceA
 		},
 		Secrets: []corev1.ObjectReference{
 			{Name: serviceAccountName + "-token-someguid"},
-			{Name: "a-secret-i-like"},
+			{Name: serviceAccountName + "-dockercfg-someguid"},
+			{Name: packageRegistrySecretName},
 		},
 	}
 	Expect(k8sClient.Create(ctx, &serviceAccount)).To(Succeed())


### PR DESCRIPTION
## Is there a related GitHub Issue?
[#1666]

## What is this change about?
k8s creates certain secrets like tokens and dockercfgs and links them to serviceaccounts that are not propagated when a new space is created. These secrets are unavailable and will cause anything using the propagated serviceaccounts to fail. This change is to only reference the package registry secret for propagated serviceaccounts since that is explicitly propagated on create space.

## Does this PR introduce a breaking change?
no

## Acceptance Steps
See issue

## Tag your pair, your PM, and/or team
@Birdrock 
