### PR TITLE
Allow scaling web processes down to 0

### DIFF
--- a/api/handlers/integration/process_test.go
+++ b/api/handlers/integration/process_test.go
@@ -7,6 +7,7 @@ import (
 	"code.cloudfoundry.org/korifi/api/handlers"
 	"code.cloudfoundry.org/korifi/api/repositories"
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
+	"code.cloudfoundry.org/korifi/tools"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -71,7 +72,7 @@ var _ = Describe("Process", func() {
 							TimeoutSeconds:           0,
 						},
 					},
-					DesiredInstances: 1,
+					DesiredInstances: tools.PtrTo(1),
 					MemoryMB:         500,
 					DiskQuotaMB:      512,
 					Ports:            []int32{8080},

--- a/api/repositories/process_repository.go
+++ b/api/repositories/process_repository.go
@@ -8,6 +8,7 @@ import (
 	"code.cloudfoundry.org/korifi/api/apierrors"
 	"code.cloudfoundry.org/korifi/api/authorization"
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
+	"code.cloudfoundry.org/korifi/tools"
 
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -162,7 +163,7 @@ func (r *ProcessRepo) ScaleProcess(ctx context.Context, authInfo authorization.I
 	}
 	cfProcess := baseCFProcess.DeepCopy()
 	if scaleProcessMessage.Instances != nil {
-		cfProcess.Spec.DesiredInstances = *scaleProcessMessage.Instances
+		cfProcess.Spec.DesiredInstances = scaleProcessMessage.Instances
 	}
 	if scaleProcessMessage.MemoryMB != nil {
 		cfProcess.Spec.MemoryMB = *scaleProcessMessage.MemoryMB
@@ -202,7 +203,7 @@ func (r *ProcessRepo) CreateProcess(ctx context.Context, authInfo authorization.
 				Type: korifiv1alpha1.HealthCheckType(message.HealthCheck.Type),
 				Data: korifiv1alpha1.HealthCheckData(message.HealthCheck.Data),
 			},
-			DesiredInstances: message.DesiredInstances,
+			DesiredInstances: tools.PtrTo(message.DesiredInstances),
 			MemoryMB:         message.MemoryMB,
 			DiskQuotaMB:      message.DiskQuotaMB,
 			Ports:            []int32{},
@@ -253,7 +254,7 @@ func (r *ProcessRepo) PatchProcess(ctx context.Context, authInfo authorization.I
 		updatedProcess.Spec.Command = *message.Command
 	}
 	if message.DesiredInstances != nil {
-		updatedProcess.Spec.DesiredInstances = *message.DesiredInstances
+		updatedProcess.Spec.DesiredInstances = message.DesiredInstances
 	}
 	if message.MemoryMB != nil {
 		updatedProcess.Spec.MemoryMB = *message.MemoryMB
@@ -330,7 +331,7 @@ func cfProcessToProcessRecord(cfProcess korifiv1alpha1.CFProcess) ProcessRecord 
 		AppGUID:          cfProcess.Spec.AppRef.Name,
 		Type:             cfProcess.Spec.ProcessType,
 		Command:          cfProcess.Spec.Command,
-		DesiredInstances: cfProcess.Spec.DesiredInstances,
+		DesiredInstances: *cfProcess.Spec.DesiredInstances,
 		MemoryMB:         cfProcess.Spec.MemoryMB,
 		DiskQuotaMB:      cfProcess.Spec.DiskQuotaMB,
 		Ports:            cfProcess.Spec.Ports,

--- a/api/repositories/process_repository_test.go
+++ b/api/repositories/process_repository_test.go
@@ -12,6 +12,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gstruct"
 	. "github.com/onsi/gomega/gstruct"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -72,7 +73,7 @@ var _ = Describe("ProcessRepo", func() {
 				Expect(processRecord.AppGUID).To(Equal(app1GUID))
 				Expect(processRecord.Type).To(Equal(cfProcess1.Spec.ProcessType))
 				Expect(processRecord.Command).To(Equal(cfProcess1.Spec.Command))
-				Expect(processRecord.DesiredInstances).To(Equal(cfProcess1.Spec.DesiredInstances))
+				Expect(processRecord.DesiredInstances).To(Equal(*cfProcess1.Spec.DesiredInstances))
 				Expect(processRecord.MemoryMB).To(Equal(cfProcess1.Spec.MemoryMB))
 				Expect(processRecord.DiskQuotaMB).To(Equal(cfProcess1.Spec.DiskQuotaMB))
 				Expect(processRecord.Ports).To(Equal(cfProcess1.Spec.Ports))
@@ -261,7 +262,7 @@ var _ = Describe("ProcessRepo", func() {
 					if instances != nil {
 						Expect(scaleProcessRecord.DesiredInstances).To(Equal(*instances))
 					} else {
-						Expect(scaleProcessRecord.DesiredInstances).To(Equal(cfProcess.Spec.DesiredInstances))
+						Expect(scaleProcessRecord.DesiredInstances).To(Equal(*cfProcess.Spec.DesiredInstances))
 					}
 					if diskMB != nil {
 						Expect(scaleProcessRecord.DiskQuotaMB).To(Equal(*diskMB))
@@ -297,7 +298,7 @@ var _ = Describe("ProcessRepo", func() {
 					&updatedCFProcess,
 				)).To(Succeed())
 
-				Expect(updatedCFProcess.Spec.DesiredInstances).To(Equal(instanceScale))
+				Expect(updatedCFProcess.Spec.DesiredInstances).To(gstruct.PointTo(Equal(instanceScale)))
 				Expect(updatedCFProcess.Spec.DiskQuotaMB).To(Equal(diskScaleMB))
 				Expect(updatedCFProcess.Spec.MemoryMB).To(Equal(memoryScaleMB))
 			})
@@ -360,7 +361,7 @@ var _ = Describe("ProcessRepo", func() {
 							TimeoutSeconds:           10,
 						},
 					},
-					DesiredInstances: 42,
+					DesiredInstances: tools.PtrTo(42),
 					MemoryMB:         456,
 					DiskQuotaMB:      123,
 					Ports:            []int32{},
@@ -468,7 +469,7 @@ var _ = Describe("ProcessRepo", func() {
 								TimeoutSeconds:           2,
 							},
 						},
-						DesiredInstances: 1,
+						DesiredInstances: tools.PtrTo(1),
 						MemoryMB:         2,
 						DiskQuotaMB:      3,
 						Ports:            []int32{8080},
@@ -549,7 +550,7 @@ var _ = Describe("ProcessRepo", func() {
 									TimeoutSeconds:           10,
 								},
 							},
-							DesiredInstances: 42,
+							DesiredInstances: tools.PtrTo(42),
 							MemoryMB:         456,
 							DiskQuotaMB:      123,
 							Ports:            []int32{8080},
@@ -597,7 +598,7 @@ var _ = Describe("ProcessRepo", func() {
 									TimeoutSeconds:           42,
 								},
 							},
-							DesiredInstances: 5,
+							DesiredInstances: tools.PtrTo(5),
 							MemoryMB:         123,
 							DiskQuotaMB:      3,
 							Ports:            []int32{8080},

--- a/api/repositories/shared_test.go
+++ b/api/repositories/shared_test.go
@@ -5,6 +5,7 @@ import (
 
 	. "code.cloudfoundry.org/korifi/api/repositories"
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
+	"code.cloudfoundry.org/korifi/tools"
 
 	"github.com/google/uuid"
 	. "github.com/onsi/gomega"
@@ -133,7 +134,7 @@ func createProcessCR(ctx context.Context, k8sClient client.Client, processGUID, 
 					TimeoutSeconds:           0,
 				},
 			},
-			DesiredInstances: 1,
+			DesiredInstances: tools.PtrTo(1),
 			MemoryMB:         500,
 			DiskQuotaMB:      512,
 			Ports:            []int32{8080},

--- a/controllers/api/v1alpha1/cfprocess_types.go
+++ b/controllers/api/v1alpha1/cfprocess_types.go
@@ -43,7 +43,7 @@ type CFProcessSpec struct {
 	HealthCheck HealthCheck `json:"healthCheck"`
 
 	// Specifies the desired number of Process replicas to deploy
-	DesiredInstances int `json:"desiredInstances"`
+	DesiredInstances *int `json:"desiredInstances,omitempty"`
 
 	// Specifies the Process memory limit in MiB
 	MemoryMB int64 `json:"memoryMB"`

--- a/controllers/api/v1alpha1/cfprocess_webhook.go
+++ b/controllers/api/v1alpha1/cfprocess_webhook.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	"context"
 
+	"code.cloudfoundry.org/korifi/tools"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -87,9 +88,15 @@ func (d *CFProcessDefaulter) defaultResources(process *CFProcess) {
 }
 
 func (d *CFProcessDefaulter) defaultInstances(process *CFProcess) {
-	if process.Spec.ProcessType == ProcessTypeWeb && process.Spec.DesiredInstances == 0 {
-		process.Spec.DesiredInstances = 1
+	if process.Spec.DesiredInstances != nil {
+		return
 	}
+
+	defaultInstances := 0
+	if process.Spec.ProcessType == ProcessTypeWeb {
+		defaultInstances = 1
+	}
+	process.Spec.DesiredInstances = tools.PtrTo(defaultInstances)
 }
 
 func (d *CFProcessDefaulter) defaultHealthCheck(process *CFProcess) {

--- a/controllers/api/v1alpha1/integration/cfprocess_webhook_integration_test.go
+++ b/controllers/api/v1alpha1/integration/cfprocess_webhook_integration_test.go
@@ -5,143 +5,173 @@ import (
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	. "code.cloudfoundry.org/korifi/controllers/controllers/workloads/testutils"
+	"code.cloudfoundry.org/korifi/tools"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gstruct"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
 var _ = Describe("CFProcessMutatingWebhook Integration Tests", func() {
-	When("a CFProcess record is created", func() {
-		const (
-			cfAppGUIDLabelKey     = "korifi.cloudfoundry.org/app-guid"
-			cfProcessGUIDLabelKey = "korifi.cloudfoundry.org/process-guid"
-			cfProcessType         = "test-process-type"
-			cfProcessTypeLabelKey = "korifi.cloudfoundry.org/process-type"
-			namespace             = "default"
-		)
+	const (
+		cfAppGUIDLabelKey     = "korifi.cloudfoundry.org/app-guid"
+		cfProcessGUIDLabelKey = "korifi.cloudfoundry.org/process-guid"
+		cfProcessType         = "test-process-type"
+		cfProcessTypeLabelKey = "korifi.cloudfoundry.org/process-type"
+		namespace             = "default"
+	)
 
-		var (
-			cfAppGUID        string
-			cfProcessGUID    string
-			cfProcess        *korifiv1alpha1.CFProcess
-			createdCFProcess *korifiv1alpha1.CFProcess
-		)
+	var (
+		cfAppGUID        string
+		cfProcessGUID    string
+		cfProcess        *korifiv1alpha1.CFProcess
+		createdCFProcess *korifiv1alpha1.CFProcess
+	)
 
-		BeforeEach(func() {
-			cfAppGUID = GenerateGUID()
-			cfProcessGUID = GenerateGUID()
-			cfProcess = &korifiv1alpha1.CFProcess{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "CFProcess",
-					APIVersion: korifiv1alpha1.GroupVersion.Identifier(),
+	BeforeEach(func() {
+		cfAppGUID = GenerateGUID()
+		cfProcessGUID = GenerateGUID()
+		cfProcess = &korifiv1alpha1.CFProcess{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "CFProcess",
+				APIVersion: korifiv1alpha1.GroupVersion.Identifier(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      cfProcessGUID,
+				Namespace: namespace,
+			},
+			Spec: korifiv1alpha1.CFProcessSpec{
+				AppRef: v1.LocalObjectReference{
+					Name: cfAppGUID,
 				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      cfProcessGUID,
-					Namespace: namespace,
-				},
-				Spec: korifiv1alpha1.CFProcessSpec{
-					AppRef: v1.LocalObjectReference{
-						Name: cfAppGUID,
-					},
-					ProcessType: cfProcessType,
-					Ports:       []int32{},
-				},
-			}
+				ProcessType: cfProcessType,
+				Ports:       []int32{},
+			},
+		}
+	})
+
+	JustBeforeEach(func() {
+		Expect(k8sClient.Create(context.Background(), cfProcess)).To(Succeed())
+		createdCFProcess = new(korifiv1alpha1.CFProcess)
+		Eventually(func(g Gomega) {
+			g.Expect(k8sClient.Get(context.Background(), types.NamespacedName{
+				Name:      cfProcessGUID,
+				Namespace: namespace,
+			}, createdCFProcess)).To(Succeed())
+		}).Should(Succeed())
+	})
+
+	Describe("labels", func() {
+		It("adds the appropriate labels", func() {
+			Expect(createdCFProcess.ObjectMeta.Labels).To(HaveKeyWithValue(cfProcessGUIDLabelKey, cfProcessGUID))
+			Expect(createdCFProcess.ObjectMeta.Labels).To(HaveKeyWithValue(cfProcessTypeLabelKey, cfProcessType))
+			Expect(createdCFProcess.ObjectMeta.Labels).To(HaveKeyWithValue(cfAppGUIDLabelKey, cfAppGUID))
 		})
 
-		JustBeforeEach(func() {
-			Expect(k8sClient.Create(context.Background(), cfProcess)).To(Succeed())
-			createdCFProcess = new(korifiv1alpha1.CFProcess)
-			Eventually(func(g Gomega) {
-				g.Expect(k8sClient.Get(context.Background(), types.NamespacedName{
-					Name:      cfProcessGUID,
-					Namespace: namespace,
-				}, createdCFProcess)).To(Succeed())
-			}).Should(Succeed())
-		})
-
-		Describe("labels", func() {
-			It("adds the appropriate labels", func() {
-				Expect(createdCFProcess.ObjectMeta.Labels).To(HaveKeyWithValue(cfProcessGUIDLabelKey, cfProcessGUID))
-				Expect(createdCFProcess.ObjectMeta.Labels).To(HaveKeyWithValue(cfProcessTypeLabelKey, cfProcessType))
-				Expect(createdCFProcess.ObjectMeta.Labels).To(HaveKeyWithValue(cfAppGUIDLabelKey, cfAppGUID))
+		When("there are other existing labels on the CFProcess record", func() {
+			BeforeEach(func() {
+				cfProcess.Labels = map[string]string{
+					"anotherLabel": "process-label",
+				}
 			})
 
-			When("there are other existing labels on the CFProcess record", func() {
-				BeforeEach(func() {
-					cfProcess.Labels = map[string]string{
-						"anotherLabel": "process-label",
-					}
-				})
-
-				It("preserves them", func() {
-					Expect(createdCFProcess.ObjectMeta.Labels).To(HaveLen(4))
-					Expect(createdCFProcess.ObjectMeta.Labels).To(HaveKeyWithValue("anotherLabel", "process-label"))
-				})
+			It("preserves them", func() {
+				Expect(createdCFProcess.ObjectMeta.Labels).To(HaveLen(4))
+				Expect(createdCFProcess.ObjectMeta.Labels).To(HaveKeyWithValue("anotherLabel", "process-label"))
 			})
 		})
+	})
 
-		Describe("memory and disk", func() {
-			It("sets the configured default memory and disk", func() {
-				Expect(createdCFProcess.Spec.MemoryMB).To(BeEquivalentTo(defaultMemoryMB))
+	Describe("memory and disk", func() {
+		It("sets the configured default memory and disk", func() {
+			Expect(createdCFProcess.Spec.MemoryMB).To(BeEquivalentTo(defaultMemoryMB))
+			Expect(createdCFProcess.Spec.DiskQuotaMB).To(BeEquivalentTo(defaultDiskQuotaMB))
+		})
+
+		When("the process already has a memory value set", func() {
+			BeforeEach(func() {
+				cfProcess.Spec.MemoryMB = 42
+			})
+
+			It("preserves it", func() {
+				Expect(createdCFProcess.Spec.MemoryMB).To(BeEquivalentTo(42))
 				Expect(createdCFProcess.Spec.DiskQuotaMB).To(BeEquivalentTo(defaultDiskQuotaMB))
 			})
+		})
 
-			When("the process already has a memory value set", func() {
-				BeforeEach(func() {
-					cfProcess.Spec.MemoryMB = 42
-				})
-
-				It("preserves it", func() {
-					Expect(createdCFProcess.Spec.MemoryMB).To(BeEquivalentTo(42))
-					Expect(createdCFProcess.Spec.DiskQuotaMB).To(BeEquivalentTo(defaultDiskQuotaMB))
-				})
+		When("the process already has a memory value set", func() {
+			BeforeEach(func() {
+				cfProcess.Spec.DiskQuotaMB = 42
 			})
 
-			When("the process already has a memory value set", func() {
-				BeforeEach(func() {
-					cfProcess.Spec.DiskQuotaMB = 42
-				})
+			It("preserves it", func() {
+				Expect(createdCFProcess.Spec.MemoryMB).To(BeEquivalentTo(defaultMemoryMB))
+				Expect(createdCFProcess.Spec.DiskQuotaMB).To(BeEquivalentTo(42))
+			})
+		})
+	})
 
-				It("preserves it", func() {
-					Expect(createdCFProcess.Spec.MemoryMB).To(BeEquivalentTo(defaultMemoryMB))
-					Expect(createdCFProcess.Spec.DiskQuotaMB).To(BeEquivalentTo(42))
-				})
+	Describe("instances", func() {
+		It("defaults desired instances to zero", func() {
+			Expect(createdCFProcess.Spec.DesiredInstances).To(gstruct.PointTo(Equal(0)))
+		})
+
+		When("the process has the instance number set", func() {
+			BeforeEach(func() {
+				cfProcess.Spec.DesiredInstances = tools.PtrTo(24)
+			})
+
+			It("leaves instances unchanged", func() {
+				Expect(createdCFProcess.Spec.DesiredInstances).To(gstruct.PointTo(Equal(24)))
 			})
 		})
 
-		Describe("instances", func() {
-			It("leaves zero desired instances as zero", func() {
-				Expect(createdCFProcess.Spec.DesiredInstances).To(Equal(0))
+		When("the process is of type web", func() {
+			BeforeEach(func() {
+				cfProcess.Spec.ProcessType = "web"
 			})
 
-			When("the process is of type web", func() {
+			It("defaults instances to 1", func() {
+				Expect(createdCFProcess.Spec.DesiredInstances).To(gstruct.PointTo(Equal(1)))
+			})
+
+			When("the process has the instance number set", func() {
 				BeforeEach(func() {
-					cfProcess.Spec.ProcessType = "web"
+					cfProcess.Spec.DesiredInstances = tools.PtrTo(42)
 				})
 
-				It("defaults instances to 1", func() {
-					Expect(createdCFProcess.Spec.DesiredInstances).To(Equal(1))
-				})
-
-				When("the process has the instance number set", func() {
-					BeforeEach(func() {
-						cfProcess.Spec.DesiredInstances = 42
-					})
-
-					It("leaves instances unchanged", func() {
-						Expect(createdCFProcess.Spec.DesiredInstances).To(Equal(42))
-					})
+				It("leaves instances unchanged", func() {
+					Expect(createdCFProcess.Spec.DesiredInstances).To(gstruct.PointTo(Equal(42)))
 				})
 			})
 		})
+	})
 
-		Describe("healthcheck", func() {
-			It("defaults healthcheck type to process", func() {
-				Expect(createdCFProcess.Spec.HealthCheck.Type).To(BeEquivalentTo("process"))
+	Describe("healthcheck", func() {
+		It("defaults healthcheck type to process", func() {
+			Expect(createdCFProcess.Spec.HealthCheck.Type).To(BeEquivalentTo("process"))
+		})
+
+		When("the type is already set", func() {
+			BeforeEach(func() {
+				cfProcess.Spec.HealthCheck.Type = "http"
+			})
+
+			It("preserves the value", func() {
+				Expect(createdCFProcess.Spec.HealthCheck.Type).To(BeEquivalentTo("http"))
+			})
+		})
+
+		When("the process is of type web", func() {
+			BeforeEach(func() {
+				cfProcess.Spec.ProcessType = "web"
+			})
+
+			It("defaults the type to port", func() {
+				Expect(createdCFProcess.Spec.HealthCheck.Type).To(BeEquivalentTo("port"))
 			})
 
 			When("the type is already set", func() {
@@ -151,26 +181,6 @@ var _ = Describe("CFProcessMutatingWebhook Integration Tests", func() {
 
 				It("preserves the value", func() {
 					Expect(createdCFProcess.Spec.HealthCheck.Type).To(BeEquivalentTo("http"))
-				})
-			})
-
-			When("the process is of type web", func() {
-				BeforeEach(func() {
-					cfProcess.Spec.ProcessType = "web"
-				})
-
-				It("defaults the type to port", func() {
-					Expect(createdCFProcess.Spec.HealthCheck.Type).To(BeEquivalentTo("port"))
-				})
-
-				When("the type is already set", func() {
-					BeforeEach(func() {
-						cfProcess.Spec.HealthCheck.Type = "http"
-					})
-
-					It("preserves the value", func() {
-						Expect(createdCFProcess.Spec.HealthCheck.Type).To(BeEquivalentTo("http"))
-					})
 				})
 			})
 		})

--- a/controllers/api/v1alpha1/zz_generated.deepcopy.go
+++ b/controllers/api/v1alpha1/zz_generated.deepcopy.go
@@ -994,6 +994,11 @@ func (in *CFProcessSpec) DeepCopyInto(out *CFProcessSpec) {
 	*out = *in
 	out.AppRef = in.AppRef
 	out.HealthCheck = in.HealthCheck
+	if in.DesiredInstances != nil {
+		in, out := &in.DesiredInstances, &out.DesiredInstances
+		*out = new(int)
+		**out = **in
+	}
 	if in.Ports != nil {
 		in, out := &in.Ports, &out.Ports
 		*out = make([]int32, len(*in))

--- a/controllers/config/crd/bases/korifi.cloudfoundry.org_cfprocesses.yaml
+++ b/controllers/config/crd/bases/korifi.cloudfoundry.org_cfprocesses.yaml
@@ -106,7 +106,6 @@ spec:
                 type: string
             required:
             - appRef
-            - desiredInstances
             - diskQuotaMB
             - healthCheck
             - memoryMB

--- a/controllers/controllers/workloads/cfprocess_controller.go
+++ b/controllers/controllers/workloads/cfprocess_controller.go
@@ -236,7 +236,9 @@ func (r *CFProcessReconciler) generateAppWorkload(actualAppWorkload *korifiv1alp
 	desiredAppWorkload.Spec.Image = cfBuild.Status.Droplet.Registry.Image
 	desiredAppWorkload.Spec.ImagePullSecrets = cfBuild.Status.Droplet.Registry.ImagePullSecrets
 	desiredAppWorkload.Spec.Ports = cfProcess.Spec.Ports
-	desiredAppWorkload.Spec.Instances = int32(cfProcess.Spec.DesiredInstances)
+	if cfProcess.Spec.DesiredInstances != nil {
+		desiredAppWorkload.Spec.Instances = int32(*cfProcess.Spec.DesiredInstances)
+	}
 
 	desiredAppWorkload.Spec.Env = generateEnvVars(appPort, envVars)
 	desiredAppWorkload.Spec.Health = korifiv1alpha1.Healthcheck{

--- a/controllers/controllers/workloads/integration/cfprocess_controller_integration_test.go
+++ b/controllers/controllers/workloads/integration/cfprocess_controller_integration_test.go
@@ -158,7 +158,7 @@ var _ = Describe("CFProcessReconciler Integration Tests", func() {
 				g.Expect(appWorkload.Spec.ProcessType).To(Equal(processTypeWeb))
 				g.Expect(appWorkload.Spec.AppGUID).To(Equal(cfApp.Name))
 				g.Expect(appWorkload.Spec.Ports).To(Equal(cfProcess.Spec.Ports))
-				g.Expect(appWorkload.Spec.Instances).To(Equal(int32(cfProcess.Spec.DesiredInstances)))
+				g.Expect(appWorkload.Spec.Instances).To(Equal(int32(*cfProcess.Spec.DesiredInstances)))
 
 				g.Expect(appWorkload.Spec.Resources.Limits.StorageEphemeral()).To(matchers.RepresentResourceQuantity(cfProcess.Spec.DiskQuotaMB, "Mi"))
 				g.Expect(appWorkload.Spec.Resources.Limits.Memory()).To(matchers.RepresentResourceQuantity(cfProcess.Spec.MemoryMB, "Mi"))

--- a/controllers/controllers/workloads/testutils/shared_test_utils.go
+++ b/controllers/controllers/workloads/testutils/shared_test_utils.go
@@ -6,6 +6,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
+	"code.cloudfoundry.org/korifi/tools"
 
 	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
@@ -219,7 +220,7 @@ func BuildCFProcessCRObject(cfProcessGUID string, namespace string, cfAppGUID st
 					TimeoutSeconds:           0,
 				},
 			},
-			DesiredInstances: 0,
+			DesiredInstances: tools.PtrTo(0),
 			MemoryMB:         1024,
 			DiskQuotaMB:      100,
 			Ports:            []int32{8080},


### PR DESCRIPTION
## Is there a related GitHub Issue?

#1672

## What is this change about?

As zero is a valid value for `CFProcess.Spec.DesiredInstances` (set to
zero when the user wants to scale down process instances to 0) we cannot
rely on the field zero value. That is why the field has its type changed
to `*int` so that the CFProcess webhook would only default the instances
value if the pointer value is not set.

## Does this PR introduce a breaking change?
No

<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
See story

<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

