### PR TITLE
Developer can push apps using the top-level disk_quota field in the manifest

### DIFF
--- a/api/actions/manifest/normalizer.go
+++ b/api/actions/manifest/normalizer.go
@@ -33,6 +33,13 @@ func (n Normalizer) Normalize(appInfo payloads.ManifestApplication, appState App
 	}
 }
 
+func procValIfSet[T any](appVal, procVal *T) *T {
+	if procVal == nil {
+		return appVal
+	}
+	return procVal
+}
+
 func (n Normalizer) normalizeProcesses(appInfo payloads.ManifestApplication, appState AppState) []payloads.ManifestApplicationProcess {
 	processes := appInfo.Processes
 
@@ -44,15 +51,14 @@ func (n Normalizer) normalizeProcesses(appInfo payloads.ManifestApplication, app
 		}
 	}
 
-	if appInfo.Memory != nil {
+	if appInfo.Memory != nil || appInfo.DiskQuota != nil {
 		if webProc == nil {
 			processes = append(processes, payloads.ManifestApplicationProcess{Type: korifiv1alpha1.ProcessTypeWeb})
 			webProc = &processes[len(processes)-1]
 		}
 
-		if webProc.Memory == nil {
-			webProc.Memory = appInfo.Memory
-		}
+		webProc.Memory = procValIfSet(appInfo.Memory, webProc.Memory)
+		webProc.DiskQuota = procValIfSet(appInfo.DiskQuota, webProc.DiskQuota)
 	}
 
 	return processes

--- a/api/actions/manifest/normalizer.go
+++ b/api/actions/manifest/normalizer.go
@@ -20,6 +20,7 @@ func NewNormalizer(defaultDomainName string) Normalizer {
 }
 
 func (n Normalizer) Normalize(appInfo payloads.ManifestApplication, appState AppState) payloads.ManifestApplication {
+	fixDeprecatedFields(&appInfo)
 	processes := n.normalizeProcesses(appInfo, appState)
 	routes := n.normalizeRoutes(appInfo, appState)
 
@@ -38,6 +39,20 @@ func procValIfSet[T any](appVal, procVal *T) *T {
 		return appVal
 	}
 	return procVal
+}
+
+func fixDeprecatedFields(appInfo *payloads.ManifestApplication) {
+	if appInfo.DiskQuota == nil {
+		//nolint:staticcheck
+		appInfo.DiskQuota = appInfo.AltDiskQuota
+	}
+
+	for i := range appInfo.Processes {
+		if appInfo.Processes[i].DiskQuota == nil {
+			//nolint:staticcheck
+			appInfo.Processes[i].DiskQuota = appInfo.Processes[i].AltDiskQuota
+		}
+	}
 }
 
 func (n Normalizer) normalizeProcesses(appInfo payloads.ManifestApplication, appState AppState) []payloads.ManifestApplicationProcess {

--- a/api/actions/manifest/normalizer_test.go
+++ b/api/actions/manifest/normalizer_test.go
@@ -7,6 +7,7 @@ import (
 	"code.cloudfoundry.org/korifi/tools"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gstruct"
 )
 
 type processParams struct {
@@ -257,6 +258,35 @@ var _ = Describe("Normalizer", func() {
 				It("does not add a random route", func() {
 					Expect(normalizedAppInfo.Routes).To(BeEmpty())
 				})
+			})
+		})
+	})
+
+	Describe("deprecated disk-quota handling", func() {
+		When("disk-quota is set on process", func() {
+			BeforeEach(func() {
+				appInfo.Processes = []payloads.ManifestApplicationProcess{
+					{
+						Type:         "bob",
+						AltDiskQuota: tools.PtrTo("123M"),
+					},
+				}
+			})
+
+			It("sets the value to disk_quota", func() {
+				Expect(normalizedAppInfo.Processes[0].DiskQuota).To(gstruct.PointTo(Equal("123M")))
+			})
+		})
+
+		When("disk-quota is set on app", func() {
+			BeforeEach(func() {
+				//nolint:staticcheck
+				appInfo.AltDiskQuota = tools.PtrTo("123M")
+			})
+
+			It("sets the value to disk_quota", func() {
+				webProc := getWebProcess(normalizedAppInfo)
+				Expect(webProc.DiskQuota).To(gstruct.PointTo(Equal("123M")))
 			})
 		})
 	})

--- a/api/handlers/space_manifest_handler_test.go
+++ b/api/handlers/space_manifest_handler_test.go
@@ -57,7 +57,7 @@ var _ = Describe("SpaceManifestHandler", func() {
                 - name: app1
                   default-route: true
                   memory: 128M
-                  disk-quota: 256M
+                  disk_quota: 256M
                   processes:
                   - type: web
                     command: start-web.sh
@@ -331,6 +331,40 @@ var _ = Describe("SpaceManifestHandler", func() {
 
 			It("response with an unprocessable entity error", func() {
 				expectUnprocessableEntityError("Key: 'Manifest.Applications[0].defaultRoute' Error:Field validation for 'defaultRoute' failed on the 'Random-route and Default-route may not be used together' tag")
+			})
+		})
+
+		When("app disk-quota and app disk_quota are both set", func() {
+			BeforeEach(func() {
+				requestBody = strings.NewReader(`---
+                version: 1
+                applications:
+                - name: app1
+                  disk-quota: 128M
+                  disk_quota: 128M
+                `)
+			})
+
+			It("response with an unprocessable entity error", func() {
+				expectUnprocessableEntityError("Cannot set both 'disk-quota' and 'disk_quota' in manifest")
+			})
+		})
+
+		When("process disk-quota and process disk_quota are both set", func() {
+			BeforeEach(func() {
+				requestBody = strings.NewReader(`---
+                version: 1
+                applications:
+                - name: app1
+                  processes:
+                  - type: foo
+                    disk-quota: 128M
+                    disk_quota: 128M
+                `)
+			})
+
+			It("response with an unprocessable entity error", func() {
+				expectUnprocessableEntityError("Cannot set both 'disk-quota' and 'disk_quota' in manifest")
 			})
 		})
 	})

--- a/api/handlers/space_manifest_handler_test.go
+++ b/api/handlers/space_manifest_handler_test.go
@@ -57,6 +57,7 @@ var _ = Describe("SpaceManifestHandler", func() {
                 - name: app1
                   default-route: true
                   memory: 128M
+                  disk-quota: 256M
                   processes:
                   - type: web
                     command: start-web.sh
@@ -90,6 +91,7 @@ var _ = Describe("SpaceManifestHandler", func() {
 				Expect(payload.Applications[0].Name).To(Equal("app1"))
 				Expect(payload.Applications[0].DefaultRoute).To(BeTrue())
 				Expect(payload.Applications[0].Memory).To(PointTo(Equal("128M")))
+				Expect(payload.Applications[0].DiskQuota).To(PointTo(Equal("256M")))
 
 				Expect(payload.Applications[0].Processes).To(HaveLen(1))
 				Expect(payload.Applications[0].Processes[0].Type).To(Equal("web"))

--- a/api/payloads/manifest.go
+++ b/api/payloads/manifest.go
@@ -14,22 +14,32 @@ type Manifest struct {
 }
 
 type ManifestApplication struct {
-	Name         string                       `yaml:"name" validate:"required"`
-	Env          map[string]string            `yaml:"env"`
-	DefaultRoute bool                         `yaml:"default-route"`
-	RandomRoute  bool                         `yaml:"random-route"`
-	NoRoute      bool                         `yaml:"no-route"`
-	Memory       *string                      `yaml:"memory" validate:"megabytestring"`
-	DiskQuota    *string                      `yaml:"disk-quota" validate:"megabytestring"`
+	Name         string            `yaml:"name" validate:"required"`
+	Env          map[string]string `yaml:"env"`
+	DefaultRoute bool              `yaml:"default-route"`
+	RandomRoute  bool              `yaml:"random-route"`
+	NoRoute      bool              `yaml:"no-route"`
+	Memory       *string           `yaml:"memory" validate:"megabytestring"`
+	DiskQuota    *string           `yaml:"disk_quota" validate:"megabytestring"`
+	// AltDiskQuota supports `disk-quota` with a hyphen for backwards compatibility.
+	// Do not set both DiskQuota and AltDiskQuota.
+	//
+	// Deprecated: Use DiskQuota instead
+	AltDiskQuota *string                      `yaml:"disk-quota" validate:"megabytestring"`
 	Processes    []ManifestApplicationProcess `yaml:"processes" validate:"dive"`
 	Routes       []ManifestRoute              `yaml:"routes" validate:"dive"`
 	Buildpacks   []string                     `yaml:"buildpacks"`
 }
 
 type ManifestApplicationProcess struct {
-	Type                         string  `yaml:"type" validate:"required"`
-	Command                      *string `yaml:"command"`
-	DiskQuota                    *string `yaml:"disk_quota" validate:"megabytestring"`
+	Type      string  `yaml:"type" validate:"required"`
+	Command   *string `yaml:"command"`
+	DiskQuota *string `yaml:"disk_quota" validate:"megabytestring"`
+	// AltDiskQuota supports `disk-quota` with a hyphen for backwards compatibility.
+	// Do not set both DiskQuota and AltDiskQuota.
+	//
+	// Deprecated: Use DiskQuota instead
+	AltDiskQuota                 *string `yaml:"disk-quota" validate:"megabytestring"`
 	HealthCheckHTTPEndpoint      *string `yaml:"health-check-http-endpoint"`
 	HealthCheckInvocationTimeout *int64  `yaml:"health-check-invocation-timeout"`
 	HealthCheckType              *string `yaml:"health-check-type" validate:"omitempty,oneof=none process port http"`

--- a/api/payloads/manifest.go
+++ b/api/payloads/manifest.go
@@ -20,6 +20,7 @@ type ManifestApplication struct {
 	RandomRoute  bool                         `yaml:"random-route"`
 	NoRoute      bool                         `yaml:"no-route"`
 	Memory       *string                      `yaml:"memory" validate:"megabytestring"`
+	DiskQuota    *string                      `yaml:"disk-quota" validate:"megabytestring"`
 	Processes    []ManifestApplicationProcess `yaml:"processes" validate:"dive"`
 	Routes       []ManifestRoute              `yaml:"routes" validate:"dive"`
 	Buildpacks   []string                     `yaml:"buildpacks"`


### PR DESCRIPTION

## Is there a related GitHub Issue?
#1584

## What is this change about?
Introducing a disk-quota field on the app level in manifest, that applies to the web process if present, unless overridden by the process itself.

Beware that the field is called `disk-quota` at the app level, but
`disk_quota` at the process level.
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No.
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
See story
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@kieron-dev
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->


