### PR TITLE
Update serviceaccount propagation for spaces

### DIFF
--- a/controllers/controllers/workloads/cfspace_controller.go
+++ b/controllers/controllers/workloads/cfspace_controller.go
@@ -187,8 +187,13 @@ func (r *CFSpaceReconciler) reconcileServiceAccounts(ctx context.Context, space 
 				newServiceAccount.Labels[korifiv1alpha1.PropagatedFromLabel] = r.rootNamespace
 				newServiceAccount.Annotations = serviceAccount.Annotations
 				newServiceAccount.ImagePullSecrets = serviceAccount.ImagePullSecrets
-				// some versions of k8s will add their own secret references which will not be available in the new namespace, so we will only reference the secret we explicitly propagate.
-				newServiceAccount.Secrets = []corev1.ObjectReference{{Name: r.packageRegistrySecretName}}
+				newServiceAccount.Secrets = []corev1.ObjectReference{}
+				// some versions of k8s will add their own secret references which will not be available in the new namespace, so we will only reference the package registry secret we explicitly propagate.
+				for i := range serviceAccount.Secrets {
+					if serviceAccount.Secrets[i].Name == r.packageRegistrySecretName {
+						newServiceAccount.Secrets = append(newServiceAccount.Secrets, serviceAccount.Secrets[i])
+					}
+				}
 
 				return nil
 			})


### PR DESCRIPTION
## Is there a related GitHub Issue?
#1666

## What is this change about?
Set the serviceaccount propagation for spaces to only add a reference to the package registry secret if it existed on the serviceaccount

## Does this PR introduce a breaking change?
No

## Acceptance Steps
See issue

## Tag your pair, your PM, and/or team
@Birdrock 
