### PR TITLE
Add test for scaling a process to 0

### DIFF
--- a/api/repositories/process_repository_test.go
+++ b/api/repositories/process_repository_test.go
@@ -303,6 +303,21 @@ var _ = Describe("ProcessRepo", func() {
 				Expect(updatedCFProcess.Spec.MemoryMB).To(Equal(memoryScaleMB))
 			})
 
+			When("scaling down a process to 0 instances", func() {
+				It("works", func() {
+					scaleProcessMessage.ProcessScaleValues = repositories.ProcessScaleValues{Instances: pointerTo(0)}
+					scaleProcessRecord, scaleProcessErr := processRepo.ScaleProcess(context.Background(), authInfo, *scaleProcessMessage)
+					Expect(scaleProcessErr).ToNot(HaveOccurred())
+
+					Expect(scaleProcessRecord.DesiredInstances).To(Equal(0))
+
+					var updatedCFProcess korifiv1alpha1.CFProcess
+					Expect(k8sClient.Get(ctx, client.ObjectKey{Name: process1GUID, Namespace: space1.Name}, &updatedCFProcess)).To(Succeed())
+
+					Expect(updatedCFProcess.Spec.DesiredInstances).To(PointTo(Equal(0)))
+				})
+			})
+
 			When("the process does not exist", func() {
 				It("returns an error", func() {
 					scaleProcessMessage.GUID = "i-dont-exist"


### PR DESCRIPTION
This behavior was broken before commit c8f84a, but now works as expected. This test will prevent any reversion

## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ --> This is related to #1672 , but it's not the exact same issue. The PR for that issue did resolve this problem, though.

## What is this change about?
<!-- _Please describe the change here._ --> This PR adds a test to ensure that the ProcessRepo is able to scale processes to 0 instances. Before #1673 this behavior was broken.

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ --> No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ --> Push an app, then use `cf scale -i 0` to scale it to 0. Confirm that the app was actually scaled down.

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ --> @danail-branekov 

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
