### PR TITLE
Support app-level `instances` in manifest

### DIFF
--- a/api/actions/manifest/normalizer.go
+++ b/api/actions/manifest/normalizer.go
@@ -66,7 +66,7 @@ func (n Normalizer) normalizeProcesses(appInfo payloads.ManifestApplication, app
 		}
 	}
 
-	if appInfo.Memory != nil || appInfo.DiskQuota != nil {
+	if appInfo.Memory != nil || appInfo.DiskQuota != nil || appInfo.Instances != nil {
 		if webProc == nil {
 			processes = append(processes, payloads.ManifestApplicationProcess{Type: korifiv1alpha1.ProcessTypeWeb})
 			webProc = &processes[len(processes)-1]
@@ -74,6 +74,7 @@ func (n Normalizer) normalizeProcesses(appInfo payloads.ManifestApplication, app
 
 		webProc.Memory = procValIfSet(appInfo.Memory, webProc.Memory)
 		webProc.DiskQuota = procValIfSet(appInfo.DiskQuota, webProc.DiskQuota)
+		webProc.Instances = procValIfSet(appInfo.Instances, webProc.Instances)
 	}
 
 	return processes

--- a/api/payloads/manifest.go
+++ b/api/payloads/manifest.go
@@ -19,6 +19,7 @@ type ManifestApplication struct {
 	DefaultRoute bool              `yaml:"default-route"`
 	RandomRoute  bool              `yaml:"random-route"`
 	NoRoute      bool              `yaml:"no-route"`
+	Instances    *int              `yaml:"instances" validate:"omitempty,gte=0"`
 	Memory       *string           `yaml:"memory" validate:"megabytestring"`
 	DiskQuota    *string           `yaml:"disk_quota" validate:"megabytestring"`
 	// AltDiskQuota supports `disk-quota` with a hyphen for backwards compatibility.


### PR DESCRIPTION
## Is there a related GitHub Issue?
#1582
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
App-level `instances` is used as default to the web process `instances`
if not set. If both are set, web process instances take priority
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
See story
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@kieron-dev
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

