### PR TITLE
Developer can push apps using the top-level command field in the manifest

### DIFF
--- a/api/actions/manifest/normalizer.go
+++ b/api/actions/manifest/normalizer.go
@@ -66,7 +66,7 @@ func (n Normalizer) normalizeProcesses(appInfo payloads.ManifestApplication, app
 		}
 	}
 
-	if appInfo.Memory != nil || appInfo.DiskQuota != nil || appInfo.Instances != nil {
+	if appInfo.Memory != nil || appInfo.DiskQuota != nil || appInfo.Instances != nil || appInfo.Command != nil {
 		if webProc == nil {
 			processes = append(processes, payloads.ManifestApplicationProcess{Type: korifiv1alpha1.ProcessTypeWeb})
 			webProc = &processes[len(processes)-1]
@@ -75,6 +75,7 @@ func (n Normalizer) normalizeProcesses(appInfo payloads.ManifestApplication, app
 		webProc.Memory = procValIfSet(appInfo.Memory, webProc.Memory)
 		webProc.DiskQuota = procValIfSet(appInfo.DiskQuota, webProc.DiskQuota)
 		webProc.Instances = procValIfSet(appInfo.Instances, webProc.Instances)
+		webProc.Command = procValIfSet(appInfo.Command, webProc.Command)
 	}
 
 	return processes

--- a/api/payloads/manifest.go
+++ b/api/payloads/manifest.go
@@ -19,6 +19,7 @@ type ManifestApplication struct {
 	DefaultRoute bool              `yaml:"default-route"`
 	RandomRoute  bool              `yaml:"random-route"`
 	NoRoute      bool              `yaml:"no-route"`
+	Command      *string           `yaml:"command"`
 	Instances    *int              `yaml:"instances" validate:"omitempty,gte=0"`
 	Memory       *string           `yaml:"memory" validate:"megabytestring"`
 	DiskQuota    *string           `yaml:"disk_quota" validate:"megabytestring"`


### PR DESCRIPTION
## Is there a related GitHub Issue?
#1583

## What is this change about?
If `command` is specified at the app level in a manifest, it will be used for the web process if the web process does not have a command set.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
See #1583

## Tag your pair, your PM, and/or team
@kieron-dev

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
