### PR TITLE
Create TLS certs in our scripts with cert-manager

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -50,47 +50,24 @@ EOF
   kubectl delete csr "${csr_name}"
 }
 
-function create_tls_secret() {
-  local secret_name=${1:?}
-  local secret_namespace=${2:?}
-  local tls_cn=${3:?}
+function create_tls_cert() {
+  local name=${1:?}
+  local component=${2:?}
+  local cn=${3:?}
 
-  tmp_dir=$(mktemp -d -t cf-tls-XXXXXX)
-  trap "rm -rf $tmp_dir" RETURN
-
-  opensslVersion="$(openssl version)"
-  if [[ $opensslVersion =~ ^OpenSSL ]]; then
-    openssl req -x509 -newkey rsa:4096 \
-      -keyout ${tmp_dir}/tls.key \
-      -out ${tmp_dir}/tls.crt \
-      -nodes \
-      -subj "/CN=${tls_cn}" \
-      -addext "subjectAltName = DNS:${tls_cn}" \
-      -days 365 2>/dev/null
-  elif [[ $opensslVersion =~ ^LibreSSL ]]; then
-    openssl req -x509 -newkey rsa:4096 \
-      -keyout ${tmp_dir}/tls.key \
-      -out ${tmp_dir}/tls.crt \
-      -nodes \
-      -subj "/CN=${tls_cn}" \
-      -extensions SAN -config <(cat /etc/ssl/openssl.cnf <(printf "[ SAN ]\nsubjectAltName='DNS:${tls_cn}'")) \
-      -days 365 2>/dev/null
-  else
-    echo "OpenSSL $(openssl version) not supported"
-    exit 1
-  fi
-
-  cat <<EOF >${tmp_dir}/kustomization.yml
-secretGenerator:
-- name: ${secret_name}
-  namespace: ${secret_namespace}
-  files:
-  - tls.crt=tls.crt
-  - tls.key=tls.key
-  type: "kubernetes.io/tls"
-generatorOptions:
-  disableNameSuffixHash: true
+  cat <<EOF | kubectl apply -f -
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: $name
+  namespace: $component-system
+spec:
+  commonName: $cn
+  dnsNames:
+  - $cn
+  issuerRef:
+    kind: Issuer
+    name: $component-selfsigned-issuer
+  secretName: $name
 EOF
-
-  kubectl apply -k $tmp_dir
 }

--- a/scripts/deploy-on-kind.sh
+++ b/scripts/deploy-on-kind.sh
@@ -241,7 +241,7 @@ function deploy_korifi_controllers() {
       make deploy-controllers
     fi
 
-    create_tls_secret "korifi-workloads-ingress-cert" "korifi-controllers-system" "*.vcap.me"
+    create_tls_cert "korifi-workloads-ingress-cert" "korifi-controllers" "\*.vcap.me"
   }
   popd >/dev/null
 
@@ -280,7 +280,7 @@ function deploy_korifi_api() {
       make deploy-api-kind
     fi
 
-    create_tls_secret "korifi-api-ingress-cert" "korifi-api-system" "localhost"
+    create_tls_cert "korifi-api-ingress-cert" "korifi-api" "api.vcap.me"
   }
   popd >/dev/null
 

--- a/scripts/samples/deploy-release.sh
+++ b/scripts/samples/deploy-release.sh
@@ -83,8 +83,8 @@ function install_dependencies() {
 
 function deploy_korifi() {
   kubectl apply -f "$release_dir" --recursive
-  create_tls_secret "korifi-workloads-ingress-cert" "korifi-controllers-system" "*.vcap.me"
-  create_tls_secret "korifi-api-ingress-cert" "korifi-api-system" "localhost"
+  create_tls_cert "korifi-workloads-ingress-cert" "korifi-controllers" "\*.vcap.me"
+  create_tls_cert "korifi-api-ingress-cert" "korifi-api" "api.vcap.me"
 
   kubectl rollout status deployment/korifi-controllers-controller-manager -w -n korifi-controllers-system
   kubectl rollout status deployment/korifi-api-deployment -w -n korifi-api-system


### PR DESCRIPTION
## Is there a related GitHub Issue?

No.

## What is this change about?

This uses `cert-manager` instead of the local `openssl` to create the TLS certs we need in our scripts.

## Does this PR introduce a breaking change?

Hopefully not 😬 