### PR TITLE
Support healthcheck manifest app-level properties

### DIFF
--- a/api/actions/manifest/normalizer.go
+++ b/api/actions/manifest/normalizer.go
@@ -66,7 +66,7 @@ func (n Normalizer) normalizeProcesses(appInfo payloads.ManifestApplication, app
 		}
 	}
 
-	if appInfo.Memory != nil || appInfo.DiskQuota != nil || appInfo.Instances != nil || appInfo.Command != nil {
+	if appInfo.Memory != nil || appInfo.DiskQuota != nil || appInfo.Instances != nil || appInfo.Command != nil || appInfo.HealthCheckHTTPEndpoint != nil {
 		if webProc == nil {
 			processes = append(processes, payloads.ManifestApplicationProcess{Type: korifiv1alpha1.ProcessTypeWeb})
 			webProc = &processes[len(processes)-1]
@@ -76,6 +76,7 @@ func (n Normalizer) normalizeProcesses(appInfo payloads.ManifestApplication, app
 		webProc.DiskQuota = procValIfSet(appInfo.DiskQuota, webProc.DiskQuota)
 		webProc.Instances = procValIfSet(appInfo.Instances, webProc.Instances)
 		webProc.Command = procValIfSet(appInfo.Command, webProc.Command)
+		webProc.HealthCheckHTTPEndpoint = procValIfSet(appInfo.HealthCheckHTTPEndpoint, webProc.HealthCheckHTTPEndpoint)
 	}
 
 	return processes

--- a/api/actions/manifest/normalizer.go
+++ b/api/actions/manifest/normalizer.go
@@ -66,7 +66,9 @@ func (n Normalizer) normalizeProcesses(appInfo payloads.ManifestApplication, app
 		}
 	}
 
-	if appInfo.Memory != nil || appInfo.DiskQuota != nil || appInfo.Instances != nil || appInfo.Command != nil || appInfo.HealthCheckHTTPEndpoint != nil {
+	if appInfo.Memory != nil || appInfo.DiskQuota != nil || appInfo.Instances != nil || appInfo.Command != nil ||
+		appInfo.HealthCheckHTTPEndpoint != nil || appInfo.HealthCheckType != nil || appInfo.HealthCheckInvocationTimeout != nil || appInfo.Timeout != nil {
+
 		if webProc == nil {
 			processes = append(processes, payloads.ManifestApplicationProcess{Type: korifiv1alpha1.ProcessTypeWeb})
 			webProc = &processes[len(processes)-1]
@@ -77,6 +79,9 @@ func (n Normalizer) normalizeProcesses(appInfo payloads.ManifestApplication, app
 		webProc.Instances = procValIfSet(appInfo.Instances, webProc.Instances)
 		webProc.Command = procValIfSet(appInfo.Command, webProc.Command)
 		webProc.HealthCheckHTTPEndpoint = procValIfSet(appInfo.HealthCheckHTTPEndpoint, webProc.HealthCheckHTTPEndpoint)
+		webProc.HealthCheckType = procValIfSet(appInfo.HealthCheckType, webProc.HealthCheckType)
+		webProc.HealthCheckInvocationTimeout = procValIfSet(appInfo.HealthCheckInvocationTimeout, webProc.HealthCheckInvocationTimeout)
+		webProc.Timeout = procValIfSet(appInfo.Timeout, webProc.Timeout)
 	}
 
 	return processes

--- a/api/actions/manifest/normalizer_test.go
+++ b/api/actions/manifest/normalizer_test.go
@@ -11,11 +11,14 @@ import (
 )
 
 type prcParams struct {
-	Command                 *string
-	Memory                  *string
-	DiskQuota               *string
-	Instances               *int
-	HealthCheckHTTPEndpoint *string
+	Command                      *string
+	Memory                       *string
+	DiskQuota                    *string
+	Instances                    *int
+	HealthCheckHTTPEndpoint      *string
+	HealthCheckInvocationTimeout *int64
+	HealthCheckType              *string
+	Timeout                      *int64
 }
 
 type (
@@ -89,6 +92,9 @@ var _ = Describe("Normalizer", func() {
 				appInfo.Instances = app.Instances
 				appInfo.Command = app.Command
 				appInfo.HealthCheckHTTPEndpoint = app.HealthCheckHTTPEndpoint
+				appInfo.HealthCheckType = app.HealthCheckType
+				appInfo.HealthCheckInvocationTimeout = app.HealthCheckInvocationTimeout
+				appInfo.Timeout = app.Timeout
 
 				updatedAppInfo := normalizer.Normalize(appInfo, appState)
 				webProc := getWebProcess(updatedAppInfo)
@@ -98,6 +104,9 @@ var _ = Describe("Normalizer", func() {
 				Expect(webProc.Instances).To(Equal(app.Instances))
 				Expect(webProc.Command).To(Equal(app.Command))
 				Expect(webProc.HealthCheckHTTPEndpoint).To(Equal(app.HealthCheckHTTPEndpoint))
+				Expect(webProc.HealthCheckType).To(Equal(app.HealthCheckType))
+				Expect(webProc.HealthCheckInvocationTimeout).To(Equal(app.HealthCheckInvocationTimeout))
+				Expect(webProc.Timeout).To(Equal(app.Timeout))
 			},
 
 			Entry("command only", appParams{Command: tools.PtrTo("echo boo")}),
@@ -105,6 +114,9 @@ var _ = Describe("Normalizer", func() {
 			Entry("disk_quota only", appParams{DiskQuota: tools.PtrTo("2G")}),
 			Entry("instances only", appParams{Instances: tools.PtrTo(3)}),
 			Entry("healthcheck endpoint only", appParams{HealthCheckHTTPEndpoint: tools.PtrTo("/health")}),
+			Entry("healthcheck type only", appParams{HealthCheckType: tools.PtrTo("typo")}),
+			Entry("healthcheck invocation timeout only", appParams{HealthCheckInvocationTimeout: tools.PtrTo(int64(64))}),
+			Entry("timeout only", appParams{Timeout: tools.PtrTo(int64(12))}),
 			Entry("memory and disk_quota", appParams{Memory: tools.PtrTo("512M"), DiskQuota: tools.PtrTo("2G")}),
 		)
 
@@ -115,14 +127,20 @@ var _ = Describe("Normalizer", func() {
 				appInfo.Instances = app.Instances
 				appInfo.Command = app.Command
 				appInfo.HealthCheckHTTPEndpoint = app.HealthCheckHTTPEndpoint
+				appInfo.HealthCheckType = app.HealthCheckType
+				appInfo.HealthCheckInvocationTimeout = app.HealthCheckInvocationTimeout
+				appInfo.Timeout = app.Timeout
 
 				appInfo.Processes = append(appInfo.Processes, payloads.ManifestApplicationProcess{
-					Type:                    "web",
-					Memory:                  process.Memory,
-					DiskQuota:               process.DiskQuota,
-					Instances:               process.Instances,
-					Command:                 process.Command,
-					HealthCheckHTTPEndpoint: process.HealthCheckHTTPEndpoint,
+					Type:                         "web",
+					Memory:                       process.Memory,
+					DiskQuota:                    process.DiskQuota,
+					Instances:                    process.Instances,
+					Command:                      process.Command,
+					HealthCheckHTTPEndpoint:      process.HealthCheckHTTPEndpoint,
+					HealthCheckType:              process.HealthCheckType,
+					HealthCheckInvocationTimeout: process.HealthCheckInvocationTimeout,
+					Timeout:                      process.Timeout,
 				})
 
 				updatedAppInfo := normalizer.Normalize(appInfo, appState)
@@ -133,6 +151,9 @@ var _ = Describe("Normalizer", func() {
 				Expect(webProc.Instances).To(Equal(effective.Instances))
 				Expect(webProc.Command).To(Equal(effective.Command))
 				Expect(webProc.HealthCheckHTTPEndpoint).To(Equal(effective.HealthCheckHTTPEndpoint))
+				Expect(webProc.HealthCheckType).To(Equal(effective.HealthCheckType))
+				Expect(webProc.HealthCheckInvocationTimeout).To(Equal(effective.HealthCheckInvocationTimeout))
+				Expect(webProc.Timeout).To(Equal(effective.Timeout))
 			},
 
 			Entry("empty proc with app memory",
@@ -151,10 +172,22 @@ var _ = Describe("Normalizer", func() {
 				appParams{Command: tools.PtrTo("echo foo")},
 				prcParams{},
 				expParams{Command: tools.PtrTo("echo foo")}),
-			Entry("empty proc with healhcheck endpoint",
+			Entry("empty proc with healthcheck endpoint",
 				appParams{HealthCheckHTTPEndpoint: tools.PtrTo("/health")},
 				prcParams{},
 				expParams{HealthCheckHTTPEndpoint: tools.PtrTo("/health")}),
+			Entry("empty proc with healthcheck type",
+				appParams{HealthCheckType: tools.PtrTo("type1")},
+				prcParams{},
+				expParams{HealthCheckType: tools.PtrTo("type1")}),
+			Entry("empty proc with healthcheck invocation timeout",
+				appParams{HealthCheckInvocationTimeout: tools.PtrTo(int64(45))},
+				prcParams{},
+				expParams{HealthCheckInvocationTimeout: tools.PtrTo(int64(45))}),
+			Entry("empty proc with timeout",
+				appParams{Timeout: tools.PtrTo(int64(32))},
+				prcParams{},
+				expParams{Timeout: tools.PtrTo(int64(32))}),
 			Entry("value from proc memory used",
 				appParams{Memory: tools.PtrTo("256M")},
 				prcParams{Memory: tools.PtrTo("512M")},
@@ -171,10 +204,22 @@ var _ = Describe("Normalizer", func() {
 				appParams{Command: tools.PtrTo("echo bar")},
 				prcParams{Command: tools.PtrTo("echo foo")},
 				expParams{Command: tools.PtrTo("echo foo")}),
-			Entry("value from proc healthcheck used",
+			Entry("value from proc healthcheck endpoint used",
 				appParams{HealthCheckHTTPEndpoint: tools.PtrTo("/apphealth")},
 				prcParams{HealthCheckHTTPEndpoint: tools.PtrTo("/prchealth")},
 				expParams{HealthCheckHTTPEndpoint: tools.PtrTo("/prchealth")}),
+			Entry("value from proc healthcheck type used",
+				appParams{HealthCheckType: tools.PtrTo("apptype")},
+				prcParams{HealthCheckType: tools.PtrTo("proctype")},
+				expParams{HealthCheckType: tools.PtrTo("proctype")}),
+			Entry("value from proc healthcheck invocation timeout used",
+				appParams{HealthCheckInvocationTimeout: tools.PtrTo(int64(345))},
+				prcParams{HealthCheckInvocationTimeout: tools.PtrTo(int64(34))},
+				expParams{HealthCheckInvocationTimeout: tools.PtrTo(int64(34))}),
+			Entry("value from proc timeout used",
+				appParams{Timeout: tools.PtrTo(int64(25))},
+				prcParams{Timeout: tools.PtrTo(int64(2))},
+				expParams{Timeout: tools.PtrTo(int64(2))}),
 			Entry("fields are individually defaulted from the app if not set on process",
 				appParams{
 					Memory:    tools.PtrTo("256M"),

--- a/api/payloads/manifest.go
+++ b/api/payloads/manifest.go
@@ -27,10 +27,11 @@ type ManifestApplication struct {
 	// Do not set both DiskQuota and AltDiskQuota.
 	//
 	// Deprecated: Use DiskQuota instead
-	AltDiskQuota *string                      `yaml:"disk-quota" validate:"megabytestring"`
-	Processes    []ManifestApplicationProcess `yaml:"processes" validate:"dive"`
-	Routes       []ManifestRoute              `yaml:"routes" validate:"dive"`
-	Buildpacks   []string                     `yaml:"buildpacks"`
+	AltDiskQuota            *string                      `yaml:"disk-quota" validate:"megabytestring"`
+	HealthCheckHTTPEndpoint *string                      `yaml:"health-check-http-endpoint"`
+	Processes               []ManifestApplicationProcess `yaml:"processes" validate:"dive"`
+	Routes                  []ManifestRoute              `yaml:"routes" validate:"dive"`
+	Buildpacks              []string                     `yaml:"buildpacks"`
 }
 
 type ManifestApplicationProcess struct {

--- a/api/payloads/manifest.go
+++ b/api/payloads/manifest.go
@@ -27,11 +27,14 @@ type ManifestApplication struct {
 	// Do not set both DiskQuota and AltDiskQuota.
 	//
 	// Deprecated: Use DiskQuota instead
-	AltDiskQuota            *string                      `yaml:"disk-quota" validate:"megabytestring"`
-	HealthCheckHTTPEndpoint *string                      `yaml:"health-check-http-endpoint"`
-	Processes               []ManifestApplicationProcess `yaml:"processes" validate:"dive"`
-	Routes                  []ManifestRoute              `yaml:"routes" validate:"dive"`
-	Buildpacks              []string                     `yaml:"buildpacks"`
+	AltDiskQuota                 *string                      `yaml:"disk-quota" validate:"megabytestring"`
+	HealthCheckHTTPEndpoint      *string                      `yaml:"health-check-http-endpoint"`
+	HealthCheckInvocationTimeout *int64                       `yaml:"health-check-invocation-timeout"`
+	HealthCheckType              *string                      `yaml:"health-check-type" validate:"omitempty,oneof=none process port http"`
+	Timeout                      *int64                       `yaml:"timeout"`
+	Processes                    []ManifestApplicationProcess `yaml:"processes" validate:"dive"`
+	Routes                       []ManifestRoute              `yaml:"routes" validate:"dive"`
+	Buildpacks                   []string                     `yaml:"buildpacks"`
 }
 
 type ManifestApplicationProcess struct {

--- a/api/payloads/manifest.go
+++ b/api/payloads/manifest.go
@@ -31,7 +31,7 @@ type ManifestApplication struct {
 	HealthCheckHTTPEndpoint      *string                      `yaml:"health-check-http-endpoint"`
 	HealthCheckInvocationTimeout *int64                       `yaml:"health-check-invocation-timeout"`
 	HealthCheckType              *string                      `yaml:"health-check-type" validate:"omitempty,oneof=none process port http"`
-	Timeout                      *int64                       `yaml:"timeout"`
+	Timeout                      *int64                       `yaml:"timeout" validate:"omitempty,gt=0"`
 	Processes                    []ManifestApplicationProcess `yaml:"processes" validate:"dive"`
 	Routes                       []ManifestRoute              `yaml:"routes" validate:"dive"`
 	Buildpacks                   []string                     `yaml:"buildpacks"`
@@ -51,7 +51,7 @@ type ManifestApplicationProcess struct {
 	HealthCheckType              *string `yaml:"health-check-type" validate:"omitempty,oneof=none process port http"`
 	Instances                    *int    `yaml:"instances" validate:"omitempty,gte=0"`
 	Memory                       *string `yaml:"memory" validate:"megabytestring"`
-	Timeout                      *int64  `yaml:"timeout"`
+	Timeout                      *int64  `yaml:"timeout" validate:"omitempty,gt=0"`
 }
 
 type ManifestRoute struct {

--- a/controllers/api/v1alpha1/cfprocess_webhook.go
+++ b/controllers/api/v1alpha1/cfprocess_webhook.go
@@ -31,12 +31,14 @@ var cfprocesslog = logf.Log.WithName("cfprocess-resource")
 type CFProcessDefaulter struct {
 	defaultMemoryMB    int64
 	defaultDiskQuotaMB int64
+	defaultTimeout     int64
 }
 
-func NewCFProcessDefaulter(defaultMemoryMB, defaultDiskQuotaMB int64) *CFProcessDefaulter {
+func NewCFProcessDefaulter(defaultMemoryMB, defaultDiskQuotaMB int64, defaultTimeout int64) *CFProcessDefaulter {
 	return &CFProcessDefaulter{
 		defaultMemoryMB:    defaultMemoryMB,
 		defaultDiskQuotaMB: defaultDiskQuotaMB,
+		defaultTimeout:     defaultTimeout,
 	}
 }
 
@@ -100,6 +102,10 @@ func (d *CFProcessDefaulter) defaultInstances(process *CFProcess) {
 }
 
 func (d *CFProcessDefaulter) defaultHealthCheck(process *CFProcess) {
+	if process.Spec.HealthCheck.Data.TimeoutSeconds == 0 {
+		process.Spec.HealthCheck.Data.TimeoutSeconds = d.defaultTimeout
+	}
+
 	if process.Spec.HealthCheck.Type != "" {
 		return
 	}

--- a/controllers/api/v1alpha1/integration/cfprocess_webhook_integration_test.go
+++ b/controllers/api/v1alpha1/integration/cfprocess_webhook_integration_test.go
@@ -85,10 +85,11 @@ var _ = Describe("CFProcessMutatingWebhook Integration Tests", func() {
 		})
 	})
 
-	Describe("memory and disk", func() {
-		It("sets the configured default memory and disk", func() {
+	Describe("memory, disk and timeout", func() {
+		It("sets the configured default memory, disk and timeout", func() {
 			Expect(createdCFProcess.Spec.MemoryMB).To(BeEquivalentTo(defaultMemoryMB))
 			Expect(createdCFProcess.Spec.DiskQuotaMB).To(BeEquivalentTo(defaultDiskQuotaMB))
+			Expect(createdCFProcess.Spec.HealthCheck.Data.TimeoutSeconds).To(BeEquivalentTo(defaultTimeout))
 		})
 
 		When("the process already has a memory value set", func() {
@@ -98,18 +99,32 @@ var _ = Describe("CFProcessMutatingWebhook Integration Tests", func() {
 
 			It("preserves it", func() {
 				Expect(createdCFProcess.Spec.MemoryMB).To(BeEquivalentTo(42))
+				Expect(createdCFProcess.Spec.HealthCheck.Data.TimeoutSeconds).To(BeEquivalentTo(defaultTimeout))
 				Expect(createdCFProcess.Spec.DiskQuotaMB).To(BeEquivalentTo(defaultDiskQuotaMB))
 			})
 		})
 
-		When("the process already has a memory value set", func() {
+		When("the process already has a disk value set", func() {
 			BeforeEach(func() {
 				cfProcess.Spec.DiskQuotaMB = 42
 			})
 
 			It("preserves it", func() {
 				Expect(createdCFProcess.Spec.MemoryMB).To(BeEquivalentTo(defaultMemoryMB))
+				Expect(createdCFProcess.Spec.HealthCheck.Data.TimeoutSeconds).To(BeEquivalentTo(defaultTimeout))
 				Expect(createdCFProcess.Spec.DiskQuotaMB).To(BeEquivalentTo(42))
+			})
+		})
+
+		When("the process already has a timeout value set", func() {
+			BeforeEach(func() {
+				cfProcess.Spec.HealthCheck.Data.TimeoutSeconds = 16
+			})
+
+			It("preserves it", func() {
+				Expect(createdCFProcess.Spec.MemoryMB).To(BeEquivalentTo(defaultMemoryMB))
+				Expect(createdCFProcess.Spec.DiskQuotaMB).To(BeEquivalentTo(defaultDiskQuotaMB))
+				Expect(createdCFProcess.Spec.HealthCheck.Data.TimeoutSeconds).To(BeEquivalentTo(16))
 			})
 		})
 	})

--- a/controllers/api/v1alpha1/integration/webhook_suite_integration_test.go
+++ b/controllers/api/v1alpha1/integration/webhook_suite_integration_test.go
@@ -48,6 +48,7 @@ import (
 const (
 	defaultMemoryMB    = 128
 	defaultDiskQuotaMB = 256
+	defaultTimeout     = 60
 )
 
 var (
@@ -121,7 +122,8 @@ var _ = BeforeSuite(func() {
 
 	Expect((&korifiv1alpha1.CFPackage{}).SetupWebhookWithManager(mgr)).To(Succeed())
 
-	Expect(korifiv1alpha1.NewCFProcessDefaulter(defaultMemoryMB, defaultDiskQuotaMB).SetupWebhookWithManager(mgr)).To(Succeed())
+	Expect(korifiv1alpha1.NewCFProcessDefaulter(defaultMemoryMB, defaultDiskQuotaMB, defaultTimeout).
+		SetupWebhookWithManager(mgr)).To(Succeed())
 
 	Expect((&korifiv1alpha1.CFBuild{}).SetupWebhookWithManager(mgr)).To(Succeed())
 

--- a/controllers/config/base/controllersconfig/korifi_controllers_config.yaml
+++ b/controllers/config/base/controllersconfig/korifi_controllers_config.yaml
@@ -3,6 +3,7 @@ runnerName: statefulset-runner
 cfProcessDefaults:
   memoryMB: 1024
   diskQuotaMB: 1024
+  timeout: 60
 cfRootNamespace: cf
 packageRegistrySecretName: image-registry-credentials # Create this secret in the rootNamespace
 # taskTTL should be series of numbers and units (d: days, h: hours, m: minutes, s: seconds)

--- a/controllers/config/config.go
+++ b/controllers/config/config.go
@@ -19,17 +19,25 @@ type ControllerConfig struct {
 }
 
 type CFProcessDefaults struct {
-	MemoryMB    int64 `yaml:"memoryMB"`
-	DiskQuotaMB int64 `yaml:"diskQuotaMB"`
+	MemoryMB    int64  `yaml:"memoryMB"`
+	DiskQuotaMB int64  `yaml:"diskQuotaMB"`
+	Timeout     *int64 `yaml:"timeout"`
 }
 
-const defaultTaskTTL = 30 * 24 * time.Hour
+const (
+	defaultTaskTTL       = 30 * 24 * time.Hour
+	defaultTimeout int64 = 60
+)
 
 func LoadFromPath(path string) (*ControllerConfig, error) {
 	var config ControllerConfig
 	err := tools.LoadConfigInto(&config, path)
 	if err != nil {
 		return nil, err
+	}
+
+	if config.CFProcessDefaults.Timeout == nil {
+		config.CFProcessDefaults.Timeout = tools.PtrTo(defaultTimeout)
 	}
 
 	return &config, nil

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -266,6 +266,7 @@ func main() {
 		if err = korifiv1alpha1.NewCFProcessDefaulter(
 			controllerConfig.CFProcessDefaults.MemoryMB,
 			controllerConfig.CFProcessDefaults.DiskQuotaMB,
+			*controllerConfig.CFProcessDefaults.Timeout,
 		).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "CFProcess")
 			os.Exit(1)


### PR DESCRIPTION

<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
#1589, #1590, #1593, #1598
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
- Support healthcheck manifest app-level properties
- Default processes `timeout` to 60 if not set
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
See stories
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@kieron-dev
