### PR TITLE
Update service account imagepullsecret propagation

### DIFF
--- a/controllers/controllers/workloads/cfspace_controller.go
+++ b/controllers/controllers/workloads/cfspace_controller.go
@@ -186,12 +186,17 @@ func (r *CFSpaceReconciler) reconcileServiceAccounts(ctx context.Context, space 
 				}
 				newServiceAccount.Labels[korifiv1alpha1.PropagatedFromLabel] = r.rootNamespace
 				newServiceAccount.Annotations = serviceAccount.Annotations
-				newServiceAccount.ImagePullSecrets = serviceAccount.ImagePullSecrets
+				newServiceAccount.ImagePullSecrets = []corev1.LocalObjectReference{}
 				newServiceAccount.Secrets = []corev1.ObjectReference{}
 				// some versions of k8s will add their own secret references which will not be available in the new namespace, so we will only reference the package registry secret we explicitly propagate.
 				for i := range serviceAccount.Secrets {
 					if serviceAccount.Secrets[i].Name == r.packageRegistrySecretName {
 						newServiceAccount.Secrets = append(newServiceAccount.Secrets, serviceAccount.Secrets[i])
+					}
+				}
+				for i := range serviceAccount.ImagePullSecrets {
+					if serviceAccount.ImagePullSecrets[i].Name == r.packageRegistrySecretName {
+						newServiceAccount.ImagePullSecrets = append(newServiceAccount.ImagePullSecrets, serviceAccount.ImagePullSecrets[i])
 					}
 				}
 

--- a/controllers/controllers/workloads/integration/cfspace_controller_integration_test.go
+++ b/controllers/controllers/workloads/integration/cfspace_controller_integration_test.go
@@ -151,7 +151,7 @@ var _ = Describe("CFSpaceReconciler Integration Tests", func() {
 			}).Should(Succeed())
 		})
 
-		It("removes service account tokens from the propagated secret", func() {
+		It("removes all secret references other than the package registry secret from the propagated service account", func() {
 			Eventually(func(g Gomega) {
 				var createdServiceAccounts corev1.ServiceAccountList
 				g.Expect(k8sClient.List(ctx, &createdServiceAccounts, client.InNamespace(cfSpace.Name))).To(Succeed())
@@ -160,7 +160,8 @@ var _ = Describe("CFSpaceReconciler Integration Tests", func() {
 						"ObjectMeta": MatchFields(IgnoreExtras, Fields{
 							"Name": Equal(serviceAccount.Name),
 						}),
-						"Secrets": ConsistOf(MatchFields(IgnoreExtras, Fields{"Name": Equal(packageRegistrySecretName)})),
+						"ImagePullSecrets": ConsistOf(MatchFields(IgnoreExtras, Fields{"Name": Equal(packageRegistrySecretName)})),
+						"Secrets":          ConsistOf(MatchFields(IgnoreExtras, Fields{"Name": Equal(packageRegistrySecretName)})),
 					}),
 				))
 			}).Should(Succeed())

--- a/controllers/controllers/workloads/integration/suite_integration_test.go
+++ b/controllers/controllers/workloads/integration/suite_integration_test.go
@@ -273,6 +273,10 @@ func createServiceAccount(ctx context.Context, k8sclient client.Client, serviceA
 			{Name: serviceAccountName + "-dockercfg-someguid"},
 			{Name: packageRegistrySecretName},
 		},
+		ImagePullSecrets: []corev1.LocalObjectReference{
+			{Name: serviceAccountName + "-dockercfg-someguid"},
+			{Name: packageRegistrySecretName},
+		},
 	}
 	Expect(k8sClient.Create(ctx, &serviceAccount)).To(Succeed())
 	return serviceAccount


### PR DESCRIPTION
## Is there a related GitHub Issue?
#1666 

## What is this change about?
k8s creates certain secrets like tokens and dockercfgs and links them to serviceaccounts that are not propagated when a new space is created. These secrets are unavailable and will cause anything using the propagated serviceaccounts to fail. There was a previous change to only reference the package registry secret from the secrets field for propagated serviceaccounts since that is explicitly propagated on create space. This is to also filter the imagepullsecrets field.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
See issue

## Tag your pair, your PM, and/or team
@Birdrock 
