### PR TITLE
Remove reconcilerName from AppWorkload CRD

### DIFF
--- a/controllers/config/crd/bases/korifi.cloudfoundry.org_appworkloads.yaml
+++ b/controllers/config/crd/bases/korifi.cloudfoundry.org_appworkloads.yaml
@@ -464,8 +464,6 @@ spec:
                     format: int32
                     type: integer
                 type: object
-              reconcilerName:
-                type: string
               resources:
                 description: ResourceRequirements describes the compute resource requirements.
                 properties:

--- a/controllers/config/samples/appworkload.yml
+++ b/controllers/config/samples/appworkload.yml
@@ -29,3 +29,4 @@ spec:
   diskMiB: 50
   cpuMillicores: 5
   processType: web
+  runnerName: statefulset-runner

--- a/controllers/config/samples/build_workload.yaml
+++ b/controllers/config/samples/build_workload.yaml
@@ -12,4 +12,4 @@ spec:
       image: gcr.io/cf-relint-greengrass/cf-crd-staging-spike/packages/665a78f8-ed97-47e6-85b2-60cbcc21d5e2
       imagePullSecrets:
         - name: image-registry-credentials
-  reconcilerName: kpack-image-builder
+  builderName: kpack-image-builder


### PR DESCRIPTION
Co-authored-by: Andrew Costa <ancosta@vmware.com>

<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
Related to #1621 and #1665.

## What is this change about?
The `reconcilerName` field was accidentally re-added to the `AppWorkload` CRD. This PR is the result of running `make manifests` to remove it again.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
See #1621 

## Tag your pair, your PM, and/or team
@acosta11 