### PR TITLE
Don't force rebuilding up-to-date package in Dockerfiles

### DIFF
--- a/statefulset-runner/Dockerfile
+++ b/statefulset-runner/Dockerfile
@@ -15,7 +15,7 @@ COPY statefulset-runner/main.go statefulset-runner/main.go
 COPY tools tools
 
 RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg/mod \
-     CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager statefulset-runner/main.go
+     CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o manager statefulset-runner/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
## Is there a related GitHub Issue?

No.

## What is this change about?

This removes the `-a` flag from the `go build` command in one of our `Dockerfile`s, so that packages that are already up-to-date in the cache don't get forcefully rebuilt. This should speed up builds.

## Does this PR introduce a breaking change?

No.
