### PR TITLE
Use `Patch` instead of `Update` in CFApp and CFServiceBinding controllers

### DIFF
--- a/controllers/controllers/services/cfservicebinding_controller.go
+++ b/controllers/controllers/services/cfservicebinding_controller.go
@@ -146,13 +146,13 @@ func (r *CFServiceBindingReconciler) ReconcileResource(ctx context.Context, cfSe
 		return r.handleGetError(ctx, err, cfServiceBinding, VCAPServicesSecretAvailableCondition, "SecretNotFound", "Secret")
 	}
 
-	updatedVcapServicesSecret := vcapServicesSecret.DeepCopy()
-	secretData := map[string][]byte{}
-	secretData["VCAP_SERVICES"] = []byte(vcapServicesData)
-	updatedVcapServicesSecret.Data = secretData
-	err = r.k8sClient.Patch(ctx, updatedVcapServicesSecret, client.MergeFrom(vcapServicesSecret))
+	err = k8s.Patch(ctx, r.k8sClient, vcapServicesSecret, func() {
+		secretData := map[string][]byte{}
+		secretData["VCAP_SERVICES"] = []byte(vcapServicesData)
+		vcapServicesSecret.Data = secretData
+	})
 	if err != nil {
-		r.log.Error(err, "failed to patch vcap services secret", "CFServiceBinding", cfServiceBinding)
+		r.log.Error(err, "failed to patch vcap services secret", "CFServiceBinding", cfServiceBinding, "secretName", vcapServicesSecret.Name)
 		return ctrl.Result{}, err
 	}
 

--- a/tools/k8s/k8s_suite_test.go
+++ b/tools/k8s/k8s_suite_test.go
@@ -1,13 +1,61 @@
 package k8s_test
 
 import (
+	"context"
 	"testing"
 
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
 )
 
 func TestK8s(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "K8s Suite")
+}
+
+var (
+	k8sClient     client.Client
+	testEnv       *envtest.Environment
+	testNamespace *corev1.Namespace
+)
+
+var _ = BeforeSuite(func() {
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{}
+
+	cfg, err := testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+})
+
+var _ = AfterSuite(func() {
+	Expect(testEnv.Stop()).To(Succeed())
+})
+
+var _ = BeforeEach(func() {
+	testNamespace = createNamespace(context.Background(), k8sClient, prefixedGUID("testns"))
+})
+
+func prefixedGUID(prefix string) string {
+	return prefix + "-" + uuid.NewString()[:8]
+}
+
+func createNamespace(ctx context.Context, k8sClient client.Client, name string) *corev1.Namespace {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+	Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+	return ns
 }

--- a/tools/k8s/patch.go
+++ b/tools/k8s/patch.go
@@ -1,0 +1,72 @@
+package k8s
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type ObjectWithDeepCopy[T any] interface {
+	*T
+
+	client.Object
+	DeepCopy() *T
+}
+
+// Patch updates k8s objects by subsequently calling k8s client `Patch()` and
+// `Status().Patch()` The `modify` lambda is expected to mutate the `obj` but
+// does not take the object as an argument as the object should be visible in
+// the parent scope
+// Example:
+//
+//	var pod *corev1.Pod
+//
+//	patchErr = k8s.Patch(ctx, fakeClient, pod, func() {
+//		pod.Spec.RestartPolicy = corev1.RestartPolicyOnFailure
+//		pod.Status.Message = "hello"
+//	})
+func Patch[T any, PT ObjectWithDeepCopy[T]](
+	ctx context.Context,
+	k8sClient client.Client,
+	obj PT,
+	modify func(),
+) error {
+	originalObj := PT(obj.DeepCopy())
+
+	// modify func takes no args, because it is a lambda that sees obj from the parent scope, e.g
+	// Patch(ctx, k8sClient
+	modify()
+
+	// Deep copy the original object after the modification is performed so
+	// that we capture status modifications We need to do that because the
+	// object patch below modifies the obj parameter to reflect the state in
+	// etcd, i.e. clears all modifications on the status
+	modifiedObj := PT(obj.DeepCopy())
+
+	objHasStatus, err := hasStatus(obj)
+	if err != nil {
+		return err
+	}
+
+	err = k8sClient.Patch(ctx, obj, client.MergeFrom(originalObj))
+	if err != nil {
+		return err
+	}
+
+	if objHasStatus {
+		return k8sClient.Status().Patch(ctx, modifiedObj, client.MergeFrom(originalObj))
+	}
+
+	return nil
+}
+
+func hasStatus(obj runtime.Object) (bool, error) {
+	unstructuredObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return false, err
+	}
+
+	_, hasStatusField := unstructuredObj["status"]
+	return hasStatusField, nil
+}

--- a/tools/k8s/patch_test.go
+++ b/tools/k8s/patch_test.go
@@ -1,0 +1,122 @@
+package k8s_test
+
+import (
+	"context"
+	"time"
+
+	"code.cloudfoundry.org/korifi/tools/k8s"
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Kubernetes Patch", func() {
+	var ctx context.Context
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
+	Describe("objects with Status", func() {
+		var (
+			pod        *corev1.Pod
+			patchedPod *corev1.Pod
+			patchErr   error
+		)
+		BeforeEach(func() {
+			pod = &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testNamespace.Name,
+					Name:      uuid.NewString(),
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:    "foo",
+						Image:   "busybox",
+						Command: []string{"echo", "hi"},
+					}},
+				},
+				Status: corev1.PodStatus{},
+			}
+			Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+		})
+
+		JustBeforeEach(func() {
+			patchErr = k8s.Patch(ctx, k8sClient, pod, func() {
+				pod.Spec.Containers[0].Image = "alpine"
+				pod.Status.Message = "hello"
+			})
+
+			patchedPod = &corev1.Pod{}
+			err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(pod), patchedPod)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("patches the object via the k8s client", func() {
+			Expect(patchErr).NotTo(HaveOccurred())
+			Expect(patchedPod.Spec.Containers[0].Image).To(Equal("alpine"))
+		})
+
+		When("patching the object fails", func() {
+			var cancel context.CancelFunc
+
+			BeforeEach(func() {
+				ctx, cancel = context.WithTimeout(ctx, -1*time.Second)
+			})
+
+			AfterEach(func() {
+				cancel()
+			})
+
+			It("returns the error", func() {
+				Expect(patchErr).To(MatchError(ContainSubstring("context deadline exceeded")))
+			})
+		})
+
+		It("patches the object status via the k8s client", func() {
+			Expect(patchErr).NotTo(HaveOccurred())
+			Expect(patchedPod.Status.Message).To(Equal("hello"))
+		})
+	})
+
+	Describe("objects without status", func() {
+		var (
+			secret        *corev1.Secret
+			patchedSecret *corev1.Secret
+		)
+
+		BeforeEach(func() {
+			secret = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testNamespace.Name,
+					Name:      uuid.NewString(),
+				},
+				Data: map[string][]byte{
+					"foo": []byte("bar"),
+				},
+			}
+			Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+		})
+
+		JustBeforeEach(func() {
+			Expect(k8s.Patch(ctx, k8sClient, secret, func() {
+				secret.Data["jim"] = []byte("bob")
+			})).To(Succeed())
+
+			patchedSecret = &corev1.Secret{}
+			err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(secret), patchedSecret)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("patches the object via the k8s client", func() {
+			Expect(patchedSecret.Data).To(Equal(map[string][]byte{
+				"foo": []byte("bar"),
+				"jim": []byte("bob"),
+			}))
+		})
+	})
+})


### PR DESCRIPTION
## Is there a related GitHub Issue?
#714
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
- Introduce generic k8s `Patch` utility
- Use the generic `Patch` in CFApp and CFServiceBinding controllers
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
N/A
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@georgethebeatle
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

