### PR TITLE
Pin `paketobuildpacks/build` to 1.3.92

### DIFF
--- a/tests/dependencies/kpack/cluster_stack.yaml
+++ b/tests/dependencies/kpack/cluster_stack.yaml
@@ -5,6 +5,6 @@ metadata:
 spec:
   id: "io.buildpacks.stacks.bionic"
   buildImage:
-    image: "paketobuildpacks/build:full-cnb"
+    image: "paketobuildpacks/build:1.3.92-full-cnb"
   runImage:
     image: "paketobuildpacks/run:full-cnb"


### PR DESCRIPTION

Co-authored-by: Danail Branekov <danailster@gmail.com>

<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
No

## What is this change about?
Latest (tag `full-cnb`) is causing build failures. Pinning the previous
version as a temporary workaround
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
pushing apps succeeds
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@georgethebeatle
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

