### PR TITLE
Create the correct healthcheck probes

### DIFF
--- a/api/handlers/space_manifest_handler_test.go
+++ b/api/handlers/space_manifest_handler_test.go
@@ -288,6 +288,82 @@ var _ = Describe("SpaceManifestHandler", func() {
 			})
 		})
 
+		When("a process's healthcheck timeout is not a positive integer", func() {
+			BeforeEach(func() {
+				requestBody = strings.NewReader(`---
+                applications:
+                - name: test-app
+                  processes:
+                  - type: web
+                    timeout: 0
+                `)
+			})
+
+			It("response with an unprocessable entity error", func() {
+				expectUnprocessableEntityError("Timeout must be 1 or greater")
+			})
+
+			It("doesn't call applyManifestAction", func() {
+				Expect(manifestApplier.ApplyCallCount()).To(Equal(0))
+			})
+		})
+
+		When("a process's healthcheck invocation timeout is not a positive integer", func() {
+			BeforeEach(func() {
+				requestBody = strings.NewReader(`---
+                applications:
+                - name: test-app
+                  processes:
+                  - type: web
+                    health-check-invocation-timeout: 0
+                `)
+			})
+
+			It("response with an unprocessable entity error", func() {
+				expectUnprocessableEntityError("HealthCheckInvocationTimeout must be 1 or greater")
+			})
+
+			It("doesn't call applyManifestAction", func() {
+				Expect(manifestApplier.ApplyCallCount()).To(Equal(0))
+			})
+		})
+
+		When("app healthcheck timeout is not a positive integer", func() {
+			BeforeEach(func() {
+				requestBody = strings.NewReader(`---
+                applications:
+                - name: test-app
+                  timeout: 0
+                `)
+			})
+
+			It("response with an unprocessable entity error", func() {
+				expectUnprocessableEntityError("Timeout must be 1 or greater")
+			})
+
+			It("doesn't call applyManifestAction", func() {
+				Expect(manifestApplier.ApplyCallCount()).To(Equal(0))
+			})
+		})
+
+		When("app healthcheck invocation timeout is not a positive integer", func() {
+			BeforeEach(func() {
+				requestBody = strings.NewReader(`---
+                applications:
+                - name: test-app
+                  health-check-invocation-timeout: 0
+                `)
+			})
+
+			It("response with an unprocessable entity error", func() {
+				expectUnprocessableEntityError("HealthCheckInvocationTimeout must be 1 or greater")
+			})
+
+			It("doesn't call applyManifestAction", func() {
+				Expect(manifestApplier.ApplyCallCount()).To(Equal(0))
+			})
+		})
+
 		When("applying the manifest errors", func() {
 			BeforeEach(func() {
 				requestBody = strings.NewReader(`---

--- a/api/payloads/manifest.go
+++ b/api/payloads/manifest.go
@@ -29,9 +29,9 @@ type ManifestApplication struct {
 	// Deprecated: Use DiskQuota instead
 	AltDiskQuota                 *string                      `yaml:"disk-quota" validate:"megabytestring"`
 	HealthCheckHTTPEndpoint      *string                      `yaml:"health-check-http-endpoint"`
-	HealthCheckInvocationTimeout *int64                       `yaml:"health-check-invocation-timeout"`
+	HealthCheckInvocationTimeout *int64                       `yaml:"health-check-invocation-timeout" validate:"omitempty,gte=1"`
 	HealthCheckType              *string                      `yaml:"health-check-type" validate:"omitempty,oneof=none process port http"`
-	Timeout                      *int64                       `yaml:"timeout" validate:"omitempty,gt=0"`
+	Timeout                      *int64                       `yaml:"timeout" validate:"omitempty,gte=1"`
 	Processes                    []ManifestApplicationProcess `yaml:"processes" validate:"dive"`
 	Routes                       []ManifestRoute              `yaml:"routes" validate:"dive"`
 	Buildpacks                   []string                     `yaml:"buildpacks"`
@@ -47,11 +47,11 @@ type ManifestApplicationProcess struct {
 	// Deprecated: Use DiskQuota instead
 	AltDiskQuota                 *string `yaml:"disk-quota" validate:"megabytestring"`
 	HealthCheckHTTPEndpoint      *string `yaml:"health-check-http-endpoint"`
-	HealthCheckInvocationTimeout *int64  `yaml:"health-check-invocation-timeout"`
+	HealthCheckInvocationTimeout *int64  `yaml:"health-check-invocation-timeout" validate:"omitempty,gte=1"`
 	HealthCheckType              *string `yaml:"health-check-type" validate:"omitempty,oneof=none process port http"`
 	Instances                    *int    `yaml:"instances" validate:"omitempty,gte=0"`
 	Memory                       *string `yaml:"memory" validate:"megabytestring"`
-	Timeout                      *int64  `yaml:"timeout" validate:"omitempty,gt=0"`
+	Timeout                      *int64  `yaml:"timeout" validate:"omitempty,gte=1"`
 }
 
 type ManifestRoute struct {

--- a/controllers/api/v1alpha1/appworkload_types.go
+++ b/controllers/api/v1alpha1/appworkload_types.go
@@ -43,6 +43,7 @@ type AppWorkloadSpec struct {
 
 	Command        []string        `json:"command,omitempty"`
 	Env            []corev1.EnvVar `json:"env,omitempty"`
+	StartupProbe   *corev1.Probe   `json:"startupProbe,omitempty"`
 	LivenessProbe  *corev1.Probe   `json:"livenessProbe,omitempty"`
 	ReadinessProbe *corev1.Probe   `json:"readinessProbe,omitempty"`
 	Ports          []int32         `json:"ports,omitempty"`

--- a/controllers/api/v1alpha1/zz_generated.deepcopy.go
+++ b/controllers/api/v1alpha1/zz_generated.deepcopy.go
@@ -106,6 +106,11 @@ func (in *AppWorkloadSpec) DeepCopyInto(out *AppWorkloadSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.StartupProbe != nil {
+		in, out := &in.StartupProbe, &out.StartupProbe
+		*out = new(v1.Probe)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.LivenessProbe != nil {
 		in, out := &in.LivenessProbe, &out.LivenessProbe
 		*out = new(v1.Probe)

--- a/controllers/config/crd/bases/korifi.cloudfoundry.org_appworkloads.yaml
+++ b/controllers/config/crd/bases/korifi.cloudfoundry.org_appworkloads.yaml
@@ -498,6 +498,150 @@ spec:
                 description: The name of the runner that should reconcile this AppWorkload
                   resource and execute running its instances
                 type: string
+              startupProbe:
+                description: Probe describes a health check to be performed against
+                  a container to determine whether it is alive or ready to receive
+                  traffic.
+                properties:
+                  exec:
+                    description: Exec specifies the action to take.
+                    properties:
+                      command:
+                        description: Command is the command line to execute inside
+                          the container, the working directory for the command  is
+                          root ('/') in the container's filesystem. The command is
+                          simply exec'd, it is not run inside a shell, so traditional
+                          shell instructions ('|', etc) won't work. To use a shell,
+                          you need to explicitly call out to that shell. Exit status
+                          of 0 is treated as live/healthy and non-zero is unhealthy.
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  failureThreshold:
+                    description: Minimum consecutive failures for the probe to be
+                      considered failed after having succeeded. Defaults to 3. Minimum
+                      value is 1.
+                    format: int32
+                    type: integer
+                  grpc:
+                    description: GRPC specifies an action involving a GRPC port. This
+                      is a beta field and requires enabling GRPCContainerProbe feature
+                      gate.
+                    properties:
+                      port:
+                        description: Port number of the gRPC service. Number must
+                          be in the range 1 to 65535.
+                        format: int32
+                        type: integer
+                      service:
+                        description: "Service is the name of the service to place
+                          in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                          \n If this is not specified, the default behavior is defined
+                          by gRPC."
+                        type: string
+                    required:
+                    - port
+                    type: object
+                  httpGet:
+                    description: HTTPGet specifies the http request to perform.
+                    properties:
+                      host:
+                        description: Host name to connect to, defaults to the pod
+                          IP. You probably want to set "Host" in httpHeaders instead.
+                        type: string
+                      httpHeaders:
+                        description: Custom headers to set in the request. HTTP allows
+                          repeated headers.
+                        items:
+                          description: HTTPHeader describes a custom header to be
+                            used in HTTP probes
+                          properties:
+                            name:
+                              description: The header field name
+                              type: string
+                            value:
+                              description: The header field value
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                      path:
+                        description: Path to access on the HTTP server.
+                        type: string
+                      port:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Name or number of the port to access on the container.
+                          Number must be in the range 1 to 65535. Name must be an
+                          IANA_SVC_NAME.
+                        x-kubernetes-int-or-string: true
+                      scheme:
+                        description: Scheme to use for connecting to the host. Defaults
+                          to HTTP.
+                        type: string
+                    required:
+                    - port
+                    type: object
+                  initialDelaySeconds:
+                    description: 'Number of seconds after the container has started
+                      before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                    format: int32
+                    type: integer
+                  periodSeconds:
+                    description: How often (in seconds) to perform the probe. Default
+                      to 10 seconds. Minimum value is 1.
+                    format: int32
+                    type: integer
+                  successThreshold:
+                    description: Minimum consecutive successes for the probe to be
+                      considered successful after having failed. Defaults to 1. Must
+                      be 1 for liveness and startup. Minimum value is 1.
+                    format: int32
+                    type: integer
+                  tcpSocket:
+                    description: TCPSocket specifies an action involving a TCP port.
+                    properties:
+                      host:
+                        description: 'Optional: Host name to connect to, defaults
+                          to the pod IP.'
+                        type: string
+                      port:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Number or name of the port to access on the container.
+                          Number must be in the range 1 to 65535. Name must be an
+                          IANA_SVC_NAME.
+                        x-kubernetes-int-or-string: true
+                    required:
+                    - port
+                    type: object
+                  terminationGracePeriodSeconds:
+                    description: Optional duration in seconds the pod needs to terminate
+                      gracefully upon probe failure. The grace period is the duration
+                      in seconds after the processes running in the pod are sent a
+                      termination signal and the time when the processes are forcibly
+                      halted with a kill signal. Set this value longer than the expected
+                      cleanup time for your process. If this value is nil, the pod's
+                      terminationGracePeriodSeconds will be used. Otherwise, this
+                      value overrides the value provided by the pod spec. Value must
+                      be non-negative integer. The value zero indicates stop immediately
+                      via the kill signal (no opportunity to shut down). This is a
+                      beta field and requires enabling ProbeTerminationGracePeriod
+                      feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                      is used if unset.
+                    format: int64
+                    type: integer
+                  timeoutSeconds:
+                    description: 'Number of seconds after which the probe times out.
+                      Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                    format: int32
+                    type: integer
+                type: object
               version:
                 type: string
             required:

--- a/controllers/controllers/workloads/integration/suite_integration_test.go
+++ b/controllers/controllers/workloads/integration/suite_integration_test.go
@@ -304,13 +304,3 @@ func patchAppWithDroplet(ctx context.Context, k8sClient client.Client, appGUID, 
 	Expect(k8sClient.Patch(ctx, patchedCFApp, client.MergeFrom(baseCFApp))).To(Succeed())
 	return baseCFApp
 }
-
-func valueForKey(m map[string]string, k string) string {
-	if m == nil {
-		return ""
-	}
-	if v, has := m[k]; has {
-		return v
-	}
-	return ""
-}

--- a/statefulset-runner/controllers/appworkload_controller.go
+++ b/statefulset-runner/controllers/appworkload_controller.go
@@ -261,9 +261,6 @@ func (r *AppWorkloadReconciler) Convert(appWorkload korifiv1alpha1.AppWorkload) 
 		ports = append(ports, corev1.ContainerPort{ContainerPort: port})
 	}
 
-	livenessProbe := appWorkload.Spec.LivenessProbe
-	readinessProbe := appWorkload.Spec.ReadinessProbe
-
 	containers := []corev1.Container{
 		{
 			Name:            ApplicationContainerName,
@@ -281,9 +278,9 @@ func (r *AppWorkloadReconciler) Convert(appWorkload korifiv1alpha1.AppWorkload) 
 					Type: corev1.SeccompProfileTypeRuntimeDefault,
 				},
 			},
-			Resources:      appWorkload.Spec.Resources,
-			LivenessProbe:  livenessProbe,
-			ReadinessProbe: readinessProbe,
+			Resources:     appWorkload.Spec.Resources,
+			StartupProbe:  appWorkload.Spec.StartupProbe,
+			LivenessProbe: appWorkload.Spec.LivenessProbe,
 		},
 	}
 

--- a/statefulset-runner/controllers/appworkload_controller_test.go
+++ b/statefulset-runner/controllers/appworkload_controller_test.go
@@ -101,20 +101,12 @@ var _ = Describe("AppWorkload to StatefulSet Converter", func() {
 		Expect(*statefulSet.Spec.Template.Spec.Containers[0].SecurityContext.SeccompProfile).To(Equal(corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault}))
 	})
 
-	It("should set the liveness probe", func() {
-		probe := statefulSet.Spec.Template.Spec.Containers[0].LivenessProbe
-		Expect(probe).NotTo(BeNil())
-		Expect(probe.ProbeHandler.HTTPGet).NotTo(BeNil())
-		Expect(probe.ProbeHandler.HTTPGet.Path).To(Equal("/healthz"))
-		Expect(probe.ProbeHandler.HTTPGet.Port.IntValue()).To(Equal(8080))
+	It("should set the startup probe", func() {
+		Expect(statefulSet.Spec.Template.Spec.Containers[0].StartupProbe).To(Equal(appWorkload.Spec.StartupProbe))
 	})
 
-	It("should set the readiness probe", func() {
-		probe := statefulSet.Spec.Template.Spec.Containers[0].ReadinessProbe
-		Expect(probe).NotTo(BeNil())
-		Expect(probe.ProbeHandler.HTTPGet).NotTo(BeNil())
-		Expect(probe.ProbeHandler.HTTPGet.Path).To(Equal("/healthz"))
-		Expect(probe.ProbeHandler.HTTPGet.Port.IntValue()).To(Equal(8080))
+	It("should set the liveness probe", func() {
+		Expect(statefulSet.Spec.Template.Spec.Containers[0].LivenessProbe).To(Equal(appWorkload.Spec.LivenessProbe))
 	})
 
 	It("should not automount service account token", func() {

--- a/statefulset-runner/controllers/integration/appworkload_controller_test.go
+++ b/statefulset-runner/controllers/integration/appworkload_controller_test.go
@@ -46,7 +46,7 @@ var _ = Describe("AppWorkloadsController", func() {
 				ImagePullSecrets: []corev1.LocalObjectReference{{Name: "something"}},
 				Env:              []corev1.EnvVar{},
 				LivenessProbe:    &corev1.Probe{},
-				ReadinessProbe:   &corev1.Probe{},
+				StartupProbe:     &corev1.Probe{},
 				Ports:            []int32{8080},
 				Instances:        5,
 				RunnerName:       "statefulset-runner",

--- a/statefulset-runner/controllers/suite_test.go
+++ b/statefulset-runner/controllers/suite_test.go
@@ -38,6 +38,16 @@ func createAppWorkload(namespace, name string) *korifiv1alpha1.AppWorkload {
 			},
 			ProcessType: "worker",
 			Env:         []corev1.EnvVar{},
+			StartupProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/healthz",
+						Port: intstr.IntOrString{Type: intstr.Int, IntVal: int32(8080)},
+					},
+				},
+				FailureThreshold: 30,
+				PeriodSeconds:    2,
+			},
 			LivenessProbe: &corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
@@ -45,18 +55,8 @@ func createAppWorkload(namespace, name string) *korifiv1alpha1.AppWorkload {
 						Port: intstr.IntOrString{Type: intstr.Int, IntVal: int32(8080)},
 					},
 				},
-				InitialDelaySeconds: 0,
-				FailureThreshold:    4,
-			},
-			ReadinessProbe: &corev1.Probe{
-				ProbeHandler: corev1.ProbeHandler{
-					HTTPGet: &corev1.HTTPGetAction{
-						Path: "/healthz",
-						Port: intstr.IntOrString{Type: intstr.Int, IntVal: int32(8080)},
-					},
-				},
-				InitialDelaySeconds: 0,
-				FailureThreshold:    1,
+				PeriodSeconds:    30,
+				FailureThreshold: 1,
 			},
 			Ports:      []int32{8888, 9999},
 			Instances:  1,


### PR DESCRIPTION
## Is there a related GitHub Issue?

#1701

## What is this change about?

CF allows `timeout` seconds for an app to start, with a probe each 2 seconds. Once started, CF probes the app each 30 seconds, killing the container if a probe fails. The `health-check-invocation-timeout` determines how long to wait for a response for these probes.

To reproduce this functionality in korifi we need to create:

1. A startup probe with:

-   periodSeconds: 2
-   timeoutSeconds: `health-check-invocation-timeout`
-   failureThreshold: (`timeout` / 2) rounded to the next integer.

2. A liveness probe with:

-   periodSeconds: 30
-   timeoutSeconds: `health-check-invocation-timeout`
-   failureThreshold: 1

The readiness probe is not required as this does not correspond to CF functionality. It would stop k8s routing traffic to an app failing the readiness probe, but would not terminate it. This might be a nice-to-have in the future.

## Does this PR introduce a breaking change?

No

## Acceptance Steps

See #1701

## Tag your pair, your PM, and/or team

@georgethebeatle
