### PR TITLE
Use `PatchingReconciler` in "core" controllers

### DIFF
--- a/controllers/controllers/networking/suite_test.go
+++ b/controllers/controllers/networking/suite_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
+	"code.cloudfoundry.org/korifi/controllers/fake"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -18,6 +19,17 @@ func TestNetworkingControllers(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Networking Controllers Unit Test Suite")
 }
+
+var (
+	fakeClient       *fake.Client
+	fakeStatusWriter *fake.StatusWriter
+)
+
+var _ = BeforeEach(func() {
+	fakeClient = new(fake.Client)
+	fakeStatusWriter = &fake.StatusWriter{}
+	fakeClient.StatusReturns(fakeStatusWriter)
+})
 
 func expectCFRouteValidStatus(cfRouteStatus korifiv1alpha1.CFRouteStatus, valid bool, desc ...string) {
 	validCondition := meta.FindStatusCondition(cfRouteStatus.Conditions, "Valid")

--- a/controllers/controllers/services/cfservicebinding_controller_test.go
+++ b/controllers/controllers/services/cfservicebinding_controller_test.go
@@ -15,7 +15,6 @@ import (
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	. "code.cloudfoundry.org/korifi/controllers/controllers/services"
 	servicesfake "code.cloudfoundry.org/korifi/controllers/controllers/services/fake"
-	"code.cloudfoundry.org/korifi/controllers/fake"
 	"code.cloudfoundry.org/korifi/tools/k8s"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -31,9 +30,7 @@ import (
 
 var _ = Describe("CFServiceBinding.Reconcile", func() {
 	var (
-		fakeClient       *fake.Client
-		fakeStatusWriter *fake.StatusWriter
-		fakeBuilder      *servicesfake.VCAPServicesSecretBuilder
+		fakeBuilder *servicesfake.VCAPServicesSecretBuilder
 
 		cfServiceBinding        *korifiv1alpha1.CFServiceBinding
 		cfServiceInstance       *korifiv1alpha1.CFServiceInstance
@@ -83,10 +80,7 @@ var _ = Describe("CFServiceBinding.Reconcile", func() {
 		secretType = "secretType"
 		secretProvider = "secretProvider"
 
-		fakeClient = new(fake.Client)
 		fakeBuilder = new(servicesfake.VCAPServicesSecretBuilder)
-		fakeStatusWriter = new(fake.StatusWriter)
-		fakeClient.StatusReturns(fakeStatusWriter)
 
 		cfServiceBinding = new(korifiv1alpha1.CFServiceBinding)
 		cfServiceInstance = new(korifiv1alpha1.CFServiceInstance)

--- a/controllers/controllers/services/cfserviceinstance_controller_test.go
+++ b/controllers/controllers/services/cfserviceinstance_controller_test.go
@@ -13,7 +13,7 @@ import (
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	. "code.cloudfoundry.org/korifi/controllers/controllers/services"
-	"code.cloudfoundry.org/korifi/controllers/fake"
+	"code.cloudfoundry.org/korifi/tools/k8s"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -27,9 +27,6 @@ import (
 
 var _ = Describe("CFServiceInstance.Reconcile", func() {
 	var (
-		fakeClient       *fake.Client
-		fakeStatusWriter *fake.StatusWriter
-
 		cfServiceInstance       *korifiv1alpha1.CFServiceInstance
 		cfServiceInstanceSecret *corev1.Secret
 
@@ -37,7 +34,7 @@ var _ = Describe("CFServiceInstance.Reconcile", func() {
 		getCFServiceInstanceSecretError   error
 		patchCFServiceInstanceStatusError error
 
-		cfServiceInstanceReconciler *CFServiceInstanceReconciler
+		cfServiceInstanceReconciler *k8s.PatchingReconciler[korifiv1alpha1.CFServiceInstance, *korifiv1alpha1.CFServiceInstance]
 		ctx                         context.Context
 		req                         ctrl.Request
 
@@ -49,10 +46,6 @@ var _ = Describe("CFServiceInstance.Reconcile", func() {
 		getCFServiceInstanceError = nil
 		getCFServiceInstanceSecretError = nil
 		patchCFServiceInstanceStatusError = nil
-
-		fakeClient = new(fake.Client)
-		fakeStatusWriter = new(fake.StatusWriter)
-		fakeClient.StatusReturns(fakeStatusWriter)
 
 		cfServiceInstance = new(korifiv1alpha1.CFServiceInstance)
 		cfServiceInstanceSecret = new(corev1.Secret)

--- a/controllers/controllers/services/suite_test.go
+++ b/controllers/controllers/services/suite_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"code.cloudfoundry.org/korifi/controllers/fake"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -15,3 +16,14 @@ func TestServicesControllers(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Services Controllers Unit Test Suite")
 }
+
+var (
+	fakeClient       *fake.Client
+	fakeStatusWriter *fake.StatusWriter
+)
+
+var _ = BeforeEach(func() {
+	fakeClient = new(fake.Client)
+	fakeStatusWriter = &fake.StatusWriter{}
+	fakeClient.StatusReturns(fakeStatusWriter)
+})

--- a/controllers/controllers/workloads/cfapp_controller_test.go
+++ b/controllers/controllers/workloads/cfapp_controller_test.go
@@ -8,7 +8,6 @@ import (
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	. "code.cloudfoundry.org/korifi/controllers/controllers/workloads"
 	. "code.cloudfoundry.org/korifi/controllers/controllers/workloads/testutils"
-	"code.cloudfoundry.org/korifi/controllers/fake"
 	"code.cloudfoundry.org/korifi/tools/k8s"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -34,9 +33,6 @@ const (
 
 var _ = Describe("CFAppReconciler", func() {
 	var (
-		fakeClient       *fake.Client
-		fakeStatusWriter *fake.StatusWriter
-
 		cfAppGUID     string
 		cfBuildGUID   string
 		cfPackageGUID string
@@ -65,8 +61,6 @@ var _ = Describe("CFAppReconciler", func() {
 	)
 
 	BeforeEach(func() {
-		fakeClient = new(fake.Client)
-
 		cfAppGUID = "cf-app-guid"
 		cfPackageGUID = "cf-package-guid"
 		cfBuildGUID = "cf-build-guid"
@@ -100,9 +94,6 @@ var _ = Describe("CFAppReconciler", func() {
 				panic("TestClient Get provided a weird obj")
 			}
 		}
-
-		fakeStatusWriter = &fake.StatusWriter{}
-		fakeClient.StatusReturns(fakeStatusWriter)
 
 		cfProcessList := korifiv1alpha1.CFProcessList{}
 		cfProcessListErr = nil

--- a/controllers/controllers/workloads/cfbuild_controller_test.go
+++ b/controllers/controllers/workloads/cfbuild_controller_test.go
@@ -9,7 +9,6 @@ import (
 	. "code.cloudfoundry.org/korifi/controllers/controllers/workloads"
 	workloadsfakes "code.cloudfoundry.org/korifi/controllers/controllers/workloads/fake"
 	. "code.cloudfoundry.org/korifi/controllers/controllers/workloads/testutils"
-	"code.cloudfoundry.org/korifi/controllers/fake"
 	"code.cloudfoundry.org/korifi/tools/k8s"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -34,9 +33,6 @@ var _ = Describe("CFBuildReconciler", func() {
 	)
 
 	var (
-		fakeClient       *fake.Client
-		fakeStatusWriter *fake.StatusWriter
-
 		fakeEnvBuilder *workloadsfakes.EnvBuilder
 
 		cfAppGUID         string
@@ -63,8 +59,6 @@ var _ = Describe("CFBuildReconciler", func() {
 	)
 
 	BeforeEach(func() {
-		fakeClient = new(fake.Client)
-
 		cfAppGUID = "cf-app-guid"
 		cfPackageGUID = "cf-package-guid"
 		cfBuildGUID = "cf-build-guid"
@@ -99,9 +93,6 @@ var _ = Describe("CFBuildReconciler", func() {
 				panic("test Client Get provided a weird obj")
 			}
 		}
-
-		fakeStatusWriter = new(fake.StatusWriter)
-		fakeClient.StatusReturns(fakeStatusWriter)
 
 		fakeEnvBuilder = new(workloadsfakes.EnvBuilder)
 		fakeEnvBuilder.BuildEnvReturns(buildEnv, nil)

--- a/controllers/controllers/workloads/cfpackage_controller_test.go
+++ b/controllers/controllers/workloads/cfpackage_controller_test.go
@@ -10,7 +10,7 @@ import (
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	. "code.cloudfoundry.org/korifi/controllers/controllers/workloads"
 	. "code.cloudfoundry.org/korifi/controllers/controllers/workloads/testutils"
-	"code.cloudfoundry.org/korifi/controllers/fake"
+	"code.cloudfoundry.org/korifi/tools/k8s"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -23,8 +23,6 @@ import (
 
 var _ = Describe("CFPackageReconciler", func() {
 	var (
-		fakeClient *fake.Client
-
 		cfAppGUID     string
 		cfPackageGUID string
 
@@ -34,7 +32,7 @@ var _ = Describe("CFPackageReconciler", func() {
 		cfPackageError       error
 		cfPackageUpdateError error
 
-		cfPackageReconciler *CFPackageReconciler
+		cfPackageReconciler *k8s.PatchingReconciler[korifiv1alpha1.CFPackage, *korifiv1alpha1.CFPackage]
 		req                 ctrl.Request
 		ctx                 context.Context
 
@@ -43,8 +41,6 @@ var _ = Describe("CFPackageReconciler", func() {
 	)
 
 	BeforeEach(func() {
-		fakeClient = new(fake.Client)
-
 		cfAppGUID = "cf-app-guid"
 		cfPackageGUID = "cf-package-guid"
 

--- a/controllers/controllers/workloads/cfprocess_controller_test.go
+++ b/controllers/controllers/workloads/cfprocess_controller_test.go
@@ -11,7 +11,7 @@ import (
 	. "code.cloudfoundry.org/korifi/controllers/controllers/workloads"
 	workloadsfakes "code.cloudfoundry.org/korifi/controllers/controllers/workloads/fake"
 	. "code.cloudfoundry.org/korifi/controllers/controllers/workloads/testutils"
-	"code.cloudfoundry.org/korifi/controllers/fake"
+	"code.cloudfoundry.org/korifi/tools/k8s"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -39,7 +39,6 @@ const (
 
 var _ = Describe("CFProcessReconciler Unit Tests", func() {
 	var (
-		fakeClient *fake.Client
 		envBuilder *workloadsfakes.EnvBuilder
 
 		cfBuild     *korifiv1alpha1.CFBuild
@@ -55,7 +54,7 @@ var _ = Describe("CFProcessReconciler Unit Tests", func() {
 		appWorkloadListError error
 		routeListError       error
 
-		cfProcessReconciler *CFProcessReconciler
+		cfProcessReconciler *k8s.PatchingReconciler[korifiv1alpha1.CFProcess, *korifiv1alpha1.CFProcess]
 		ctx                 context.Context
 		req                 ctrl.Request
 
@@ -63,8 +62,6 @@ var _ = Describe("CFProcessReconciler Unit Tests", func() {
 	)
 
 	BeforeEach(func() {
-		fakeClient = new(fake.Client)
-
 		envBuilder = new(workloadsfakes.EnvBuilder)
 
 		cfApp = BuildCFAppCRObject(testAppGUID, testNamespace)

--- a/controllers/controllers/workloads/suite_test.go
+++ b/controllers/controllers/workloads/suite_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"code.cloudfoundry.org/korifi/controllers/fake"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -15,3 +16,14 @@ func TestWorkloadsControllers(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Workloads Controllers Unit Test Suite")
 }
+
+var (
+	fakeClient       *fake.Client
+	fakeStatusWriter *fake.StatusWriter
+)
+
+var _ = BeforeEach(func() {
+	fakeClient = new(fake.Client)
+	fakeStatusWriter = &fake.StatusWriter{}
+	fakeClient.StatusReturns(fakeStatusWriter)
+})


### PR DESCRIPTION
NOTE: DO NOT merge prior releasing 0.3

## Is there a related GitHub Issue?
#714

## What is this change about?
Use `PatchingReconciler` in all "core" controllers so that those controllers do
not need to patch the object being reconciled anymore. If they need to patch a
dependent object (e.g. a referenced secret), they use the `k8s.Patch` utility
that implements the standard patching k8s idiom.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Not functional change, green tests

