### PR TITLE
Fix typo in install.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -270,7 +270,7 @@ spec:
   - \*.apps.$BASE_DOMAIN
   issuerRef:
     kind: Issuer
-    name: korifi-workloads-selfsigned-issuer
+    name: korifi-controllers-selfsigned-issuer
   secretName: korifi-workloads-ingress-cert
 EOF
 ```


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
The cert manager issuer in the controllers namespace is actually called `korifi-controllers-selfsigned-issuer`.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Follow the install.md instructions, including using cert manager to generate ingress certs, and it should work.

## Tag your pair, your PM, and/or team

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
