### PR TITLE
Print additional debug info on `Droplet not found` e2e failures

### DIFF
--- a/tests/e2e/helpers/fail_handler.go
+++ b/tests/e2e/helpers/fail_handler.go
@@ -70,6 +70,24 @@ func E2EFailHandler(correlationId func() string) func(string, ...int) {
 				LabelValue: "controller-manager",
 				Container:  "manager",
 			},
+			{
+				Namespace:  "korifi-job-task-runner-system",
+				LabelKey:   "control-plane",
+				LabelValue: "controller-manager",
+				Container:  "manager",
+			},
+			{
+				Namespace:  "korifi-kpack-build-system",
+				LabelKey:   "control-plane",
+				LabelValue: "controller-manager",
+				Container:  "manager",
+			},
+			{
+				Namespace:  "korifi-statefulset-runner-system",
+				LabelKey:   "control-plane",
+				LabelValue: "controller-manager",
+				Container:  "manager",
+			},
 		})
 
 		if strings.Contains(message, "Droplet not found") {

--- a/tests/e2e/helpers/fail_handler.go
+++ b/tests/e2e/helpers/fail_handler.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 
 	"code.cloudfoundry.org/korifi/tools"
@@ -70,6 +71,10 @@ func E2EFailHandler(correlationId func() string) func(string, ...int) {
 				Container:  "manager",
 			},
 		})
+
+		if strings.Contains(message, "Droplet not found") {
+			printDropletNotFoundDebugInfo(clientset, message)
+		}
 	}
 }
 
@@ -82,39 +87,69 @@ func printPodsLogs(clientset kubernetes.Interface, podContainerDescriptors []pod
 		pods, err := getPods(clientset, desc.Namespace, desc.LabelKey, desc.LabelValue)
 		if err != nil {
 			fmt.Fprintf(ginkgo.GinkgoWriter, "Failed to get pods with label %s=%s: %v\n", desc.LabelKey, desc.LabelValue, err)
+			continue
+		}
+
+		if len(pods) == 0 {
+			fmt.Fprintf(ginkgo.GinkgoWriter, "No pods with label %s=%s found\n", desc.LabelKey, desc.LabelValue)
+			continue
 		}
 
 		for _, pod := range pods {
-			log, err := getSinglePodLog(clientset, pod, desc.Container, desc.CorrelationId)
-			if err != nil {
-				fmt.Fprintf(ginkgo.GinkgoWriter, "Failed to get logs for pod %s: %v\n", pod.Name, err)
-
-				continue
+			for _, container := range selectContainers(pod, desc.Container) {
+				printPodContainerLogs(clientset, pod, container, desc.CorrelationId)
 			}
-			if log == "" {
-				log = "No relevant logs found"
-			}
-
-			logHeader := fmt.Sprintf(
-				"Logs for pod %q (last %d lines)",
-				pod.Name,
-				logTailLines,
-			)
-			if !fullLogOnErr() && desc.CorrelationId != "" {
-				logHeader = fmt.Sprintf(
-					"Logs for pod %q with correlation ID %q (last %d lines)",
-					pod.Name,
-					desc.CorrelationId,
-					logTailLines,
-				)
-			}
-
-			fmt.Fprintf(ginkgo.GinkgoWriter,
-				"\n\n===== %s =====\n%s\n==============================================\n\n",
-				logHeader,
-				log)
 		}
 	}
+}
+
+func selectContainers(pod corev1.Pod, container string) []string {
+	if container != "" {
+		return []string{container}
+	}
+
+	result := []string{}
+	for _, initC := range pod.Spec.InitContainers {
+		result = append(result, initC.Name)
+	}
+	for _, c := range pod.Spec.Containers {
+		result = append(result, c.Name)
+	}
+
+	return result
+}
+
+func printPodContainerLogs(clientset kubernetes.Interface, pod corev1.Pod, container, correlationId string) {
+	log, err := getPodContainerLog(clientset, pod, container, correlationId)
+	if err != nil {
+		fmt.Fprintf(ginkgo.GinkgoWriter, "Failed to get logs for pod %q, container %q: %v\n", pod.Name, container, err)
+		return
+
+	}
+	if log == "" {
+		log = "No relevant logs found"
+	}
+
+	logHeader := fmt.Sprintf(
+		"Logs for pod %q, container %q (last %d lines)",
+		pod.Name,
+		container,
+		logTailLines,
+	)
+	if !fullLogOnErr() && correlationId != "" {
+		logHeader = fmt.Sprintf(
+			"Logs for pod %q, container %q with correlation ID %q (last %d lines)",
+			pod.Name,
+			container,
+			correlationId,
+			logTailLines,
+		)
+	}
+
+	fmt.Fprintf(ginkgo.GinkgoWriter,
+		"\n\n===== %s =====\n%s\n==============================================\n\n",
+		logHeader,
+		log)
 }
 
 func getPods(clientset kubernetes.Interface, namespace, labelKey, labelValue string) ([]corev1.Pod, error) {
@@ -128,7 +163,7 @@ func getPods(clientset kubernetes.Interface, namespace, labelKey, labelValue str
 	return pods.Items, nil
 }
 
-func getSinglePodLog(clientset kubernetes.Interface, pod corev1.Pod, container, correlationId string) (string, error) {
+func getPodContainerLog(clientset kubernetes.Interface, pod corev1.Pod, container, correlationId string) (string, error) {
 	podLogOpts := corev1.PodLogOptions{TailLines: tools.PtrTo(logTailLines), Container: container}
 	req := clientset.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &podLogOpts)
 
@@ -148,4 +183,49 @@ func getSinglePodLog(clientset kubernetes.Interface, pod corev1.Pod, container, 
 	}
 
 	return logBuf.String(), logScanner.Err()
+}
+
+func printDropletNotFoundDebugInfo(clientset kubernetes.Interface, message string) {
+	fmt.Fprint(ginkgo.GinkgoWriter, "\n\n========== Droplet not found debug log (start) ==========\n")
+
+	fmt.Fprint(ginkgo.GinkgoWriter, "\n========== Kpack logs ==========\n")
+	printPodsLogs(clientset, []podContainerDescriptor{
+		{
+			Namespace:  "kpack",
+			LabelKey:   "app",
+			LabelValue: "kpack-controller",
+		},
+		{
+			Namespace:  "kpack",
+			LabelKey:   "app",
+			LabelValue: "kpack-webhook",
+		},
+	})
+
+	dropletGUID, err := getDropletGUID(message)
+	if err != nil {
+		fmt.Fprintf(ginkgo.GinkgoWriter, "Failed to get droplet GUID from message %v\n", err)
+		return
+	}
+
+	fmt.Fprint(ginkgo.GinkgoWriter, "\n\n========== Droplet build logs ==========\n")
+	fmt.Fprintf(ginkgo.GinkgoWriter, "DropletGUID: %q\n", dropletGUID)
+	printPodsLogs(clientset, []podContainerDescriptor{
+		{
+			LabelKey:   "image.kpack.io/image",
+			LabelValue: dropletGUID,
+		},
+	})
+
+	fmt.Fprint(ginkgo.GinkgoWriter, "\n\n========== Droplet not found debug log (end) ==========\n\n")
+}
+
+func getDropletGUID(message string) (string, error) {
+	r := regexp.MustCompile(`Request.*droplets/(.*)`)
+	matches := r.FindStringSubmatch(message)
+	if len(matches) != 2 {
+		return "", fmt.Errorf("message does not match regex: %s", r.String())
+	}
+
+	return matches[1], nil
 }


### PR DESCRIPTION
## Is there a related GitHub Issue?
#1714

## What is this change about?
Print kpack logs and droplet build pod logs when the `Droplet not found` error occurs.

While being here, also print "non-core" korifi controllers logs as well on every e2e failure
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Figure out what is causing the `Droplet not found` error
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@georgethebeatle
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

