### PR TITLE
Bump golang to 1.19.2 in all Dockerfiles

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:experimental
-FROM golang:1.19.1 as builder
+FROM golang:1.19.2 as builder
 
 WORKDIR /workspace
 

--- a/api/remote-debug/Dockerfile
+++ b/api/remote-debug/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:experimental
-FROM golang:1.19.1 as builder
+FROM golang:1.19.2 as builder
 
 WORKDIR /workspace
 

--- a/controllers/Dockerfile
+++ b/controllers/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:experimental
-FROM golang:1.19.1 as builder
+FROM golang:1.19.2 as builder
 
 WORKDIR /workspace
 

--- a/controllers/remote-debug/Dockerfile
+++ b/controllers/remote-debug/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:experimental
-FROM golang:1.19.1 as builder
+FROM golang:1.19.2 as builder
 
 WORKDIR /workspace
 

--- a/job-task-runner/Dockerfile
+++ b/job-task-runner/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.19.1 as builder
+FROM golang:1.19.2 as builder
 
 WORKDIR /workspace
 

--- a/job-task-runner/remote-debug/Dockerfile
+++ b/job-task-runner/remote-debug/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.19.1 as builder
+FROM golang:1.19.2 as builder
 
 WORKDIR /workspace
 

--- a/kpack-image-builder/Dockerfile
+++ b/kpack-image-builder/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:experimental
-FROM golang:1.19.1 as builder
+FROM golang:1.19.2 as builder
 
 WORKDIR /workspace
 

--- a/kpack-image-builder/remote-debug/Dockerfile
+++ b/kpack-image-builder/remote-debug/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:experimental
-FROM golang:1.19.1 as builder
+FROM golang:1.19.2 as builder
 
 WORKDIR /workspace
 

--- a/statefulset-runner/Dockerfile
+++ b/statefulset-runner/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:experimental
-FROM golang:1.19.1 as builder
+FROM golang:1.19.2 as builder
 
 WORKDIR /workspace
 

--- a/statefulset-runner/remote-debug/Dockerfile
+++ b/statefulset-runner/remote-debug/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:experimental
-FROM golang:1.19.1 as builder
+FROM golang:1.19.2 as builder
 
 WORKDIR /workspace
 


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Bump golang to 1.19.2 in all Dockerfiles so that we do not have to bump all the dependabot PRs one by one
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
Passing tests
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@kieron-dev
