### PR TITLE
Create default domain and ingress certs (optionally) with helm

### DIFF
--- a/controllers/controllers/networking/cfroute_controller.go
+++ b/controllers/controllers/networking/cfroute_controller.go
@@ -66,7 +66,7 @@ func NewCFRouteReconciler(
 //+kubebuilder:rbac:groups=korifi.cloudfoundry.org,resources=cfroutes/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=korifi.cloudfoundry.org,resources=cfroutes/finalizers,verbs=update
 
-//+kubebuilder:rbac:groups=korifi.cloudfoundry.org,resources=cfdomains,verbs=get;list;watch
+//+kubebuilder:rbac:groups=korifi.cloudfoundry.org,resources=cfdomains,verbs=get;list;watch;create;patch;update
 
 //+kubebuilder:rbac:groups=projectcontour.io,resources=httpproxies,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=projectcontour.io,resources=httpproxies/status,verbs=get

--- a/helm/api/templates/configmap.yaml
+++ b/helm/api/templates/configmap.yaml
@@ -21,7 +21,7 @@ data:
       stagingDiskMB: {{ .Values.lifecycle.stagingRequirements.diskMB }}
     packageRegistryBase: {{ .Values.packageRegistry.base }}
     packageRegistrySecretName: {{ .Values.packageRegistry.secret }}
-    defaultDomainName: {{ .Values.defaultDomainName }}
+    defaultDomainName: {{ .Values.global.defaultAppDomainName }}
     userCertificateExpirationWarningDuration: {{ .Values.userCertificateExpirationWarningDuration }}
     authProxyHost: {{ .Values.authProxy.host }}
     authProxyCACert: {{ .Values.authProxy.caCert }}

--- a/helm/api/templates/ingress-cert.yaml
+++ b/helm/api/templates/ingress-cert.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.global.generateIngressCertificates }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: korifi-api-ingress-cert
+  namespace: {{ .Values.namespace }}
+spec:
+  commonName: {{ .Values.apiServer.url }}
+  dnsNames:
+  - {{ .Values.apiServer.url }}
+  issuerRef:
+    kind: Issuer
+    name: korifi-api-selfsigned-issuer
+  secretName: korifi-api-ingress-cert
+{{- end }}

--- a/helm/api/values.yaml
+++ b/helm/api/values.yaml
@@ -2,6 +2,7 @@ global:
   rootNamespace: cf
   debug: false
   defaultAppDomainName: apps.my-cf-domain.com
+  generateIngressCertificates: false
 
 include: true
 namespace: korifi-api-system

--- a/helm/api/values.yaml
+++ b/helm/api/values.yaml
@@ -1,6 +1,7 @@
 global:
   rootNamespace: cf
   debug: false
+  defaultAppDomainName: apps.my-cf-domain.com
 
 include: true
 namespace: korifi-api-system
@@ -35,7 +36,6 @@ packageRegistry:
   # The container registry where app source packages will be stored
   base: registry-org/package-repo-name
   secret: image-registry-credentials
-defaultDomainName: apps.my-cf-domain.com
 userCertificateExpirationWarningDuration: 168h
 
 authProxy:

--- a/helm/controllers/templates/ingress-cert.yaml
+++ b/helm/controllers/templates/ingress-cert.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.global.generateIngressCertificates }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: korifi-workloads-ingress-cert
+  namespace: {{ .Values.namespace }}
+spec:
+  commonName: \*.{{ .Values.global.defaultAppDomainName }}
+  dnsNames:
+  - \*.{{ .Values.global.defaultAppDomainName }}
+  issuerRef:
+    kind: Issuer
+    name: korifi-controllers-selfsigned-issuer
+  secretName: korifi-workloads-ingress-cert
+{{- end}}

--- a/helm/controllers/templates/post-install-app-domain.yaml
+++ b/helm/controllers/templates/post-install-app-domain.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: delete-builderinfo
+  name: create-app-domain
   namespace: {{ .Values.namespace }}
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
@@ -9,22 +9,24 @@ metadata:
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
   annotations:
-    "helm.sh/hook": pre-delete
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "-5"
     "helm.sh/hook-delete-policy": hook-succeeded
 spec:
   template:
     metadata:
-      name: delete-builderinfo
+      name: create-app-domain
       labels:
         app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
         app.kubernetes.io/instance: {{ .Release.Name | quote }}
         helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     spec:
-      serviceAccountName: korifi-kpack-build-controller-manager
+      serviceAccountName: korifi-controllers-controller-manager
       restartPolicy: Never
       containers:
-      - name: pre-delete-builderinfo
+      - name: post-install-create-app-domain
         image: "alpine/k8s:1.25.2"
         securityContext:
           allowPrivilegeEscalation: false
@@ -38,4 +40,12 @@ spec:
         command:
         - sh
         - -c
-        - "kubectl -n {{ .Values.global.rootNamespace }} delete builderinfo kpack-image-builder"
+        - |
+          cat <<EOF | kubectl -n {{ .Values.global.rootNamespace }} apply -f -
+          apiVersion: korifi.cloudfoundry.org/v1alpha1
+          kind: CFDomain
+          metadata:
+            name: default-domain
+          spec:
+            name: {{ .Values.global.defaultAppDomainName }}
+          EOF

--- a/helm/controllers/templates/role.yaml
+++ b/helm/controllers/templates/role.yaml
@@ -216,8 +216,11 @@ rules:
   resources:
   - cfdomains
   verbs:
+  - create
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - korifi.cloudfoundry.org

--- a/helm/controllers/values.yaml
+++ b/helm/controllers/values.yaml
@@ -2,6 +2,7 @@ global:
   rootNamespace: cf
   debug: false
   defaultAppDomainName: apps.my-cf-domain.com
+  generateIngressCertificates: false
 
 include: true
 namespace: korifi-controllers-system

--- a/helm/controllers/values.yaml
+++ b/helm/controllers/values.yaml
@@ -1,6 +1,7 @@
 global:
   rootNamespace: cf
   debug: false
+  defaultAppDomainName: apps.my-cf-domain.com
 
 include: true
 namespace: korifi-controllers-system

--- a/helm/korifi/values.yaml
+++ b/helm/korifi/values.yaml
@@ -2,6 +2,7 @@ global:
   rootNamespace: cf
   debug: false
   defaultAppDomainName: apps.my-cf-domain.com
+  generateIngressCertificates: false
 
 api:
   image: cloudfoundry/korifi-api:latest

--- a/helm/korifi/values.yaml
+++ b/helm/korifi/values.yaml
@@ -1,6 +1,7 @@
 global:
   rootNamespace: cf
   debug: false
+  defaultAppDomainName: apps.my-cf-domain.com
 
 api:
   image: cloudfoundry/korifi-api:latest

--- a/helm/kpack-image-builder/templates/post-install-builderinfo.yaml
+++ b/helm/kpack-image-builder/templates/post-install-builderinfo.yaml
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name | quote }}
         helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     spec:
-      serviceAccount: korifi-kpack-build-controller-manager
+      serviceAccountName: korifi-kpack-build-controller-manager
       restartPolicy: Never
       containers:
       - name: post-install-create-builderinfo

--- a/helm/kpack-image-builder/templates/pre-delete-builderinfo.yaml
+++ b/helm/kpack-image-builder/templates/pre-delete-builderinfo.yaml
@@ -38,4 +38,4 @@ spec:
         command:
         - sh
         - -c
-        - "kubectl -n {{ .Values.global.rootNamespace }} delete builderinfo kpack-image-builder"
+        - "kubectl -n {{ .Values.global.rootNamespace }} delete builderinfo kpack-image-builder --ignore-not-found"

--- a/scripts/assets/values-template.yaml
+++ b/scripts/assets/values-template.yaml
@@ -1,5 +1,6 @@
 global:
   defaultAppDomainName: vcap.me
+  generateIngressCertificates: true
 
 api:
   apiServer:

--- a/scripts/assets/values-template.yaml
+++ b/scripts/assets/values-template.yaml
@@ -1,10 +1,12 @@
+global:
+  defaultAppDomainName: vcap.me
+
 api:
   apiServer:
     url: localhost
   image: cloudfoundry/korifi-api:latest
   packageRegistry:
     base: localregistry-docker-registry.default.svc.cluster.local:30050/kpack/packages
-  defaultDomainName: vcap.me
 
 controllers:
   taskTTL: 5s

--- a/scripts/deploy-on-kind.sh
+++ b/scripts/deploy-on-kind.sh
@@ -22,9 +22,6 @@ flags:
   -v, --verbose
       Verbose output (bash -x).
 
-  -d, --default-domain
-      Creates the vcap.me CF domain.
-
   -D, --debug
       Builds controller and api images with debugging hooks and
       wires up ports for remote debugging:
@@ -40,7 +37,6 @@ EOF
 
 cluster=""
 use_local_registry=""
-default_domain=""
 debug=""
 
 while [[ $# -gt 0 ]]; do
@@ -48,10 +44,6 @@ while [[ $# -gt 0 ]]; do
   case $i in
     -l | --use-local-registry)
       use_local_registry="true"
-      shift
-      ;;
-    -d | --default-domain)
-      default_domain="true"
       shift
       ;;
     -D | --debug)
@@ -210,10 +202,6 @@ function deploy_korifi() {
     create_tls_cert "korifi-api-ingress-cert" "korifi-api" "api.vcap.me"
   }
   popd >/dev/null
-
-  if [[ -n "${default_domain}" ]]; then
-    sed 's/vcap\.me/'${APP_FQDN:-vcap.me}'/' ${CONTROLLER_DIR}/config/samples/cfdomain.yaml | kubectl apply -f-
-  fi
 }
 
 ensure_kind_cluster "${cluster}"

--- a/scripts/deploy-on-kind.sh
+++ b/scripts/deploy-on-kind.sh
@@ -4,11 +4,6 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 SCRIPT_DIR="${ROOT_DIR}/scripts"
-API_DIR="${ROOT_DIR}/api"
-CONTROLLER_DIR="${ROOT_DIR}/controllers"
-export PATH="${PATH}:${API_DIR}/bin"
-
-source "$SCRIPT_DIR/common.sh"
 
 function usage_text() {
   cat <<EOF
@@ -197,9 +192,6 @@ function deploy_korifi() {
       --values=scripts/assets/values.yaml \
       --set=global.debug="$doDebug" \
       --wait
-
-    create_tls_cert "korifi-workloads-ingress-cert" "korifi-controllers" "\*.vcap.me"
-    create_tls_cert "korifi-api-ingress-cert" "korifi-api" "api.vcap.me"
   }
   popd >/dev/null
 }


### PR DESCRIPTION
## Is there a related GitHub Issue?
#1704

## What is this change about?
- Create default cf domain in the controllers helm chart
- Add ingress certs to helm chart
  - Optionally activated with the `global.generateIngressCertificates` value

## Does this PR introduce a breaking change?
No

## Acceptance Steps
deploy-on-kind and CI continue to work

## Tag your pair, your PM, and/or team
@kieron-dev

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
