### PR TITLE
Korifi configuration in the halm chart

### DIFF
--- a/helm/api/templates/configmap.yaml
+++ b/helm/api/templates/configmap.yaml
@@ -19,8 +19,8 @@ data:
       stack: {{ .Values.lifecycle.stack }}
       stagingMemoryMB: {{ .Values.lifecycle.stagingRequirements.memoryMB }}
       stagingDiskMB: {{ .Values.lifecycle.stagingRequirements.diskMB }}
-    packageRegistryBase: {{ .Values.packageRegistry.base }}
-    packageRegistrySecretName: {{ .Values.packageRegistry.secret }}
+    packageRegistryBase: {{ .Values.packageRegistry }}
+    packageRegistrySecretName: {{ .Values.global.packageRegistrySecret }}
     defaultDomainName: {{ .Values.global.defaultAppDomainName }}
     userCertificateExpirationWarningDuration: {{ .Values.userCertificateExpirationWarningDuration }}
     authProxyHost: "{{ .Values.authProxy.host }}"

--- a/helm/api/templates/configmap.yaml
+++ b/helm/api/templates/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
 data:
   korifi_api_config.yaml: |
     externalFQDN: {{ .Values.apiServer.url }}
-    externalPort: {{ .Values.externalPort }}
+    externalPort: {{ .Values.externalPort | default 0 }}
     internalPort: {{ .Values.apiServer.internalPort }}
     idleTimeout: {{ .Values.apiServer.timeouts.idle }}
     readTimeout: {{ .Values.apiServer.timeouts.read }}
@@ -23,8 +23,8 @@ data:
     packageRegistrySecretName: {{ .Values.packageRegistry.secret }}
     defaultDomainName: {{ .Values.global.defaultAppDomainName }}
     userCertificateExpirationWarningDuration: {{ .Values.userCertificateExpirationWarningDuration }}
-    authProxyHost: {{ .Values.authProxy.host }}
-    authProxyCACert: {{ .Values.authProxy.caCert }}
+    authProxyHost: "{{ .Values.authProxy.host }}"
+    authProxyCACert: "{{ .Values.authProxy.caCert }}"
 
   role_mappings_config.yaml: |
     roleMappings:

--- a/helm/api/values.yaml
+++ b/helm/api/values.yaml
@@ -3,6 +3,7 @@ global:
   debug: false
   defaultAppDomainName: apps.my-cf-domain.com
   generateIngressCertificates: false
+  packageRegistrySecret: image-registry-credentials
 
 include: true
 namespace: korifi-api-system
@@ -33,10 +34,7 @@ lifecycle:
     diskMB: 1024
 
 builderName: kpack-image-builder
-packageRegistry:
-  # The container registry where app source packages will be stored
-  base: registry-org/package-repo-name
-  secret: image-registry-credentials
+packageRegistry: registry-org/package-repo-name
 userCertificateExpirationWarningDuration: 168h
 
 authProxy:

--- a/helm/controllers/templates/configmap.yaml
+++ b/helm/controllers/templates/configmap.yaml
@@ -11,7 +11,7 @@ data:
       memoryMB: {{ .Values.processDefaults.memoryMB }}
       diskQuotaMB: {{ .Values.processDefaults.diskQuotaMB }}
     cfRootNamespace: {{ .Values.global.rootNamespace }}
-    packageRegistrySecretName: {{ .Values.packageRegistry.secret }}
+    packageRegistrySecretName: {{ .Values.global.packageRegistrySecret }}
     taskTTL: {{ .Values.taskTTL }}
     workloads_tls_secret_name: {{ .Values.workloadsTLSSecret.name }}
     workloads_tls_secret_namespace: {{ .Values.workloadsTLSSecret.namespace }}

--- a/helm/controllers/templates/root-namespace.yaml
+++ b/helm/controllers/templates/root-namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.global.rootNamespace }}
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/helm/controllers/values.yaml
+++ b/helm/controllers/values.yaml
@@ -3,6 +3,7 @@ global:
   debug: false
   defaultAppDomainName: apps.my-cf-domain.com
   generateIngressCertificates: false
+  packageRegistrySecret: image-registry-credentials
 
 include: true
 namespace: korifi-controllers-system
@@ -22,8 +23,6 @@ reconcilers:
 processDefaults:
   memoryMB: 1024
   diskQuotaMB: 1024
-packageRegistry:
-  secret: image-registry-credentials
 taskTTL: 30d
 workloadsTLSSecret:
   name: korifi-workloads-ingress-cert

--- a/helm/korifi/templates/admin-user.yaml
+++ b/helm/korifi/templates/admin-user.yaml
@@ -1,18 +1,9 @@
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: cf
-  labels:
-    pod-security.kubernetes.io/enforce: restricted
-    pod-security.kubernetes.io/audit: restricted
-
----
+{{- if .Values.createAdminUser }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: default-admin-binding
-  namespace: cf
+  namespace: {{ .Values.global.rootNamespace }}
   annotations:
     cloudfoundry.org/propagate-cf-role: "true"
 roleRef:
@@ -20,6 +11,7 @@ roleRef:
   kind: ClusterRole
   name: korifi-controllers-admin
 subjects:
-- apiGroup: rbac.authorization.k8s.io
-  kind: User
-  name: cf-admin
+  - apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: {{ .Values.adminUserName }}
+{{- end }}

--- a/helm/korifi/values.yaml
+++ b/helm/korifi/values.yaml
@@ -3,6 +3,10 @@ global:
   debug: false
   defaultAppDomainName: apps.my-cf-domain.com
   generateIngressCertificates: false
+  packageRegistrySecret: image-registry-credentials
+
+createAdminUser: false
+adminUserName: cf-admin
 
 api:
   image: cloudfoundry/korifi-api:latest

--- a/helm/kpack-image-builder/templates/cluster-builder.yaml
+++ b/helm/kpack-image-builder/templates/cluster-builder.yaml
@@ -1,0 +1,53 @@
+{{- if .Values.exampleClusterBuilder.create }}
+apiVersion: kpack.io/v1alpha2
+kind: ClusterStore
+metadata:
+  name: cf-default-buildpacks
+spec:
+  sources:
+  - image: gcr.io/paketo-buildpacks/java
+  - image: gcr.io/paketo-buildpacks/nodejs
+  - image: gcr.io/paketo-buildpacks/ruby
+  - image: gcr.io/paketo-buildpacks/procfile
+  - image: gcr.io/paketo-buildpacks/go
+
+---
+apiVersion: kpack.io/v1alpha2
+kind: ClusterStack
+metadata:
+  name: cf-default-stack
+spec:
+  id: "io.buildpacks.stacks.bionic"
+  buildImage:
+    image: "paketobuildpacks/build:full-cnb"
+  runImage:
+    image: "paketobuildpacks/run:full-cnb"
+
+---
+apiVersion: kpack.io/v1alpha2
+kind: ClusterBuilder
+metadata:
+  name: {{ .Values.clusterBuilderName }}
+spec:
+  serviceAccountRef:
+    name: kpack-service-account
+    namespace: {{ .Values.global.rootNamespace }}
+  tag: {{ .Values.exampleClusterBuilder.kpackBuilderRegistry }}
+  stack:
+    name: cf-default-stack
+    kind: ClusterStack
+  store:
+    name: cf-default-buildpacks
+    kind: ClusterStore
+  order:
+  - group:
+    - id: paketo-buildpacks/java
+  - group:
+    - id: paketo-buildpacks/go
+  - group:
+    - id: paketo-buildpacks/nodejs
+  - group:
+    - id: paketo-buildpacks/ruby
+  - group:
+    - id: paketo-buildpacks/procfile
+{{- end }}

--- a/helm/kpack-image-builder/templates/configmap.yaml
+++ b/helm/kpack-image-builder/templates/configmap.yaml
@@ -7,5 +7,4 @@ data:
   kpack_build_controllers_config.yaml: |
     cfRootNamespace: {{ .Values.global.rootNamespace }}
     clusterBuilderName: {{ .Values.clusterBuilderName }}
-    kpackImageTag: {{ .Values.packageRegistry.base }}
-    packageRegistrySecretName: {{ .Values.packageRegistry.secret }}
+    kpackImageTag: {{ .Values.packageRegistry }}

--- a/helm/kpack-image-builder/templates/service-account.yaml
+++ b/helm/kpack-image-builder/templates/service-account.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kpack-service-account
+  namespace: {{ .Values.global.rootNamespace }}
+  annotations:
+    cloudfoundry.org/propagate-service-account: "true"
+secrets:
+  - name: {{ .Values.global.packageRegistrySecret }}
+imagePullSecrets:
+  - name: {{ .Values.global.packageRegistrySecret }}

--- a/helm/kpack-image-builder/values.yaml
+++ b/helm/kpack-image-builder/values.yaml
@@ -1,6 +1,7 @@
 global:
   rootNamespace: cf
   debug: false
+  packageRegistrySecret: image-registry-credentials
 
 include: true
 namespace: korifi-kpack-build-system
@@ -15,8 +16,8 @@ resources:
 
 image: cloudfoundry/korifi-kpack-image-builder:latest
 
-packageRegistry:
-  # The container registry where built app images will be stored
-  base: registry-org/package-repo-name
-  secret: image-registry-credentials
+packageRegistry: registry-org/package-repo-name
 clusterBuilderName: cf-kpack-cluster-builder
+exampleClusterBuilder:
+  create: false
+  kpackBuilderRegistry: registry-org/kpack-builder-repo-name

--- a/scripts/assets/kind-config.yaml
+++ b/scripts/assets/kind-config.yaml
@@ -1,0 +1,39 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches: |-
+  [plugins."io.containerd.grpc.v1.cri".registry]
+    [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+      [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localregistry-docker-registry.default.svc.cluster.local:30050"]
+        endpoint = ["http://127.0.0.1:30050"]
+    [plugins."io.containerd.grpc.v1.cri".registry.configs]
+      [plugins."io.containerd.grpc.v1.cri".registry.configs."127.0.0.1:30050".tls]
+        insecure_skip_verify = true
+featureGates:
+  EphemeralContainers: true
+nodes:
+- role: control-plane
+  extraPortMappings:
+  - containerPort: 80
+    hostPort: 80
+    protocol: TCP
+  - containerPort: 443
+    hostPort: 443
+    protocol: TCP
+  - containerPort: 30050
+    hostPort: 30050
+    protocol: TCP
+  - containerPort: 30051
+    hostPort: 30051
+    protocol: TCP
+  - containerPort: 30052
+    hostPort: 30052
+    protocol: TCP
+  - containerPort: 30053
+    hostPort: 30053
+    protocol: TCP
+  - containerPort: 30054
+    hostPort: 30054
+    protocol: TCP
+  - containerPort: 30055
+    hostPort: 30055
+    protocol: TCP

--- a/scripts/assets/values-template.yaml
+++ b/scripts/assets/values-template.yaml
@@ -2,12 +2,13 @@ global:
   defaultAppDomainName: vcap.me
   generateIngressCertificates: true
 
+createAdminUser: true
+
 api:
   apiServer:
     url: localhost
   image: cloudfoundry/korifi-api:latest
-  packageRegistry:
-    base: localregistry-docker-registry.default.svc.cluster.local:30050/kpack/packages
+  packageRegistry: localregistry-docker-registry.default.svc.cluster.local:30050/kpack/packages
 
 controllers:
   taskTTL: 5s
@@ -19,8 +20,10 @@ job-task-runner:
 
 kpack-image-builder:
   image: cloudfoundry/korifi-kpack-image-builder:latest
-  packageRegistry:
-    base: localregistry-docker-registry.default.svc.cluster.local:30050/korifi-controllers/kpack/images
+  packageRegistry: localregistry-docker-registry.default.svc.cluster.local:30050/korifi-controllers/kpack/images
+  exampleClusterBuilder:
+    create: true
+    kpackBuilderRegistry: localregistry-docker-registry.default.svc.cluster.local:30050/cf-relint-greengrass/korifi/kpack/beta
 
 statefulset-runner:
   image: cloudfoundry/korifi-statefulset-runner:latest


### PR DESCRIPTION
- Default optional values in api config map template
- Korifi configuration by helm chart

<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
#1704
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
The heml chart now
* creates the cf root namepsace
* created the kpack service account and optionally configures the cluster builder

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
Korifi deploys and tests are green
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@kieron-dev
