### PR TITLE
Replace `sed` with `yq` in Makefiles

### DIFF
--- a/helm/api/templates/role.yaml
+++ b/helm/api/templates/role.yaml
@@ -5,72 +5,72 @@ metadata:
   creationTimestamp: null
   name: korifi-api-system-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  verbs:
-  - list
-- apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
-  verbs:
-  - create
-- apiGroups:
-  - korifi.cloudfoundry.org
-  resources:
-  - cfapps
-  - cfbuilds
-  - cfpackages
-  - cfprocesses
-  - cfspaces
-  - cftasks
-  verbs:
-  - list
-- apiGroups:
-  - korifi.cloudfoundry.org
-  resources:
-  - cfdomains
-  - cfroutes
-  verbs:
-  - list
-- apiGroups:
-  - korifi.cloudfoundry.org
-  resources:
-  - cfservicebindings
-  - cfserviceinstances
-  verbs:
-  - list
-- apiGroups:
-  - metrics.k8s.io
-  resources:
-  - pods
-  verbs:
-  - get
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
-  - rolebindings
-  verbs:
-  - list
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - list
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - korifi.cloudfoundry.org
+    resources:
+      - cfapps
+      - cfbuilds
+      - cfpackages
+      - cfprocesses
+      - cfspaces
+      - cftasks
+    verbs:
+      - list
+  - apiGroups:
+      - korifi.cloudfoundry.org
+    resources:
+      - cfdomains
+      - cfroutes
+    verbs:
+      - list
+  - apiGroups:
+      - korifi.cloudfoundry.org
+    resources:
+      - cfservicebindings
+      - cfserviceinstances
+    verbs:
+      - list
+  - apiGroups:
+      - metrics.k8s.io
+    resources:
+      - pods
+    verbs:
+      - get
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - rolebindings
+    verbs:
+      - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   creationTimestamp: null
   name: korifi-api-system-role
-  namespace: {{ .Values.global.rootNamespace }}
+  namespace: '{{ .Values.global.rootNamespace }}'
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-- apiGroups:
-  - ""
-  resources:
-  - serviceaccounts
-  verbs:
-  - get
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - get

--- a/helm/controllers/templates/manifests.yaml
+++ b/helm/controllers/templates/manifests.yaml
@@ -2,295 +2,295 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  annotations:
-    cert-manager.io/inject-ca-from: "{{ .Values.namespace }}/korifi-controllers-serving-cert"
   creationTimestamp: null
   name: korifi-controllers-mutating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: '{{ .Values.namespace }}/korifi-controllers-serving-cert'
 webhooks:
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: korifi-controllers-webhook-service
-      namespace: "{{ .Values.namespace }}"
-      path: /mutate-korifi-cloudfoundry-org-v1alpha1-cfapp
-  failurePolicy: Fail
-  name: mcfapp.korifi.cloudfoundry.org
-  rules:
-  - apiGroups:
-    - korifi.cloudfoundry.org
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - cfapps
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: korifi-controllers-webhook-service
-      namespace: "{{ .Values.namespace }}"
-      path: /mutate-korifi-cloudfoundry-org-v1alpha1-cfbuild
-  failurePolicy: Fail
-  name: mcfbuild.korifi.cloudfoundry.org
-  rules:
-  - apiGroups:
-    - korifi.cloudfoundry.org
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - cfbuilds
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: korifi-controllers-webhook-service
-      namespace: "{{ .Values.namespace }}"
-      path: /mutate-korifi-cloudfoundry-org-v1alpha1-cfpackage
-  failurePolicy: Fail
-  name: mcfpackage.korifi.cloudfoundry.org
-  rules:
-  - apiGroups:
-    - korifi.cloudfoundry.org
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - cfpackages
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: korifi-controllers-webhook-service
-      namespace: "{{ .Values.namespace }}"
-      path: /mutate-korifi-cloudfoundry-org-v1alpha1-cfprocess
-  failurePolicy: Fail
-  name: mcfprocess.korifi.cloudfoundry.org
-  rules:
-  - apiGroups:
-    - korifi.cloudfoundry.org
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - cfprocesses
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: korifi-controllers-webhook-service
-      namespace: "{{ .Values.namespace }}"
-      path: /mutate-korifi-cloudfoundry-org-v1alpha1-cfroute
-  failurePolicy: Fail
-  name: mcfroute.korifi.cloudfoundry.org
-  rules:
-  - apiGroups:
-    - korifi.cloudfoundry.org
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - cfroutes
-  sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-controllers-webhook-service
+        namespace: '{{ .Values.namespace }}'
+        path: /mutate-korifi-cloudfoundry-org-v1alpha1-cfapp
+    failurePolicy: Fail
+    name: mcfapp.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - cfapps
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-controllers-webhook-service
+        namespace: '{{ .Values.namespace }}'
+        path: /mutate-korifi-cloudfoundry-org-v1alpha1-cfbuild
+    failurePolicy: Fail
+    name: mcfbuild.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - cfbuilds
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-controllers-webhook-service
+        namespace: '{{ .Values.namespace }}'
+        path: /mutate-korifi-cloudfoundry-org-v1alpha1-cfpackage
+    failurePolicy: Fail
+    name: mcfpackage.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - cfpackages
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-controllers-webhook-service
+        namespace: '{{ .Values.namespace }}'
+        path: /mutate-korifi-cloudfoundry-org-v1alpha1-cfprocess
+    failurePolicy: Fail
+    name: mcfprocess.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - cfprocesses
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-controllers-webhook-service
+        namespace: '{{ .Values.namespace }}'
+        path: /mutate-korifi-cloudfoundry-org-v1alpha1-cfroute
+    failurePolicy: Fail
+    name: mcfroute.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - cfroutes
+    sideEffects: None
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  annotations:
-    cert-manager.io/inject-ca-from: "{{ .Values.namespace }}/korifi-controllers-serving-cert"
   creationTimestamp: null
   name: korifi-controllers-validating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: '{{ .Values.namespace }}/korifi-controllers-serving-cert'
 webhooks:
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: korifi-controllers-webhook-service
-      namespace: "{{ .Values.namespace }}"
-      path: /validate-korifi-cloudfoundry-org-v1alpha1-cfdomain
-  failurePolicy: Fail
-  name: vcfdomain.korifi.cloudfoundry.org
-  rules:
-  - apiGroups:
-    - korifi.cloudfoundry.org
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - cfdomains
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: korifi-controllers-webhook-service
-      namespace: "{{ .Values.namespace }}"
-      path: /validate-korifi-cloudfoundry-org-v1alpha1-cfroute
-  failurePolicy: Fail
-  name: vcfroute.korifi.cloudfoundry.org
-  rules:
-  - apiGroups:
-    - korifi.cloudfoundry.org
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    - DELETE
-    resources:
-    - cfroutes
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: korifi-controllers-webhook-service
-      namespace: "{{ .Values.namespace }}"
-      path: /validate-korifi-cloudfoundry-org-v1alpha1-cfservicebinding
-  failurePolicy: Fail
-  name: vcfservicebinding.korifi.cloudfoundry.org
-  rules:
-  - apiGroups:
-    - korifi.cloudfoundry.org
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    - DELETE
-    resources:
-    - cfservicebindings
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: korifi-controllers-webhook-service
-      namespace: "{{ .Values.namespace }}"
-      path: /validate-korifi-cloudfoundry-org-v1alpha1-cfserviceinstance
-  failurePolicy: Fail
-  name: vcfserviceinstance.korifi.cloudfoundry.org
-  rules:
-  - apiGroups:
-    - korifi.cloudfoundry.org
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    - DELETE
-    resources:
-    - cfserviceinstances
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: korifi-controllers-webhook-service
-      namespace: "{{ .Values.namespace }}"
-      path: /validate-korifi-cloudfoundry-org-v1alpha1-cfapp
-  failurePolicy: Fail
-  name: vcfapp.korifi.cloudfoundry.org
-  rules:
-  - apiGroups:
-    - korifi.cloudfoundry.org
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    - DELETE
-    resources:
-    - cfapps
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: korifi-controllers-webhook-service
-      namespace: "{{ .Values.namespace }}"
-      path: /validate-korifi-cloudfoundry-org-v1alpha1-cforg
-  failurePolicy: Fail
-  name: vcforg.korifi.cloudfoundry.org
-  rules:
-  - apiGroups:
-    - korifi.cloudfoundry.org
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    - DELETE
-    resources:
-    - cforgs
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: korifi-controllers-webhook-service
-      namespace: "{{ .Values.namespace }}"
-      path: /validate-korifi-cloudfoundry-org-v1alpha1-cfspace
-  failurePolicy: Fail
-  name: vcfspace.korifi.cloudfoundry.org
-  rules:
-  - apiGroups:
-    - korifi.cloudfoundry.org
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    - DELETE
-    resources:
-    - cfspaces
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: korifi-controllers-webhook-service
-      namespace: "{{ .Values.namespace }}"
-      path: /validate-korifi-cloudfoundry-org-v1alpha1-cftask
-  failurePolicy: Fail
-  name: vcftask.korifi.cloudfoundry.org
-  rules:
-  - apiGroups:
-    - korifi.cloudfoundry.org
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - cftasks
-  sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: korifi-controllers-webhook-service
+        namespace: '{{ .Values.namespace }}'
+        path: /validate-korifi-cloudfoundry-org-v1alpha1-cfdomain
+    failurePolicy: Fail
+    name: vcfdomain.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - cfdomains
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-controllers-webhook-service
+        namespace: '{{ .Values.namespace }}'
+        path: /validate-korifi-cloudfoundry-org-v1alpha1-cfroute
+    failurePolicy: Fail
+    name: vcfroute.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - cfroutes
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-controllers-webhook-service
+        namespace: '{{ .Values.namespace }}'
+        path: /validate-korifi-cloudfoundry-org-v1alpha1-cfservicebinding
+    failurePolicy: Fail
+    name: vcfservicebinding.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - cfservicebindings
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-controllers-webhook-service
+        namespace: '{{ .Values.namespace }}'
+        path: /validate-korifi-cloudfoundry-org-v1alpha1-cfserviceinstance
+    failurePolicy: Fail
+    name: vcfserviceinstance.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - cfserviceinstances
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-controllers-webhook-service
+        namespace: '{{ .Values.namespace }}'
+        path: /validate-korifi-cloudfoundry-org-v1alpha1-cfapp
+    failurePolicy: Fail
+    name: vcfapp.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - cfapps
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-controllers-webhook-service
+        namespace: '{{ .Values.namespace }}'
+        path: /validate-korifi-cloudfoundry-org-v1alpha1-cforg
+    failurePolicy: Fail
+    name: vcforg.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - cforgs
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-controllers-webhook-service
+        namespace: '{{ .Values.namespace }}'
+        path: /validate-korifi-cloudfoundry-org-v1alpha1-cfspace
+    failurePolicy: Fail
+    name: vcfspace.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - cfspaces
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-controllers-webhook-service
+        namespace: '{{ .Values.namespace }}'
+        path: /validate-korifi-cloudfoundry-org-v1alpha1-cftask
+    failurePolicy: Fail
+    name: vcftask.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - cftasks
+    sideEffects: None

--- a/helm/kpack-image-builder/templates/manifests.yaml
+++ b/helm/kpack-image-builder/templates/manifests.yaml
@@ -2,34 +2,34 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  annotations:
-    cert-manager.io/inject-ca-from: "{{ .Values.namespace }}/korifi-kpack-build-serving-cert"
   creationTimestamp: null
   name: korifi-kpack-build-mutating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: '{{ .Values.namespace }}/korifi-kpack-build-serving-cert'
 webhooks:
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: korifi-kpack-build-webhook-service
-      namespace: "{{ .Values.namespace }}"
-      path: /mutate--v1-pod
-  failurePolicy: Ignore
-  objectSelector:
-    matchExpressions:
-    - key: kpack.io/build
-      operator: Exists
-    - key: korifi.cloudfoundry.org/build-workload-name
-      operator: Exists
-  name: mkpackbuildpod.korifi.cloudfoundry.org
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    resources:
-    - pods
-  sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-kpack-build-webhook-service
+        namespace: '{{ .Values.namespace }}'
+        path: /mutate--v1-pod
+    failurePolicy: Ignore
+    name: mkpackbuildpod.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
+    objectSelector:
+      matchExpressions:
+        - key: kpack.io/build
+          operator: Exists
+        - key: korifi.cloudfoundry.org/build-workload-name
+          operator: Exists

--- a/helm/statefulset-runner/templates/manifests.yaml
+++ b/helm/statefulset-runner/templates/manifests.yaml
@@ -2,30 +2,30 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  annotations:
-    cert-manager.io/inject-ca-from: "{{ .Values.namespace }}/korifi-statefulset-runner-serving-cert"
   creationTimestamp: null
   name: korifi-statefulset-runner-mutating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: '{{ .Values.namespace }}/korifi-statefulset-runner-serving-cert'
 webhooks:
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: korifi-statefulset-runner-webhook-service
-      namespace: "{{ .Values.namespace }}"
-      path: /mutate--v1-pod
-  failurePolicy: Fail
-  objectSelector:
-    matchLabels:
-      korifi.cloudfoundry.org/add-stsr-index: "true"
-  name: mstspod.korifi.cloudfoundry.org
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    resources:
-    - pods
-  sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: korifi-statefulset-runner-webhook-service
+        namespace: '{{ .Values.namespace }}'
+        path: /mutate--v1-pod
+    failurePolicy: Fail
+    name: mstspod.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
+    objectSelector:
+      matchLabels:
+        korifi.cloudfoundry.org/add-stsr-index: "true"

--- a/kpack-image-builder/Makefile
+++ b/kpack-image-builder/Makefile
@@ -39,6 +39,7 @@ help: ## Display this help.
 
 ##@ Development
 
+webhooks-file = ../helm/kpack-image-builder/templates/manifests.yaml
 .PHONY: manifests
 manifests: install-controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) \
@@ -47,13 +48,11 @@ manifests: install-controller-gen ## Generate WebhookConfiguration, ClusterRole 
 		rbac:roleName=korifi-kpack-build-manager-role \
 		output:webhook:artifacts:config=../helm/kpack-image-builder/templates \
 		output:rbac:artifacts:config=../helm/kpack-image-builder/templates
-
-	sed -i.bak -e '/^metadata:.*/a \ \ annotations:\n    cert-manager.io/inject-ca-from: "{{ .Values.namespace }}/korifi-kpack-build-serving-cert"' ../helm/kpack-image-builder/templates/manifests.yaml
-	sed -i.bak -e 's/name: \(webhook-service\)/name: korifi-kpack-build-\1/' ../helm/kpack-image-builder/templates/manifests.yaml
-	sed -i.bak -e 's/namespace: system/namespace: "{{ .Values.namespace }}"/' ../helm/kpack-image-builder/templates/manifests.yaml
-	sed -i.bak -e 's/name: \(.*-webhook-configuration\)/name: korifi-kpack-build-\1/' ../helm/kpack-image-builder/templates/manifests.yaml
-	sed -i.bak -e '/failurePolicy:.*/a\  objectSelector:\n    matchExpressions:\n    - key: kpack.io/build\n      operator: Exists\n    - key: korifi.cloudfoundry.org/build-workload-name\n      operator: Exists' ../helm/kpack-image-builder/templates/manifests.yaml
-	rm -f ../helm/kpack-image-builder/templates/manifests.yaml.bak
+	yq -i 'with(.metadata; .annotations["cert-manager.io/inject-ca-from"]="{{ .Values.namespace }}/korifi-kpack-build-serving-cert")' $(webhooks-file)
+	yq -i 'with(.metadata; .name="korifi-kpack-build-" + .name)' $(webhooks-file)
+	yq -i 'with(.webhooks[]; .clientConfig.service.namespace="{{ .Values.namespace }}")' $(webhooks-file)
+	yq -i 'with(.webhooks[]; .clientConfig.service.name="korifi-kpack-build-" + .clientConfig.service.name)' $(webhooks-file)
+	yq -i 'with(.webhooks[]; .objectSelector.matchExpressions=[{"key":"kpack.io/build", "operator":"Exists"},{"key":"korifi.cloudfoundry.org/build-workload-name", "operator":"Exists"}])' $(webhooks-file)
 
 .PHONY: generate
 generate: install-controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.

--- a/scripts/assets/kind-config.yaml
+++ b/scripts/assets/kind-config.yaml
@@ -1,6 +1,7 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
-containerdConfigPatches: |-
+containerdConfigPatches:
+- |-
   [plugins."io.containerd.grpc.v1.cri".registry]
     [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
       [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localregistry-docker-registry.default.svc.cluster.local:30050"]

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -43,7 +43,7 @@ else
   export API_SERVER_ROOT="${API_SERVER_ROOT:-https://localhost}"
 
   if [ -z "${SKIP_DEPLOY:-}" ]; then
-    "${SCRIPT_DIR}/deploy-on-kind.sh" -l -d e2e
+    "${SCRIPT_DIR}/deploy-on-kind.sh" -l e2e
   fi
 
   # creates user keys/certs and service accounts and exports vars for them

--- a/statefulset-runner/Makefile
+++ b/statefulset-runner/Makefile
@@ -40,6 +40,7 @@ help: ## Display this help.
 
 ##@ Development
 
+webhooks-file = ../helm/statefulset-runner/templates/manifests.yaml
 .PHONY: manifests
 manifests: install-controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) \
@@ -49,12 +50,11 @@ manifests: install-controller-gen ## Generate WebhookConfiguration, ClusterRole 
 		output:rbac:artifacts:config=../helm/statefulset-runner/templates \
 		output:webhook:artifacts:config=../helm/statefulset-runner/templates
 
-	sed -i.bak -e '/^metadata:.*/a \ \ annotations:\n    cert-manager.io/inject-ca-from: "{{ .Values.namespace }}/korifi-statefulset-runner-serving-cert"' ../helm/statefulset-runner/templates/manifests.yaml
-	sed -i.bak -e 's/name: \(webhook-service\)/name: korifi-statefulset-runner-\1/' ../helm/statefulset-runner/templates/manifests.yaml
-	sed -i.bak -e 's/namespace: system/namespace: "{{ .Values.namespace }}"/' ../helm/statefulset-runner/templates/manifests.yaml
-	sed -i.bak -e 's/name: \(.*-webhook-configuration\)/name: korifi-statefulset-runner-\1/' ../helm/statefulset-runner/templates/manifests.yaml
-	sed -i.bak -e '/failurePolicy:.*/a\  objectSelector:\n    matchLabels:\n      korifi.cloudfoundry.org/add-stsr-index: "true"' ../helm/statefulset-runner/templates/manifests.yaml
-	rm -f ../helm/statefulset-runner/templates/manifests.yaml.bak
+	yq -i 'with(.metadata; .annotations["cert-manager.io/inject-ca-from"]="{{ .Values.namespace }}/korifi-statefulset-runner-serving-cert")' $(webhooks-file)
+	yq -i 'with(.metadata; .name="korifi-statefulset-runner-" + .name)' $(webhooks-file)
+	yq -i 'with(.webhooks[]; .clientConfig.service.namespace="{{ .Values.namespace }}")' $(webhooks-file)
+	yq -i 'with(.webhooks[]; .clientConfig.service.name="korifi-statefulset-runner-" + .clientConfig.service.name)' $(webhooks-file)
+	yq -i 'with(.webhooks[]; .objectSelector.matchLabels["korifi.cloudfoundry.org/add-stsr-index"]="true")' $(webhooks-file)
 
 
 .PHONY: generate


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Replace `sed` with `yq` in Makefiles: `sed` behaves differently on macos and linux and fails on `make manifests`

Also, fix `make test-e2e` to correctly create the cluster and provide proper arguments to `deploy-on-kind`

<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
`make test-e2e` succeeds
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@kieron-dev
