### PR TITLE
Create the cfroot namespace in a pre-install hook

### DIFF
--- a/helm/controllers/templates/pre-install-cfroot-namespace.yaml
+++ b/helm/controllers/templates/pre-install-cfroot-namespace.yaml
@@ -1,0 +1,100 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: create-cfroot-namespace
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  template:
+    metadata:
+      name: create-cfroot-namespace
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    spec:
+      serviceAccountName: create-cf-service-account
+      restartPolicy: Never
+      containers:
+      - name: pre-install-create-cfroot-namespace
+        image: "alpine/k8s:1.25.2"
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 1000
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
+        command:
+        - sh
+        - -c
+        - |
+          cat <<EOF | kubectl apply -f -
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            labels:
+              control-plane: controller-manager
+              pod-security.kubernetes.io/audit: {{ ternary "privileged" "restricted" .Values.global.debug }}
+              pod-security.kubernetes.io/enforce: {{ ternary "privileged" "restricted" .Values.global.debug }}
+            name: {{ .Values.global.rootNamespace }}
+          EOF
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: create-cf-service-account
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/hook: pre-install
+    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-weight: "-10"
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: create-ns-role
+  annotations:
+    helm.sh/hook: pre-install
+    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-weight: "-10"
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - create
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: create-ns-role-binding
+  annotations:
+    helm.sh/hook: pre-install
+    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-weight: "-10"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: create-ns-role
+subjects:
+- kind: ServiceAccount
+  name: create-cf-service-account
+  namespace: {{ .Release.Namespace }}

--- a/helm/controllers/templates/root-namespace.yaml
+++ b/helm/controllers/templates/root-namespace.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ .Values.global.rootNamespace }}
-  labels:
-    pod-security.kubernetes.io/enforce: restricted
-    pod-security.kubernetes.io/audit: restricted


### PR DESCRIPTION
## Is there a related GitHub Issue?
#1704

## What is this change about?
Create the cfroot namespace via a pre-install helm hook. Thus the root
namespace remains after uninstalling the Korifi/controllers chart
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
Delete the korifi chart, see the cf root namespace remains
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@kieron-dev
