### PR TITLE
Pin the java paketo buildpack to v7.5.0

### DIFF
--- a/helm/kpack-image-builder/templates/cluster-builder.yaml
+++ b/helm/kpack-image-builder/templates/cluster-builder.yaml
@@ -5,7 +5,7 @@ metadata:
   name: cf-default-buildpacks
 spec:
   sources:
-  - image: gcr.io/paketo-buildpacks/java
+  - image: gcr.io/paketo-buildpacks/java:7.5.0
   - image: gcr.io/paketo-buildpacks/nodejs
   - image: gcr.io/paketo-buildpacks/ruby
   - image: gcr.io/paketo-buildpacks/procfile


### PR DESCRIPTION
## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Pin the paketo java buildpack to 7.5.0. With current latest (7.6.0) we are seeing build failures on CI
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
Green tests
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@georgethebeatle
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->
