### PR TITLE
Rename the API clusterrolebinding

### DIFF
--- a/helm/api/templates/rbac.yaml
+++ b/helm/api/templates/rbac.yaml
@@ -8,7 +8,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: korifi-api-system-clusterrolebinding
+  name: korifi-api-system-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
## Is there a related GitHub Issue?
No. This is related to the work to create a Helm chart.

## What is this change about?
Renaming the API's clusterrole without renaming the corresponding clusterrolebinding caused upgrades to fail due to the inability to update the roleRef of a clusterrolebinding.

## Does this PR introduce a breaking change?
No.

## Acceptance Steps
Install Korifi v0.3.0 and then upgrade to "main".

## Tag your pair, your PM, and/or team
@julian-hj 