### PR TITLE
Make helm hooks more resilient

### DIFF
--- a/helm/controllers/templates/post-install-app-domain.yaml
+++ b/helm/controllers/templates/post-install-app-domain.yaml
@@ -13,7 +13,7 @@ metadata:
     # job is considered part of the release.
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
 spec:
   template:
     metadata:

--- a/helm/controllers/templates/pre-install-cfroot-namespace.yaml
+++ b/helm/controllers/templates/pre-install-cfroot-namespace.yaml
@@ -13,7 +13,7 @@ metadata:
     # job is considered part of the release.
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
 spec:
   template:
     metadata:
@@ -60,7 +60,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     helm.sh/hook: pre-install
-    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation
     helm.sh/hook-weight: "-10"
 
 ---
@@ -70,7 +70,7 @@ metadata:
   name: create-ns-role
   annotations:
     helm.sh/hook: pre-install
-    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation
     helm.sh/hook-weight: "-10"
 rules:
 - apiGroups:

--- a/helm/kpack-image-builder/templates/post-install-builderinfo.yaml
+++ b/helm/kpack-image-builder/templates/post-install-builderinfo.yaml
@@ -13,7 +13,7 @@ metadata:
     # job is considered part of the release.
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
 spec:
   template:
     metadata:

--- a/helm/kpack-image-builder/templates/pre-delete-builderinfo.yaml
+++ b/helm/kpack-image-builder/templates/pre-delete-builderinfo.yaml
@@ -11,7 +11,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
 spec:
   template:
     metadata:


### PR DESCRIPTION

<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
No

## What is this change about?
* Change delete policies to add before-hook-creation to hook-succeeded.
  This means that if a hook fails, you can re-run and not automatically
  get an error that the resource already exists
* Change the delete policy for the role and binding used in the
  pre-install hook. When set to hook-succeeded, there is a chance the
  role or binding will be deleted before the job that relies on them
  starts. So use the default before-hook-creation instead.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
This should fix deploy on acceptance :)

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
