### PR TITLE
Helm pre-delete hook job namespace fix

### DIFF
--- a/helm/controllers/templates/pre-install-cfroot-namespace.yaml
+++ b/helm/controllers/templates/pre-install-cfroot-namespace.yaml
@@ -12,7 +12,7 @@ metadata:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
     "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
 spec:
   template:
@@ -88,8 +88,8 @@ metadata:
   name: create-ns-role-binding
   annotations:
     helm.sh/hook: pre-install
-    helm.sh/hook-delete-policy: hook-succeeded
-    helm.sh/hook-weight: "-10"
+    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/hook-weight: "-5"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/helm/kpack-image-builder/templates/pre-delete-builderinfo.yaml
+++ b/helm/kpack-image-builder/templates/pre-delete-builderinfo.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: delete-builderinfo
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
   annotations:
     "helm.sh/hook": pre-delete
-    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
 spec:
   template:
@@ -21,7 +21,7 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name | quote }}
         helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     spec:
-      serviceAccountName: korifi-kpack-build-controller-manager
+      serviceAccountName: delete-builderinfo-service-account
       restartPolicy: Never
       containers:
       - name: pre-delete-builderinfo
@@ -39,3 +39,51 @@ spec:
         - sh
         - -c
         - "kubectl -n {{ .Values.global.rootNamespace }} delete builderinfo kpack-image-builder --ignore-not-found"
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: delete-builderinfo-service-account
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/hook-weight: "-10"
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: delete-builderinfo-role
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/hook-weight: "-10"
+rules:
+- apiGroups:
+  - "korifi.cloudfoundry.org"
+  resources:
+  - builderinfos
+  verbs:
+  - get
+  - list
+  - delete
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: delete-builderinfo-role-binding
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/hook-weight: "-5"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: delete-builderinfo-role
+subjects:
+- kind: ServiceAccount
+  name: delete-builderinfo-service-account
+  namespace: {{ .Release.Namespace }}


### PR DESCRIPTION

<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
No

## What is this change about?
We have seen this delete hook failing when the install hasn't completed
as far as creating the korifi-kpack-image-builder-system namespace. So
it is safer to use the helm release namespace, defaulting to `default`,
which stands a better chance of existing.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
