### PR TITLE
Remove exampleClusterBuilder.create property

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -76,7 +76,6 @@ helm install korifi https://github.com/cloudfoundry/korifi/releases/download/v<v
     --set=api.apiServer.url=api.$BASE_DOMAIN \
     --set=global.defaultAppDomainName=apps.$BASE_DOMAIN \
     --set=api.packageRegistry=us-east4-docker.pkg.dev/vigilant-card-347116/korifi/packages \
-    --set=kpack-image-builder.exampleClusterBuilder.create=true \
     --set=kpack-image-builder.exampleClusterBuilder.kpackBuilderRegistry=us-east4-docker.pkg.dev/vigilant-card-347116/korifi/kpack \
     --set=kpack-image-builder.packageRegistry=us-east4-docker.pkg.dev/vigilant-card-347116/korifi/droplets
 ```
@@ -91,8 +90,7 @@ helm install korifi https://github.com/cloudfoundry/korifi/releases/download/v<v
 - `api.packageRegistry` specifies the tag prefix used for the source packages uploaded to Korifi. Its hostname should point to your container registry and its path should be valid for the registry.
   - If using **DockerHub**, `api.packageRegistry` should be `index.docker.io/<username>`.
   - If using **GCR**, `api.packageRegistry` should be `gcr.io/<project-id>/packages`.
-- `kpack-image-builder.exampleClusterBuilder.create` activates creation of the example kpack cluster builder, store and stack resources.
-- `kpack-image-builder.exampleClusterBuilder.kpackBuilderRegistry` is the registry location for the kpack builder image (pushed by kpack).
+- `kpack-image-builder.exampleClusterBuilder.kpackBuilderRegistry` is the registry location for the kpack builder image. This is part of the example cluster builder configuration that is created when `kpack-image-builder.clusterBuilderName` is left empty.
 - `kpack-image-builder.packageRegistry` specifies the tag prefix used for the images built by Korifi. Its hostname should point to your container registry and its path should be valid for the registry.
   - If using **DockerHub**, `kpack-image-builder.packageRegistry` should be `index.docker.io/<username>`.
   - If using **GCR**, `kpack-image-builder.packageRegistry` should be `gcr.io/<project-id>/droplets`.
@@ -103,16 +101,17 @@ The chart provides various other values that can be set. See [helm/README.values
 
 If you are using an authentication proxy with your cluster to enable SSO, you must alter the above `helm install` command to set the following values:
 
--   Set the `api.authProxy.host` helm value to the IP address of your cluster's auth proxy.
--   Set the `api.authProxy.caCert` helm value to the CA certificate of your cluster's auth proxy.
+- Set the `api.authProxy.host` helm value to the IP address of your cluster's auth proxy.
+- Set the `api.authProxy.caCert` helm value to the CA certificate of your cluster's auth proxy.
 
 ## Post-install Configuration
 
 ### Kpack Configuration
 
-The korifi helm chart will create an example kpack configuration (cluster builder, cluster store and cluster stack) if the `kpack-image-builder.exampleClusterBuilder.create` helm property has been set to `true`.
-You can opt out of doing that by setting the property to `false` (that's the default value).
-In that case you have to configure those yourself.
+The korifi helm chart will create an example kpack configuration (cluster builder, cluster store and cluster stack) if the `kpack-image-builder.clusterBuilderName` helm property is left unset.
+If you want to use your own kpack configuration, supply the name of the cluster builder in that property.
+
+To create your own kpack configuration, you will need a cluster store, a cluster stack and a cluster builder:
 
 #### `ClusterStore`
 
@@ -126,13 +125,13 @@ Follow the [documentation](https://github.com/pivotal/kpack/blob/main/docs/stack
 
 Follow the [documentation](https://github.com/pivotal/kpack/blob/main/docs/builders.md#cluster-builders) to create a `ClusterBuilder` for your cluster. Make sure that:
 
--   `metadata.name` matches the `korifi-image-builder.clusterBuilderName` helm value (default is `cf-kpack-cluster-builder`)
--   `spec.tag` points to your container registry:
-    -   if using **DockerHub**, it should be `index.docker.io/<username>/korifi-cluster-builder`;
-    -   if using **GCP**, it should be `gcr.io/<project-id>/korifi-cluster-builder`;
--   `spec.stack` references to the previously created `ClusterStack`;
--   `spec.store` references to the previously created `ClusterStore`;
--   `spec.serviceAccountRef` should be `kpack-service-account`.
+- `metadata.name` matches the `korifi-image-builder.clusterBuilderName` helm value
+- `spec.tag` points to your container registry:
+  - if using **DockerHub**, it should be `index.docker.io/<username>/korifi-cluster-builder`;
+  - if using **GCP**, it should be `gcr.io/<project-id>/korifi-cluster-builder`;
+- `spec.stack` references to the previously created `ClusterStack`;
+- `spec.store` references to the previously created `ClusterStore`;
+- `spec.serviceAccountRef` should be `kpack-service-account`.
 
 ### Container registry credentials `Secret`
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -76,7 +76,7 @@ helm install korifi https://github.com/cloudfoundry/korifi/releases/download/v<v
     --set=api.apiServer.url=api.$BASE_DOMAIN \
     --set=global.defaultAppDomainName=apps.$BASE_DOMAIN \
     --set=api.packageRegistry=us-east4-docker.pkg.dev/vigilant-card-347116/korifi/packages \
-    --set=kpack-image-builder.exampleClusterBuilder.kpackBuilderRegistry=us-east4-docker.pkg.dev/vigilant-card-347116/korifi/kpack \
+    --set=kpack-image-builder.builderRegistry=us-east4-docker.pkg.dev/vigilant-card-347116/korifi/kpack \
     --set=kpack-image-builder.packageRegistry=us-east4-docker.pkg.dev/vigilant-card-347116/korifi/droplets
 ```
 
@@ -90,7 +90,7 @@ helm install korifi https://github.com/cloudfoundry/korifi/releases/download/v<v
 - `api.packageRegistry` specifies the tag prefix used for the source packages uploaded to Korifi. Its hostname should point to your container registry and its path should be valid for the registry.
   - If using **DockerHub**, `api.packageRegistry` should be `index.docker.io/<username>`.
   - If using **GCR**, `api.packageRegistry` should be `gcr.io/<project-id>/packages`.
-- `kpack-image-builder.exampleClusterBuilder.kpackBuilderRegistry` is the registry location for the kpack builder image. This is part of the example cluster builder configuration that is created when `kpack-image-builder.clusterBuilderName` is left empty.
+- `kpack-image-builder.builderRegistry` is the registry location for the kpack builder image. This is part of the example cluster builder configuration that is created when `kpack-image-builder.clusterBuilderName` is left empty.
 - `kpack-image-builder.packageRegistry` specifies the tag prefix used for the images built by Korifi. Its hostname should point to your container registry and its path should be valid for the registry.
   - If using **DockerHub**, `kpack-image-builder.packageRegistry` should be `index.docker.io/<username>`.
   - If using **GCR**, `kpack-image-builder.packageRegistry` should be `gcr.io/<project-id>/droplets`.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -76,7 +76,7 @@ helm install korifi https://github.com/cloudfoundry/korifi/releases/download/v<v
     --set=api.apiServer.url=api.$BASE_DOMAIN \
     --set=global.defaultAppDomainName=apps.$BASE_DOMAIN \
     --set=api.packageRegistry=us-east4-docker.pkg.dev/vigilant-card-347116/korifi/source-package \
-    --set=kpack-image-builder.builderRegistry=us-east4-docker.pkg.dev/vigilant-card-347116/korifi/kpack-builder \
+    --set=kpack-image-builder.builderRepository=us-east4-docker.pkg.dev/vigilant-card-347116/korifi/kpack-builder \
     --set=kpack-image-builder.dropletRegistry=us-east4-docker.pkg.dev/vigilant-card-347116/korifi/droplet
 ```
 
@@ -90,7 +90,9 @@ helm install korifi https://github.com/cloudfoundry/korifi/releases/download/v<v
 - `api.packageRegistry` specifies the tag prefix used for the source packages uploaded to Korifi. Its hostname should point to your container registry and its path should be valid for the registry.
   - If using **DockerHub**, `api.packageRegistry` should be `index.docker.io/<username>`.
   - If using **GCR**, `api.packageRegistry` should be `gcr.io/<project-id>/packages`.
-- `kpack-image-builder.builderRegistry` is the registry tag for the kpack builder image. This is part of the example cluster builder configuration that is created when `kpack-image-builder.clusterBuilderName` is left empty.
+- `kpack-image-builder.builderRepository` is the docker repository URL for the kpack builder image. This is part of the example cluster builder configuration that is created when `kpack-image-builder.clusterBuilderName` is left empty.
+  - If using **DockerHub**, `kpack-image-builder.builderRepository` should be `index.docker.io/<username>/kpack-builder`.
+  - If using **GCR**, `kpack-image-builder.builderRepository` should be `gcr.io/<project-id>/kpack-builder`.
 - `kpack-image-builder.dropletRegistry` specifies the tag prefix used for the droplet images built by Korifi. Its hostname should point to your container registry and its path should be valid for the registry.
   - If using **DockerHub**, `kpack-image-builder.packageRegistry` should be `index.docker.io/<username>`.
   - If using **GCR**, `kpack-image-builder.packageRegistry` should be `gcr.io/<project-id>/droplets`.

--- a/INSTALL_kind.md
+++ b/INSTALL_kind.md
@@ -47,7 +47,7 @@ When using `helm install`, you should set the following helm values:
 
 ```
   --set=api.packageRegistry=index.docker.io/<username> \
-  --set=kpack-image-builder.builderRegistry=index.docker.io/<username> \
+  --set=kpack-image-builder.builderRepository=index.docker.io/<username>/kpack-builder \
   --set=kpack-image-builder.packageRegistry=index.docker.io/<username>
 ```
 

--- a/INSTALL_kind.md
+++ b/INSTALL_kind.md
@@ -47,7 +47,7 @@ When using `helm install`, you should set the following helm values:
 
 ```
   --set=api.packageRegistry=index.docker.io/<username> \
-  --set=kpack-image-builder.exampleClusterBuilder.kpackBuilderRegistry=index.docker.io/<username> \
+  --set=kpack-image-builder.builderRegistry=index.docker.io/<username> \
   --set=kpack-image-builder.packageRegistry=index.docker.io/<username>
 ```
 

--- a/helm/README.values.md
+++ b/helm/README.values.md
@@ -151,11 +151,10 @@ kpack-image-builder:
 
   # The image registry where droplet images are pushed to
   packageRegistry: registry-org/package-repo-name
-  # The name of the cluster builder kpack has been configured with
+  # The name of the cluster builder kpack has been configured with.
+  # Leave blank to let kpack-image-builder create an example cluster builder
   clusterBuilderName: cf-kpack-cluster-builder
   exampleClusterBuilder:
-    # create an example cluster store, stack and builder
-    create: false
     # registry location to store cluster builder image
     kpackBuilderRegistry: registry-org/kpack-builder-repo-name
 

--- a/helm/README.values.md
+++ b/helm/README.values.md
@@ -154,9 +154,8 @@ kpack-image-builder:
   # The name of the cluster builder kpack has been configured with.
   # Leave blank to let kpack-image-builder create an example cluster builder
   clusterBuilderName: cf-kpack-cluster-builder
-  exampleClusterBuilder:
-    # registry location to store cluster builder image
-    kpackBuilderRegistry: registry-org/kpack-builder-repo-name
+  # registry location to store cluster builder image when clusterBuilderName not provided
+  builderRegistry: registry-org/kpack-builder-repo-name
 
 statefulset-runner:
   # Deploy the statefulset-runner component

--- a/helm/README.values.md
+++ b/helm/README.values.md
@@ -150,7 +150,7 @@ kpack-image-builder:
   image: cloudfoundry/korifi-kpack-image-builder:latest
 
   # The image registry where droplet images are pushed to
-  packageRegistry: registry-org/package-repo-name
+  dropletRegistry: registry-org/droplet-repo-name
   # The name of the cluster builder kpack has been configured with.
   # Leave blank to let kpack-image-builder create an example cluster builder
   clusterBuilderName: cf-kpack-cluster-builder

--- a/helm/README.values.md
+++ b/helm/README.values.md
@@ -61,7 +61,7 @@ api:
   # ID of the builder to use on source packages
   builderName: kpack-image-builder
   # The container registry where app source packages will be stored
-  packageRegistry: registry-org/package-repo-name
+  packageRegistry: index.docker.io/my-dockerhub-username
   # Warn if user cert provided for login has a long expiry
   userCertificateExpirationWarningDuration: 168h
 
@@ -150,12 +150,12 @@ kpack-image-builder:
   image: cloudfoundry/korifi-kpack-image-builder:latest
 
   # The image registry where droplet images are pushed to
-  dropletRegistry: registry-org/droplet-repo-name
+  dropletRegistry: index.docker.io/my-dockerhub-username
   # The name of the cluster builder kpack has been configured with.
   # Leave blank to let kpack-image-builder create an example cluster builder
   clusterBuilderName: cf-kpack-cluster-builder
-  # registry location to store cluster builder image when clusterBuilderName not provided
-  builderRegistry: registry-org/kpack-builder-repo-name
+  # docker repository to store cluster builder image (required when clusterBuilderName not provided)
+  builderRepository: index.docker.io/my-dockerhub-username
 
 statefulset-runner:
   # Deploy the statefulset-runner component

--- a/helm/api/values.yaml
+++ b/helm/api/values.yaml
@@ -34,7 +34,7 @@ lifecycle:
     diskMB: 1024
 
 builderName: kpack-image-builder
-packageRegistry: registry-org/package-repo-name
+packageRegistry: index.docker.io/my-dockerhub-username
 userCertificateExpirationWarningDuration: 168h
 
 authProxy:

--- a/helm/kpack-image-builder/templates/cluster-builder.yaml
+++ b/helm/kpack-image-builder/templates/cluster-builder.yaml
@@ -32,7 +32,7 @@ spec:
   serviceAccountRef:
     name: kpack-service-account
     namespace: {{ .Values.global.rootNamespace }}
-  tag: {{ required "exampleClusterBuilder.kpackBuilderRegistry is required when clusterBuilderName is unset" .Values.exampleClusterBuilder.kpackBuilderRegistry }}
+  tag: {{ required "builderRegistry is required when clusterBuilderName is unset" .Values.builderRegistry }}
   stack:
     name: cf-default-stack
     kind: ClusterStack

--- a/helm/kpack-image-builder/templates/cluster-builder.yaml
+++ b/helm/kpack-image-builder/templates/cluster-builder.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.exampleClusterBuilder.create }}
+{{- if not .Values.clusterBuilderName }}
 apiVersion: kpack.io/v1alpha2
 kind: ClusterStore
 metadata:
@@ -27,12 +27,12 @@ spec:
 apiVersion: kpack.io/v1alpha2
 kind: ClusterBuilder
 metadata:
-  name: {{ .Values.clusterBuilderName }}
+  name: cf-kpack-cluster-builder
 spec:
   serviceAccountRef:
     name: kpack-service-account
     namespace: {{ .Values.global.rootNamespace }}
-  tag: {{ .Values.exampleClusterBuilder.kpackBuilderRegistry }}
+  tag: {{ required "exampleClusterBuilder.kpackBuilderRegistry is required when clusterBuilderName is unset" .Values.exampleClusterBuilder.kpackBuilderRegistry }}
   stack:
     name: cf-default-stack
     kind: ClusterStack

--- a/helm/kpack-image-builder/templates/cluster-builder.yaml
+++ b/helm/kpack-image-builder/templates/cluster-builder.yaml
@@ -32,7 +32,7 @@ spec:
   serviceAccountRef:
     name: kpack-service-account
     namespace: {{ .Values.global.rootNamespace }}
-  tag: {{ required "builderRegistry is required when clusterBuilderName is unset" .Values.builderRegistry }}
+  tag: {{ required "builderRepository is required when clusterBuilderName is unset" .Values.builderRepository }}
   stack:
     name: cf-default-stack
     kind: ClusterStack

--- a/helm/kpack-image-builder/templates/configmap.yaml
+++ b/helm/kpack-image-builder/templates/configmap.yaml
@@ -6,5 +6,5 @@ metadata:
 data:
   kpack_build_controllers_config.yaml: |
     cfRootNamespace: {{ .Values.global.rootNamespace }}
-    clusterBuilderName: {{ .Values.clusterBuilderName }}
+    clusterBuilderName: {{ default "cf-kpack-cluster-builder" .Values.clusterBuilderName }}
     kpackImageTag: {{ .Values.packageRegistry }}

--- a/helm/kpack-image-builder/templates/configmap.yaml
+++ b/helm/kpack-image-builder/templates/configmap.yaml
@@ -7,4 +7,4 @@ data:
   kpack_build_controllers_config.yaml: |
     cfRootNamespace: {{ .Values.global.rootNamespace }}
     clusterBuilderName: {{ default "cf-kpack-cluster-builder" .Values.clusterBuilderName }}
-    kpackImageTag: {{ .Values.packageRegistry }}
+    kpackImageTag: {{ .Values.dropletRegistry }}

--- a/helm/kpack-image-builder/values.yaml
+++ b/helm/kpack-image-builder/values.yaml
@@ -16,6 +16,6 @@ resources:
 
 image: cloudfoundry/korifi-kpack-image-builder:latest
 
-dropletRegistry: registry-org/droplet-repo-name
+dropletRegistry: index.docker.io/my-dockerhub-username
 clusterBuilderName:
-builderRegistry: registry-org/kpack-builder-repo-name
+builderRepository: index.docker.io/my-dockerhub-username/kpack-builder

--- a/helm/kpack-image-builder/values.yaml
+++ b/helm/kpack-image-builder/values.yaml
@@ -18,5 +18,4 @@ image: cloudfoundry/korifi-kpack-image-builder:latest
 
 packageRegistry: registry-org/package-repo-name
 clusterBuilderName:
-exampleClusterBuilder:
-  kpackBuilderRegistry: registry-org/kpack-builder-repo-name
+builderRegistry: registry-org/kpack-builder-repo-name

--- a/helm/kpack-image-builder/values.yaml
+++ b/helm/kpack-image-builder/values.yaml
@@ -16,6 +16,6 @@ resources:
 
 image: cloudfoundry/korifi-kpack-image-builder:latest
 
-packageRegistry: registry-org/package-repo-name
+dropletRegistry: registry-org/droplet-repo-name
 clusterBuilderName:
 builderRegistry: registry-org/kpack-builder-repo-name

--- a/helm/kpack-image-builder/values.yaml
+++ b/helm/kpack-image-builder/values.yaml
@@ -17,7 +17,6 @@ resources:
 image: cloudfoundry/korifi-kpack-image-builder:latest
 
 packageRegistry: registry-org/package-repo-name
-clusterBuilderName: cf-kpack-cluster-builder
+clusterBuilderName:
 exampleClusterBuilder:
-  create: false
   kpackBuilderRegistry: registry-org/kpack-builder-repo-name

--- a/scripts/assets/values-template.yaml
+++ b/scripts/assets/values-template.yaml
@@ -19,8 +19,7 @@ job-task-runner:
 kpack-image-builder:
   image: cloudfoundry/korifi-kpack-image-builder:latest
   packageRegistry: localregistry-docker-registry.default.svc.cluster.local:30050/korifi-controllers/kpack/images
-  exampleClusterBuilder:
-    kpackBuilderRegistry: localregistry-docker-registry.default.svc.cluster.local:30050/cf-relint-greengrass/korifi/kpack/beta
+  builderRegistry: localregistry-docker-registry.default.svc.cluster.local:30050/cf-relint-greengrass/korifi/kpack/beta
 
 statefulset-runner:
   image: cloudfoundry/korifi-statefulset-runner:latest

--- a/scripts/assets/values-template.yaml
+++ b/scripts/assets/values-template.yaml
@@ -20,7 +20,6 @@ kpack-image-builder:
   image: cloudfoundry/korifi-kpack-image-builder:latest
   packageRegistry: localregistry-docker-registry.default.svc.cluster.local:30050/korifi-controllers/kpack/images
   exampleClusterBuilder:
-    create: true
     kpackBuilderRegistry: localregistry-docker-registry.default.svc.cluster.local:30050/cf-relint-greengrass/korifi/kpack/beta
 
 statefulset-runner:

--- a/scripts/assets/values-template.yaml
+++ b/scripts/assets/values-template.yaml
@@ -6,7 +6,7 @@ api:
   apiServer:
     url: localhost
   image: cloudfoundry/korifi-api:latest
-  packageRegistry: localregistry-docker-registry.default.svc.cluster.local:30050/kpack/packages
+  packageRegistry: localregistry-docker-registry.default.svc.cluster.local:30050/sources
 
 controllers:
   taskTTL: 5s
@@ -18,8 +18,8 @@ job-task-runner:
 
 kpack-image-builder:
   image: cloudfoundry/korifi-kpack-image-builder:latest
-  packageRegistry: localregistry-docker-registry.default.svc.cluster.local:30050/korifi-controllers/kpack/images
-  builderRegistry: localregistry-docker-registry.default.svc.cluster.local:30050/cf-relint-greengrass/korifi/kpack/beta
+  dropletRegistry: localregistry-docker-registry.default.svc.cluster.local:30050/droplets
+  builderRegistry: localregistry-docker-registry.default.svc.cluster.local:30050/kpack-builder
 
 statefulset-runner:
   image: cloudfoundry/korifi-statefulset-runner:latest

--- a/scripts/assets/values-template.yaml
+++ b/scripts/assets/values-template.yaml
@@ -19,7 +19,7 @@ job-task-runner:
 kpack-image-builder:
   image: cloudfoundry/korifi-kpack-image-builder:latest
   dropletRegistry: localregistry-docker-registry.default.svc.cluster.local:30050/droplets
-  builderRegistry: localregistry-docker-registry.default.svc.cluster.local:30050/kpack-builder
+  builderRepository: localregistry-docker-registry.default.svc.cluster.local:30050/kpack-builder
 
 statefulset-runner:
   image: cloudfoundry/korifi-statefulset-runner:latest


### PR DESCRIPTION
## Is there a related GitHub Issue?
#1578

## What is this change about?
Instead of putting `exampleClusterBuilder.create: true`, we now just leave `clusterBuilderName` empty in order to make helm create the example cluster builder configuration.


## Does this PR introduce a breaking change?
No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
