### PR TITLE
Remove korifi helm property `createAdminUser`

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -72,7 +72,6 @@ As of v0.4.0 Korifi is distributed as a helm chart. You can set the required con
 helm install korifi https://github.com/cloudfoundry/korifi/releases/download/v<version>/korifi-<version>.tgz \
     --set=global.generateIngressCertificates=true \
     --set=global.rootNamespace=$ROOT_NAMESPACE \
-    --set=createAdminUser=true \
     --set=adminUserName=$ADMIN_USERNAME \
     --set=api.apiServer.url=api.$BASE_DOMAIN \
     --set=global.defaultAppDomainName=apps.$BASE_DOMAIN \
@@ -86,8 +85,7 @@ helm install korifi https://github.com/cloudfoundry/korifi/releases/download/v<v
 
 - `global.generateIngressCertificates` when set to `true` generates self-signed certificates for the applications and API HTTP endpoint
 - `global.rootNamespace` is the name of the CF root namespace containing base CF resources, like CFOrgs.
-- `createAdminUser` when set to `true` creates the rolebinding between the `$ADMIN_USERNAME` and the cf-admin role.
-- `adminUserName` is the username used above.
+- `adminUserName` is the username that will be bound to the cf admin role.
 - `api.apiServer.url` is the domain name that will be used by the Korifi API, and is usually of the format `api.$BASE_DOMAIN`.
 - `global.defaultAppDomainName` is the default base domain name for the apps deployed by Korifi, and is usually of the format `apps.$BASE_DOMAIN`.
 - `api.packageRegistry` specifies the tag prefix used for the source packages uploaded to Korifi. Its hostname should point to your container registry and its path should be valid for the registry.

--- a/helm/README.values.md
+++ b/helm/README.values.md
@@ -16,9 +16,7 @@ global:
   # The secret to use when pushing source and droplet images to the package registry
   packageRegistrySecret: image-registry-credentials
 
-# Set to false to omit admin user role-binding creation
-createAdminUser: true
-# Name of admin user to use in above role-binding creation
+# Name of admin user that will be bound to the cf admin role
 adminUserName: cf-admin
 
 # API component configuration

--- a/helm/korifi/templates/admin-user.yaml
+++ b/helm/korifi/templates/admin-user.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.createAdminUser }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -13,5 +12,4 @@ roleRef:
 subjects:
   - apiGroup: rbac.authorization.k8s.io
     kind: User
-    name: {{ .Values.adminUserName }}
-{{- end }}
+    name: {{ required "adminUserName value not set" .Values.adminUserName }}

--- a/helm/korifi/values.yaml
+++ b/helm/korifi/values.yaml
@@ -5,7 +5,6 @@ global:
   generateIngressCertificates: false
   packageRegistrySecret: image-registry-credentials
 
-createAdminUser: false
 adminUserName: cf-admin
 
 api:

--- a/scripts/assets/values-template.yaml
+++ b/scripts/assets/values-template.yaml
@@ -2,8 +2,6 @@ global:
   defaultAppDomainName: vcap.me
   generateIngressCertificates: true
 
-createAdminUser: true
-
 api:
   apiServer:
     url: localhost


### PR DESCRIPTION
## Is there a related GitHub Issue?
#1704

## What is this change about?
We will always create the binding from `adminUserName` to the cf-admin role

## Does this PR introduce a breaking change?
No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
