### PR TITLE
Restart deployments when their config changes

### DIFF
--- a/helm/api/templates/deployment.yaml
+++ b/helm/api/templates/deployment.yaml
@@ -14,6 +14,8 @@ spec:
     metadata:
       labels:
         app: korifi-api
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
       containers:
       - env:

--- a/helm/controllers/templates/deployment.yaml
+++ b/helm/controllers/templates/deployment.yaml
@@ -17,6 +17,7 @@ spec:
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
       labels:
         control-plane: controller-manager
     spec:

--- a/helm/job-task-runner/templates/deployment.yaml
+++ b/helm/job-task-runner/templates/deployment.yaml
@@ -17,6 +17,7 @@ spec:
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
       labels:
         control-plane: controller-manager
     spec:

--- a/helm/kpack-image-builder/templates/deployment.yaml
+++ b/helm/kpack-image-builder/templates/deployment.yaml
@@ -17,6 +17,7 @@ spec:
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
       labels:
         control-plane: controller-manager
     spec:


### PR DESCRIPTION

<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
No

## What is this change about?
Annotate deployment pods with a checksum of the deployment configmap. This way when you helm upgrade and a configmap has changed, the corresponding pods will be restarted.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
