### PR TITLE
Combine korifi components into single namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,9 +69,9 @@ manifests-controllers: install-controller-gen ## Generate WebhookConfiguration, 
 		output:rbac:artifacts:config=helm/controllers/templates \
 		output:webhook:artifacts:config=helm/controllers/templates
 
-	$(SED) -i.bak -e '/^metadata:.*/a \ \ annotations:\n    cert-manager.io/inject-ca-from: "{{ .Values.namespace }}/korifi-controllers-serving-cert"' helm/controllers/templates/manifests.yaml
+	$(SED) -i.bak -e '/^metadata:.*/a \ \ annotations:\n    cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/korifi-controllers-serving-cert"' helm/controllers/templates/manifests.yaml
 	$(SED) -i.bak -e 's/name: \(webhook-service\)/name: korifi-controllers-\1/' helm/controllers/templates/manifests.yaml
-	$(SED) -i.bak -e 's/namespace: system/namespace: "{{ .Values.namespace }}"/' helm/controllers/templates/manifests.yaml
+	$(SED) -i.bak -e 's/namespace: system/namespace: "{{ .Release.Namespace }}"/' helm/controllers/templates/manifests.yaml
 	$(SED) -i.bak -e 's/name: \(.*-webhook-configuration\)/name: korifi-controllers-\1/' helm/controllers/templates/manifests.yaml
 	rm -f helm/controllers/templates/manifests.yaml.bak
 

--- a/helm/README.values.md
+++ b/helm/README.values.md
@@ -23,8 +23,6 @@ adminUserName: cf-admin
 api:
   # Deploy the API component
   include: true
-  # Namespace for the API resources
-  namespace: korifi-api-system
   # Number of replicas
   replicas: 1
   # Resource requests
@@ -77,8 +75,6 @@ api:
 controllers:
   # Deploy the controllers component
   include: true
-  # Namespace for the controllers resources
-  namespace: korifi-controllers-system
   # Number of replicas
   replicas: 1
   # Resource requests and limits
@@ -107,13 +103,10 @@ controllers:
   # The TLS secret used when setting up app route
   workloadsTLSSecret:
     name: korifi-workloads-ingress-cert
-    namespace: korifi-controllers-system
 
 job-task-runner:
   # Deploy the job-task-runner component
   include: true
-  # Namespace of the job-task-runner resources
-  namespace: korifi-job-task-runner-system
   # Number of replicas
   replicas: 1
   # Resource requests and limits
@@ -133,8 +126,6 @@ job-task-runner:
 kpack-image-builder:
   # Deploy the kpack-image-builder component
   include: true
-  # Namespace of the kpack-image-builder resources
-  namespace: korifi-kpack-build-system
   # Number of replicas
   replicas: 1
   # Resource requests and limits
@@ -160,8 +151,6 @@ kpack-image-builder:
 statefulset-runner:
   # Deploy the statefulset-runner component
   include: true
-  # Namespace of the statefulset-runner resources
-  namespace: korifi-statefulset-runner-system
   # Number of replicas
   replicas: 1
   # Resource requests and limits

--- a/helm/api/templates/cert-mgr-internal-cert.yaml
+++ b/helm/api/templates/cert-mgr-internal-cert.yaml
@@ -2,27 +2,17 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: korifi-api-internal-cert
-  namespace: {{ .Values.namespace }}
 spec:
-  commonName: korifi-api-svc.{{ .Values.namespace }}.svc.cluster.local
+  commonName: korifi-api-svc.{{ .Release.Namespace }}.svc.cluster.local
   dnsNames:
-  - korifi-api-svc.{{ .Values.namespace }}.svc
-  - korifi-api-svc.{{ .Values.namespace }}.svc.cluster.local
+  - korifi-api-svc.{{ .Release.Namespace }}.svc
+  - korifi-api-svc.{{ .Release.Namespace }}.svc.cluster.local
   issuerRef:
     kind: Issuer
-    name: korifi-api-selfsigned-issuer
+    name: selfsigned-issuer
   secretName: korifi-api-internal-cert
   subject:
     organizations:
     - korifi
   usages:
   - server auth
-
----
-apiVersion: cert-manager.io/v1
-kind: Issuer
-metadata:
-  name: korifi-api-selfsigned-issuer
-  namespace: {{ .Values.namespace }}
-spec:
-  selfSigned: {}

--- a/helm/api/templates/configmap.yaml
+++ b/helm/api/templates/configmap.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: korifi-api-config
-  namespace: {{ .Values.namespace }}
 data:
   korifi_api_config.yaml: |
     externalFQDN: {{ .Values.apiServer.url }}

--- a/helm/api/templates/deployment.yaml
+++ b/helm/api/templates/deployment.yaml
@@ -4,7 +4,6 @@ metadata:
   labels:
     app: korifi-api
   name: korifi-api-deployment
-  namespace: {{ .Values.namespace }}
 spec:
   replicas: {{ .Values.replicas }}
   selector:

--- a/helm/api/templates/ingress-cert.yaml
+++ b/helm/api/templates/ingress-cert.yaml
@@ -3,13 +3,12 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: korifi-api-ingress-cert
-  namespace: {{ .Values.namespace }}
 spec:
   commonName: {{ .Values.apiServer.url }}
   dnsNames:
   - {{ .Values.apiServer.url }}
   issuerRef:
     kind: Issuer
-    name: korifi-api-selfsigned-issuer
+    name: selfsigned-issuer
   secretName: korifi-api-ingress-cert
 {{- end }}

--- a/helm/api/templates/ingress.yaml
+++ b/helm/api/templates/ingress.yaml
@@ -4,7 +4,6 @@ metadata:
   labels:
     app: korifi-api
   name: korifi-api-proxy
-  namespace: {{ .Values.namespace }}
 spec:
   routes:
   - conditions:
@@ -14,7 +13,7 @@ spec:
       port: 443
       validation:
         caSecret: korifi-api-internal-cert
-        subjectName: korifi-api-svc.{{ .Values.namespace }}.svc.cluster.local
+        subjectName: korifi-api-svc.{{ .Release.Namespace }}.svc.cluster.local
     timeoutPolicy:
       response: 5m
   virtualhost:

--- a/helm/api/templates/namespace.yaml
+++ b/helm/api/templates/namespace.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    pod-security.kubernetes.io/audit: {{ ternary "privileged" "restricted" .Values.global.debug }}
-    pod-security.kubernetes.io/enforce: {{ ternary "privileged" "restricted" .Values.global.debug }}
-  name: {{ .Values.namespace }}

--- a/helm/api/templates/rbac.yaml
+++ b/helm/api/templates/rbac.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: korifi-api-system-serviceaccount
-  namespace: {{ .Values.namespace }}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -16,7 +15,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: korifi-api-system-serviceaccount
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -31,4 +30,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: korifi-api-system-serviceaccount
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}

--- a/helm/api/templates/service.yaml
+++ b/helm/api/templates/service.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     app: korifi-api
   name: korifi-api-svc
-  namespace: {{ .Values.namespace }}
 spec:
   ports:
   - name: web
@@ -23,7 +22,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: api-debug-port
-  namespace: {{ .Values.namespace }}
 spec:
   ports:
     - name: debug-30052

--- a/helm/api/values.yaml
+++ b/helm/api/values.yaml
@@ -6,7 +6,6 @@ global:
   packageRegistrySecret: image-registry-credentials
 
 include: true
-namespace: korifi-api-system
 replicas: 1
 resources:
   requests:

--- a/helm/controllers/templates/cert-mgr-internal-cert.yaml
+++ b/helm/controllers/templates/cert-mgr-internal-cert.yaml
@@ -2,20 +2,11 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: korifi-controllers-serving-cert
-  namespace: {{ .Values.namespace }}
 spec:
   dnsNames:
-  - korifi-controllers-webhook-service.{{ .Values.namespace }}.svc
-  - korifi-controllers-webhook-service.{{ .Values.namespace }}.svc.cluster.local
+  - korifi-controllers-webhook-service.{{ .Release.Namespace }}.svc
+  - korifi-controllers-webhook-service.{{ .Release.Namespace }}.svc.cluster.local
   issuerRef:
     kind: Issuer
-    name: korifi-controllers-selfsigned-issuer
-  secretName: webhook-server-cert
----
-apiVersion: cert-manager.io/v1
-kind: Issuer
-metadata:
-  name: korifi-controllers-selfsigned-issuer
-  namespace: {{ .Values.namespace }}
-spec:
-  selfSigned: {}
+    name: selfsigned-issuer
+  secretName: controllers-webhook-server-cert

--- a/helm/controllers/templates/configmap.yaml
+++ b/helm/controllers/templates/configmap.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: korifi-controllers-config
-  namespace: {{ .Values.namespace }}
 data:
   korifi_controllers_config.yaml: |-
     builderName: {{ .Values.reconcilers.build }}
@@ -14,4 +13,4 @@ data:
     packageRegistrySecretName: {{ .Values.global.packageRegistrySecret }}
     taskTTL: {{ .Values.taskTTL }}
     workloads_tls_secret_name: {{ .Values.workloadsTLSSecret.name }}
-    workloads_tls_secret_namespace: {{ .Values.workloadsTLSSecret.namespace }}
+    workloads_tls_secret_namespace: {{ .Release.Namespace }}

--- a/helm/controllers/templates/deployment.yaml
+++ b/helm/controllers/templates/deployment.yaml
@@ -2,14 +2,13 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    control-plane: controller-manager
+    app: korifi-controllers
   name: korifi-controllers-controller-manager
-  namespace: {{ .Values.namespace }}
 spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      control-plane: controller-manager
+      app: korifi-controllers
   template:
     metadata:
       annotations:
@@ -19,7 +18,7 @@ spec:
         prometheus.io/scrape: "true"
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
       labels:
-        control-plane: controller-manager
+        app: korifi-controllers
     spec:
       containers:
       - name: manager
@@ -97,7 +96,7 @@ spec:
       - name: cert
         secret:
           defaultMode: 420
-          secretName: webhook-server-cert
+          secretName: controllers-webhook-server-cert
       - configMap:
           name: korifi-controllers-config
         name: korifi-controllers-config

--- a/helm/controllers/templates/ingress-cert.yaml
+++ b/helm/controllers/templates/ingress-cert.yaml
@@ -3,13 +3,12 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: korifi-workloads-ingress-cert
-  namespace: {{ .Values.namespace }}
 spec:
   commonName: \*.{{ .Values.global.defaultAppDomainName }}
   dnsNames:
   - \*.{{ .Values.global.defaultAppDomainName }}
   issuerRef:
     kind: Issuer
-    name: korifi-controllers-selfsigned-issuer
+    name: selfsigned-issuer
   secretName: korifi-workloads-ingress-cert
 {{- end}}

--- a/helm/controllers/templates/manifests.yaml
+++ b/helm/controllers/templates/manifests.yaml
@@ -3,7 +3,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: "{{ .Values.namespace }}/korifi-controllers-serving-cert"
+    cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/korifi-controllers-serving-cert"
   creationTimestamp: null
   name: korifi-controllers-mutating-webhook-configuration
 webhooks:
@@ -13,7 +13,7 @@ webhooks:
   clientConfig:
     service:
       name: korifi-controllers-webhook-service
-      namespace: "{{ .Values.namespace }}"
+      namespace: "{{ .Release.Namespace }}"
       path: /mutate-korifi-cloudfoundry-org-v1alpha1-cfapp
   failurePolicy: Fail
   name: mcfapp.korifi.cloudfoundry.org
@@ -34,7 +34,7 @@ webhooks:
   clientConfig:
     service:
       name: korifi-controllers-webhook-service
-      namespace: "{{ .Values.namespace }}"
+      namespace: "{{ .Release.Namespace }}"
       path: /mutate-korifi-cloudfoundry-org-v1alpha1-cfbuild
   failurePolicy: Fail
   name: mcfbuild.korifi.cloudfoundry.org
@@ -55,7 +55,7 @@ webhooks:
   clientConfig:
     service:
       name: korifi-controllers-webhook-service
-      namespace: "{{ .Values.namespace }}"
+      namespace: "{{ .Release.Namespace }}"
       path: /mutate-korifi-cloudfoundry-org-v1alpha1-cfpackage
   failurePolicy: Fail
   name: mcfpackage.korifi.cloudfoundry.org
@@ -76,7 +76,7 @@ webhooks:
   clientConfig:
     service:
       name: korifi-controllers-webhook-service
-      namespace: "{{ .Values.namespace }}"
+      namespace: "{{ .Release.Namespace }}"
       path: /mutate-korifi-cloudfoundry-org-v1alpha1-cfprocess
   failurePolicy: Fail
   name: mcfprocess.korifi.cloudfoundry.org
@@ -97,7 +97,7 @@ webhooks:
   clientConfig:
     service:
       name: korifi-controllers-webhook-service
-      namespace: "{{ .Values.namespace }}"
+      namespace: "{{ .Release.Namespace }}"
       path: /mutate-korifi-cloudfoundry-org-v1alpha1-cfroute
   failurePolicy: Fail
   name: mcfroute.korifi.cloudfoundry.org
@@ -117,7 +117,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: "{{ .Values.namespace }}/korifi-controllers-serving-cert"
+    cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/korifi-controllers-serving-cert"
   creationTimestamp: null
   name: korifi-controllers-validating-webhook-configuration
 webhooks:
@@ -126,7 +126,7 @@ webhooks:
   clientConfig:
     service:
       name: korifi-controllers-webhook-service
-      namespace: "{{ .Values.namespace }}"
+      namespace: "{{ .Release.Namespace }}"
       path: /validate-korifi-cloudfoundry-org-v1alpha1-cfdomain
   failurePolicy: Fail
   name: vcfdomain.korifi.cloudfoundry.org
@@ -147,7 +147,7 @@ webhooks:
   clientConfig:
     service:
       name: korifi-controllers-webhook-service
-      namespace: "{{ .Values.namespace }}"
+      namespace: "{{ .Release.Namespace }}"
       path: /validate-korifi-cloudfoundry-org-v1alpha1-cfroute
   failurePolicy: Fail
   name: vcfroute.korifi.cloudfoundry.org
@@ -169,7 +169,7 @@ webhooks:
   clientConfig:
     service:
       name: korifi-controllers-webhook-service
-      namespace: "{{ .Values.namespace }}"
+      namespace: "{{ .Release.Namespace }}"
       path: /validate-korifi-cloudfoundry-org-v1alpha1-cfservicebinding
   failurePolicy: Fail
   name: vcfservicebinding.korifi.cloudfoundry.org
@@ -191,7 +191,7 @@ webhooks:
   clientConfig:
     service:
       name: korifi-controllers-webhook-service
-      namespace: "{{ .Values.namespace }}"
+      namespace: "{{ .Release.Namespace }}"
       path: /validate-korifi-cloudfoundry-org-v1alpha1-cfserviceinstance
   failurePolicy: Fail
   name: vcfserviceinstance.korifi.cloudfoundry.org
@@ -213,7 +213,7 @@ webhooks:
   clientConfig:
     service:
       name: korifi-controllers-webhook-service
-      namespace: "{{ .Values.namespace }}"
+      namespace: "{{ .Release.Namespace }}"
       path: /validate-korifi-cloudfoundry-org-v1alpha1-cfapp
   failurePolicy: Fail
   name: vcfapp.korifi.cloudfoundry.org
@@ -235,7 +235,7 @@ webhooks:
   clientConfig:
     service:
       name: korifi-controllers-webhook-service
-      namespace: "{{ .Values.namespace }}"
+      namespace: "{{ .Release.Namespace }}"
       path: /validate-korifi-cloudfoundry-org-v1alpha1-cforg
   failurePolicy: Fail
   name: vcforg.korifi.cloudfoundry.org
@@ -257,7 +257,7 @@ webhooks:
   clientConfig:
     service:
       name: korifi-controllers-webhook-service
-      namespace: "{{ .Values.namespace }}"
+      namespace: "{{ .Release.Namespace }}"
       path: /validate-korifi-cloudfoundry-org-v1alpha1-cfspace
   failurePolicy: Fail
   name: vcfspace.korifi.cloudfoundry.org
@@ -279,7 +279,7 @@ webhooks:
   clientConfig:
     service:
       name: korifi-controllers-webhook-service
-      namespace: "{{ .Values.namespace }}"
+      namespace: "{{ .Release.Namespace }}"
       path: /validate-korifi-cloudfoundry-org-v1alpha1-cftask
   failurePolicy: Fail
   name: vcftask.korifi.cloudfoundry.org

--- a/helm/controllers/templates/namespace.yaml
+++ b/helm/controllers/templates/namespace.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    control-plane: controller-manager
-    pod-security.kubernetes.io/audit: {{ ternary "privileged" "restricted" .Values.global.debug }}
-    pod-security.kubernetes.io/enforce: {{ ternary "privileged" "restricted" .Values.global.debug }}
-  name: {{ .Values.namespace }}

--- a/helm/controllers/templates/post-install-app-domain.yaml
+++ b/helm/controllers/templates/post-install-app-domain.yaml
@@ -2,7 +2,6 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: create-app-domain
-  namespace: {{ .Values.namespace }}
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/instance: {{ .Release.Name | quote }}

--- a/helm/controllers/templates/pre-install-cfroot-namespace.yaml
+++ b/helm/controllers/templates/pre-install-cfroot-namespace.yaml
@@ -46,7 +46,6 @@ spec:
           kind: Namespace
           metadata:
             labels:
-              control-plane: controller-manager
               pod-security.kubernetes.io/audit: {{ ternary "privileged" "restricted" .Values.global.debug }}
               pod-security.kubernetes.io/enforce: {{ ternary "privileged" "restricted" .Values.global.debug }}
             name: {{ .Values.global.rootNamespace }}

--- a/helm/controllers/templates/rbac.yaml
+++ b/helm/controllers/templates/rbac.yaml
@@ -2,14 +2,12 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: korifi-controllers-controller-manager
-  namespace: {{ .Values.namespace }}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: korifi-controllers-leader-election-role
-  namespace: {{ .Values.namespace }}
 rules:
 - apiGroups:
   - ""
@@ -48,7 +46,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: korifi-controllers-leader-election-rolebinding
-  namespace: {{ .Values.namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -56,7 +53,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: korifi-controllers-controller-manager
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -70,4 +67,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: korifi-controllers-controller-manager
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}

--- a/helm/controllers/templates/service.yaml
+++ b/helm/controllers/templates/service.yaml
@@ -2,13 +2,12 @@ apiVersion: v1
 kind: Service
 metadata:
   name: korifi-controllers-webhook-service
-  namespace: {{ .Values.namespace }}
 spec:
   ports:
   - port: 443
     targetPort: 9443
   selector:
-    control-plane: controller-manager
+    app: korifi-controllers
 
 {{- if .Values.global.debug }}
 ---
@@ -25,6 +24,6 @@ spec:
       protocol: TCP
       targetPort: 40000
   selector:
-    app: korifi-controllers-controller-manager
+    app: korifi-controllers
   type: NodePort
 {{- end }}

--- a/helm/controllers/templates/tls-cert-delegation.yaml
+++ b/helm/controllers/templates/tls-cert-delegation.yaml
@@ -2,7 +2,6 @@ apiVersion: projectcontour.io/v1
 kind: TLSCertificateDelegation
 metadata:
   name: korifi-controllers-workloads-fallback-delegation
-  namespace: {{ .Values.namespace }}
 spec:
   delegations:
   - secretName: korifi-workloads-ingress-cert

--- a/helm/controllers/values.yaml
+++ b/helm/controllers/values.yaml
@@ -6,7 +6,6 @@ global:
   packageRegistrySecret: image-registry-credentials
 
 include: true
-namespace: korifi-controllers-system
 replicas: 1
 resources:
   limits:
@@ -26,4 +25,3 @@ processDefaults:
 taskTTL: 30d
 workloadsTLSSecret:
   name: korifi-workloads-ingress-cert
-  namespace: korifi-controllers-system

--- a/helm/job-task-runner/templates/configmap.yaml
+++ b/helm/job-task-runner/templates/configmap.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: korifi-job-task-runner-config
-  namespace: {{ .Values.namespace }}
 data:
   job_task_runner_config.yaml: |
     jobTTL: {{ .Values.jobTTL }}

--- a/helm/job-task-runner/templates/controller-rbac.yaml
+++ b/helm/job-task-runner/templates/controller-rbac.yaml
@@ -2,14 +2,12 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: korifi-job-task-runner-controller-manager
-  namespace: {{ .Values.namespace }}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: korifi-job-task-runner-leader-election-role
-  namespace: {{ .Values.namespace }}
 rules:
 - apiGroups:
   - ""
@@ -48,7 +46,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: korifi-job-task-runner-leader-election-rolebinding
-  namespace: {{ .Values.namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -56,7 +53,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: korifi-job-task-runner-controller-manager
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -70,4 +67,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: korifi-job-task-runner-controller-manager
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}

--- a/helm/job-task-runner/templates/deployment.yaml
+++ b/helm/job-task-runner/templates/deployment.yaml
@@ -2,14 +2,13 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    control-plane: controller-manager
+    app: korifi-job-task-runner
   name: korifi-job-task-runner-controller-manager
-  namespace: {{ .Values.namespace }}
 spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      control-plane: controller-manager
+      app: korifi-job-task-runner
   template:
     metadata:
       annotations:
@@ -19,7 +18,7 @@ spec:
         prometheus.io/scrape: "true"
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
       labels:
-        control-plane: controller-manager
+        app: korifi-job-task-runner
     spec:
       containers:
       - name: manager

--- a/helm/job-task-runner/templates/namespace.yaml
+++ b/helm/job-task-runner/templates/namespace.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    control-plane: controller-manager
-    pod-security.kubernetes.io/audit: {{ ternary "privileged" "restricted" .Values.global.debug }}
-    pod-security.kubernetes.io/enforce: {{ ternary "privileged" "restricted" .Values.global.debug }}
-  name: {{ .Values.namespace }}

--- a/helm/job-task-runner/templates/service.yaml
+++ b/helm/job-task-runner/templates/service.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: korifi-job-task-runner-controller-manager-debug-port
-  name: {{ .Values.namespace }}
 spec:
   ports:
     - name: debug-30055
@@ -12,6 +11,6 @@ spec:
       protocol: TCP
       targetPort: 40000
   selector:
-    app: korifi-job-task-runner-controller-manager
+    app: korifi-job-task-runner
   type: NodePort
 {{- end }}

--- a/helm/job-task-runner/values.yaml
+++ b/helm/job-task-runner/values.yaml
@@ -3,7 +3,6 @@ global:
   debug: false
 
 include: true
-namespace: korifi-job-task-runner-system
 replicas: 1
 resources:
   limits:

--- a/helm/korifi/templates/cert-mgr-issuer.yaml
+++ b/helm/korifi/templates/cert-mgr-issuer.yaml
@@ -1,0 +1,6 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+spec:
+  selfSigned: {}

--- a/helm/kpack-image-builder/templates/cert-mgr-internal-cert.yaml
+++ b/helm/kpack-image-builder/templates/cert-mgr-internal-cert.yaml
@@ -2,20 +2,11 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: korifi-kpack-build-serving-cert
-  namespace: {{ .Values.namespace }}
 spec:
   dnsNames:
-  - korifi-kpack-build-webhook-service.{{ .Values.namespace }}.svc
-  - korifi-kpack-build-webhook-service.{{ .Values.namespace }}.svc.cluster.local
+  - korifi-kpack-build-webhook-service.{{ .Release.Namespace }}.svc
+  - korifi-kpack-build-webhook-service.{{ .Release.Namespace }}.svc.cluster.local
   issuerRef:
     kind: Issuer
-    name: korifi-kpack-build-selfsigned-issuer
-  secretName: webhook-server-cert
----
-apiVersion: cert-manager.io/v1
-kind: Issuer
-metadata:
-  name: korifi-kpack-build-selfsigned-issuer
-  namespace: {{ .Values.namespace }}
-spec:
-  selfSigned: {}
+    name: selfsigned-issuer
+  secretName: kpack-image-builder-webhook-server-cert

--- a/helm/kpack-image-builder/templates/configmap.yaml
+++ b/helm/kpack-image-builder/templates/configmap.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: korifi-kpack-build-config
-  namespace: korifi-kpack-build-system
 data:
   kpack_build_controllers_config.yaml: |
     cfRootNamespace: {{ .Values.global.rootNamespace }}

--- a/helm/kpack-image-builder/templates/deployment.yaml
+++ b/helm/kpack-image-builder/templates/deployment.yaml
@@ -2,14 +2,13 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    control-plane: controller-manager
+    app: korifi-kpack-image-builder
   name: korifi-kpack-build-controller-manager
-  namespace: {{ .Values.namespace }}
 spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      control-plane: controller-manager
+      app: korifi-kpack-image-builder
   template:
     metadata:
       annotations:
@@ -19,7 +18,7 @@ spec:
         prometheus.io/scrape: "true"
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
       labels:
-        control-plane: controller-manager
+        app: korifi-kpack-image-builder
     spec:
       containers:
       - name: manager
@@ -97,7 +96,7 @@ spec:
       - name: cert
         secret:
           defaultMode: 420
-          secretName: webhook-server-cert
+          secretName: kpack-image-builder-webhook-server-cert
       - configMap:
           name: korifi-kpack-build-config
         name: korifi-kpack-build-config

--- a/helm/kpack-image-builder/templates/manifests.yaml
+++ b/helm/kpack-image-builder/templates/manifests.yaml
@@ -3,7 +3,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: "{{ .Values.namespace }}/korifi-kpack-build-serving-cert"
+    cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/korifi-kpack-build-serving-cert"
   creationTimestamp: null
   name: korifi-kpack-build-mutating-webhook-configuration
 webhooks:
@@ -13,7 +13,7 @@ webhooks:
   clientConfig:
     service:
       name: korifi-kpack-build-webhook-service
-      namespace: "{{ .Values.namespace }}"
+      namespace: "{{ .Release.Namespace }}"
       path: /mutate--v1-pod
   failurePolicy: Ignore
   objectSelector:

--- a/helm/kpack-image-builder/templates/namespace.yaml
+++ b/helm/kpack-image-builder/templates/namespace.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    control-plane: controller-manager
-    pod-security.kubernetes.io/audit: {{ ternary "privileged" "restricted" .Values.global.debug }}
-    pod-security.kubernetes.io/enforce: {{ ternary "privileged" "restricted" .Values.global.debug }}
-  name: {{ .Values.namespace }}

--- a/helm/kpack-image-builder/templates/post-install-builderinfo.yaml
+++ b/helm/kpack-image-builder/templates/post-install-builderinfo.yaml
@@ -2,7 +2,6 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: create-builderinfo
-  namespace: {{ .Values.namespace }}
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/instance: {{ .Release.Name | quote }}

--- a/helm/kpack-image-builder/templates/rbac.yaml
+++ b/helm/kpack-image-builder/templates/rbac.yaml
@@ -2,13 +2,11 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: korifi-kpack-build-controller-manager
-  namespace: {{ .Values.namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: korifi-kpack-build-leader-election-role
-  namespace: {{ .Values.namespace }}
 rules:
 - apiGroups:
   - ""
@@ -46,7 +44,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: korifi-kpack-build-leader-election-rolebinding
-  namespace: {{ .Values.namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -54,7 +51,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: korifi-kpack-build-controller-manager
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -67,4 +64,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: korifi-kpack-build-controller-manager
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}

--- a/helm/kpack-image-builder/templates/service.yaml
+++ b/helm/kpack-image-builder/templates/service.yaml
@@ -2,14 +2,13 @@ apiVersion: v1
 kind: Service
 metadata:
   name: korifi-kpack-build-webhook-service
-  namespace: {{ .Values.namespace }}
 spec:
   ports:
   - port: 443
     protocol: TCP
     targetPort: 9443
   selector:
-    control-plane: controller-manager
+    app: korifi-kpack-image-builder
 
 {{- if .Values.global.debug }}
 ---
@@ -17,7 +16,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: korifi-kpack-image-builder-controller-manager-debug-port
-  namespace: {{ .Values.namespace }}
 spec:
   ports:
   - name: debug-30053
@@ -26,6 +24,6 @@ spec:
     protocol: TCP
     targetPort: 40000
   selector:
-    app: korifi-kpack-image-builder-controller-manager
+    app: korifi-kpack-image-builder
   type: NodePort
 {{- end }}

--- a/helm/kpack-image-builder/values.yaml
+++ b/helm/kpack-image-builder/values.yaml
@@ -4,7 +4,6 @@ global:
   packageRegistrySecret: image-registry-credentials
 
 include: true
-namespace: korifi-kpack-build-system
 replicas: 1
 resources:
   limits:

--- a/helm/statefulset-runner/templates/cert-mgr-internal-cert.yaml
+++ b/helm/statefulset-runner/templates/cert-mgr-internal-cert.yaml
@@ -3,20 +3,11 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: korifi-statefulset-runner-serving-cert
-  namespace: {{ .Values.namespace }}
 spec:
   dnsNames:
-  - korifi-statefulset-runner-webhook-service.{{ .Values.namespace }}.svc
-  - korifi-statefulset-runner-webhook-service.{{ .Values.namespace }}.svc.cluster.local
+  - korifi-statefulset-runner-webhook-service.{{ .Release.Namespace }}.svc
+  - korifi-statefulset-runner-webhook-service.{{ .Release.Namespace }}.svc.cluster.local
   issuerRef:
     kind: Issuer
-    name: korifi-statefulset-runner-selfsigned-issuer
-  secretName: webhook-server-cert
----
-apiVersion: cert-manager.io/v1
-kind: Issuer
-metadata:
-  name: korifi-statefulset-runner-selfsigned-issuer
-  namespace: {{ .Values.namespace }}
-spec:
-  selfSigned: {}
+    name: selfsigned-issuer
+  secretName: statefulset-runner-webhook-server-cert

--- a/helm/statefulset-runner/templates/controller-rbac.yaml
+++ b/helm/statefulset-runner/templates/controller-rbac.yaml
@@ -2,14 +2,12 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: korifi-statefulset-runner-controller-manager
-  namespace: {{ .Values.namespace }}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: korifi-statefulset-runner-leader-election-role
-  namespace: {{ .Values.namespace }}
 rules:
 - apiGroups:
   - ""
@@ -48,7 +46,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: korifi-statefulset-runner-leader-election-rolebinding
-  namespace: {{ .Values.namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -56,7 +53,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: korifi-statefulset-runner-controller-manager
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -70,4 +67,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: korifi-statefulset-runner-controller-manager
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}

--- a/helm/statefulset-runner/templates/deployment.yaml
+++ b/helm/statefulset-runner/templates/deployment.yaml
@@ -2,14 +2,13 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    control-plane: controller-manager
+    app: korifi-statefulset-runner
   name: korifi-statefulset-runner-controller-manager
-  namespace: {{ .Values.namespace }}
 spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      control-plane: controller-manager
+      app: korifi-statefulset-runner
   template:
     metadata:
       annotations:
@@ -18,7 +17,7 @@ spec:
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       labels:
-        control-plane: controller-manager
+        app: korifi-statefulset-runner
     spec:
       containers:
       - name: manager
@@ -89,4 +88,4 @@ spec:
       - name: cert
         secret:
           defaultMode: 420
-          secretName: webhook-server-cert
+          secretName: statefulset-runner-webhook-server-cert

--- a/helm/statefulset-runner/templates/manifests.yaml
+++ b/helm/statefulset-runner/templates/manifests.yaml
@@ -3,7 +3,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: "{{ .Values.namespace }}/korifi-statefulset-runner-serving-cert"
+    cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/korifi-statefulset-runner-serving-cert"
   creationTimestamp: null
   name: korifi-statefulset-runner-mutating-webhook-configuration
 webhooks:
@@ -12,7 +12,7 @@ webhooks:
   clientConfig:
     service:
       name: korifi-statefulset-runner-webhook-service
-      namespace: "{{ .Values.namespace }}"
+      namespace: "{{ .Release.Namespace }}"
       path: /mutate--v1-pod
   failurePolicy: Fail
   objectSelector:

--- a/helm/statefulset-runner/templates/namespace.yaml
+++ b/helm/statefulset-runner/templates/namespace.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    control-plane: controller-manager
-    pod-security.kubernetes.io/audit: {{ ternary "privileged" "restricted" .Values.global.debug }}
-    pod-security.kubernetes.io/enforce: {{ ternary "privileged" "restricted" .Values.global.debug }}
-  name: {{ .Values.namespace }}

--- a/helm/statefulset-runner/templates/service.yaml
+++ b/helm/statefulset-runner/templates/service.yaml
@@ -2,14 +2,13 @@ apiVersion: v1
 kind: Service
 metadata:
   name: korifi-statefulset-runner-webhook-service
-  namespace: {{ .Values.namespace }}
 spec:
   ports:
   - port: 443
     protocol: TCP
     targetPort: 9443
   selector:
-    control-plane: controller-manager
+    app: korifi-statefulset-runner
 
 {{- if .Values.global.debug }}
 ---
@@ -17,7 +16,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: korifi-statefulset-runner-controller-manager-debug-port
-  namespace: {{ .Values.namespace }}
 spec:
   ports:
     - name: debug-30054
@@ -26,6 +24,6 @@ spec:
       protocol: TCP
       targetPort: 40000
   selector:
-    app: korifi-statefulset-runner-controller-manager
+    app: korifi-statefulset-runner
   type: NodePort
 {{- end }}

--- a/helm/statefulset-runner/values.yaml
+++ b/helm/statefulset-runner/values.yaml
@@ -3,7 +3,6 @@ global:
   debug: false
 
 include: true
-namespace: korifi-statefulset-runner-system
 replicas: 1
 resources:
   limits:

--- a/kpack-image-builder/Makefile
+++ b/kpack-image-builder/Makefile
@@ -55,9 +55,9 @@ manifests: install-controller-gen ## Generate WebhookConfiguration, ClusterRole 
 		output:webhook:artifacts:config=../helm/kpack-image-builder/templates \
 		output:rbac:artifacts:config=../helm/kpack-image-builder/templates
 
-	$(SED) -i.bak -e '/^metadata:.*/a \ \ annotations:\n    cert-manager.io/inject-ca-from: "{{ .Values.namespace }}/korifi-kpack-build-serving-cert"' ../helm/kpack-image-builder/templates/manifests.yaml
+	$(SED) -i.bak -e '/^metadata:.*/a \ \ annotations:\n    cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/korifi-kpack-build-serving-cert"' ../helm/kpack-image-builder/templates/manifests.yaml
 	$(SED) -i.bak -e 's/name: \(webhook-service\)/name: korifi-kpack-build-\1/' ../helm/kpack-image-builder/templates/manifests.yaml
-	$(SED) -i.bak -e 's/namespace: system/namespace: "{{ .Values.namespace }}"/' ../helm/kpack-image-builder/templates/manifests.yaml
+	$(SED) -i.bak -e 's/namespace: system/namespace: "{{ .Release.Namespace }}"/' ../helm/kpack-image-builder/templates/manifests.yaml
 	$(SED) -i.bak -e 's/name: \(.*-webhook-configuration\)/name: korifi-kpack-build-\1/' ../helm/kpack-image-builder/templates/manifests.yaml
 	$(SED) -i.bak -e '/failurePolicy:.*/a\  objectSelector:\n    matchExpressions:\n    - key: kpack.io/build\n      operator: Exists\n    - key: korifi.cloudfoundry.org/build-workload-name\n      operator: Exists' ../helm/kpack-image-builder/templates/manifests.yaml
 	rm -f ../helm/kpack-image-builder/templates/manifests.yaml.bak

--- a/scripts/deploy-on-kind.sh
+++ b/scripts/deploy-on-kind.sh
@@ -136,11 +136,23 @@ function deploy_korifi() {
     helm dependency update helm/korifi
 
     doDebug="false"
+    secLevel="restricted"
     if [[ -n "${debug}" ]]; then
       doDebug="true"
+      secLevel="privileged"
     fi
 
+    cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    pod-security.kubernetes.io/enforce: $secLevel
+  name: korifi
+EOF
+
     helm upgrade --install korifi helm/korifi \
+      --namespace korifi \
       --values=scripts/assets/values.yaml \
       --set=global.debug="$doDebug" \
       --wait

--- a/statefulset-runner/Makefile
+++ b/statefulset-runner/Makefile
@@ -56,9 +56,9 @@ manifests: install-controller-gen ## Generate WebhookConfiguration, ClusterRole 
 		output:rbac:artifacts:config=../helm/statefulset-runner/templates \
 		output:webhook:artifacts:config=../helm/statefulset-runner/templates
 
-	$(SED) -i.bak -e '/^metadata:.*/a \ \ annotations:\n    cert-manager.io/inject-ca-from: "{{ .Values.namespace }}/korifi-statefulset-runner-serving-cert"' ../helm/statefulset-runner/templates/manifests.yaml
+	$(SED) -i.bak -e '/^metadata:.*/a \ \ annotations:\n    cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/korifi-statefulset-runner-serving-cert"' ../helm/statefulset-runner/templates/manifests.yaml
 	$(SED) -i.bak -e 's/name: \(webhook-service\)/name: korifi-statefulset-runner-\1/' ../helm/statefulset-runner/templates/manifests.yaml
-	$(SED) -i.bak -e 's/namespace: system/namespace: "{{ .Values.namespace }}"/' ../helm/statefulset-runner/templates/manifests.yaml
+	$(SED) -i.bak -e 's/namespace: system/namespace: "{{ .Release.Namespace }}"/' ../helm/statefulset-runner/templates/manifests.yaml
 	$(SED) -i.bak -e 's/name: \(.*-webhook-configuration\)/name: korifi-statefulset-runner-\1/' ../helm/statefulset-runner/templates/manifests.yaml
 	$(SED) -i.bak -e '/failurePolicy:.*/a\  objectSelector:\n    matchLabels:\n      korifi.cloudfoundry.org/add-stsr-index: "true"' ../helm/statefulset-runner/templates/manifests.yaml
 	rm -f ../helm/statefulset-runner/templates/manifests.yaml.bak

--- a/tests/e2e/helpers/fail_handler.go
+++ b/tests/e2e/helpers/fail_handler.go
@@ -56,36 +56,37 @@ func E2EFailHandler(correlationId func() string) func(string, ...int) {
 			return
 		}
 
+		namespace := "korifi"
 		printPodsLogs(clientset, []podContainerDescriptor{
 			{
-				Namespace:     "korifi-api-system",
+				Namespace:     namespace,
 				LabelKey:      "app",
 				LabelValue:    "korifi-api",
 				Container:     "korifi-api",
 				CorrelationId: correlationId(),
 			},
 			{
-				Namespace:  "korifi-controllers-system",
-				LabelKey:   "control-plane",
-				LabelValue: "controller-manager",
+				Namespace:  namespace,
+				LabelKey:   "app",
+				LabelValue: "korifi-controllers",
 				Container:  "manager",
 			},
 			{
-				Namespace:  "korifi-job-task-runner-system",
-				LabelKey:   "control-plane",
-				LabelValue: "controller-manager",
+				Namespace:  namespace,
+				LabelKey:   "app",
+				LabelValue: "korifi-job-task-runner",
 				Container:  "manager",
 			},
 			{
-				Namespace:  "korifi-kpack-build-system",
-				LabelKey:   "control-plane",
-				LabelValue: "controller-manager",
+				Namespace:  namespace,
+				LabelKey:   "app",
+				LabelValue: "korifi-kpack-image-builder",
 				Container:  "manager",
 			},
 			{
-				Namespace:  "korifi-statefulset-runner-system",
-				LabelKey:   "control-plane",
-				LabelValue: "controller-manager",
+				Namespace:  namespace,
+				LabelKey:   "app",
+				LabelValue: "korifi-statefulset-runner",
 				Container:  "manager",
 			},
 		})


### PR DESCRIPTION
## Is there a related GitHub Issue?
#1478

## What is this change about?
Combine the korifi components into a single namespace.

This will be the namespace provided via the `--namespace` option of `helm install / helm upgrade --install`.

The namespace will either need to be created in advance, in which case we can ensure setting the correct pod security level annotations.
Otherwise, you can use the `--create-namespace` flag with helm to make it create it (but with no way of setting the pod security).

## Does this PR introduce a breaking change?
Yes:
- you need to change the helm install command to include the namespace
- you need to change where you look for the korifi components when debugging, etc.

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@cloudfoundry/eirini

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
