### PR TITLE
Adds RunnerName validation back on statefulset-runner

### DIFF
--- a/statefulset-runner/controllers/appworkload_controller.go
+++ b/statefulset-runner/controllers/appworkload_controller.go
@@ -113,6 +113,10 @@ func NewAppWorkloadReconciler(
 //+kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=create;patch;deletecollection
 
 func (r *AppWorkloadReconciler) ReconcileResource(ctx context.Context, appWorkload *korifiv1alpha1.AppWorkload) (ctrl.Result, error) {
+	if appWorkload.Spec.RunnerName != AppWorkloadReconcilerName {
+		return ctrl.Result{}, nil
+	}
+
 	statefulSet, err := r.workloadsToStSet.Convert(appWorkload)
 	// Not clear what errors this would produce, but we may use it later
 	if err != nil {

--- a/statefulset-runner/controllers/appworkload_controller_test.go
+++ b/statefulset-runner/controllers/appworkload_controller_test.go
@@ -143,6 +143,16 @@ var _ = Describe("AppWorkload Reconcile", func() {
 				Expect(reconcileErr).To(MatchError("big sad"))
 			})
 		})
+
+		When("reconciler name on the AppWorkload is not statefulset-runner", func() {
+			BeforeEach(func() {
+				appWorkload.Spec.RunnerName = "MyCustomReconciler"
+			})
+
+			It("does not create/patch statefulset", func() {
+				Expect(fakeClient.CreateCallCount()).To(Equal(0), "Client.Create call count mismatch")
+			})
+		})
 	})
 
 	When("the appworkload is being deleted", func() {


### PR DESCRIPTION


<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->
No

## What is this change about?
<!-- _Please describe the change here._ -->
Adds the validation to check the runnerName back onto statefulset reconciler

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->
No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->
All tests should pass

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->
@davewalter 

<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
