### PR TITLE
Use a standard logging for kpack-image-builder

### DIFF
--- a/kpack-image-builder/main.go
+++ b/kpack-image-builder/main.go
@@ -19,6 +19,8 @@ package main
 import (
 	"flag"
 	"fmt"
+	"go.uber.org/zap/zapcore"
+	"k8s.io/klog/v2"
 	"os"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
@@ -65,12 +67,14 @@ func main() {
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	opts := zap.Options{
-		Development: true,
+		TimeEncoder: zapcore.RFC3339NanoTimeEncoder,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	klog.SetLogger(ctrl.Log)
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,


### PR DESCRIPTION
## Is there a related GitHub Issue?
[#1183]<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
- use json logging with RFC3339 timestamps
- set the same logger to klog so that the low level controller runtime calls also log to the same format.
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
[#1183]<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->
@matt-royal 