### PR TITLE
Add namespace to all namespaced resources

### DIFF
--- a/helm/api/templates/cert-mgr-internal-cert.yaml
+++ b/helm/api/templates/cert-mgr-internal-cert.yaml
@@ -2,6 +2,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: korifi-api-internal-cert
+  namespace: {{ .Release.Namespace }}
 spec:
   commonName: korifi-api-svc.{{ .Release.Namespace }}.svc.cluster.local
   dnsNames:

--- a/helm/api/templates/configmap.yaml
+++ b/helm/api/templates/configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: korifi-api-config
+  namespace: {{ .Release.Namespace }}
 data:
   korifi_api_config.yaml: |
     externalFQDN: {{ .Values.apiServer.url }}

--- a/helm/api/templates/deployment.yaml
+++ b/helm/api/templates/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     app: korifi-api
   name: korifi-api-deployment
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.replicas }}
   selector:

--- a/helm/api/templates/ingress-cert.yaml
+++ b/helm/api/templates/ingress-cert.yaml
@@ -3,6 +3,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: korifi-api-ingress-cert
+  namespace: {{ .Release.Namespace }}
 spec:
   commonName: {{ .Values.apiServer.url }}
   dnsNames:

--- a/helm/api/templates/ingress.yaml
+++ b/helm/api/templates/ingress.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     app: korifi-api
   name: korifi-api-proxy
+  namespace: {{ .Release.Namespace }}
 spec:
   routes:
   - conditions:

--- a/helm/api/templates/rbac.yaml
+++ b/helm/api/templates/rbac.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: korifi-api-system-serviceaccount
+  namespace: {{ .Release.Namespace }}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/api/templates/service.yaml
+++ b/helm/api/templates/service.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     app: korifi-api
   name: korifi-api-svc
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
   - name: web
@@ -22,6 +23,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: api-debug-port
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
     - name: debug-30052

--- a/helm/controllers/templates/cert-mgr-internal-cert.yaml
+++ b/helm/controllers/templates/cert-mgr-internal-cert.yaml
@@ -2,6 +2,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: korifi-controllers-serving-cert
+  namespace: {{ .Release.Namespace }}
 spec:
   dnsNames:
   - korifi-controllers-webhook-service.{{ .Release.Namespace }}.svc

--- a/helm/controllers/templates/configmap.yaml
+++ b/helm/controllers/templates/configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: korifi-controllers-config
+  namespace: {{ .Release.Namespace }}
 data:
   korifi_controllers_config.yaml: |-
     builderName: {{ .Values.reconcilers.build }}

--- a/helm/controllers/templates/deployment.yaml
+++ b/helm/controllers/templates/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     app: korifi-controllers
   name: korifi-controllers-controller-manager
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.replicas }}
   selector:

--- a/helm/controllers/templates/ingress-cert.yaml
+++ b/helm/controllers/templates/ingress-cert.yaml
@@ -3,6 +3,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: korifi-workloads-ingress-cert
+  namespace: {{ .Release.Namespace }}
 spec:
   commonName: \*.{{ .Values.global.defaultAppDomainName }}
   dnsNames:

--- a/helm/controllers/templates/post-install-app-domain.yaml
+++ b/helm/controllers/templates/post-install-app-domain.yaml
@@ -1,18 +1,19 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: create-app-domain
-  labels:
-    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
-    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "-5"
     "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  name: create-app-domain
+  namespace: {{ .Release.Namespace }}
 spec:
   template:
     metadata:

--- a/helm/controllers/templates/pre-install-cfroot-namespace.yaml
+++ b/helm/controllers/templates/pre-install-cfroot-namespace.yaml
@@ -1,19 +1,19 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: create-cfroot-namespace
-  namespace: {{ .Release.Namespace }}
-  labels:
-    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
-    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  name: create-cfroot-namespace
+  namespace: {{ .Release.Namespace }}
 spec:
   template:
     metadata:

--- a/helm/controllers/templates/rbac.yaml
+++ b/helm/controllers/templates/rbac.yaml
@@ -2,12 +2,14 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: korifi-controllers-controller-manager
+  namespace: {{ .Release.Namespace }}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: korifi-controllers-leader-election-role
+  namespace: {{ .Release.Namespace }}
 rules:
 - apiGroups:
   - ""
@@ -46,6 +48,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: korifi-controllers-leader-election-rolebinding
+  namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/helm/controllers/templates/service.yaml
+++ b/helm/controllers/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: korifi-controllers-webhook-service
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
   - port: 443
@@ -15,7 +16,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: controller-manager-debug-port
-  namespace: korifi-controllers-system
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
     - name: debug-30051

--- a/helm/controllers/templates/tls-cert-delegation.yaml
+++ b/helm/controllers/templates/tls-cert-delegation.yaml
@@ -2,6 +2,7 @@ apiVersion: projectcontour.io/v1
 kind: TLSCertificateDelegation
 metadata:
   name: korifi-controllers-workloads-fallback-delegation
+  namespace: {{ .Release.Namespace }}
 spec:
   delegations:
   - secretName: korifi-workloads-ingress-cert

--- a/helm/job-task-runner/templates/configmap.yaml
+++ b/helm/job-task-runner/templates/configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: korifi-job-task-runner-config
+  namespace: {{ .Release.Namespace }}
 data:
   job_task_runner_config.yaml: |
     jobTTL: {{ .Values.jobTTL }}

--- a/helm/job-task-runner/templates/controller-rbac.yaml
+++ b/helm/job-task-runner/templates/controller-rbac.yaml
@@ -2,12 +2,14 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: korifi-job-task-runner-controller-manager
+  namespace: {{ .Release.Namespace }}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: korifi-job-task-runner-leader-election-role
+  namespace: {{ .Release.Namespace }}
 rules:
 - apiGroups:
   - ""
@@ -46,6 +48,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: korifi-job-task-runner-leader-election-rolebinding
+  namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/helm/job-task-runner/templates/deployment.yaml
+++ b/helm/job-task-runner/templates/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     app: korifi-job-task-runner
   name: korifi-job-task-runner-controller-manager
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.replicas }}
   selector:

--- a/helm/job-task-runner/templates/service.yaml
+++ b/helm/job-task-runner/templates/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: korifi-job-task-runner-controller-manager-debug-port
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
     - name: debug-30055

--- a/helm/kpack-image-builder/templates/cert-mgr-internal-cert.yaml
+++ b/helm/kpack-image-builder/templates/cert-mgr-internal-cert.yaml
@@ -2,6 +2,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: korifi-kpack-build-serving-cert
+  namespace: {{ .Release.Namespace }}
 spec:
   dnsNames:
   - korifi-kpack-build-webhook-service.{{ .Release.Namespace }}.svc

--- a/helm/kpack-image-builder/templates/configmap.yaml
+++ b/helm/kpack-image-builder/templates/configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: korifi-kpack-build-config
+  namespace: {{ .Release.Namespace }}
 data:
   kpack_build_controllers_config.yaml: |
     cfRootNamespace: {{ .Values.global.rootNamespace }}

--- a/helm/kpack-image-builder/templates/deployment.yaml
+++ b/helm/kpack-image-builder/templates/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     app: korifi-kpack-image-builder
   name: korifi-kpack-build-controller-manager
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.replicas }}
   selector:

--- a/helm/kpack-image-builder/templates/post-install-builderinfo.yaml
+++ b/helm/kpack-image-builder/templates/post-install-builderinfo.yaml
@@ -1,18 +1,19 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: create-builderinfo
-  labels:
-    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
-    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "-5"
     "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  name: create-builderinfo
+  namespace: {{ .Release.Namespace }}
 spec:
   template:
     metadata:

--- a/helm/kpack-image-builder/templates/pre-delete-builderinfo.yaml
+++ b/helm/kpack-image-builder/templates/pre-delete-builderinfo.yaml
@@ -1,17 +1,17 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: delete-builderinfo
-  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-  annotations:
-    "helm.sh/hook": pre-delete
-    "helm.sh/hook-weight": "0"
-    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+  name: delete-builderinfo
+  namespace: {{ .Release.Namespace }}
 spec:
   template:
     metadata:

--- a/helm/kpack-image-builder/templates/rbac.yaml
+++ b/helm/kpack-image-builder/templates/rbac.yaml
@@ -2,11 +2,14 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: korifi-kpack-build-controller-manager
+  namespace: {{ .Release.Namespace }}
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: korifi-kpack-build-leader-election-role
+  namespace: {{ .Release.Namespace }}
 rules:
 - apiGroups:
   - ""
@@ -39,11 +42,13 @@ rules:
   verbs:
   - create
   - patch
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: korifi-kpack-build-leader-election-rolebinding
+  namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -52,6 +57,7 @@ subjects:
 - kind: ServiceAccount
   name: korifi-kpack-build-controller-manager
   namespace: {{ .Release.Namespace }}
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/helm/kpack-image-builder/templates/service.yaml
+++ b/helm/kpack-image-builder/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: korifi-kpack-build-webhook-service
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
   - port: 443
@@ -16,6 +17,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: korifi-kpack-image-builder-controller-manager-debug-port
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
   - name: debug-30053

--- a/helm/statefulset-runner/templates/cert-mgr-internal-cert.yaml
+++ b/helm/statefulset-runner/templates/cert-mgr-internal-cert.yaml
@@ -3,6 +3,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: korifi-statefulset-runner-serving-cert
+  namespace: {{ .Release.Namespace }}
 spec:
   dnsNames:
   - korifi-statefulset-runner-webhook-service.{{ .Release.Namespace }}.svc

--- a/helm/statefulset-runner/templates/controller-rbac.yaml
+++ b/helm/statefulset-runner/templates/controller-rbac.yaml
@@ -2,12 +2,14 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: korifi-statefulset-runner-controller-manager
+  namespace: {{ .Release.Namespace }}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: korifi-statefulset-runner-leader-election-role
+  namespace: {{ .Release.Namespace }}
 rules:
 - apiGroups:
   - ""
@@ -46,6 +48,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: korifi-statefulset-runner-leader-election-rolebinding
+  namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/helm/statefulset-runner/templates/deployment.yaml
+++ b/helm/statefulset-runner/templates/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     app: korifi-statefulset-runner
   name: korifi-statefulset-runner-controller-manager
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.replicas }}
   selector:

--- a/helm/statefulset-runner/templates/service.yaml
+++ b/helm/statefulset-runner/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: korifi-statefulset-runner-webhook-service
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
   - port: 443
@@ -16,6 +17,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: korifi-statefulset-runner-controller-manager-debug-port
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
     - name: debug-30054


### PR DESCRIPTION
## Is there a related GitHub Issue?
Related to #1478 & #1785 

## What is this change about?
This PR adds the namespace to all namespaced resources to fix an issue where the `helm template` command does not inject the namespace, even if the `--namespace` flag is specified. This means that users cannot render the templates and then use other deployment tools (such as `kapp`) that rely on the namespaced resources defining which namespace to use.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
See #1478 

