### PR TITLE
Fix call to deploy-on-kind from run-tests script

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -43,7 +43,7 @@ else
   export API_SERVER_ROOT="${API_SERVER_ROOT:-https://localhost}"
 
   if [ -z "${SKIP_DEPLOY:-}" ]; then
-    "${SCRIPT_DIR}/deploy-on-kind.sh" -l e2e
+    "${SCRIPT_DIR}/deploy-on-kind.sh" e2e
   fi
 
   # creates user keys/certs and service accounts and exports vars for them


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
Remove the `-l` from the call to deploy-on-kind from run-tests script

## Does this PR introduce a breaking change?
No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
