### PR TITLE
Improve helm value names

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -79,9 +79,9 @@ helm install korifi https://github.com/cloudfoundry/korifi/releases/download/v<v
     --set=adminUserName=$ADMIN_USERNAME \
     --set=api.apiServer.url=api.$BASE_DOMAIN \
     --set=global.defaultAppDomainName=apps.$BASE_DOMAIN \
-    --set=api.packageRegistry=us-east4-docker.pkg.dev/vigilant-card-347116/korifi/source-package \
+    --set=api.packageRepositoryPrefix=us-east4-docker.pkg.dev/vigilant-card-347116/korifi/source-package \
     --set=kpack-image-builder.builderRepository=us-east4-docker.pkg.dev/vigilant-card-347116/korifi/kpack-builder \
-    --set=kpack-image-builder.dropletRegistry=us-east4-docker.pkg.dev/vigilant-card-347116/korifi/droplet
+    --set=kpack-image-builder.dropletRepositoryPrefix=us-east4-docker.pkg.dev/vigilant-card-347116/korifi/droplet
 ```
 
 ### Description of helm values
@@ -91,15 +91,15 @@ helm install korifi https://github.com/cloudfoundry/korifi/releases/download/v<v
 - `adminUserName` is the username that will be bound to the cf admin role.
 - `api.apiServer.url` is the domain name that will be used by the Korifi API, and is usually of the format `api.$BASE_DOMAIN`.
 - `global.defaultAppDomainName` is the default base domain name for the apps deployed by Korifi, and is usually of the format `apps.$BASE_DOMAIN`.
-- `api.packageRegistry` specifies the tag prefix used for the source packages uploaded to Korifi. Its hostname should point to your container registry and its path should be valid for the registry.
-  - If using **DockerHub**, `api.packageRegistry` should be `index.docker.io/<username>`.
-  - If using **GCR**, `api.packageRegistry` should be `gcr.io/<project-id>/packages`.
+- `api.packageRepositoryPrefix` specifies the prefix used for the source packages uploaded to Korifi. Its hostname should point to your container registry and its path should be valid for the registry.
+  - If using **DockerHub**, `api.packageRepositoryPrefix` should be `index.docker.io/<username>`.
+  - If using **GCR**, `api.packageRepositoryPrefix` should be `gcr.io/<project-id>/packages`.
 - `kpack-image-builder.builderRepository` is the docker repository URL for the kpack builder image. This is part of the example cluster builder configuration that is created when `kpack-image-builder.clusterBuilderName` is left empty.
   - If using **DockerHub**, `kpack-image-builder.builderRepository` should be `index.docker.io/<username>/kpack-builder`.
   - If using **GCR**, `kpack-image-builder.builderRepository` should be `gcr.io/<project-id>/kpack-builder`.
-- `kpack-image-builder.dropletRegistry` specifies the tag prefix used for the droplet images built by Korifi. Its hostname should point to your container registry and its path should be valid for the registry.
-  - If using **DockerHub**, `kpack-image-builder.packageRegistry` should be `index.docker.io/<username>`.
-  - If using **GCR**, `kpack-image-builder.packageRegistry` should be `gcr.io/<project-id>/droplets`.
+- `kpack-image-builder.dropletRepositoryPrefix` specifies the prefix used for the droplet images built by Korifi. Its hostname should point to your container registry and its path should be valid for the registry.
+  - If using **DockerHub**, `kpack-image-builder.dropletRepositoryPrefix` should be `index.docker.io/<username>`.
+  - If using **GCR**, `kpack-image-builder.dropletRepositoryPrefix` should be `gcr.io/<project-id>/droplets`.
 
 The chart provides various other values that can be set. See [helm/README.values.md](./helm/README.values.md) for details.
 

--- a/Makefile
+++ b/Makefile
@@ -232,7 +232,7 @@ deploy-api-kind: manifests-api
 		--values=$(API_VALUES) \
 		--set=apiServer.url=localhost \
 		--set=defaultDomainName=$(APP_FQDN) \
-		--set=packageRegistry.base=gcr.io/cf-relint-greengrass/korifi/kpack/beta \
+		--set=packageRepositoryPrefix=gcr.io/cf-relint-greengrass/korifi/kpack/beta \
 		--wait
 
 local-registry = localregistry-docker-registry.default.svc.cluster.local:30050/kpack/packages
@@ -242,7 +242,7 @@ deploy-api-kind-local: manifests-api
 		--set=image=$(IMG_API) \
 		--set=apiServer.url=localhost \
 		--set=defaultDomainName=$(APP_FQDN) \
-		--set=packageRegistry.base=$(local-registry) \
+		--set=packageRepositoryPrefix=$(local-registry) \
 		--wait
 
 deploy-api-kind-local-debug: manifests-api
@@ -251,7 +251,7 @@ deploy-api-kind-local-debug: manifests-api
 		--set=image=$(IMG_API) \
 		--set=apiServer.url=localhost \
 		--set=defaultDomainName=$(APP_FQDN) \
-		--set=packageRegistry.base=$(local-registry) \
+		--set=packageRepositoryPrefix=$(local-registry) \
 		--set=global.debug=true \
 		--wait
 

--- a/helm/README.md
+++ b/helm/README.md
@@ -58,8 +58,8 @@ api:
 
   # ID of the builder to use on source packages
   builderName: kpack-image-builder
-  # The container registry where app source packages will be stored
-  packageRegistry: index.docker.io/my-dockerhub-username
+  # Prefix to the container repository where app source packages will be stored
+  packageRepositoryPrefix: index.docker.io/my-dockerhub-username
   # Warn if user cert provided for login has a long expiry
   userCertificateExpirationWarningDuration: 168h
 
@@ -101,8 +101,7 @@ controllers:
   # How long before the CFTask object is deleted after the task has completed
   taskTTL: 30d
   # The TLS secret used when setting up app route
-  workloadsTLSSecret:
-    name: korifi-workloads-ingress-cert
+  workloadsTLSSecret: korifi-workloads-ingress-cert
 
 job-task-runner:
   # Deploy the job-task-runner component
@@ -140,8 +139,8 @@ kpack-image-builder:
   # Docker image
   image: cloudfoundry/korifi-kpack-image-builder:latest
 
-  # The image registry where droplet images are pushed to
-  dropletRegistry: index.docker.io/my-dockerhub-username
+  # Prefix to the docker image repository where droplet images are stored
+  dropletRepositoryPrefix: index.docker.io/my-dockerhub-username
   # The name of the cluster builder kpack has been configured with.
   # Leave blank to let kpack-image-builder create an example cluster builder
   clusterBuilderName: cf-kpack-cluster-builder

--- a/helm/api/templates/configmap.yaml
+++ b/helm/api/templates/configmap.yaml
@@ -19,7 +19,7 @@ data:
       stack: {{ .Values.lifecycle.stack }}
       stagingMemoryMB: {{ .Values.lifecycle.stagingRequirements.memoryMB }}
       stagingDiskMB: {{ .Values.lifecycle.stagingRequirements.diskMB }}
-    packageRegistryBase: {{ .Values.packageRegistry }}
+    packageRegistryBase: {{ .Values.packageRepositoryPrefix }}
     packageRegistrySecretName: {{ .Values.global.packageRegistrySecret }}
     defaultDomainName: {{ .Values.global.defaultAppDomainName }}
     userCertificateExpirationWarningDuration: {{ .Values.userCertificateExpirationWarningDuration }}

--- a/helm/api/values.yaml
+++ b/helm/api/values.yaml
@@ -33,7 +33,7 @@ lifecycle:
     diskMB: 1024
 
 builderName: kpack-image-builder
-packageRegistry: index.docker.io/my-dockerhub-username
+packageRepositoryPrefix: index.docker.io/my-dockerhub-username
 userCertificateExpirationWarningDuration: 168h
 
 authProxy:

--- a/helm/controllers/templates/configmap.yaml
+++ b/helm/controllers/templates/configmap.yaml
@@ -13,5 +13,5 @@ data:
     cfRootNamespace: {{ .Values.global.rootNamespace }}
     packageRegistrySecretName: {{ .Values.global.packageRegistrySecret }}
     taskTTL: {{ .Values.taskTTL }}
-    workloads_tls_secret_name: {{ .Values.workloadsTLSSecret.name }}
+    workloads_tls_secret_name: {{ .Values.workloadsTLSSecret }}
     workloads_tls_secret_namespace: {{ .Release.Namespace }}

--- a/helm/controllers/templates/ingress-cert.yaml
+++ b/helm/controllers/templates/ingress-cert.yaml
@@ -11,5 +11,5 @@ spec:
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer
-  secretName: korifi-workloads-ingress-cert
+  secretName: {{ .Values.workloadsTLSSecret }}
 {{- end}}

--- a/helm/controllers/values.yaml
+++ b/helm/controllers/values.yaml
@@ -23,5 +23,4 @@ processDefaults:
   memoryMB: 1024
   diskQuotaMB: 1024
 taskTTL: 30d
-workloadsTLSSecret:
-  name: korifi-workloads-ingress-cert
+workloadsTLSSecret: korifi-workloads-ingress-cert

--- a/helm/kpack-image-builder/templates/configmap.yaml
+++ b/helm/kpack-image-builder/templates/configmap.yaml
@@ -7,4 +7,4 @@ data:
   kpack_build_controllers_config.yaml: |
     cfRootNamespace: {{ .Values.global.rootNamespace }}
     clusterBuilderName: {{ default "cf-kpack-cluster-builder" .Values.clusterBuilderName }}
-    kpackImageTag: {{ .Values.dropletRegistry }}
+    kpackImageTag: {{ .Values.dropletRepositoryPrefix }}

--- a/helm/kpack-image-builder/values.yaml
+++ b/helm/kpack-image-builder/values.yaml
@@ -15,6 +15,6 @@ resources:
 
 image: cloudfoundry/korifi-kpack-image-builder:latest
 
-dropletRegistry: index.docker.io/my-dockerhub-username
+dropletRepositoryPrefix: index.docker.io/my-dockerhub-username
 clusterBuilderName:
 builderRepository: index.docker.io/my-dockerhub-username/kpack-builder

--- a/kpack-image-builder/Makefile
+++ b/kpack-image-builder/Makefile
@@ -114,14 +114,14 @@ deploy-kind-local: manifests
 	helm upgrade --install kpack-image-builder ../helm/kpack-image-builder \
 		--values=$(KIB_VALUES) \
 		--set=image=$(IMG_KIB) \
-		--set=packageRegistry=localregistry-docker-registry.default.svc.cluster.local:30050/korifi-controllers/kpack/images \
+		--set=dropletRepositoryPrefix=localregistry-docker-registry.default.svc.cluster.local:30050/korifi-controllers/kpack/images \
 		--wait
 
 deploy-kind-local-debug: manifests
 	helm upgrade --install kpack-image-builder ../helm/kpack-image-builder \
 		--values=$(KIB_VALUES) \
 		--set=image=$(IMG_KIB) \
-		--set=packageRegistry=localregistry-docker-registry.default.svc.cluster.local:30050/korifi-controllers/kpack/images \
+		--set=dropletRepositoryPrefix=localregistry-docker-registry.default.svc.cluster.local:30050/korifi-controllers/kpack/images \
 		--set=global.debug=true \
 		--wait
 

--- a/scripts/assets/values-template.yaml
+++ b/scripts/assets/values-template.yaml
@@ -6,7 +6,7 @@ api:
   apiServer:
     url: localhost
   image: cloudfoundry/korifi-api:latest
-  packageRegistry: localregistry-docker-registry.default.svc.cluster.local:30050/sources
+  packageRepositoryPrefix: localregistry-docker-registry.default.svc.cluster.local:30050/sources
 
 controllers:
   taskTTL: 5s
@@ -18,7 +18,7 @@ job-task-runner:
 
 kpack-image-builder:
   image: cloudfoundry/korifi-kpack-image-builder:latest
-  dropletRegistry: localregistry-docker-registry.default.svc.cluster.local:30050/droplets
+  dropletRepositoryPrefix: localregistry-docker-registry.default.svc.cluster.local:30050/droplets
   builderRepository: localregistry-docker-registry.default.svc.cluster.local:30050/kpack-builder
 
 statefulset-runner:

--- a/scripts/deploy-on-kind.sh
+++ b/scripts/deploy-on-kind.sh
@@ -17,8 +17,8 @@ flags:
       - DOCKER_SERVER
       - DOCKER_USERNAME
       - DOCKER_PASSWORD
-      - PACKAGE_REGISTRY
-      - DROPLET_REGISTRY
+      - PACKAGE_REPOSITORY_PREFIX
+      - DROPLET_REPOSITORY_PREFIX
       - KPACK_BUILDER_REPOSITORY
 
   -v, --verbose
@@ -47,7 +47,7 @@ while [[ $# -gt 0 ]]; do
     -r | --use-custom-registry)
       use_custom_registry="true"
       # blow up if required vars not set
-      echo "$DOCKER_SERVER $DOCKER_USERNAME $DOCKER_PASSWORD $PACKAGE_REGISTRY $DROPLET_REGISTRY $KPACK_BUILDER_REPOSITORY" >/dev/null
+      echo "$DOCKER_SERVER $DOCKER_USERNAME $DOCKER_PASSWORD $PACKAGE_REPOSITORY_PREFIX $DROPLET_REPOSITORY_PREFIX $KPACK_BUILDER_REPOSITORY" >/dev/null
       shift
       ;;
     -D | --debug)
@@ -158,8 +158,8 @@ EOF
         --namespace korifi \
         --values=scripts/assets/values.yaml \
         --set=global.debug="$doDebug" \
-        --set=api.packageRegistry="$PACKAGE_REGISTRY" \
-        --set=kpack-image-builder.dropletRegistry="$DROPLET_REGISTRY" \
+        --set=api.packageRepositoryPrefix="$PACKAGE_REPOSITORY_PREFIX" \
+        --set=kpack-image-builder.dropletRepositoryPrefix="$DROPLET_REPOSITORY_PREFIX" \
         --set=kpack-image-builder.builderRepository="$KPACK_BUILDER_REPOSITORY" \
         --wait
     else


### PR DESCRIPTION
## Is there a related GitHub Issue?

#1806

## What is this change about?

-   Rename `api.packageRegistry` to `api.packageRepositoryPrefix`.
-   Rename `kpack-image-builder.dropletRegistry` to `kpack-image-builder.dropletRepositoryPrefix`.
-   Replace `controllers.workloadsTLSSecret.name` with just `controllers.workloadsTLSSecret`.

Rename helm/README.values.md to helm/README.md for make it appear nicely
in github

## Does this PR introduce a breaking change?

Rename your helm values appropriately!

## Acceptance Steps

<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team

<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

## Things to remember

<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
