### PR TITLE
Validate CF cli version

### DIFF
--- a/api/handlers/cli_version_middleware.go
+++ b/api/handlers/cli_version_middleware.go
@@ -1,0 +1,68 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+
+	"code.cloudfoundry.org/korifi/api/apierrors"
+	"code.cloudfoundry.org/korifi/api/correlation"
+	"github.com/Masterminds/semver"
+	"github.com/go-http-utils/headers"
+	"github.com/go-logr/logr"
+	"github.com/mileusna/useragent"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const minSupportedVersion = ">= 8.5.0"
+
+type CFCliVersionMiddleware struct{}
+
+func NewCFCliVersionMiddleware() *CFCliVersionMiddleware {
+	return &CFCliVersionMiddleware{}
+}
+
+func (m CFCliVersionMiddleware) Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		logger := correlation.AddCorrelationIDToLogger(r.Context(), logf.Log.WithName("cf-cli-version-check"))
+		userAgents := r.Header[headers.UserAgent]
+		if len(userAgents) == 0 {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		userAgent := useragent.Parse(userAgents[0])
+		if userAgent.Name != "cf" {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		cfCLIVersion, err := semver.NewVersion(userAgent.Version)
+		if err != nil {
+			presentError(logger, w, apierrors.NewInvalidRequestError(
+				err,
+				fmt.Sprintf("Failed to determine CF CLI version. Korifi requires CF CLI %s", minSupportedVersion),
+			))
+			return
+		}
+
+		if !m.versionConstraint(logger).Check(cfCLIVersion) {
+			presentError(logger, w, apierrors.NewInvalidRequestError(
+				err,
+				fmt.Sprintf("CF CLI version %s is not supported. Korifi requires CF CLI %s", cfCLIVersion, minSupportedVersion),
+			))
+			return
+
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (m CFCliVersionMiddleware) versionConstraint(logger logr.Logger) *semver.Constraints {
+	versionConstraint, err := semver.NewConstraint(minSupportedVersion)
+	if err != nil {
+		logger.Error(err, "failed to convert minSupportedVersion to version constraint", "minSupportedVersion", minSupportedVersion)
+		return &semver.Constraints{}
+	}
+	return versionConstraint
+}

--- a/api/handlers/cli_version_middleware_test.go
+++ b/api/handlers/cli_version_middleware_test.go
@@ -1,0 +1,103 @@
+package handlers_test
+
+import (
+	"net/http"
+
+	"code.cloudfoundry.org/korifi/api/handlers"
+	"github.com/go-http-utils/headers"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("CliVersionMiddleware", func() {
+	var (
+		cliVersionMiddleware *handlers.CFCliVersionMiddleware
+		nextHandler          http.Handler
+		requestHeaders       map[string][]string
+	)
+
+	BeforeEach(func() {
+		requestHeaders = map[string][]string{}
+		nextHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusTeapot)
+		})
+
+		cliVersionMiddleware = handlers.NewCFCliVersionMiddleware()
+	})
+
+	JustBeforeEach(func() {
+		request, err := http.NewRequest(http.MethodGet, "http://localhost/foo", nil)
+		request.Header = requestHeaders
+		Expect(err).NotTo(HaveOccurred())
+		cliVersionMiddleware.Middleware(nextHandler).ServeHTTP(rr, request)
+	})
+
+	It("delegates to the next handler", func() {
+		Expect(rr).To(HaveHTTPStatus(http.StatusTeapot))
+	})
+
+	When("the user agent is not formatted properly", func() {
+		BeforeEach(func() {
+			requestHeaders[headers.UserAgent] = []string{"i-am-not-formatted-properly"}
+		})
+
+		It("delegates to the next handler", func() {
+			Expect(rr).To(HaveHTTPStatus(http.StatusTeapot))
+		})
+	})
+
+	When("the user agent is not cf cli", func() {
+		BeforeEach(func() {
+			requestHeaders[headers.UserAgent] = []string{"curl/7.81.0"}
+		})
+
+		It("delegates to the next handler", func() {
+			Expect(rr).To(HaveHTTPStatus(http.StatusTeapot))
+		})
+	})
+
+	When("the user agent is cf cli", func() {
+		BeforeEach(func() {
+			requestHeaders[headers.UserAgent] = []string{"cf/8.5.0+73aa161.2022-09-12 (go1.18.5; amd64 linux)"}
+		})
+
+		It("delegates to the next handler", func() {
+			Expect(rr).To(HaveHTTPStatus(http.StatusTeapot))
+		})
+
+		When("the cf cli version is too old", func() {
+			BeforeEach(func() {
+				requestHeaders[headers.UserAgent] = []string{"cf/8.4.0+73aa161.2022-09-12 (go1.18.5; amd64 linux)"}
+			})
+
+			It("returns an informative error", func() {
+				Expect(rr).To(HaveHTTPStatus(http.StatusBadRequest))
+				Expect(rr).To(HaveHTTPBody(ContainSubstring("Korifi requires CF CLI >= 8.5.0")))
+			})
+		})
+
+		When("there are  multiple UserAgent header values", func() {
+			BeforeEach(func() {
+				requestHeaders[headers.UserAgent] = []string{
+					"cf/8.5.0+73aa161.2022-09-12 (go1.18.5; amd64 linux)",
+					"cf/8.4.0+73aa161.2022-09-12 (go1.18.5; amd64 linux)",
+				}
+			})
+
+			It("respects the first one", func() {
+				Expect(rr).To(HaveHTTPStatus(http.StatusTeapot))
+			})
+		})
+
+		When("the cf cli version cannot be parsed", func() {
+			BeforeEach(func() {
+				requestHeaders[headers.UserAgent] = []string{"cf/unknown"}
+			})
+
+			It("returns an informative error", func() {
+				Expect(rr).To(HaveHTTPStatus(http.StatusBadRequest))
+				Expect(rr).To(HaveHTTPBody(ContainSubstring("Korifi requires CF CLI >= 8.5.0")))
+			})
+		})
+	})
+})

--- a/api/main.go
+++ b/api/main.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"fmt"
-	"go.uber.org/zap/zapcore"
 	"net/http"
 	"net/url"
 	"os"
 	"path"
 	"time"
+
+	"go.uber.org/zap/zapcore"
 
 	"code.cloudfoundry.org/korifi/api/actions"
 	"code.cloudfoundry.org/korifi/api/actions/manifest"
@@ -297,6 +298,7 @@ func main() {
 	authInfoParser := authorization.NewInfoParser()
 	router.Use(
 		handlers.NewCorrelationIDMiddleware().Middleware,
+		handlers.NewCFCliVersionMiddleware().Middleware,
 		handlers.NewHTTPLogging().Middleware,
 		handlers.NewAuthenticationMiddleware(
 			authInfoParser,

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.18
 require (
 	code.cloudfoundry.org/bytefmt v0.0.0-20211005130812-5bb3c17173e5
 	code.cloudfoundry.org/go-loggregator/v8 v8.0.5
+	github.com/Masterminds/semver v1.5.0
 	github.com/SermoDigital/jose v0.9.2-0.20161205224733-f6df55f235c2
 	github.com/buildpacks/lifecycle v0.14.2
 	github.com/buildpacks/pack v0.27.0
@@ -24,6 +25,7 @@ require (
 	github.com/gorilla/schema v1.2.0
 	github.com/jonboulle/clockwork v0.3.0
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.5.0
+	github.com/mileusna/useragent v1.2.1
 	github.com/onsi/ginkgo/v2 v2.3.1
 	github.com/onsi/gomega v1.22.1
 	github.com/pivotal/kpack v0.7.1

--- a/go.sum
+++ b/go.sum
@@ -141,6 +141,7 @@ github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YH
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
@@ -1092,6 +1093,8 @@ github.com/miekg/dns v1.1.35/go.mod h1:KNUDUusw/aVsxyTYZM1oqvCicbwhgbNgztCETuNZ7
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=
 github.com/miekg/pkcs11 v1.0.2/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
 github.com/miekg/pkcs11 v1.0.3/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
+github.com/mileusna/useragent v1.2.1 h1:p3RJWhi3LfuI6BHdddojREyK3p6qX67vIfOVMnUIVr0=
+github.com/mileusna/useragent v1.2.1/go.mod h1:3d8TOmwL/5I8pJjyVDteHtgDGcefrFUX4ccGOMKNYYc=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/cli v1.1.0/go.mod h1:xcISNoH86gajksDmfB23e/pu+B+GeFRMYmoHXxx3xhI=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=

--- a/tests/e2e/cli_version_test.go
+++ b/tests/e2e/cli_version_test.go
@@ -1,0 +1,32 @@
+package e2e_test
+
+import (
+	"crypto/tls"
+	"net/http"
+
+	"github.com/go-http-utils/headers"
+	"github.com/go-resty/resty/v2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Min CF CLI Version", func() {
+	var (
+		client   *resty.Client
+		httpResp *resty.Response
+	)
+
+	BeforeEach(func() {
+		client = resty.New().SetBaseURL(apiServerRoot).SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true})
+	})
+
+	JustBeforeEach(func() {
+		var err error
+		httpResp, err = client.SetHeader(headers.UserAgent, "cf/0.0.1").R().Get("/v3")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("validates the minimum cli version", func() {
+		Expect(httpResp).To(HaveRestyStatusCode(http.StatusBadRequest))
+	})
+})


### PR DESCRIPTION
## Is there a related GitHub Issue?
https://github.com/cloudfoundry/korifi/issues/1771
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Introduce an API middleware that returns an error if the user agen is CF
cli and its version is `< 8.5.0`
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
* `cf api` succeeds with CF cli `>= 8.5.0`
* `cf api` fails with CF CLI `< 8.5.0`
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@georgethebeatle
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

