### PR TITLE
Implement CFApp spec buildpacks patching

### DIFF
--- a/api/actions/manifest/applier.go
+++ b/api/actions/manifest/applier.go
@@ -56,16 +56,10 @@ func (a *Applier) applyApp(
 	if appState.App.GUID == "" {
 		appRecord, err := a.appRepo.CreateApp(ctx, authInfo, appInfo.ToAppCreateMessage(spaceGUID))
 		return AppState{App: appRecord}, err
+	} else {
+		_, err := a.appRepo.PatchApp(ctx, authInfo, appInfo.ToAppPatchMessage(appState.App.GUID, spaceGUID))
+		return appState, err
 	}
-
-	_, err := a.appRepo.CreateOrPatchAppEnvVars(ctx, authInfo, repositories.CreateOrPatchAppEnvVarsMessage{
-		AppGUID:              appState.App.GUID,
-		AppEtcdUID:           appState.App.EtcdUID,
-		SpaceGUID:            appState.App.SpaceGUID,
-		EnvironmentVariables: appInfo.Env,
-	})
-
-	return appState, err
 }
 
 func (a *Applier) applyProcesses(

--- a/api/actions/manifest/applier_test.go
+++ b/api/actions/manifest/applier_test.go
@@ -14,7 +14,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gstruct"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 var _ = Describe("Applier", func() {
@@ -95,20 +94,17 @@ var _ = Describe("Applier", func() {
 				}
 			})
 
-			It("updates its env", func() {
+			It("updates the app buildpacks", func() {
 				Expect(applierErr).NotTo(HaveOccurred())
-				Expect(appRepo.CreateOrPatchAppEnvVarsCallCount()).To(Equal(1))
-				_, _, envVarMsg := appRepo.CreateOrPatchAppEnvVarsArgsForCall(0)
-				Expect(envVarMsg.AppEtcdUID).To(Equal(types.UID("etcd-uid")))
-				Expect(envVarMsg.AppGUID).To(Equal("my-guid"))
-				Expect(envVarMsg.SpaceGUID).To(Equal("space-guid"))
-				Expect(envVarMsg.EnvironmentVariables).To(HaveKeyWithValue("FOO", "bar"))
-				Expect(envVarMsg.EnvironmentVariables).To(HaveKeyWithValue("BOB", "bob"))
+				Expect(appRepo.PatchAppCallCount()).To(Equal(1))
+				_, _, patchAppMsg := appRepo.PatchAppArgsForCall(0)
+				Expect(patchAppMsg.AppGUID).To(Equal("my-guid"))
+				Expect(patchAppMsg.Lifecycle.Data.Buildpacks).To(Equal([]string{"buildpack-a"}))
 			})
 
 			When("patching the app fails", func() {
 				BeforeEach(func() {
-					appRepo.CreateOrPatchAppEnvVarsReturns(repositories.AppEnvVarsRecord{}, errors.New("patch-app-failed"))
+					appRepo.PatchAppReturns(repositories.AppRecord{}, errors.New("patch-app-failed"))
 				})
 
 				It("returns the error", func() {

--- a/api/actions/shared/fake/cfapp_repository.go
+++ b/api/actions/shared/fake/cfapp_repository.go
@@ -72,6 +72,21 @@ type CFAppRepository struct {
 		result1 repositories.AppRecord
 		result2 error
 	}
+	PatchAppStub        func(context.Context, authorization.Info, repositories.PatchAppMessage) (repositories.AppRecord, error)
+	patchAppMutex       sync.RWMutex
+	patchAppArgsForCall []struct {
+		arg1 context.Context
+		arg2 authorization.Info
+		arg3 repositories.PatchAppMessage
+	}
+	patchAppReturns struct {
+		result1 repositories.AppRecord
+		result2 error
+	}
+	patchAppReturnsOnCall map[int]struct {
+		result1 repositories.AppRecord
+		result2 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -341,6 +356,72 @@ func (fake *CFAppRepository) GetAppByNameAndSpaceReturnsOnCall(i int, result1 re
 	}{result1, result2}
 }
 
+func (fake *CFAppRepository) PatchApp(arg1 context.Context, arg2 authorization.Info, arg3 repositories.PatchAppMessage) (repositories.AppRecord, error) {
+	fake.patchAppMutex.Lock()
+	ret, specificReturn := fake.patchAppReturnsOnCall[len(fake.patchAppArgsForCall)]
+	fake.patchAppArgsForCall = append(fake.patchAppArgsForCall, struct {
+		arg1 context.Context
+		arg2 authorization.Info
+		arg3 repositories.PatchAppMessage
+	}{arg1, arg2, arg3})
+	stub := fake.PatchAppStub
+	fakeReturns := fake.patchAppReturns
+	fake.recordInvocation("PatchApp", []interface{}{arg1, arg2, arg3})
+	fake.patchAppMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *CFAppRepository) PatchAppCallCount() int {
+	fake.patchAppMutex.RLock()
+	defer fake.patchAppMutex.RUnlock()
+	return len(fake.patchAppArgsForCall)
+}
+
+func (fake *CFAppRepository) PatchAppCalls(stub func(context.Context, authorization.Info, repositories.PatchAppMessage) (repositories.AppRecord, error)) {
+	fake.patchAppMutex.Lock()
+	defer fake.patchAppMutex.Unlock()
+	fake.PatchAppStub = stub
+}
+
+func (fake *CFAppRepository) PatchAppArgsForCall(i int) (context.Context, authorization.Info, repositories.PatchAppMessage) {
+	fake.patchAppMutex.RLock()
+	defer fake.patchAppMutex.RUnlock()
+	argsForCall := fake.patchAppArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *CFAppRepository) PatchAppReturns(result1 repositories.AppRecord, result2 error) {
+	fake.patchAppMutex.Lock()
+	defer fake.patchAppMutex.Unlock()
+	fake.PatchAppStub = nil
+	fake.patchAppReturns = struct {
+		result1 repositories.AppRecord
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *CFAppRepository) PatchAppReturnsOnCall(i int, result1 repositories.AppRecord, result2 error) {
+	fake.patchAppMutex.Lock()
+	defer fake.patchAppMutex.Unlock()
+	fake.PatchAppStub = nil
+	if fake.patchAppReturnsOnCall == nil {
+		fake.patchAppReturnsOnCall = make(map[int]struct {
+			result1 repositories.AppRecord
+			result2 error
+		})
+	}
+	fake.patchAppReturnsOnCall[i] = struct {
+		result1 repositories.AppRecord
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *CFAppRepository) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -352,6 +433,8 @@ func (fake *CFAppRepository) Invocations() map[string][][]interface{} {
 	defer fake.getAppMutex.RUnlock()
 	fake.getAppByNameAndSpaceMutex.RLock()
 	defer fake.getAppByNameAndSpaceMutex.RUnlock()
+	fake.patchAppMutex.RLock()
+	defer fake.patchAppMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/api/actions/shared/shared.go
+++ b/api/actions/shared/shared.go
@@ -25,6 +25,7 @@ type CFAppRepository interface {
 	GetAppByNameAndSpace(context.Context, authorization.Info, string, string) (repositories.AppRecord, error)
 	CreateOrPatchAppEnvVars(context.Context, authorization.Info, repositories.CreateOrPatchAppEnvVarsMessage) (repositories.AppEnvVarsRecord, error)
 	CreateApp(context.Context, authorization.Info, repositories.CreateAppMessage) (repositories.AppRecord, error)
+	PatchApp(context.Context, authorization.Info, repositories.PatchAppMessage) (repositories.AppRecord, error)
 }
 
 //counterfeiter:generate -o fake -fake-name CFBuildRepository . CFBuildRepository

--- a/api/payloads/manifest.go
+++ b/api/payloads/manifest.go
@@ -73,6 +73,21 @@ func (a ManifestApplication) ToAppCreateMessage(spaceGUID string) repositories.C
 	}
 }
 
+func (a ManifestApplication) ToAppPatchMessage(appGUID, spaceGUID string) repositories.PatchAppMessage {
+	return repositories.PatchAppMessage{
+		Name:      a.Name,
+		AppGUID:   appGUID,
+		SpaceGUID: spaceGUID,
+		Lifecycle: repositories.Lifecycle{
+			Type: string(korifiv1alpha1.BuildpackLifecycle),
+			Data: repositories.LifecycleData{
+				Buildpacks: a.Buildpacks,
+			},
+		},
+		EnvironmentVariables: a.Env,
+	}
+}
+
 func (p ManifestApplicationProcess) ToProcessCreateMessage(appGUID, spaceGUID string) repositories.CreateProcessMessage {
 	msg := repositories.CreateProcessMessage{
 		AppGUID:   appGUID,

--- a/api/repositories/shared_test.go
+++ b/api/repositories/shared_test.go
@@ -222,6 +222,23 @@ func initializeAppCreateMessage(appName string, spaceGUID string) CreateAppMessa
 	}
 }
 
+func initializeAppPatchMessage(appName, appGUID, spaceGUID string) PatchAppMessage {
+	return PatchAppMessage{
+		Name:      appName,
+		AppGUID:   appGUID,
+		SpaceGUID: spaceGUID,
+		Lifecycle: Lifecycle{
+			Type: "buildpack",
+			Data: LifecycleData{
+				Buildpacks: []string{
+					"some-buildpack",
+				},
+				Stack: "cflinuxfs3",
+			},
+		},
+	}
+}
+
 func generateAppEnvSecretName(appGUID string) string {
 	return appGUID + "-env"
 }

--- a/kpack-image-builder/main.go
+++ b/kpack-image-builder/main.go
@@ -19,8 +19,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"go.uber.org/zap/zapcore"
-	"k8s.io/klog/v2"
 	"os"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
@@ -28,6 +26,8 @@ import (
 	"code.cloudfoundry.org/korifi/kpack-image-builder/config"
 	"code.cloudfoundry.org/korifi/kpack-image-builder/controllers"
 	"code.cloudfoundry.org/korifi/kpack-image-builder/controllers/imageprocessfetcher"
+
+	//+kubebuilder:scaffold:imports
 
 	buildv1alpha2 "github.com/pivotal/kpack/pkg/apis/build/v1alpha2"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -37,11 +37,12 @@ import (
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
+	"go.uber.org/zap/zapcore"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	//+kubebuilder:scaffold:imports
 )
 
 var (
@@ -52,7 +53,6 @@ var (
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(buildv1alpha2.AddToScheme(scheme))
-
 	utilruntime.Must(korifiv1alpha1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
 }
@@ -61,14 +61,17 @@ func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string
+
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+
 	opts := zap.Options{
 		TimeEncoder: zapcore.RFC3339NanoTimeEncoder,
 	}
+
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
@@ -149,6 +152,7 @@ func main() {
 		setupLog.Error(err, "unable to set up health check")
 		os.Exit(1)
 	}
+
 	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up ready check")
 		os.Exit(1)


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
#1632 

## What is this change about?
Plumb through buildpack info in app update requests to properly trigger errors on unsupported buildpacks the same way as on create.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
See issue #1632 

## Tag your pair, your PM, and/or team
paired w/ @davewalter @Birdrock and clinty(but not using @ as he is out of office)

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->

Note that we followed the pattern from the create app implementation and were not sure if there was an appropriate end to end test to author. If y'all ideas for how that would look, we'd be happy to spend another cycle on it.