### PR TITLE
Delete AppWorkloads for processes scaled down to 0

### DIFF
--- a/controllers/controllers/workloads/testutils/shared_test_utils.go
+++ b/controllers/controllers/workloads/testutils/shared_test_utils.go
@@ -220,7 +220,7 @@ func BuildCFProcessCRObject(cfProcessGUID string, namespace string, cfAppGUID st
 					TimeoutSeconds:           0,
 				},
 			},
-			DesiredInstances: tools.PtrTo(0),
+			DesiredInstances: tools.PtrTo(1),
 			MemoryMB:         1024,
 			DiskQuotaMB:      100,
 			Ports:            []int32{8080},


### PR DESCRIPTION
## Is there a related GitHub Issue?

https://github.com/cloudfoundry/korifi/issues/1731

<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?

Delete `AppWorkload`s for `CFProcess`es that have been scaled down to 0 instances. This has the side effect that `Statefulset`s for that app workload are also deleted as they are owned by `AppWorkload`s

As `CFProcess.Spec.DesiredInstances` is a pointer (i.e. can be unset), this PR treats the unset instances pointer as zero instances, therefore when `DesiredInstances` is unset on the spec, the `AppWorkload` gets deleted.

<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?

No

<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps

See #1731

<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->
