### PR TITLE
Unpin paketo-buildpacks/java

### DIFF
--- a/helm/kpack-image-builder/templates/cluster-builder.yaml
+++ b/helm/kpack-image-builder/templates/cluster-builder.yaml
@@ -5,7 +5,7 @@ metadata:
   name: cf-default-buildpacks
 spec:
   sources:
-  - image: gcr.io/paketo-buildpacks/java:7.5.0
+  - image: gcr.io/paketo-buildpacks/java
   - image: gcr.io/paketo-buildpacks/nodejs
   - image: gcr.io/paketo-buildpacks/ruby
   - image: gcr.io/paketo-buildpacks/procfile


### PR DESCRIPTION
## Is there a related GitHub Issue?
#1764
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Unpin `paketo-buildpacks/java`, their latest release (`v7.7.0`) fixes the [maven buildpack issue](https://github.com/paketo-buildpacks/maven/issues/194) that made us pin it
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
Green E2E tests
