### PR TITLE
Normalize deprecated manifest `buildpack` into `buildpacks`

### DIFF
--- a/api/actions/manifest/normalizer.go
+++ b/api/actions/manifest/normalizer.go
@@ -53,6 +53,14 @@ func fixDeprecatedFields(appInfo *payloads.ManifestApplication) {
 			appInfo.Processes[i].DiskQuota = appInfo.Processes[i].AltDiskQuota
 		}
 	}
+
+	if hasBuildpackSet(appInfo.Buildpack) { // nolint: staticcheck
+		appInfo.Buildpacks = append(appInfo.Buildpacks, appInfo.Buildpack) // nolint: staticcheck
+	}
+}
+
+func hasBuildpackSet(buildpack string) bool {
+	return buildpack != "" && buildpack != "default" && buildpack != "null"
 }
 
 func (n Normalizer) normalizeProcesses(appInfo payloads.ManifestApplication, appState AppState) []payloads.ManifestApplicationProcess {

--- a/api/actions/manifest/normalizer_test.go
+++ b/api/actions/manifest/normalizer_test.go
@@ -72,6 +72,42 @@ var _ = Describe("Normalizer", func() {
 				Expect(normalizedAppInfo.NoRoute).To(BeTrue())
 			})
 		})
+
+		When("deprecated 'buildpack' is specified", func() {
+			BeforeEach(func() {
+				appInfo.Buildpack = "deprecated-buildpack" // nolint: staticcheck
+			})
+
+			It("adds it to the buildpacks list", func() {
+				Expect(normalizedAppInfo.Buildpacks).To(
+					ConsistOf("deprecated-buildpack", "buildpack-one", "buildpack-two"),
+				)
+			})
+
+			When("set to 'default'", func() {
+				BeforeEach(func() {
+					appInfo.Buildpack = "default" // nolint: staticcheck
+				})
+
+				It("ignores it", func() {
+					Expect(normalizedAppInfo.Buildpacks).To(
+						ConsistOf("buildpack-one", "buildpack-two"),
+					)
+				})
+			})
+
+			When("set to 'null'", func() {
+				BeforeEach(func() {
+					appInfo.Buildpack = "null" // nolint: staticcheck
+				})
+
+				It("ignores it", func() {
+					Expect(normalizedAppInfo.Buildpacks).To(
+						ConsistOf("buildpack-one", "buildpack-two"),
+					)
+				})
+			})
+		})
 	})
 
 	Describe("process normalization", func() {

--- a/api/payloads/manifest.go
+++ b/api/payloads/manifest.go
@@ -35,6 +35,8 @@ type ManifestApplication struct {
 	Processes                    []ManifestApplicationProcess `yaml:"processes" validate:"dive"`
 	Routes                       []ManifestRoute              `yaml:"routes" validate:"dive"`
 	Buildpacks                   []string                     `yaml:"buildpacks"`
+	// Deprecated: Use Buildpacks instead
+	Buildpack string `yaml:"buildpack"`
 }
 
 type ManifestApplicationProcess struct {


### PR DESCRIPTION
## Is there a related GitHub Issue?
https://github.com/cloudfoundry/korifi/issues/1633
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Since kpack-image-builder currently rejects any content of `buildpacks`,
this now makes the behaviour consistent as it will now also reject any
(non-trivial) content of `buildpack`.
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
See ammended story acceptance
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@kieron-dev
