### PR TITLE
Do not check rolebindings for `system:masters` users

### DIFF
--- a/api/authorization/cert_inspector.go
+++ b/api/authorization/cert_inspector.go
@@ -52,7 +52,8 @@ func (c *CertInspector) WhoAmI(ctx context.Context, certPEM []byte) (Identity, e
 	}
 
 	return Identity{
-		Name: cert.Subject.CommonName,
-		Kind: rbacv1.UserKind,
+		Name:   cert.Subject.CommonName,
+		Groups: cert.Subject.Organization,
+		Kind:   rbacv1.UserKind,
 	}, nil
 }

--- a/api/authorization/cert_inspector_test.go
+++ b/api/authorization/cert_inspector_test.go
@@ -27,7 +27,7 @@ var _ = Describe("CertInspector", func() {
 	BeforeEach(func() {
 		ctx = context.Background()
 		certInspector = authorization.NewCertInspector(k8sConfig)
-		certData, keyData := testhelpers.ObtainClientCert(testEnv, "alice")
+		certData, keyData := testhelpers.ObtainClientCert(testEnv, "alice", "my-group")
 		certPEM = certData
 		certPEM = append(certPEM, keyData...)
 	})
@@ -40,6 +40,7 @@ var _ = Describe("CertInspector", func() {
 		Expect(inspectorErr).NotTo(HaveOccurred())
 		Expect(id.Kind).To(Equal(rbacv1.UserKind))
 		Expect(id.Name).To(Equal("alice"))
+		Expect(id.Groups).To(ContainElement("my-group"))
 	})
 
 	When("the certificate is not recognized by the cluster", func() {

--- a/api/authorization/identity_provider.go
+++ b/api/authorization/identity_provider.go
@@ -15,8 +15,9 @@ const (
 //counterfeiter:generate -o fake -fake-name CertIdentityInspector . CertIdentityInspector
 
 type Identity struct {
-	Name string
-	Kind string
+	Name   string
+	Kind   string
+	Groups []string
 }
 
 type TokenIdentityInspector interface {

--- a/api/authorization/namespace_permissions.go
+++ b/api/authorization/namespace_permissions.go
@@ -17,6 +17,8 @@ import (
 
 //counterfeiter:generate -o fake -fake-name IdentityProvider . IdentityProvider
 
+const systemMastersGroup = "system:masters"
+
 type IdentityProvider interface {
 	GetIdentity(context.Context, Info) (Identity, error)
 }
@@ -41,15 +43,30 @@ func (o *NamespacePermissions) GetAuthorizedSpaceNamespaces(ctx context.Context,
 	return o.getAuthorizedNamespaces(ctx, info, korifiv1alpha1.SpaceNameLabel, "Space")
 }
 
+func isSystemMaster(identity Identity) bool {
+	for _, g := range identity.Groups {
+		if g == systemMastersGroup {
+			return true
+		}
+	}
+
+	return false
+}
+
+func toMap(namespaces []corev1.Namespace) map[string]bool {
+	nsMap := map[string]bool{}
+
+	for _, ns := range namespaces {
+		nsMap[ns.Name] = true
+	}
+
+	return nsMap
+}
+
 func (o *NamespacePermissions) getAuthorizedNamespaces(ctx context.Context, info Info, orgSpaceLabel, resourceType string) (map[string]bool, error) {
 	identity, err := o.identityProvider.GetIdentity(ctx, info)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get identity: %w", err)
-	}
-
-	var rolebindings rbacv1.RoleBindingList
-	if err := o.privilegedClient.List(ctx, &rolebindings); err != nil {
-		return nil, fmt.Errorf("failed to list rolebindings: %w", apierrors.FromK8sError(err, resourceType))
 	}
 
 	var cfOrgsOrSpaces corev1.NamespaceList
@@ -57,13 +74,17 @@ func (o *NamespacePermissions) getAuthorizedNamespaces(ctx context.Context, info
 		return nil, fmt.Errorf("failed to list namespaces: %w", apierrors.FromK8sError(err, resourceType))
 	}
 
-	cfNamespaces := map[string]bool{}
-	for _, ns := range cfOrgsOrSpaces.Items {
-		cfNamespaces[ns.Name] = true
+	cfNamespaces := toMap(cfOrgsOrSpaces.Items)
+	if isSystemMaster(identity) {
+		return cfNamespaces, nil
+	}
+
+	var rolebindings rbacv1.RoleBindingList
+	if err := o.privilegedClient.List(ctx, &rolebindings); err != nil {
+		return nil, fmt.Errorf("failed to list rolebindings: %w", apierrors.FromK8sError(err, resourceType))
 	}
 
 	authorizedNamespaces := map[string]bool{}
-
 	for _, roleBinding := range rolebindings.Items {
 		for _, subject := range roleBinding.Subjects {
 			if subject.Kind == identity.Kind && subject.Name == identity.Name {
@@ -78,6 +99,10 @@ func (o *NamespacePermissions) getAuthorizedNamespaces(ctx context.Context, info
 }
 
 func (o *NamespacePermissions) AuthorizedIn(ctx context.Context, identity Identity, namespace string) (bool, error) {
+	if isSystemMaster(identity) {
+		return true, nil
+	}
+
 	var rolebindings rbacv1.RoleBindingList
 	err := o.privilegedClient.List(ctx, &rolebindings, client.InNamespace(namespace))
 	if err != nil {

--- a/api/authorization/namespace_permissions_test.go
+++ b/api/authorization/namespace_permissions_test.go
@@ -141,6 +141,21 @@ var _ = Describe("Namespace Permissions", func() {
 			Expect(namespaces).To(Equal(map[string]bool{org1NS: true}))
 		})
 
+		When("the user has the system:masters group", func() {
+			BeforeEach(func() {
+				identity.Groups = []string{"foo", "system:masters", "bar"}
+				identityProvider.GetIdentityReturns(identity, nil)
+			})
+
+			It("returns all the orgs", func() {
+				Expect(getErr).NotTo(HaveOccurred())
+				Expect(namespaces).To(SatisfyAll(
+					HaveKeyWithValue(org1NS, true),
+					HaveKeyWithValue(org2NS, true),
+				))
+			})
+		})
+
 		When("the id provider fails", func() {
 			BeforeEach(func() {
 				identityProvider.GetIdentityReturns(authorization.Identity{}, errors.New("boom"))
@@ -165,7 +180,7 @@ var _ = Describe("Namespace Permissions", func() {
 			})
 		})
 
-		When("listing the rolebindings fails", func() {
+		When("listing the namespaces fails", func() {
 			var cancelCtx context.CancelFunc
 
 			BeforeEach(func() {
@@ -177,7 +192,7 @@ var _ = Describe("Namespace Permissions", func() {
 			})
 
 			It("returns an error", func() {
-				Expect(getErr).To(MatchError(ContainSubstring("failed to list rolebindings")))
+				Expect(getErr).To(MatchError(ContainSubstring("failed to list namespaces")))
 			})
 		})
 	})
@@ -203,6 +218,21 @@ var _ = Describe("Namespace Permissions", func() {
 		It("lists the namespaces with bindings for current user", func() {
 			Expect(getErr).NotTo(HaveOccurred())
 			Expect(namespaces).To(Equal(map[string]bool{space1NS: true}))
+		})
+
+		When("the user has the system:masters group", func() {
+			BeforeEach(func() {
+				identity.Groups = []string{"foo", "system:masters", "bar"}
+				identityProvider.GetIdentityReturns(identity, nil)
+			})
+
+			It("returns all the spaces", func() {
+				Expect(getErr).NotTo(HaveOccurred())
+				Expect(namespaces).To(SatisfyAll(
+					HaveKeyWithValue(space1NS, true),
+					HaveKeyWithValue(space2NS, true),
+				))
+			})
 		})
 
 		When("the user does not have a rolebinding associated with it", func() {
@@ -243,10 +273,27 @@ var _ = Describe("Namespace Permissions", func() {
 		})
 
 		When("the user does not have a RoleBinding in the namespace", func() {
-			It("returns false", func() {
-				authorized, err := nsPerms.AuthorizedIn(ctx, identity, org2NS)
+			var authorized bool
+
+			JustBeforeEach(func() {
+				var err error
+				authorized, err = nsPerms.AuthorizedIn(ctx, identity, org2NS)
 				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("returns false", func() {
 				Expect(authorized).To(BeFalse())
+			})
+
+			When("the user has the system:masters group", func() {
+				BeforeEach(func() {
+					identity.Groups = []string{"foo", "system:masters", "bar"}
+					identityProvider.GetIdentityReturns(identity, nil)
+				})
+
+				It("returns true", func() {
+					Expect(authorized).To(BeTrue())
+				})
 			})
 		})
 	})

--- a/api/authorization/testhelpers/client_cert.go
+++ b/api/authorization/testhelpers/client_cert.go
@@ -5,8 +5,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 )
 
-func ObtainClientCert(testEnv *envtest.Environment, name string) ([]byte, []byte) {
-	authUser, err := testEnv.ControlPlane.AddUser(envtest.User{Name: name}, testEnv.Config)
+func ObtainClientCert(testEnv *envtest.Environment, name string, groups ...string) ([]byte, []byte) {
+	authUser, err := testEnv.ControlPlane.AddUser(envtest.User{Name: name, Groups: groups}, testEnv.Config)
 	Expect(err).NotTo(HaveOccurred())
 
 	userConfig := authUser.Config()

--- a/api/authorization/token_reviewer.go
+++ b/api/authorization/token_reviewer.go
@@ -60,8 +60,9 @@ func (r *TokenReviewer) WhoAmI(ctx context.Context, token string) (Identity, err
 	}
 
 	return Identity{
-		Name: idName,
-		Kind: idKind,
+		Name:   idName,
+		Kind:   idKind,
+		Groups: tokenReview.Status.User.Groups,
 	}, nil
 }
 

--- a/api/authorization/token_reviewer_test.go
+++ b/api/authorization/token_reviewer_test.go
@@ -25,7 +25,7 @@ var _ = Describe("TokenReviewer", func() {
 	BeforeEach(func() {
 		ctx = context.Background()
 		tokenReviewer = authorization.NewTokenReviewer(k8sClient)
-		token = authProvider.GenerateJWTToken("alice")
+		token = authProvider.GenerateJWTToken("alice", "my-group")
 		passErrConstraints = Succeed()
 	})
 
@@ -38,6 +38,7 @@ var _ = Describe("TokenReviewer", func() {
 	It("extracts identity from a valid token", func() {
 		Expect(id.Kind).To(Equal(rbacv1.UserKind))
 		Expect(id.Name).To(Equal(oidcPrefix + "alice"))
+		Expect(id.Groups).To(ContainElement("my-group"))
 	})
 
 	When("the token is issued for a serviceaccount", func() {
@@ -57,6 +58,7 @@ var _ = Describe("TokenReviewer", func() {
 		It("extracts the identity of the serviceaccount", func() {
 			Expect(id.Kind).To(Equal(rbacv1.ServiceAccountKind))
 			Expect(id.Name).To(Equal("my-serviceaccount"))
+			Expect(id.Groups).To(ContainElement("system:serviceaccounts"))
 		})
 	})
 

--- a/api/handlers/whoami_handler_test.go
+++ b/api/handlers/whoami_handler_test.go
@@ -26,7 +26,11 @@ var _ = Describe("WhoAmI", func() {
 	BeforeEach(func() {
 		requestPath = whoAmIBase
 		identityProvider = new(fake.IdentityProvider)
-		identityProvider.GetIdentityReturns(authorization.Identity{Name: "the-user", Kind: rbacv1.UserKind}, nil)
+		identityProvider.GetIdentityReturns(authorization.Identity{
+			Name:   "the-user",
+			Groups: []string{"foo", "bar"},
+			Kind:   rbacv1.UserKind,
+		}, nil)
 		ctx = authorization.NewContext(ctx, &authorization.Info{Token: "the-token"})
 		whoAmIHandler = apis.NewWhoAmI(identityProvider, *serverURL)
 		whoAmIHandler.RegisterRoutes(router)
@@ -46,6 +50,7 @@ var _ = Describe("WhoAmI", func() {
 			Expect(rr).To(HaveHTTPHeaderWithValue("Content-Type", "application/json"))
 			Expect(rr).To(HaveHTTPBody(MatchJSON(`{
                 "name": "the-user",
+                "groups": ["foo", "bar"],
                 "kind": "User"
             }`)))
 		})

--- a/api/presenter/identity.go
+++ b/api/presenter/identity.go
@@ -5,13 +5,15 @@ import (
 )
 
 type IdentityResponse struct {
-	Name string `json:"name"`
-	Kind string `json:"kind"`
+	Name   string   `json:"name"`
+	Groups []string `json:"groups"`
+	Kind   string   `json:"kind"`
 }
 
 func ForWhoAmI(identity authorization.Identity) IdentityResponse {
 	return IdentityResponse{
-		Name: identity.Name,
-		Kind: identity.Kind,
+		Name:   identity.Name,
+		Groups: identity.Groups,
+		Kind:   identity.Kind,
 	}
 }


### PR DESCRIPTION
## Is there a related GitHub Issue?
https://github.com/cloudfoundry/korifi/issues/1710
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
`system:masters` is a K8S built-in group that gives its user super
powers. For those users we do not need to check rolebindings as they are
allowed to do anything.

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
* Login to Korifi using the K8S admin user (not the cf-admin one)
* Create an org
* See the org created can be listed
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@kieron-dev
