### PR TITLE
Fix gosec vuln in api

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -341,6 +341,7 @@ func main() {
 
 		srv.TLSConfig = &tls.Config{
 			NextProtos:     []string{"h2"},
+			MinVersion:     tls.VersionTLS12,
 			GetCertificate: certWatcher.GetCertificate,
 		}
 		err = srv.ListenAndServeTLS("", "")


### PR DESCRIPTION
## Is there a related GitHub Issue?
[#1786]

## What is this change about?
gosec flags a vulnerability about TLS version

## Does this PR introduce a breaking change?
No

## Acceptance Steps
`gosec api/...` should not report G402 (there are some other false positives still)

## Tag your pair, your PM, and/or team
@matt-royal 
