### PR TITLE
fix: broken link to kind install guide

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -19,7 +19,7 @@ This document was tested on:
 
 - [EKS](https://aws.amazon.com/eks/), using GCP's [Artifact Registry](https://cloud.google.com/artifact-registry);
 - [GKE](https://cloud.google.com/kubernetes-engine), using GCP's [Artifact Registry](https://cloud.google.com/artifact-registry);
-- [kind](https://kind.sigs.k8s.io/), using [DockerHub](https://hub.docker.com/) (see [_Install Korifi on kind_](./INSTALL_kind.md)).
+- [kind](https://kind.sigs.k8s.io/), using [DockerHub](https://hub.docker.com/) (see [_Install Korifi on kind_](./INSTALL.kind.md)).
 
 ## Initial setup
 


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
Fixing a broken link in the docs
