### PR TITLE
Fix service account image pull secret propagation

### DIFF
--- a/controllers/controllers/workloads/integration/cfspace_controller_integration_test.go
+++ b/controllers/controllers/workloads/integration/cfspace_controller_integration_test.go
@@ -280,6 +280,7 @@ var _ = Describe("CFSpaceReconciler Integration Tests", func() {
 			rootServiceAccount       *corev1.ServiceAccount
 			propagatedServiceAccount corev1.ServiceAccount
 			tokenSecretName          string
+			dockercfgSecretName      string
 		)
 		BeforeEach(func() {
 			Expect(k8sClient.Create(ctx, cfSpace)).To(Succeed())
@@ -298,7 +299,9 @@ var _ = Describe("CFSpaceReconciler Integration Tests", func() {
 			// Simulate k8s adding a token secret to the propagated service account AND the propagated service account having a stale image registry credential secret
 			Expect(k8s.PatchResource(ctx, k8sClient, &propagatedServiceAccount, func() {
 				tokenSecretName = rootServiceAccount.Name + "-token-XYZABC"
-				propagatedServiceAccount.Secrets = []corev1.ObjectReference{{Name: tokenSecretName}, {Name: "out-of-date-registry-credentials"}}
+				dockercfgSecretName = rootServiceAccount.Name + "-dockercfg-ABCXYZ"
+				propagatedServiceAccount.Secrets = []corev1.ObjectReference{{Name: tokenSecretName}, {Name: dockercfgSecretName}, {Name: "out-of-date-registry-credentials"}}
+				propagatedServiceAccount.ImagePullSecrets = []corev1.LocalObjectReference{{Name: dockercfgSecretName}, {Name: "out-of-date-registry-credentials"}}
 			})).To(Succeed())
 
 			// Modify the root service account to trigger reconciliation
@@ -315,9 +318,14 @@ var _ = Describe("CFSpaceReconciler Integration Tests", func() {
 				).To(Succeed())
 				g.Expect(updatedPropagatedServiceAccount.Secrets).To(ConsistOf(
 					corev1.ObjectReference{Name: tokenSecretName},
+					corev1.ObjectReference{Name: dockercfgSecretName},
 					corev1.ObjectReference{Name: packageRegistrySecretName},
 				))
-				g.Expect(updatedPropagatedServiceAccount.ImagePullSecrets).To(Equal(rootServiceAccount.ImagePullSecrets))
+
+				g.Expect(updatedPropagatedServiceAccount.ImagePullSecrets).To(ConsistOf(
+					corev1.LocalObjectReference{Name: dockercfgSecretName},
+					corev1.LocalObjectReference{Name: packageRegistrySecretName},
+				))
 			}).Should(Succeed())
 		})
 	})
@@ -327,6 +335,7 @@ var _ = Describe("CFSpaceReconciler Integration Tests", func() {
 			rootServiceAccount       *corev1.ServiceAccount
 			propagatedServiceAccount corev1.ServiceAccount
 			tokenSecretName          string
+			dockercfgSecretName      string
 		)
 		BeforeEach(func() {
 			Expect(k8sClient.Create(ctx, cfSpace)).To(Succeed())
@@ -353,12 +362,15 @@ var _ = Describe("CFSpaceReconciler Integration Tests", func() {
 			// Simulate k8s adding a token secret to the propagated service account
 			Expect(k8s.PatchResource(ctx, k8sClient, &propagatedServiceAccount, func() {
 				tokenSecretName = rootServiceAccount.Name + "-token-XYZABC"
-				propagatedServiceAccount.Secrets = []corev1.ObjectReference{{Name: tokenSecretName}}
+				dockercfgSecretName = rootServiceAccount.Name + "-dockercfg-ABCXYZ"
+				propagatedServiceAccount.Secrets = []corev1.ObjectReference{{Name: tokenSecretName}, {Name: dockercfgSecretName}}
+				propagatedServiceAccount.ImagePullSecrets = []corev1.LocalObjectReference{{Name: dockercfgSecretName}}
 			})).To(Succeed())
 
 			// Add the package registry secret to the root service account
 			Expect(k8s.PatchResource(ctx, k8sClient, rootServiceAccount, func() {
 				rootServiceAccount.Secrets = []corev1.ObjectReference{{Name: packageRegistrySecretName}}
+				rootServiceAccount.ImagePullSecrets = []corev1.LocalObjectReference{{Name: packageRegistrySecretName}}
 			})).To(Succeed())
 		})
 
@@ -370,52 +382,13 @@ var _ = Describe("CFSpaceReconciler Integration Tests", func() {
 				).To(Succeed())
 				g.Expect(updatedPropagatedServiceAccount.Secrets).To(ConsistOf(
 					corev1.ObjectReference{Name: tokenSecretName},
+					corev1.ObjectReference{Name: dockercfgSecretName},
 					corev1.ObjectReference{Name: packageRegistrySecretName},
 				))
-			}).Should(Succeed())
-		})
-	})
-
-	When("the image pull secrets are updated on the root service account", func() {
-		var (
-			rootServiceAccount       *corev1.ServiceAccount
-			propagatedServiceAccount corev1.ServiceAccount
-		)
-		BeforeEach(func() {
-			Expect(k8sClient.Create(ctx, cfSpace)).To(Succeed())
-			Eventually(func(g Gomega) {
-				var createdSpace korifiv1alpha1.CFSpace
-				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: orgNamespace.Name, Name: spaceGUID}, &createdSpace)).To(Succeed())
-				g.Expect(meta.IsStatusConditionTrue(createdSpace.Status.Conditions, "Ready")).To(BeTrue())
-			}, 20*time.Second).Should(Succeed())
-
-			rootServiceAccount = &corev1.ServiceAccount{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        PrefixedGUID("existing-service-account"),
-					Namespace:   cfRootNamespace,
-					Annotations: map[string]string{"cloudfoundry.org/propagate-service-account": "true"},
-				},
-			}
-			Expect(k8sClient.Create(ctx, rootServiceAccount)).To(Succeed())
-
-			// Ensure that the service account is propagated into the CFSpace namespace
-			Eventually(func() error {
-				return k8sClient.Get(ctx, types.NamespacedName{Name: rootServiceAccount.Name, Namespace: cfSpace.Name}, &propagatedServiceAccount)
-			}).Should(Succeed())
-
-			// Add image pull secrets to the root service account
-			Expect(k8s.PatchResource(ctx, k8sClient, rootServiceAccount, func() {
-				rootServiceAccount.ImagePullSecrets = []corev1.LocalObjectReference{{Name: "this-could-be-anything"}, {Name: "another-name-here"}}
-			})).To(Succeed())
-		})
-
-		It("updates the image pull secrets on the space's copy of the service account", func() {
-			Eventually(func(g Gomega) {
-				var updatedPropagatedServiceAccount corev1.ServiceAccount
-				g.Expect(
-					k8sClient.Get(ctx, client.ObjectKeyFromObject(&propagatedServiceAccount), &updatedPropagatedServiceAccount),
-				).To(Succeed())
-				g.Expect(updatedPropagatedServiceAccount.ImagePullSecrets).To(Equal(rootServiceAccount.ImagePullSecrets))
+				g.Expect(updatedPropagatedServiceAccount.ImagePullSecrets).To(ConsistOf(
+					corev1.LocalObjectReference{Name: dockercfgSecretName},
+					corev1.LocalObjectReference{Name: packageRegistrySecretName},
+				))
 			}).Should(Succeed())
 		})
 	})


### PR DESCRIPTION
## Is there a related GitHub Issue?
no

## What is this change about?
Fix service account image pull secret propagation when copying service accounts to spaces. Some distributions of k8s create a dockercfg auto generated secret and adds it to service accounts. Copying service accounts with these secrets present in the secret or image pull secret fields causes a not found error because those secrets will not be copied into the space namespace.

## Does this PR introduce a breaking change?
no

## Acceptance Steps
All unit, integration, and e2e tests pass.

## Tag your pair, your PM, and/or team
@davewalter @matt-royal @julian-hj 
