### PR TITLE
Cleanup unused Makefile targets

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -39,7 +39,7 @@ jobs:
         go-version: '^1.18'
 
     - name: Run Controllers tests
-      run: make test-controllers
+      run: make -C controllers test
 
   api-tests:
     runs-on: ubuntu-latest
@@ -60,7 +60,7 @@ jobs:
         go-version: '^1.18'
 
     - name: Run API unit tests
-      run: make test-api
+      run: make -C api test
 
   kpack-image-builder-tests:
     runs-on: ubuntu-latest
@@ -82,7 +82,7 @@ jobs:
           go-version: '^1.18'
 
       - name: Run kpack-image-builder tests
-        run: make test-kpack-image-builder
+        run: make -C kpack-image-builder test
 
   statefulset-runner-tests:
     runs-on: ubuntu-latest
@@ -104,7 +104,7 @@ jobs:
           go-version: '^1.18'
 
       - name: Run statefulset-runner tests
-        run: make test-statefulset-runner
+        run: make -C statefulset-runner test
 
   job-task-runner-tests:
     runs-on: ubuntu-latest
@@ -126,4 +126,4 @@ jobs:
           go-version: '^1.18'
 
       - name: Run job-task-runner tests
-        run: make test-job-task-runner
+        run: make -C job-task-runner test

--- a/HACKING.md
+++ b/HACKING.md
@@ -4,14 +4,13 @@
 
 In order to build & test korifi yourself, consider installing:
 
-- [Golang](https://go.dev/doc/install)
-- [Docker](https://docs.docker.com/get-docker/)
-- [kind](https://kubernetes.io/docs/tasks/tools/#kind)
-- [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl)
-- [cf cli v8+](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html)
-- [helm](https://helm.sh/docs/intro/install/)
-- [kbld](https://carvel.dev/kbld/docs/develop/install/)
-
+-   [Golang](https://go.dev/doc/install)
+-   [Docker](https://docs.docker.com/get-docker/)
+-   [kind](https://kubernetes.io/docs/tasks/tools/#kind)
+-   [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl)
+-   [cf cli v8+](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html)
+-   [helm](https://helm.sh/docs/intro/install/)
+-   [kbld](https://carvel.dev/kbld/docs/develop/install/)
 
 ## Running the tests
 
@@ -19,46 +18,21 @@ In order to build & test korifi yourself, consider installing:
 make test
 ```
 
-or
-
-```
-make test-controllers
-```
-
-or
-
-```
-make test-api
-```
-
 > Note: Some Controller and API tests run a real Kubernetes API/etcd via the [`envtest`](https://book.kubebuilder.io/reference/envtest.html) package. These tests rely on the CRDs from `controllers` subdirectory.
-> To update these CRDs use the `make generate-controllers` target described below.
+> To update these CRDs use the `make generate` target described below.
 
-or
+> Note: e2e tests deploy korifi to a local kind cluster configured with port forwarding and a local docker registry before running a set of tests to interact with the CloudFoundry API. This test suite will fail if you already have Korifi deployed locally on a standard kind cluster, or you have some other process using ports 80 or 443.
 
-```
-make test-e2e
-```
+## Deploying locally
 
-> Note: e2e tests deploy korifi to a local kind cluster before running a set of tests to interact with the CloudFoundry API. This test suite will fail if you already have Korifi deployed locally, or you have some other process using ports 80 or 443.
-
-
-## Deploying to `kind` with a locally deployed container registry
-This is the easiest method for deploying a kick-the-tires installation, or testing code changes end-to-end.
+This is the easiest method for deploying a kick-the-tires installation, or testing code changes end-to-end. It deploys Korifi on a local kind cluster with a local docker registry.
 
 ```
 ./scripts/deploy-on-kind <kind-cluster-name>
 ```
 
-or
-
-```
-./scripts/deploy-on-kind --help
-```
-
-for usage notes.
-
 ### User Permissions Disclaimer
+
 When using the deploy-on-kind script, you will get a separate `cf-admin` user by default with which to interact with the cf api.
 
 So when prompted to select a user by the cli you may see something like:
@@ -74,16 +48,18 @@ API endpoint: https://localhost
 Of these options, `cf-admin` is the user with permissions set up by default. Selecting the other user may allow you to login and
 successfully create resources, but you may notice that the user lacks the permissions to list those resources once created.
 
-
 ## Deploying to `kind` for remote debugging with a locally deployed container registry
+
 This is the above method, but run with `dlv` for remote debugging.
 
 ```
 ./scripts/deploy-on-kind <kind-cluster-name> --debug
 ```
+
 To remote debug, connect with `dlv` on `localhost:30051` (controller), `localhost:30052` (api), `localhost:30053` (kpack-image-builder), `localhost:30054` (statefulset-runner), or `localhost:30055` (job-task-runner).
 
 A sample VSCode `launch.json` configuration is provided below:
+
 ```
 {
     "version": "0.2.0",
@@ -127,13 +103,6 @@ A sample VSCode `launch.json` configuration is provided below:
 > image, rather than distroless, so deploying with --debug is useful if you plan
 > to `kubectl exec` into the running containers for any reason.
 
-
-## Install all dependencies with script
-```sh
-scripts/install-dependencies.sh
-```
-
-
 ## Image tagging conventions
 
 We store korifi docker images on docker hub.
@@ -151,131 +120,3 @@ The format is `dev-<next-release>-<commit sha>`.
 When a new korifi version is released, the images will be tagged with the release version, e.g. `0.2.0`.
 These will also be tagged as `latest`.
 This way the `latest` tag always refers to the latest _release_ and not the head of the main branch.
-
-## Build, Install and Deploy to a K8s cluster
-
-Set the $IMG_XXX environment variables to locations where you have push/pull access. For example:
-
-```sh
-export IMG_CONTROLLERS=foo/korifi-controllers:bar #Replace this with your image ref
-export IMG_API=foo/korifi-api:bar #Replace this with your image ref
-export IMG_KIB=foo/korifi-kpack-image-builder:bar #Replace this with your image ref
-export IMG_SSR=foo/korifi-statefulset-runner:bar #Replace this with your image ref
-export IMG_JTR=foo/korifi-job-task-runner:bar #Replace this with your image ref
-make generate docker-build docker-push deploy
-```
-
-This will generate the CRD bases, build and push images with the repository and tags specified by the environment variables, install CRDs and deploy the controller manager and API Shim.
-
-## Sample Resources
-The `samples` directory contains examples of the custom resources that are created by the API shim when a user interacts with the API. They are useful for testing controllers in isolation.
-### Apply sample instances of the resources
-```
-kubectl apply -f controllers/config/samples/. --recursive
-```
-
-## Using the Makefile
-
-### Running controllers locally
-
-```
-make run-controllers
-```
-
-### Running the API Shim Locally
-
-```
-make run-api
-```
-
-To specify a custom configuration file, set the `APICONFIG` environment variable to its path when running the web server. Refer to the [default config](api/config/base/apiconfig/korifi_api_config.yaml) for the config file structure and options.
-
-### Set image respository and tag for controller manager
-
-```sh
-export IMG_CONTROLLERS=foo/korifi-controllers:bar #Replace this with your image ref
-```
-
-### Set image respository and tag for API
-
-```sh
-export IMG_API=foo/korifi-api:bar #Replace this with your image ref
-```
-
-### Generate CRD bases
-
-```
-make generate-controllers
-```
-
-### Build Docker image
-
-```
-make docker-build
-```
-or
-
-```
-make docker-build-controllers
-```
-or
-
-```
-make docker-build-api
-```
-
-### Push Docker image
-
-```
-make docker-push
-```
-or
-
-```
-make docker-push-controllers
-```
-or
-
-```
-make docker-push-api
-```
-
-### Install CRDs to K8s in current Kubernetes context
-
-```
-make install-crds
-```
-
-### Deploy controller manager/API to K8s in current Kubernetes context
-
-```
-make deploy
-```
-or
-
-```
-make deploy-controllers
-```
-or
-
-```
-make deploy-api
-```
-
-### Regenerate kubernetes resources after making changes
-
-To regenerate the generated kubernetes resources under `./api/config` and `./controllers/config`:
-
-```
-make manifests
-```
-or
-
-```
-make manifests-controllers
-```
-or
-
-```
-make manifests-api
-```

--- a/api/Makefile
+++ b/api/Makefile
@@ -1,10 +1,3 @@
-
-# Image URL to use all building/pushing image targets
-IMG_JTR ?= cloudfoundry/korifi-job-task-runner:latest
-# ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.24.1
-CLUSTER_NAME ?= "e2e"
-
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -12,14 +5,18 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
+# Use gsed on Mac, sed on linux
+ifeq (,$(shell which gsed))
+SED=sed
+else
+SED=gsed
+endif
+
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # This is a requirement for 'setup-envtest.sh' in the test target.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
-
-.PHONY: all
-all: build
 
 ##@ General
 
@@ -34,38 +31,32 @@ all: build
 # More info on the awk command:
 # http://linuxcommand.org/lc3_adv_awk.php
 
-.PHONY: help
 help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 ##@ Development
-.PHONY: manifests
-manifests: install-controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
+
+manifests: install-controller-gen
 	$(CONTROLLER_GEN) \
-		paths="./..." \
-		rbac:roleName=korifi-job-task-runner-taskworkload-manager-role \
-		output:rbac:artifacts:config=../helm/job-task-runner/templates
+		paths=./... \
+		output:rbac:artifacts:config=../helm/api/templates \
+		rbac:roleName=korifi-api-system-role
 
-.PHONY: generate
-generate: install-controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
-	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
+	$(SED) -i.bak -e 's/ROOT_NAMESPACE/{{ .Values.global.rootNamespace }}/' ../helm/api/templates/role.yaml
+	rm -f ../helm/api/templates/role.yaml.bak
 
-.PHONY: test
-test: install-ginkgo manifests generate ## Run tests.
-	../scripts/run-tests.sh
+test: install-ginkgo
+	../scripts/run-tests.sh --skip-package=test
 
-##@ Build Dependencies
-CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
-.PHONY: install-controller-gen
+CONTROLLER_GEN = $(shell pwd)/controllers/bin/controller-gen
 install-controller-gen: ## Download controller-gen locally if necessary.
-	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.9.2)
+	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.9.2)
 
 install-ginkgo:
 	go install github.com/onsi/ginkgo/v2/ginkgo
 
-# go-get-tool will 'go get' any package $2 and install it to $1.
-PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
-define go-get-tool
+# go-install-tool will 'go get' any package $2 and install it to $1.
+define go-install-tool
 @[ -f $(1) ] || { \
 set -e ;\
 TMP_DIR=$$(mktemp -d) ;\

--- a/api/Makefile
+++ b/api/Makefile
@@ -48,7 +48,7 @@ manifests: install-controller-gen
 test: install-ginkgo
 	../scripts/run-tests.sh --skip-package=test
 
-CONTROLLER_GEN = $(shell pwd)/controllers/bin/controller-gen
+CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 install-controller-gen: ## Download controller-gen locally if necessary.
 	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.9.2)
 

--- a/controllers/Makefile
+++ b/controllers/Makefile
@@ -1,9 +1,9 @@
-
-# Image URL to use all building/pushing image targets
-IMG_JTR ?= cloudfoundry/korifi-job-task-runner:latest
-# ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.24.1
-CLUSTER_NAME ?= "e2e"
+# Run controllers tests with two nodes by default to (potentially) minimise
+# flakes.
+CONTROLLERS_GINKGO_NODES ?= 2
+ifdef GINKGO_NODES
+CONTROLLERS_GINKGO_NODES = $(GINKGO_NODES)
+endif
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -12,14 +12,18 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
+# Use gsed on Mac, sed on linux
+ifeq (,$(shell which gsed))
+SED=sed
+else
+SED=gsed
+endif
+
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # This is a requirement for 'setup-envtest.sh' in the test target.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
-
-.PHONY: all
-all: build
 
 ##@ General
 
@@ -34,38 +38,42 @@ all: build
 # More info on the awk command:
 # http://linuxcommand.org/lc3_adv_awk.php
 
-.PHONY: help
 help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 ##@ Development
-.PHONY: manifests
-manifests: install-controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
+
+manifests: install-controller-gen
 	$(CONTROLLER_GEN) \
 		paths="./..." \
-		rbac:roleName=korifi-job-task-runner-taskworkload-manager-role \
-		output:rbac:artifacts:config=../helm/job-task-runner/templates
+		crd \
+		rbac:roleName=korifi-controllers-manager-role \
+		webhook \
+		output:crd:artifacts:config=../helm/controllers/templates/crds \
+		output:rbac:artifacts:config=../helm/controllers/templates \
+		output:webhook:artifacts:config=../helm/controllers/templates
 
-.PHONY: generate
-generate: install-controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
-	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
+	$(SED) -i.bak -e '/^metadata:.*/a \ \ annotations:\n    cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/korifi-controllers-serving-cert"' ../helm/controllers/templates/manifests.yaml
+	$(SED) -i.bak -e 's/name: \(webhook-service\)/name: korifi-controllers-\1/' ../helm/controllers/templates/manifests.yaml
+	$(SED) -i.bak -e 's/namespace: system/namespace: "{{ .Release.Namespace }}"/' ../helm/controllers/templates/manifests.yaml
+	$(SED) -i.bak -e 's/name: \(.*-webhook-configuration\)/name: korifi-controllers-\1/' ../helm/controllers/templates/manifests.yaml
+	rm -f ../helm/controllers/templates/manifests.yaml.bak
 
-.PHONY: test
+generate: install-controller-gen
+	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./controllers/..."
+
 test: install-ginkgo manifests generate ## Run tests.
-	../scripts/run-tests.sh
+	GINKGO_NODES=$(CONTROLLERS_GINKGO_NODES) ../scripts/run-tests.sh
 
-##@ Build Dependencies
-CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
-.PHONY: install-controller-gen
+CONTROLLER_GEN = $(shell pwd)/controllers/bin/controller-gen
 install-controller-gen: ## Download controller-gen locally if necessary.
-	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.9.2)
+	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.9.2)
 
 install-ginkgo:
 	go install github.com/onsi/ginkgo/v2/ginkgo
 
-# go-get-tool will 'go get' any package $2 and install it to $1.
-PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
-define go-get-tool
+# go-install-tool will 'go get' any package $2 and install it to $1.
+define go-install-tool
 @[ -f $(1) ] || { \
 set -e ;\
 TMP_DIR=$$(mktemp -d) ;\

--- a/controllers/Makefile
+++ b/controllers/Makefile
@@ -60,12 +60,12 @@ manifests: install-controller-gen
 	rm -f ../helm/controllers/templates/manifests.yaml.bak
 
 generate: install-controller-gen
-	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./controllers/..."
+	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
 test: install-ginkgo manifests generate ## Run tests.
 	GINKGO_NODES=$(CONTROLLERS_GINKGO_NODES) ../scripts/run-tests.sh
 
-CONTROLLER_GEN = $(shell pwd)/controllers/bin/controller-gen
+CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 install-controller-gen: ## Download controller-gen locally if necessary.
 	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.9.2)
 

--- a/kpack-image-builder/Makefile
+++ b/kpack-image-builder/Makefile
@@ -66,85 +66,14 @@ manifests: install-controller-gen ## Generate WebhookConfiguration, ClusterRole 
 generate: install-controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
-.PHONY: fmt
-fmt: install-gofumpt install-shfmt
-	$(GOFUMPT) -w .
-	$(SHFMT) -w -i 2 -ci .
-
-.PHONY: vet
-vet: ## Run go vet against code.
-	go vet ./...
-
 .PHONY: test
-test: install-ginkgo manifests generate fmt vet ## Run tests.
+test: install-ginkgo manifests generate ## Run tests.
 	../scripts/run-tests.sh
-
-##@ Build
-
-.PHONY: build
-build: generate fmt vet ## Build manager binary.
-	go build -o bin/manager main.go
-
-.PHONY: run
-run: manifests generate fmt vet ## Run a controller from your host.
-	CONTROLLERSCONFIG=$(shell pwd)/kpack-image-builder/config/base/controllersconfig ENABLE_WEBHOOKS=false go run ./kpack-image-builder/main.go
-
-.PHONY: docker-build
-docker-build: ## Build docker image with the manager.
-	docker buildx build --load -f ./Dockerfile -t ${IMG_KIB} ..
-
-.PHONY: docker-build-debug
-docker-build-debug: ## Build docker image with the manager.
-	docker buildx build --load -f ./remote-debug/Dockerfile -t ${IMG_KIB} ..
-
-.PHONY: docker-push
-docker-push: ## Push docker image with the manager.
-	docker push ${IMG_KIB}
-
-##@ Deployment
-
-KIB_VALUES ?= ../helm/kpack-image-builder/values.yaml
-deploy: manifests
-	helm upgrade --install kpack-image-builder ../helm/kpack-image-builder \
-		--values=$(KIB_VALUES) \
-		--set=image=$(IMG_KIB) \
-		--wait
-
-deploy-kind-local: manifests
-	helm upgrade --install kpack-image-builder ../helm/kpack-image-builder \
-		--values=$(KIB_VALUES) \
-		--set=image=$(IMG_KIB) \
-		--set=dropletRepositoryPrefix=localregistry-docker-registry.default.svc.cluster.local:30050/korifi-controllers/kpack/images \
-		--wait
-
-deploy-kind-local-debug: manifests
-	helm upgrade --install kpack-image-builder ../helm/kpack-image-builder \
-		--values=$(KIB_VALUES) \
-		--set=image=$(IMG_KIB) \
-		--set=dropletRepositoryPrefix=localregistry-docker-registry.default.svc.cluster.local:30050/korifi-controllers/kpack/images \
-		--set=global.debug=true \
-		--wait
-
-.PHONY: undeploy
-undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
-	@if helm status kpack-image-builder 2>/dev/null; then \
-		helm delete kpack-image-builder --wait; \
-	else \
-		echo "kpack-image-builder chart not found - skipping"; \
-	fi
 
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 .PHONY: install-controller-gen
 install-controller-gen: ## Download controller-gen locally if necessary.
 	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.9.2)
-
-GOFUMPT = $(shell go env GOPATH)/bin/gofumpt
-install-gofumpt:
-	go install mvdan.cc/gofumpt@latest
-
-SHFMT = $(shell go env GOPATH)/bin/shfmt
-install-shfmt:
-	go install mvdan.cc/sh/v3/cmd/shfmt@latest
 
 install-ginkgo:
 	go install github.com/onsi/ginkgo/v2/ginkgo

--- a/scripts/check-everything.sh
+++ b/scripts/check-everything.sh
@@ -15,10 +15,10 @@ main() {
   print_message "about to run tests in parallel, it will be awesome" $GREEN
   print_message "ctrl-d panes when they are done" $RED
   tmux new-window -n korifi-tests "/bin/bash -c \"make lint; bash --init-file <(echo 'history -s make lint')\""
-  tmux split-window -h -p 75 "GINKGO_NODES=2 /bin/bash -c \"make test-kpack-image-builder; bash --init-file <(echo 'history -s make test-kpack-image-builder')\""
-  tmux split-window -h -p 67 "GINKGO_NODES=2 /bin/bash -c \"make test-statefulset-runner; bash --init-file <(echo 'history -s make test-statefulset-runner')\""
-  tmux split-window -h -p 50 "GINKGO_NODES=2 /bin/bash -c \"make test-job-task-runner; bash --init-file <(echo 'history -s make test-job-task-runner')\""
-  tmux split-window -vfb -p 66 "/bin/bash -c \"make test-controllers-api; bash --init-file <(echo 'history -s make test-controllers-api')\""
+  tmux split-window -h -p 75 "GINKGO_NODES=2 /bin/bash -c \"make -C kpack-image-builder test; bash --init-file <(echo 'history -s make -C kpack-image-builder test')\""
+  tmux split-window -h -p 67 "GINKGO_NODES=2 /bin/bash -c \"make -C statefulset-runner test; bash --init-file <(echo 'history -s make -C statefulset-runner test')\""
+  tmux split-window -h -p 50 "GINKGO_NODES=2 /bin/bash -c \"make -C job-task-runner test; bash --init-file <(echo 'history -s make -C job-task-runner test')\""
+  tmux split-window -vfb -p 66 "/bin/bash -c \"make -C api test && make -C controllers test; bash --init-file <(echo 'history -s make -C api test \&\& make -C controllers test')\""
   tmux split-window -h -p 50 "/bin/bash -c \"make test-e2e; bash --init-file <(echo 'history -s make test-e2e')\""
 }
 

--- a/statefulset-runner/Makefile
+++ b/statefulset-runner/Makefile
@@ -68,84 +68,14 @@ manifests: install-controller-gen ## Generate WebhookConfiguration, ClusterRole 
 generate: install-controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
-.PHONY: generate-fakes
-generate-fakes:
-	go generate ./...
-
-.PHONY: fmt
-fmt: install-gofumpt install-shfmt
-	$(GOFUMPT) -w .
-	$(SHFMT) -w -i 2 -ci .
-
-.PHONY: vet
-vet: ## Run go vet against code.
-	go vet ./...
-
 .PHONY: test
-test: install-ginkgo manifests generate fmt vet ## Run tests.
+test: install-ginkgo manifests generate ## Run tests.
 	../scripts/run-tests.sh
-
-##@ Build
-
-.PHONY: build
-build: generate fmt vet ## Build manager binary.
-	go build -o bin/manager main.go
-
-.PHONY: run
-run: manifests generate fmt vet ## Run a controller from your host.
-	ENABLE_WEBHOOKS=false go run ./main.go
-
-.PHONY: docker-build
-docker-build: ## Build docker image with the manager.
-	docker buildx build --load -f ./Dockerfile -t ${IMG_SSR} ..
-
-.PHONY: docker-build-debug
-docker-build-debug: ## Build docker image with the manager.
-	docker buildx build --load -f ./remote-debug/Dockerfile -t ${IMG_SSR} ..
-
-.PHONY: docker-push
-docker-push: ## Push docker image with the manager.
-	docker push ${IMG_SSR}
-
-##@ Deployment
-
-SSR_VALUES ?= ../helm/statefulset-runner/values.yaml
-deploy: manifests
-	helm upgrade --install statefulset-runner ../helm/statefulset-runner \
-		--values=$(SSR_VALUES) \
-		--set=image=$(IMG_SSR) \
-		--wait
-
-deploy-kind-local: deploy
-
-deploy-kind-local-debug: manifests
-	helm upgrade --install statefulset-runner ../helm/statefulset-runner \
-		--values=$(SSR_VALUES) \
-		--set=image=$(IMG_SSR) \
-		--set=global.debug=true \
-		--wait
-
-.PHONY: undeploy
-undeploy:
-	@if helm status statefulset-runner 2>/dev/null; then \
-		helm delete statefulset-runner --wait; \
-	else \
-		echo "statefulset-runner chart not found - skipping"; \
-	fi
 
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 .PHONY: install-controller-gen
 install-controller-gen: ## Download controller-gen locally if necessary.
 	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.9.2)
-
-
-GOFUMPT = $(shell go env GOPATH)/bin/gofumpt
-install-gofumpt:
-	go install mvdan.cc/gofumpt@latest
-
-SHFMT = $(shell go env GOPATH)/bin/shfmt
-install-shfmt:
-	go install mvdan.cc/sh/v3/cmd/shfmt@latest
 
 install-ginkgo:
 	go install github.com/onsi/ginkgo/v2/ginkgo


### PR DESCRIPTION
## Is there a related GitHub Issue?

https://github.com/cloudfoundry/korifi/issues/1778

<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?

-   Remove unused targets
-   Extract Makefiles for api and controllers
-   The top-level Makefile just delegates to inner make targets.
-   Remove `fmt` and `vet` targets from the nested Makefiles as the
top-level targets are recursive
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No

<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
Not a functional change, generally make targets should work

<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@danail-branekov

<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

