### PR TITLE
Use local yq to have consistent makefile across platforms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,6 @@ test: lint
 test-e2e: install-ginkgo
 	./scripts/run-tests.sh tests/e2e
 
-
 GOFUMPT = $(shell go env GOPATH)/bin/gofumpt
 install-gofumpt:
 	go install mvdan.cc/gofumpt@latest

--- a/api/Makefile
+++ b/api/Makefile
@@ -49,21 +49,8 @@ test: install-ginkgo
 	../scripts/run-tests.sh --skip-package=test
 
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
-install-controller-gen: ## Download controller-gen locally if necessary.
-	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.9.2)
+install-controller-gen:
+	GOBIN=$(shell pwd)/bin go install sigs.k8s.io/controller-tools/cmd/controller-gen
 
 install-ginkgo:
 	go install github.com/onsi/ginkgo/v2/ginkgo
-
-# go-install-tool will 'go get' any package $2 and install it to $1.
-define go-install-tool
-@[ -f $(1) ] || { \
-set -e ;\
-TMP_DIR=$$(mktemp -d) ;\
-cd $$TMP_DIR ;\
-go mod init tmp ;\
-echo "Downloading $(2)" ;\
-GOBIN=$$(dirname $(CONTROLLER_GEN)) go install $(2) ;\
-rm -rf $$TMP_DIR ;\
-}
-endef

--- a/api/Makefile
+++ b/api/Makefile
@@ -36,14 +36,13 @@ help: ## Display this help.
 
 ##@ Development
 
-manifests: install-controller-gen
+manifests: install-controller-gen install-yq
 	$(CONTROLLER_GEN) \
 		paths=./... \
 		output:rbac:artifacts:config=../helm/api/templates \
 		rbac:roleName=korifi-api-system-role
 
-	$(SED) -i.bak -e 's/ROOT_NAMESPACE/{{ .Values.global.rootNamespace }}/' ../helm/api/templates/role.yaml
-	rm -f ../helm/api/templates/role.yaml.bak
+	$(YQ) -i 'with(.metadata | select(.namespace == "ROOT_NAMESPACE"); .namespace="{{ .Values.global.rootNamespace }}")' ../helm/api/templates/role.yaml
 
 test: install-ginkgo
 	../scripts/run-tests.sh --skip-package=test
@@ -54,3 +53,7 @@ install-controller-gen:
 
 install-ginkgo:
 	go install github.com/onsi/ginkgo/v2/ginkgo
+
+YQ = $(shell pwd)/bin/yq
+install-yq:
+	GOBIN=$(shell pwd)/bin go install github.com/mikefarah/yq/v4@latest

--- a/controllers/Makefile
+++ b/controllers/Makefile
@@ -66,21 +66,8 @@ test: install-ginkgo manifests generate ## Run tests.
 	GINKGO_NODES=$(CONTROLLERS_GINKGO_NODES) ../scripts/run-tests.sh
 
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
-install-controller-gen: ## Download controller-gen locally if necessary.
-	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.9.2)
+install-controller-gen:
+	GOBIN=$(shell pwd)/bin go install sigs.k8s.io/controller-tools/cmd/controller-gen
 
 install-ginkgo:
 	go install github.com/onsi/ginkgo/v2/ginkgo
-
-# go-install-tool will 'go get' any package $2 and install it to $1.
-define go-install-tool
-@[ -f $(1) ] || { \
-set -e ;\
-TMP_DIR=$$(mktemp -d) ;\
-cd $$TMP_DIR ;\
-go mod init tmp ;\
-echo "Downloading $(2)" ;\
-GOBIN=$$(dirname $(CONTROLLER_GEN)) go install $(2) ;\
-rm -rf $$TMP_DIR ;\
-}
-endef

--- a/controllers/Makefile
+++ b/controllers/Makefile
@@ -12,13 +12,6 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
-# Use gsed on Mac, sed on linux
-ifeq (,$(shell which gsed))
-SED=sed
-else
-SED=gsed
-endif
-
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # This is a requirement for 'setup-envtest.sh' in the test target.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
@@ -43,7 +36,8 @@ help: ## Display this help.
 
 ##@ Development
 
-manifests: install-controller-gen
+webhooks-file = ../helm/controllers/templates/manifests.yaml
+manifests: install-controller-gen install-yq
 	$(CONTROLLER_GEN) \
 		paths="./..." \
 		crd \
@@ -53,11 +47,10 @@ manifests: install-controller-gen
 		output:rbac:artifacts:config=../helm/controllers/templates \
 		output:webhook:artifacts:config=../helm/controllers/templates
 
-	$(SED) -i.bak -e '/^metadata:.*/a \ \ annotations:\n    cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/korifi-controllers-serving-cert"' ../helm/controllers/templates/manifests.yaml
-	$(SED) -i.bak -e 's/name: \(webhook-service\)/name: korifi-controllers-\1/' ../helm/controllers/templates/manifests.yaml
-	$(SED) -i.bak -e 's/namespace: system/namespace: "{{ .Release.Namespace }}"/' ../helm/controllers/templates/manifests.yaml
-	$(SED) -i.bak -e 's/name: \(.*-webhook-configuration\)/name: korifi-controllers-\1/' ../helm/controllers/templates/manifests.yaml
-	rm -f ../helm/controllers/templates/manifests.yaml.bak
+	$(YQ) -i 'with(.metadata; .annotations["cert-manager.io/inject-ca-from"]="{{ .Release.Namespace }}/korifi-controllers-serving-cert")' $(webhooks-file)
+	$(YQ) -i 'with(.metadata; .name="korifi-controllers-" + .name)' $(webhooks-file)
+	$(YQ) -i 'with(.webhooks[]; .clientConfig.service.namespace="{{ .Release.Namespace }}")' $(webhooks-file)
+	$(YQ) -i 'with(.webhooks[]; .clientConfig.service.name="korifi-controllers-" + .clientConfig.service.name)' $(webhooks-file)
 
 generate: install-controller-gen
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
@@ -71,3 +64,7 @@ install-controller-gen:
 
 install-ginkgo:
 	go install github.com/onsi/ginkgo/v2/ginkgo
+
+YQ = $(shell pwd)/bin/yq
+install-yq:
+	GOBIN=$(shell pwd)/bin go install github.com/mikefarah/yq/v4@latest

--- a/helm/api/templates/role.yaml
+++ b/helm/api/templates/role.yaml
@@ -5,55 +5,55 @@ metadata:
   creationTimestamp: null
   name: korifi-api-system-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  verbs:
-  - list
-- apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
-  verbs:
-  - create
-- apiGroups:
-  - korifi.cloudfoundry.org
-  resources:
-  - cfapps
-  - cfbuilds
-  - cfpackages
-  - cfprocesses
-  - cfspaces
-  - cftasks
-  verbs:
-  - list
-- apiGroups:
-  - korifi.cloudfoundry.org
-  resources:
-  - cfdomains
-  - cfroutes
-  verbs:
-  - list
-- apiGroups:
-  - korifi.cloudfoundry.org
-  resources:
-  - cfservicebindings
-  - cfserviceinstances
-  verbs:
-  - list
-- apiGroups:
-  - metrics.k8s.io
-  resources:
-  - pods
-  verbs:
-  - get
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
-  - rolebindings
-  verbs:
-  - list
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - list
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - korifi.cloudfoundry.org
+    resources:
+      - cfapps
+      - cfbuilds
+      - cfpackages
+      - cfprocesses
+      - cfspaces
+      - cftasks
+    verbs:
+      - list
+  - apiGroups:
+      - korifi.cloudfoundry.org
+    resources:
+      - cfdomains
+      - cfroutes
+    verbs:
+      - list
+  - apiGroups:
+      - korifi.cloudfoundry.org
+    resources:
+      - cfservicebindings
+      - cfserviceinstances
+    verbs:
+      - list
+  - apiGroups:
+      - metrics.k8s.io
+    resources:
+      - pods
+    verbs:
+      - get
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - rolebindings
+    verbs:
+      - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -62,15 +62,15 @@ metadata:
   name: korifi-api-system-role
   namespace: {{ .Values.global.rootNamespace }}
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-- apiGroups:
-  - ""
-  resources:
-  - serviceaccounts
-  verbs:
-  - get
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - get

--- a/helm/api/templates/role.yaml
+++ b/helm/api/templates/role.yaml
@@ -60,7 +60,7 @@ kind: Role
 metadata:
   creationTimestamp: null
   name: korifi-api-system-role
-  namespace: {{ .Values.global.rootNamespace }}
+  namespace: '{{ .Values.global.rootNamespace }}'
 rules:
   - apiGroups:
       - ""

--- a/helm/controllers/templates/crds/korifi.cloudfoundry.org_appworkloads.yaml
+++ b/helm/controllers/templates/crds/korifi.cloudfoundry.org_appworkloads.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: appworkloads.korifi.cloudfoundry.org
 spec:

--- a/helm/controllers/templates/crds/korifi.cloudfoundry.org_builderinfos.yaml
+++ b/helm/controllers/templates/crds/korifi.cloudfoundry.org_builderinfos.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: builderinfos.korifi.cloudfoundry.org
 spec:

--- a/helm/controllers/templates/crds/korifi.cloudfoundry.org_buildworkloads.yaml
+++ b/helm/controllers/templates/crds/korifi.cloudfoundry.org_buildworkloads.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: buildworkloads.korifi.cloudfoundry.org
 spec:

--- a/helm/controllers/templates/crds/korifi.cloudfoundry.org_cfapps.yaml
+++ b/helm/controllers/templates/crds/korifi.cloudfoundry.org_cfapps.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: cfapps.korifi.cloudfoundry.org
 spec:

--- a/helm/controllers/templates/crds/korifi.cloudfoundry.org_cfbuilds.yaml
+++ b/helm/controllers/templates/crds/korifi.cloudfoundry.org_cfbuilds.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: cfbuilds.korifi.cloudfoundry.org
 spec:

--- a/helm/controllers/templates/crds/korifi.cloudfoundry.org_cfdomains.yaml
+++ b/helm/controllers/templates/crds/korifi.cloudfoundry.org_cfdomains.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: cfdomains.korifi.cloudfoundry.org
 spec:

--- a/helm/controllers/templates/crds/korifi.cloudfoundry.org_cforgs.yaml
+++ b/helm/controllers/templates/crds/korifi.cloudfoundry.org_cforgs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: cforgs.korifi.cloudfoundry.org
 spec:

--- a/helm/controllers/templates/crds/korifi.cloudfoundry.org_cfpackages.yaml
+++ b/helm/controllers/templates/crds/korifi.cloudfoundry.org_cfpackages.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: cfpackages.korifi.cloudfoundry.org
 spec:

--- a/helm/controllers/templates/crds/korifi.cloudfoundry.org_cfprocesses.yaml
+++ b/helm/controllers/templates/crds/korifi.cloudfoundry.org_cfprocesses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: cfprocesses.korifi.cloudfoundry.org
 spec:

--- a/helm/controllers/templates/crds/korifi.cloudfoundry.org_cfroutes.yaml
+++ b/helm/controllers/templates/crds/korifi.cloudfoundry.org_cfroutes.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: cfroutes.korifi.cloudfoundry.org
 spec:

--- a/helm/controllers/templates/crds/korifi.cloudfoundry.org_cfservicebindings.yaml
+++ b/helm/controllers/templates/crds/korifi.cloudfoundry.org_cfservicebindings.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: cfservicebindings.korifi.cloudfoundry.org
 spec:

--- a/helm/controllers/templates/crds/korifi.cloudfoundry.org_cfserviceinstances.yaml
+++ b/helm/controllers/templates/crds/korifi.cloudfoundry.org_cfserviceinstances.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: cfserviceinstances.korifi.cloudfoundry.org
 spec:

--- a/helm/controllers/templates/crds/korifi.cloudfoundry.org_cfspaces.yaml
+++ b/helm/controllers/templates/crds/korifi.cloudfoundry.org_cfspaces.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: cfspaces.korifi.cloudfoundry.org
 spec:

--- a/helm/controllers/templates/crds/korifi.cloudfoundry.org_cftasks.yaml
+++ b/helm/controllers/templates/crds/korifi.cloudfoundry.org_cftasks.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: cftasks.korifi.cloudfoundry.org
 spec:

--- a/helm/controllers/templates/crds/korifi.cloudfoundry.org_taskworkloads.yaml
+++ b/helm/controllers/templates/crds/korifi.cloudfoundry.org_taskworkloads.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: taskworkloads.korifi.cloudfoundry.org
 spec:

--- a/helm/controllers/templates/manifests.yaml
+++ b/helm/controllers/templates/manifests.yaml
@@ -2,10 +2,10 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  annotations:
-    cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/korifi-controllers-serving-cert"
   creationTimestamp: null
   name: korifi-controllers-mutating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/korifi-controllers-serving-cert'
 webhooks:
   - admissionReviewVersions:
       - v1
@@ -13,7 +13,7 @@ webhooks:
     clientConfig:
       service:
         name: korifi-controllers-webhook-service
-        namespace: "{{ .Release.Namespace }}"
+        namespace: '{{ .Release.Namespace }}'
         path: /mutate-korifi-cloudfoundry-org-v1alpha1-cfapp
     failurePolicy: Fail
     name: mcfapp.korifi.cloudfoundry.org
@@ -34,7 +34,7 @@ webhooks:
     clientConfig:
       service:
         name: korifi-controllers-webhook-service
-        namespace: "{{ .Release.Namespace }}"
+        namespace: '{{ .Release.Namespace }}'
         path: /mutate-korifi-cloudfoundry-org-v1alpha1-cfbuild
     failurePolicy: Fail
     name: mcfbuild.korifi.cloudfoundry.org
@@ -55,7 +55,7 @@ webhooks:
     clientConfig:
       service:
         name: korifi-controllers-webhook-service
-        namespace: "{{ .Release.Namespace }}"
+        namespace: '{{ .Release.Namespace }}'
         path: /mutate-korifi-cloudfoundry-org-v1alpha1-cfpackage
     failurePolicy: Fail
     name: mcfpackage.korifi.cloudfoundry.org
@@ -76,7 +76,7 @@ webhooks:
     clientConfig:
       service:
         name: korifi-controllers-webhook-service
-        namespace: "{{ .Release.Namespace }}"
+        namespace: '{{ .Release.Namespace }}'
         path: /mutate-korifi-cloudfoundry-org-v1alpha1-cfprocess
     failurePolicy: Fail
     name: mcfprocess.korifi.cloudfoundry.org
@@ -97,7 +97,7 @@ webhooks:
     clientConfig:
       service:
         name: korifi-controllers-webhook-service
-        namespace: "{{ .Release.Namespace }}"
+        namespace: '{{ .Release.Namespace }}'
         path: /mutate-korifi-cloudfoundry-org-v1alpha1-cfroute
     failurePolicy: Fail
     name: mcfroute.korifi.cloudfoundry.org
@@ -116,17 +116,17 @@ webhooks:
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  annotations:
-    cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/korifi-controllers-serving-cert"
   creationTimestamp: null
   name: korifi-controllers-validating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/korifi-controllers-serving-cert'
 webhooks:
   - admissionReviewVersions:
       - v1
     clientConfig:
       service:
         name: korifi-controllers-webhook-service
-        namespace: "{{ .Release.Namespace }}"
+        namespace: '{{ .Release.Namespace }}'
         path: /validate-korifi-cloudfoundry-org-v1alpha1-cfdomain
     failurePolicy: Fail
     name: vcfdomain.korifi.cloudfoundry.org
@@ -147,7 +147,7 @@ webhooks:
     clientConfig:
       service:
         name: korifi-controllers-webhook-service
-        namespace: "{{ .Release.Namespace }}"
+        namespace: '{{ .Release.Namespace }}'
         path: /validate-korifi-cloudfoundry-org-v1alpha1-cfroute
     failurePolicy: Fail
     name: vcfroute.korifi.cloudfoundry.org
@@ -169,7 +169,7 @@ webhooks:
     clientConfig:
       service:
         name: korifi-controllers-webhook-service
-        namespace: "{{ .Release.Namespace }}"
+        namespace: '{{ .Release.Namespace }}'
         path: /validate-korifi-cloudfoundry-org-v1alpha1-cfservicebinding
     failurePolicy: Fail
     name: vcfservicebinding.korifi.cloudfoundry.org
@@ -191,7 +191,7 @@ webhooks:
     clientConfig:
       service:
         name: korifi-controllers-webhook-service
-        namespace: "{{ .Release.Namespace }}"
+        namespace: '{{ .Release.Namespace }}'
         path: /validate-korifi-cloudfoundry-org-v1alpha1-cfserviceinstance
     failurePolicy: Fail
     name: vcfserviceinstance.korifi.cloudfoundry.org
@@ -213,7 +213,7 @@ webhooks:
     clientConfig:
       service:
         name: korifi-controllers-webhook-service
-        namespace: "{{ .Release.Namespace }}"
+        namespace: '{{ .Release.Namespace }}'
         path: /validate-korifi-cloudfoundry-org-v1alpha1-cfapp
     failurePolicy: Fail
     name: vcfapp.korifi.cloudfoundry.org
@@ -235,7 +235,7 @@ webhooks:
     clientConfig:
       service:
         name: korifi-controllers-webhook-service
-        namespace: "{{ .Release.Namespace }}"
+        namespace: '{{ .Release.Namespace }}'
         path: /validate-korifi-cloudfoundry-org-v1alpha1-cforg
     failurePolicy: Fail
     name: vcforg.korifi.cloudfoundry.org
@@ -257,7 +257,7 @@ webhooks:
     clientConfig:
       service:
         name: korifi-controllers-webhook-service
-        namespace: "{{ .Release.Namespace }}"
+        namespace: '{{ .Release.Namespace }}'
         path: /validate-korifi-cloudfoundry-org-v1alpha1-cfspace
     failurePolicy: Fail
     name: vcfspace.korifi.cloudfoundry.org
@@ -279,7 +279,7 @@ webhooks:
     clientConfig:
       service:
         name: korifi-controllers-webhook-service
-        namespace: "{{ .Release.Namespace }}"
+        namespace: '{{ .Release.Namespace }}'
         path: /validate-korifi-cloudfoundry-org-v1alpha1-cftask
     failurePolicy: Fail
     name: vcftask.korifi.cloudfoundry.org

--- a/helm/controllers/templates/manifests.yaml
+++ b/helm/controllers/templates/manifests.yaml
@@ -7,111 +7,111 @@ metadata:
   creationTimestamp: null
   name: korifi-controllers-mutating-webhook-configuration
 webhooks:
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: korifi-controllers-webhook-service
-      namespace: "{{ .Release.Namespace }}"
-      path: /mutate-korifi-cloudfoundry-org-v1alpha1-cfapp
-  failurePolicy: Fail
-  name: mcfapp.korifi.cloudfoundry.org
-  rules:
-  - apiGroups:
-    - korifi.cloudfoundry.org
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - cfapps
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: korifi-controllers-webhook-service
-      namespace: "{{ .Release.Namespace }}"
-      path: /mutate-korifi-cloudfoundry-org-v1alpha1-cfbuild
-  failurePolicy: Fail
-  name: mcfbuild.korifi.cloudfoundry.org
-  rules:
-  - apiGroups:
-    - korifi.cloudfoundry.org
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - cfbuilds
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: korifi-controllers-webhook-service
-      namespace: "{{ .Release.Namespace }}"
-      path: /mutate-korifi-cloudfoundry-org-v1alpha1-cfpackage
-  failurePolicy: Fail
-  name: mcfpackage.korifi.cloudfoundry.org
-  rules:
-  - apiGroups:
-    - korifi.cloudfoundry.org
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - cfpackages
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: korifi-controllers-webhook-service
-      namespace: "{{ .Release.Namespace }}"
-      path: /mutate-korifi-cloudfoundry-org-v1alpha1-cfprocess
-  failurePolicy: Fail
-  name: mcfprocess.korifi.cloudfoundry.org
-  rules:
-  - apiGroups:
-    - korifi.cloudfoundry.org
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - cfprocesses
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: korifi-controllers-webhook-service
-      namespace: "{{ .Release.Namespace }}"
-      path: /mutate-korifi-cloudfoundry-org-v1alpha1-cfroute
-  failurePolicy: Fail
-  name: mcfroute.korifi.cloudfoundry.org
-  rules:
-  - apiGroups:
-    - korifi.cloudfoundry.org
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - cfroutes
-  sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-controllers-webhook-service
+        namespace: "{{ .Release.Namespace }}"
+        path: /mutate-korifi-cloudfoundry-org-v1alpha1-cfapp
+    failurePolicy: Fail
+    name: mcfapp.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - cfapps
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-controllers-webhook-service
+        namespace: "{{ .Release.Namespace }}"
+        path: /mutate-korifi-cloudfoundry-org-v1alpha1-cfbuild
+    failurePolicy: Fail
+    name: mcfbuild.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - cfbuilds
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-controllers-webhook-service
+        namespace: "{{ .Release.Namespace }}"
+        path: /mutate-korifi-cloudfoundry-org-v1alpha1-cfpackage
+    failurePolicy: Fail
+    name: mcfpackage.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - cfpackages
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-controllers-webhook-service
+        namespace: "{{ .Release.Namespace }}"
+        path: /mutate-korifi-cloudfoundry-org-v1alpha1-cfprocess
+    failurePolicy: Fail
+    name: mcfprocess.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - cfprocesses
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-controllers-webhook-service
+        namespace: "{{ .Release.Namespace }}"
+        path: /mutate-korifi-cloudfoundry-org-v1alpha1-cfroute
+    failurePolicy: Fail
+    name: mcfroute.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - cfroutes
+    sideEffects: None
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -121,176 +121,176 @@ metadata:
   creationTimestamp: null
   name: korifi-controllers-validating-webhook-configuration
 webhooks:
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: korifi-controllers-webhook-service
-      namespace: "{{ .Release.Namespace }}"
-      path: /validate-korifi-cloudfoundry-org-v1alpha1-cfdomain
-  failurePolicy: Fail
-  name: vcfdomain.korifi.cloudfoundry.org
-  rules:
-  - apiGroups:
-    - korifi.cloudfoundry.org
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - cfdomains
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: korifi-controllers-webhook-service
-      namespace: "{{ .Release.Namespace }}"
-      path: /validate-korifi-cloudfoundry-org-v1alpha1-cfroute
-  failurePolicy: Fail
-  name: vcfroute.korifi.cloudfoundry.org
-  rules:
-  - apiGroups:
-    - korifi.cloudfoundry.org
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    - DELETE
-    resources:
-    - cfroutes
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: korifi-controllers-webhook-service
-      namespace: "{{ .Release.Namespace }}"
-      path: /validate-korifi-cloudfoundry-org-v1alpha1-cfservicebinding
-  failurePolicy: Fail
-  name: vcfservicebinding.korifi.cloudfoundry.org
-  rules:
-  - apiGroups:
-    - korifi.cloudfoundry.org
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    - DELETE
-    resources:
-    - cfservicebindings
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: korifi-controllers-webhook-service
-      namespace: "{{ .Release.Namespace }}"
-      path: /validate-korifi-cloudfoundry-org-v1alpha1-cfserviceinstance
-  failurePolicy: Fail
-  name: vcfserviceinstance.korifi.cloudfoundry.org
-  rules:
-  - apiGroups:
-    - korifi.cloudfoundry.org
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    - DELETE
-    resources:
-    - cfserviceinstances
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: korifi-controllers-webhook-service
-      namespace: "{{ .Release.Namespace }}"
-      path: /validate-korifi-cloudfoundry-org-v1alpha1-cfapp
-  failurePolicy: Fail
-  name: vcfapp.korifi.cloudfoundry.org
-  rules:
-  - apiGroups:
-    - korifi.cloudfoundry.org
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    - DELETE
-    resources:
-    - cfapps
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: korifi-controllers-webhook-service
-      namespace: "{{ .Release.Namespace }}"
-      path: /validate-korifi-cloudfoundry-org-v1alpha1-cforg
-  failurePolicy: Fail
-  name: vcforg.korifi.cloudfoundry.org
-  rules:
-  - apiGroups:
-    - korifi.cloudfoundry.org
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    - DELETE
-    resources:
-    - cforgs
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: korifi-controllers-webhook-service
-      namespace: "{{ .Release.Namespace }}"
-      path: /validate-korifi-cloudfoundry-org-v1alpha1-cfspace
-  failurePolicy: Fail
-  name: vcfspace.korifi.cloudfoundry.org
-  rules:
-  - apiGroups:
-    - korifi.cloudfoundry.org
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    - DELETE
-    resources:
-    - cfspaces
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: korifi-controllers-webhook-service
-      namespace: "{{ .Release.Namespace }}"
-      path: /validate-korifi-cloudfoundry-org-v1alpha1-cftask
-  failurePolicy: Fail
-  name: vcftask.korifi.cloudfoundry.org
-  rules:
-  - apiGroups:
-    - korifi.cloudfoundry.org
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - cftasks
-  sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: korifi-controllers-webhook-service
+        namespace: "{{ .Release.Namespace }}"
+        path: /validate-korifi-cloudfoundry-org-v1alpha1-cfdomain
+    failurePolicy: Fail
+    name: vcfdomain.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - cfdomains
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-controllers-webhook-service
+        namespace: "{{ .Release.Namespace }}"
+        path: /validate-korifi-cloudfoundry-org-v1alpha1-cfroute
+    failurePolicy: Fail
+    name: vcfroute.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - cfroutes
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-controllers-webhook-service
+        namespace: "{{ .Release.Namespace }}"
+        path: /validate-korifi-cloudfoundry-org-v1alpha1-cfservicebinding
+    failurePolicy: Fail
+    name: vcfservicebinding.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - cfservicebindings
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-controllers-webhook-service
+        namespace: "{{ .Release.Namespace }}"
+        path: /validate-korifi-cloudfoundry-org-v1alpha1-cfserviceinstance
+    failurePolicy: Fail
+    name: vcfserviceinstance.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - cfserviceinstances
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-controllers-webhook-service
+        namespace: "{{ .Release.Namespace }}"
+        path: /validate-korifi-cloudfoundry-org-v1alpha1-cfapp
+    failurePolicy: Fail
+    name: vcfapp.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - cfapps
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-controllers-webhook-service
+        namespace: "{{ .Release.Namespace }}"
+        path: /validate-korifi-cloudfoundry-org-v1alpha1-cforg
+    failurePolicy: Fail
+    name: vcforg.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - cforgs
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-controllers-webhook-service
+        namespace: "{{ .Release.Namespace }}"
+        path: /validate-korifi-cloudfoundry-org-v1alpha1-cfspace
+    failurePolicy: Fail
+    name: vcfspace.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - cfspaces
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-controllers-webhook-service
+        namespace: "{{ .Release.Namespace }}"
+        path: /validate-korifi-cloudfoundry-org-v1alpha1-cftask
+    failurePolicy: Fail
+    name: vcftask.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - cftasks
+    sideEffects: None

--- a/helm/kpack-image-builder/templates/manifests.yaml
+++ b/helm/kpack-image-builder/templates/manifests.yaml
@@ -7,29 +7,29 @@ metadata:
   creationTimestamp: null
   name: korifi-kpack-build-mutating-webhook-configuration
 webhooks:
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: korifi-kpack-build-webhook-service
-      namespace: "{{ .Release.Namespace }}"
-      path: /mutate--v1-pod
-  failurePolicy: Ignore
-  objectSelector:
-    matchExpressions:
-    - key: kpack.io/build
-      operator: Exists
-    - key: korifi.cloudfoundry.org/build-workload-name
-      operator: Exists
-  name: mkpackbuildpod.korifi.cloudfoundry.org
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    resources:
-    - pods
-  sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-kpack-build-webhook-service
+        namespace: "{{ .Release.Namespace }}"
+        path: /mutate--v1-pod
+    failurePolicy: Ignore
+    objectSelector:
+      matchExpressions:
+        - key: kpack.io/build
+          operator: Exists
+        - key: korifi.cloudfoundry.org/build-workload-name
+          operator: Exists
+    name: mkpackbuildpod.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None

--- a/helm/kpack-image-builder/templates/manifests.yaml
+++ b/helm/kpack-image-builder/templates/manifests.yaml
@@ -2,10 +2,10 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  annotations:
-    cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/korifi-kpack-build-serving-cert"
   creationTimestamp: null
   name: korifi-kpack-build-mutating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/korifi-kpack-build-serving-cert'
 webhooks:
   - admissionReviewVersions:
       - v1
@@ -13,15 +13,9 @@ webhooks:
     clientConfig:
       service:
         name: korifi-kpack-build-webhook-service
-        namespace: "{{ .Release.Namespace }}"
+        namespace: '{{ .Release.Namespace }}'
         path: /mutate--v1-pod
     failurePolicy: Ignore
-    objectSelector:
-      matchExpressions:
-        - key: kpack.io/build
-          operator: Exists
-        - key: korifi.cloudfoundry.org/build-workload-name
-          operator: Exists
     name: mkpackbuildpod.korifi.cloudfoundry.org
     rules:
       - apiGroups:
@@ -33,3 +27,9 @@ webhooks:
         resources:
           - pods
     sideEffects: None
+    objectSelector:
+      matchExpressions:
+        - key: kpack.io/build
+          operator: Exists
+        - key: korifi.cloudfoundry.org/build-workload-name
+          operator: Exists

--- a/helm/statefulset-runner/templates/manifests.yaml
+++ b/helm/statefulset-runner/templates/manifests.yaml
@@ -7,25 +7,25 @@ metadata:
   creationTimestamp: null
   name: korifi-statefulset-runner-mutating-webhook-configuration
 webhooks:
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: korifi-statefulset-runner-webhook-service
-      namespace: "{{ .Release.Namespace }}"
-      path: /mutate--v1-pod
-  failurePolicy: Fail
-  objectSelector:
-    matchLabels:
-      korifi.cloudfoundry.org/add-stsr-index: "true"
-  name: mstspod.korifi.cloudfoundry.org
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    resources:
-    - pods
-  sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: korifi-statefulset-runner-webhook-service
+        namespace: "{{ .Release.Namespace }}"
+        path: /mutate--v1-pod
+    failurePolicy: Fail
+    objectSelector:
+      matchLabels:
+        korifi.cloudfoundry.org/add-stsr-index: "true"
+    name: mstspod.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None

--- a/helm/statefulset-runner/templates/manifests.yaml
+++ b/helm/statefulset-runner/templates/manifests.yaml
@@ -2,22 +2,19 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  annotations:
-    cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/korifi-statefulset-runner-serving-cert"
   creationTimestamp: null
   name: korifi-statefulset-runner-mutating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/korifi-statefulset-runner-serving-cert'
 webhooks:
   - admissionReviewVersions:
       - v1
     clientConfig:
       service:
         name: korifi-statefulset-runner-webhook-service
-        namespace: "{{ .Release.Namespace }}"
+        namespace: '{{ .Release.Namespace }}'
         path: /mutate--v1-pod
     failurePolicy: Fail
-    objectSelector:
-      matchLabels:
-        korifi.cloudfoundry.org/add-stsr-index: "true"
     name: mstspod.korifi.cloudfoundry.org
     rules:
       - apiGroups:
@@ -29,3 +26,6 @@ webhooks:
         resources:
           - pods
     sideEffects: None
+    objectSelector:
+      matchLabels:
+        korifi.cloudfoundry.org/add-stsr-index: "true"

--- a/job-task-runner/Makefile
+++ b/job-task-runner/Makefile
@@ -55,24 +55,10 @@ test: install-ginkgo manifests generate ## Run tests.
 	../scripts/run-tests.sh
 
 ##@ Build Dependencies
-CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 .PHONY: install-controller-gen
-install-controller-gen: ## Download controller-gen locally if necessary.
-	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.9.2)
+CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
+install-controller-gen:
+	GOBIN=$(shell pwd)/bin go install sigs.k8s.io/controller-tools/cmd/controller-gen
 
 install-ginkgo:
 	go install github.com/onsi/ginkgo/v2/ginkgo
-
-# go-get-tool will 'go get' any package $2 and install it to $1.
-PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
-define go-get-tool
-@[ -f $(1) ] || { \
-set -e ;\
-TMP_DIR=$$(mktemp -d) ;\
-cd $$TMP_DIR ;\
-go mod init tmp ;\
-echo "Downloading $(2)" ;\
-GOBIN=$$(dirname $(CONTROLLER_GEN)) go install $(2) ;\
-rm -rf $$TMP_DIR ;\
-}
-endef

--- a/kpack-image-builder/Makefile
+++ b/kpack-image-builder/Makefile
@@ -70,24 +70,10 @@ generate: install-controller-gen ## Generate code containing DeepCopy, DeepCopyI
 test: install-ginkgo manifests generate ## Run tests.
 	../scripts/run-tests.sh
 
-CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 .PHONY: install-controller-gen
-install-controller-gen: ## Download controller-gen locally if necessary.
-	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.9.2)
+CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
+install-controller-gen:
+	GOBIN=$(shell pwd)/bin go install sigs.k8s.io/controller-tools/cmd/controller-gen
 
 install-ginkgo:
 	go install github.com/onsi/ginkgo/v2/ginkgo
-
-# go-get-tool will 'go get' any package $2 and install it to $1.
-PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
-define go-get-tool
-@[ -f $(1) ] || { \
-set -e ;\
-TMP_DIR=$$(mktemp -d) ;\
-cd $$TMP_DIR ;\
-go mod init tmp ;\
-echo "Downloading $(2)" ;\
-GOBIN=$$(dirname $(CONTROLLER_GEN)) go install $(2) ;\
-rm -rf $$TMP_DIR ;\
-}
-endef

--- a/kpack-image-builder/Makefile
+++ b/kpack-image-builder/Makefile
@@ -11,13 +11,6 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
-# Use gsed on Mac, sed on linux
-ifeq (,$(shell which gsed))
-SED=sed
-else
-SED=gsed
-endif
-
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # This is a requirement for 'setup-envtest.sh' in the test target.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
@@ -47,7 +40,8 @@ help: ## Display this help.
 ##@ Development
 
 .PHONY: manifests
-manifests: install-controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
+webhooks-file = ../helm/kpack-image-builder/templates/manifests.yaml
+manifests: install-controller-gen install-yq
 	$(CONTROLLER_GEN) \
 		paths="./..." \
 		webhook \
@@ -55,12 +49,11 @@ manifests: install-controller-gen ## Generate WebhookConfiguration, ClusterRole 
 		output:webhook:artifacts:config=../helm/kpack-image-builder/templates \
 		output:rbac:artifacts:config=../helm/kpack-image-builder/templates
 
-	$(SED) -i.bak -e '/^metadata:.*/a \ \ annotations:\n    cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/korifi-kpack-build-serving-cert"' ../helm/kpack-image-builder/templates/manifests.yaml
-	$(SED) -i.bak -e 's/name: \(webhook-service\)/name: korifi-kpack-build-\1/' ../helm/kpack-image-builder/templates/manifests.yaml
-	$(SED) -i.bak -e 's/namespace: system/namespace: "{{ .Release.Namespace }}"/' ../helm/kpack-image-builder/templates/manifests.yaml
-	$(SED) -i.bak -e 's/name: \(.*-webhook-configuration\)/name: korifi-kpack-build-\1/' ../helm/kpack-image-builder/templates/manifests.yaml
-	$(SED) -i.bak -e '/failurePolicy:.*/a\  objectSelector:\n    matchExpressions:\n    - key: kpack.io/build\n      operator: Exists\n    - key: korifi.cloudfoundry.org/build-workload-name\n      operator: Exists' ../helm/kpack-image-builder/templates/manifests.yaml
-	rm -f ../helm/kpack-image-builder/templates/manifests.yaml.bak
+	$(YQ) -i 'with(.metadata; .annotations["cert-manager.io/inject-ca-from"]="{{ .Release.Namespace }}/korifi-kpack-build-serving-cert")' $(webhooks-file)
+	$(YQ) -i 'with(.metadata; .name="korifi-kpack-build-" + .name)' $(webhooks-file)
+	$(YQ) -i 'with(.webhooks[]; .clientConfig.service.namespace="{{ .Release.Namespace }}")' $(webhooks-file)
+	$(YQ) -i 'with(.webhooks[]; .clientConfig.service.name="korifi-kpack-build-" + .clientConfig.service.name)' $(webhooks-file)
+	$(YQ) -i 'with(.webhooks[]; .objectSelector.matchExpressions=[{"key":"kpack.io/build", "operator":"Exists"},{"key":"korifi.cloudfoundry.org/build-workload-name", "operator":"Exists"}])' $(webhooks-file)
 
 .PHONY: generate
 generate: install-controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
@@ -77,3 +70,7 @@ install-controller-gen:
 
 install-ginkgo:
 	go install github.com/onsi/ginkgo/v2/ginkgo
+
+YQ = $(shell pwd)/bin/yq
+install-yq:
+	GOBIN=$(shell pwd)/bin go install github.com/mikefarah/yq/v4@latest

--- a/statefulset-runner/Makefile
+++ b/statefulset-runner/Makefile
@@ -72,24 +72,10 @@ generate: install-controller-gen ## Generate code containing DeepCopy, DeepCopyI
 test: install-ginkgo manifests generate ## Run tests.
 	../scripts/run-tests.sh
 
-CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 .PHONY: install-controller-gen
-install-controller-gen: ## Download controller-gen locally if necessary.
-	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.9.2)
+CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
+install-controller-gen:
+	GOBIN=$(shell pwd)/bin go install sigs.k8s.io/controller-tools/cmd/controller-gen
 
 install-ginkgo:
 	go install github.com/onsi/ginkgo/v2/ginkgo
-
-# go-get-tool will 'go get' any package $2 and install it to $1.
-PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
-define go-get-tool
-@[ -f $(1) ] || { \
-set -e ;\
-TMP_DIR=$$(mktemp -d) ;\
-cd $$TMP_DIR ;\
-go mod init tmp ;\
-echo "Downloading $(2)" ;\
-GOBIN=$$(dirname $(CONTROLLER_GEN)) go install $(2) ;\
-rm -rf $$TMP_DIR ;\
-}
-endef

--- a/statefulset-runner/Makefile
+++ b/statefulset-runner/Makefile
@@ -12,13 +12,6 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
-# Use gsed on Mac, sed on linux
-ifeq (,$(shell which gsed))
-SED=sed
-else
-SED=gsed
-endif
-
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # This is a requirement for 'setup-envtest.sh' in the test target.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
@@ -47,8 +40,9 @@ help: ## Display this help.
 
 ##@ Development
 
+webhooks-file = ../helm/statefulset-runner/templates/manifests.yaml
 .PHONY: manifests
-manifests: install-controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
+manifests: install-controller-gen install-yq
 	$(CONTROLLER_GEN) \
 		paths="./..." \
 		rbac:roleName=korifi-statefulset-runner-appworkload-manager-role \
@@ -56,12 +50,11 @@ manifests: install-controller-gen ## Generate WebhookConfiguration, ClusterRole 
 		output:rbac:artifacts:config=../helm/statefulset-runner/templates \
 		output:webhook:artifacts:config=../helm/statefulset-runner/templates
 
-	$(SED) -i.bak -e '/^metadata:.*/a \ \ annotations:\n    cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/korifi-statefulset-runner-serving-cert"' ../helm/statefulset-runner/templates/manifests.yaml
-	$(SED) -i.bak -e 's/name: \(webhook-service\)/name: korifi-statefulset-runner-\1/' ../helm/statefulset-runner/templates/manifests.yaml
-	$(SED) -i.bak -e 's/namespace: system/namespace: "{{ .Release.Namespace }}"/' ../helm/statefulset-runner/templates/manifests.yaml
-	$(SED) -i.bak -e 's/name: \(.*-webhook-configuration\)/name: korifi-statefulset-runner-\1/' ../helm/statefulset-runner/templates/manifests.yaml
-	$(SED) -i.bak -e '/failurePolicy:.*/a\  objectSelector:\n    matchLabels:\n      korifi.cloudfoundry.org/add-stsr-index: "true"' ../helm/statefulset-runner/templates/manifests.yaml
-	rm -f ../helm/statefulset-runner/templates/manifests.yaml.bak
+	$(YQ) -i 'with(.metadata; .annotations["cert-manager.io/inject-ca-from"]="{{ .Release.Namespace }}/korifi-statefulset-runner-serving-cert")' $(webhooks-file)
+	$(YQ) -i 'with(.metadata; .name="korifi-statefulset-runner-" + .name)' $(webhooks-file)
+	$(YQ) -i 'with(.webhooks[]; .clientConfig.service.namespace="{{ .Release.Namespace }}")' $(webhooks-file)
+	$(YQ) -i 'with(.webhooks[]; .clientConfig.service.name="korifi-statefulset-runner-" + .clientConfig.service.name)' $(webhooks-file)
+	$(YQ) -i 'with(.webhooks[]; .objectSelector.matchLabels["korifi.cloudfoundry.org/add-stsr-index"]="true")' $(webhooks-file)
 
 
 .PHONY: generate
@@ -79,3 +72,7 @@ install-controller-gen:
 
 install-ginkgo:
 	go install github.com/onsi/ginkgo/v2/ginkgo
+
+YQ = $(shell pwd)/bin/yq
+install-yq:
+	GOBIN=$(shell pwd)/bin go install github.com/mikefarah/yq/v4@latest


### PR DESCRIPTION
## Is there a related GitHub Issue?

#1849

## What is this change about?

Instead of making users install `gsed` on a mac in order to be able to use our makefiles, install `yq` locally instead.

We install away from `$HOME/go/bin`, which might be in the path, so that this `yq` does not clash with the other `yq` that might be installed and used in non-Korifi scripts.

`yq` also happens to be a lot more robust for modifying YAML that `sed`.

## Does this PR introduce a breaking change?

No.

## Acceptance Steps

`make manifests` and `make generate` work on Linux and Mac.

## Tag your pair, your PM, and/or team

@kieron-dev
