### PR TITLE
Remove dependency to `buildpack/lifecycle`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	code.cloudfoundry.org/go-loggregator/v8 v8.0.5
 	github.com/Masterminds/semver v1.5.0
 	github.com/SermoDigital/jose v0.9.2-0.20161205224733-f6df55f235c2
-	github.com/buildpacks/lifecycle v0.14.3
 	github.com/buildpacks/pack v0.27.0
 	github.com/cloudfoundry/cf-test-helpers v1.0.1-0.20220603211108-d498b915ef74
 	github.com/go-http-utils/headers v0.0.0-20181008091004-fed159eddc2a

--- a/go.sum
+++ b/go.sum
@@ -245,8 +245,7 @@ github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0Bsq
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
 github.com/buildpacks/imgutil v0.0.0-20221021152825-caf937b72cf0 h1:ZtuZiPSGb9aeFxjaozDmehKmJaRKTvcGXcF1CZW4aJg=
 github.com/buildpacks/imgutil v0.0.0-20221021152825-caf937b72cf0/go.mod h1:4Xx0RybUdfOQkjUEgxHf9d2xG8v3HXMcJ1QhFAE30WQ=
-github.com/buildpacks/lifecycle v0.14.3 h1:pTiE3D1YuILFA2n2FvCLdhShRzwJtKntYaVNBIYpBbo=
-github.com/buildpacks/lifecycle v0.14.3/go.mod h1:IDLDJ6s4pCqZiwriOxsGHTxTiu4znPdmtzVMB0FeCvU=
+github.com/buildpacks/lifecycle v0.14.1 h1:CkMsUbotZvru+VOTn08BWPbJRZnAx6Xx2yQYoqVLOW8=
 github.com/buildpacks/pack v0.27.0 h1:diMvn/aR0wbfs0ke7DOBtrkFzJqDw+moJPTWLdUTuhE=
 github.com/buildpacks/pack v0.27.0/go.mod h1:ifPVxBoY2EKbSrA8Hkyy0YFfSGCzyYnzlyjrLsxxAIY=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
@@ -607,7 +606,6 @@ github.com/golang/mock v1.4.1/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt
 github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
 github.com/golang/mock v1.5.0/go.mod h1:CWnOUgYIOo4TcNZ0wHX3YZCqsaM1I1Jvs6v3mP3KVu8=
-github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
 github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/golang/protobuf v0.0.0-20161109072736-4bd1920723d7/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -966,8 +964,8 @@ github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0Gq
 github.com/moby/term v0.0.0-20200312100748-672ec06f55cd/go.mod h1:DdlQx2hp0Ss5/fLikoLlEeIYiATotOjgB//nb973jeo=
 github.com/moby/term v0.0.0-20201216013528-df9cb8a40635/go.mod h1:FBS0z0QWA44HXygs7VXDUOGoN/1TV3RuWkLO04am3wc=
 github.com/moby/term v0.0.0-20210610120745-9d4ed1856297/go.mod h1:vgPCkQMyxTZ7IDy8SXRufE172gr8+K/JE/7hHFxHW3A=
+github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 h1:dcztxKSvZ4Id8iPpHERQBbIJfabdt4wUm5qy3wOL2Zc=
 github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6/go.mod h1:E2VnQOmVuvZB6UYnnDB0qG5Nq/1tD9acaOpo6xmt0Kw=
-github.com/moby/term v0.0.0-20220808134915-39b0c02b01ae h1:O4SWKdcHVCvYqyDV+9CJA1fcDN2L11Bule0iFy3YlAI=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/kpack-image-builder/controllers/imageprocessfetcher/image_process_fetcher.go
+++ b/kpack-image-builder/controllers/imageprocessfetcher/image_process_fetcher.go
@@ -6,8 +6,6 @@ import (
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 
-	"github.com/buildpacks/lifecycle/launch"
-	"github.com/buildpacks/lifecycle/platform"
 	"github.com/go-logr/logr"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -15,8 +13,22 @@ import (
 	"k8s.io/utils/net"
 )
 
+const (
+	buildpackBuildMetadataLabel = "io.buildpacks.build.metadata"
+)
+
 type ImageProcessFetcher struct {
 	Log logr.Logger
+}
+
+type buildMetadata struct {
+	Processes []process `json:"processes"`
+}
+
+type process struct {
+	Type    string   `json:"type"`
+	Command string   `json:"command"`
+	Args    []string `json:"args"`
 }
 
 func (f *ImageProcessFetcher) Fetch(imageRef string, credsOption remote.Option, transport remote.Option) ([]korifiv1alpha1.ProcessType, []int32, error) {
@@ -39,8 +51,8 @@ func (f *ImageProcessFetcher) Fetch(imageRef string, credsOption remote.Option, 
 	}
 
 	// Unmarshall Build Metadata information from Image Config
-	var buildMetadata platform.BuildMetadata
-	err = json.Unmarshal([]byte(cfgFile.Config.Labels[platform.BuildMetadataLabel]), &buildMetadata)
+	var buildMd buildMetadata
+	err = json.Unmarshal([]byte(cfgFile.Config.Labels[buildpackBuildMetadataLabel]), &buildMd)
 	if err != nil {
 		f.Log.Info(fmt.Sprintf("Error unmarshalling image build metadata: %s\n", err))
 		return nil, nil, err
@@ -48,7 +60,7 @@ func (f *ImageProcessFetcher) Fetch(imageRef string, credsOption remote.Option, 
 
 	// Loop over all the Processes and extract the complete command string
 	processTypes := []korifiv1alpha1.ProcessType{}
-	for _, process := range buildMetadata.Processes {
+	for _, process := range buildMd.Processes {
 		processTypes = append(processTypes, korifiv1alpha1.ProcessType{
 			Type:    process.Type,
 			Command: extractFullCommand(process),
@@ -64,7 +76,7 @@ func (f *ImageProcessFetcher) Fetch(imageRef string, credsOption remote.Option, 
 }
 
 // Reconstruct command with arguments into a single command string
-func extractFullCommand(process launch.Process) string {
+func extractFullCommand(process process) string {
 	cmdString := process.Command
 	for _, a := range process.Args {
 		cmdString = fmt.Sprintf(`%s %q`, cmdString, a)


### PR DESCRIPTION
## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Its latest release (`0.15.0`) carries dependency to
`github.com/Sirupsen/logrus` (note the uppercase `S`) that causes
`case-insensitive import collision` error. As we are using
`buildpack/lifecycle` by only referring their types to unmarshal image
config, we now just define owr own types and use them instead.
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
No functional change, everything should work as before
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@danail-branekov
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

