### PR TITLE
Get rid of the service binding finalizer

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -134,7 +134,8 @@ func main() {
 	buildRepo := repositories.NewBuildRepo(namespaceRetriever, userClientFactory)
 	packageRepo := repositories.NewPackageRepo(userClientFactory, namespaceRetriever, nsPermissions)
 	serviceInstanceRepo := repositories.NewServiceInstanceRepo(namespaceRetriever, userClientFactory, nsPermissions)
-	serviceBindingRepo := repositories.NewServiceBindingRepo(namespaceRetriever, userClientFactory, nsPermissions, createTimeout)
+	bindingConditionAwaiter := conditions.NewConditionAwaiter[*korifiv1alpha1.CFServiceBinding, korifiv1alpha1.CFServiceBindingList](createTimeout)
+	serviceBindingRepo := repositories.NewServiceBindingRepo(namespaceRetriever, userClientFactory, nsPermissions, bindingConditionAwaiter)
 	buildpackRepo := repositories.NewBuildpackRepository(config.BuilderName, userClientFactory, config.RootNamespace)
 	roleRepo := repositories.NewRoleRepo(
 		userClientFactory,

--- a/controllers/api/v1alpha1/cfservicebinding_types.go
+++ b/controllers/api/v1alpha1/cfservicebinding_types.go
@@ -71,6 +71,10 @@ type CFServiceBindingList struct {
 	Items           []CFServiceBinding `json:"items"`
 }
 
+func (b CFServiceBinding) StatusConditions() []metav1.Condition {
+	return b.Status.Conditions
+}
+
 func init() {
 	SchemeBuilder.Register(&CFServiceBinding{}, &CFServiceBindingList{})
 }

--- a/controllers/controllers/services/integration/suite_integration_test.go
+++ b/controllers/controllers/services/integration/suite_integration_test.go
@@ -25,7 +25,6 @@ import (
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	. "code.cloudfoundry.org/korifi/controllers/controllers/services"
 	. "code.cloudfoundry.org/korifi/controllers/controllers/shared"
-	"code.cloudfoundry.org/korifi/controllers/controllers/workloads/env"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -98,7 +97,6 @@ var _ = BeforeSuite(func() {
 		k8sManager.GetClient(),
 		k8sManager.GetScheme(),
 		ctrl.Log.WithName("controllers").WithName("CFServiceBinding"),
-		env.NewBuilder(k8sManager.GetClient()),
 	)).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/controllers/controllers/workloads/fake/vcapservices_secret_builder.go
+++ b/controllers/controllers/workloads/fake/vcapservices_secret_builder.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 
 	"code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
-	"code.cloudfoundry.org/korifi/controllers/controllers/services"
+	"code.cloudfoundry.org/korifi/controllers/controllers/workloads"
 )
 
 type VCAPServicesSecretBuilder struct {
@@ -117,4 +117,4 @@ func (fake *VCAPServicesSecretBuilder) recordInvocation(key string, args []inter
 	fake.invocations[key] = append(fake.invocations[key], args)
 }
 
-var _ services.VCAPServicesSecretBuilder = new(VCAPServicesSecretBuilder)
+var _ workloads.VCAPServicesSecretBuilder = new(VCAPServicesSecretBuilder)

--- a/controllers/controllers/workloads/integration/suite_integration_test.go
+++ b/controllers/controllers/workloads/integration/suite_integration_test.go
@@ -109,6 +109,7 @@ var _ = BeforeSuite(func() {
 		k8sManager.GetClient(),
 		k8sManager.GetScheme(),
 		ctrl.Log.WithName("controllers").WithName("CFApp"),
+		env.NewBuilder(k8sManager.GetClient()),
 	)).SetupWithManager(k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -126,6 +126,7 @@ func main() {
 			mgr.GetClient(),
 			mgr.GetScheme(),
 			ctrl.Log.WithName("controllers").WithName("CFApp"),
+			env.NewBuilder(mgr.GetClient()),
 		)).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "CFApp")
 			os.Exit(1)
@@ -185,7 +186,6 @@ func main() {
 			mgr.GetClient(),
 			mgr.GetScheme(),
 			ctrl.Log.WithName("controllers").WithName("CFServiceBinding"),
-			env.NewBuilder(mgr.GetClient()),
 		)).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "CFServiceBinding")
 			os.Exit(1)

--- a/tests/e2e/apps_test.go
+++ b/tests/e2e/apps_test.go
@@ -546,43 +546,47 @@ var _ = Describe("Apps", func() {
 		})
 
 		It("returns the app environment", func() {
-			Expect(result).To(HaveKeyWithValue("environment_variables", HaveKeyWithValue("foo", "var")))
-			Expect(result).To(
-				HaveKeyWithValue("system_env_json",
-					HaveKeyWithValue("VCAP_SERVICES",
-						HaveKeyWithValue("user-provided", ConsistOf(
-							map[string]interface{}{
-								"syslog_drain_url": nil,
-								"tags":             []interface{}{},
-								"instance_name":    instanceName,
-								"binding_guid":     bindingGUID,
-								"credentials": map[string]interface{}{
-									"type": "user-provided",
+			Eventually(func(g Gomega) {
+				_, err := certClient.R().SetResult(&result).Get("/v3/apps/" + appGUID + "/env")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(result).To(HaveKeyWithValue("environment_variables", HaveKeyWithValue("foo", "var")))
+				g.Expect(result).To(
+					HaveKeyWithValue("system_env_json",
+						HaveKeyWithValue("VCAP_SERVICES",
+							HaveKeyWithValue("user-provided", ConsistOf(
+								map[string]interface{}{
+									"syslog_drain_url": nil,
+									"tags":             []interface{}{},
+									"instance_name":    instanceName,
+									"binding_guid":     bindingGUID,
+									"credentials": map[string]interface{}{
+										"type": "user-provided",
+									},
+									"volume_mounts": []interface{}{},
+									"label":         "user-provided",
+									"name":          instanceName,
+									"instance_guid": instanceGUID,
+									"binding_name":  nil,
 								},
-								"volume_mounts": []interface{}{},
-								"label":         "user-provided",
-								"name":          instanceName,
-								"instance_guid": instanceGUID,
-								"binding_name":  nil,
-							},
-							map[string]interface{}{
-								"syslog_drain_url": nil,
-								"tags":             []interface{}{},
-								"instance_name":    instanceName2,
-								"binding_guid":     bindingGUID2,
-								"credentials": map[string]interface{}{
-									"type": "user-provided",
-								},
-								"volume_mounts": []interface{}{},
-								"label":         "user-provided",
-								"name":          instanceName2,
-								"instance_guid": instanceGUID2,
-								"binding_name":  nil,
-							}),
+								map[string]interface{}{
+									"syslog_drain_url": nil,
+									"tags":             []interface{}{},
+									"instance_name":    instanceName2,
+									"binding_guid":     bindingGUID2,
+									"credentials": map[string]interface{}{
+										"type": "user-provided",
+									},
+									"volume_mounts": []interface{}{},
+									"label":         "user-provided",
+									"name":          instanceName2,
+									"instance_guid": instanceGUID2,
+									"binding_name":  nil,
+								}),
+							),
 						),
 					),
-				),
-			)
+				)
+			}).Should(Succeed())
 		})
 
 		When("a deleted service binding changes the app env", func() {
@@ -594,7 +598,7 @@ var _ = Describe("Apps", func() {
 			It("returns the updated app environment", func() {
 				Eventually(func(g Gomega) {
 					_, err := certClient.R().SetResult(&result).Get("/v3/apps/" + appGUID + "/env")
-					Expect(err).To(Succeed())
+					g.Expect(err).NotTo(HaveOccurred())
 					g.Expect(result).To(HaveKeyWithValue("environment_variables", HaveKeyWithValue("foo", "var")))
 					g.Expect(result).To(HaveKeyWithValue("system_env_json", HaveKeyWithValue("VCAP_SERVICES", map[string]interface{}{
 						"user-provided": []interface{}{


### PR DESCRIPTION
## Is there a related GitHub Issue?
https://github.com/cloudfoundry/korifi/issues/1716

## What is this change about?
The finalizer purpose was to ensure that a service binding is deleted
when an app is being deleted. This has now been replaced with an owner
reference from the app to the binding so that K8S takes care of that for
us. It is the reponsibility of the service binding creator to set the
owner ref, therefore this code was moved to the repository.

The binding finalizer also had the reponsibility to update the app
VCAP_SERVICES secret. Now this is taken care of by the app controller
that now listens to service binding events and rebuilds the secret
accordingly.

While being here, use the awaiter utility to wait for the binding ready
condition in the repository.
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
Service bindings created by kubectl users that have not their owner references
set are now no longer deleted automatically when the cf app is deleted.
Automatic deletion still works for bindings created by the CF API shim.
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
N/A - no functional change
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@danail-branekov
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

