### PR TITLE
Simplify finalizers

### DIFF
--- a/api/handlers/build_handler.go
+++ b/api/handlers/build_handler.go
@@ -98,7 +98,7 @@ func (h *BuildHandler) buildCreateHandler(ctx context.Context, logger logr.Logge
 		)
 	}
 
-	buildCreateMessage := payload.ToMessage(appRecord, packageRecord)
+	buildCreateMessage := payload.ToMessage(appRecord)
 
 	record, err := h.buildRepo.CreateBuild(r.Context(), authInfo, buildCreateMessage)
 	if err != nil {

--- a/api/handlers/build_handler_test.go
+++ b/api/handlers/build_handler_test.go
@@ -6,8 +6,6 @@ import (
 	"net/http"
 	"strings"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"code.cloudfoundry.org/korifi/api/apierrors"
 	"code.cloudfoundry.org/korifi/api/repositories"
 
@@ -439,12 +437,6 @@ var _ = Describe("BuildHandler", func() {
 				Expect(actualCreate.Lifecycle.Type).To(Equal(expectedLifecycleType))
 				Expect(actualCreate.Lifecycle.Data.Buildpacks).To(Equal(expectedLifecycleBuildpacks))
 				Expect(actualCreate.Lifecycle.Data.Stack).To(Equal(expectedLifecycleStack))
-				Expect(actualCreate.OwnerRef).To(Equal(metav1.OwnerReference{
-					APIVersion: "korifi.cloudfoundry.org/v1alpha1",
-					Kind:       "CFPackage",
-					Name:       packageGUID,
-					UID:        packageUID,
-				}))
 			})
 
 			It("returns the Build in the response", func() {

--- a/api/handlers/package_handler_test.go
+++ b/api/handlers/package_handler_test.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	"code.cloudfoundry.org/korifi/api/apierrors"
@@ -522,12 +521,6 @@ var _ = Describe("PackageHandler", func() {
 				Type:      "bits",
 				AppGUID:   appGUID,
 				SpaceGUID: spaceGUID,
-				OwnerRef: metav1.OwnerReference{
-					APIVersion: "korifi.cloudfoundry.org/v1alpha1",
-					Kind:       "CFApp",
-					Name:       appGUID,
-					UID:        appUID,
-				},
 			}))
 		})
 

--- a/api/payloads/build.go
+++ b/api/payloads/build.go
@@ -1,8 +1,6 @@
 package payloads
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"code.cloudfoundry.org/korifi/api/repositories"
 )
 
@@ -14,7 +12,7 @@ type BuildCreate struct {
 	Metadata        Metadata          `json:"metadata"`
 }
 
-func (c *BuildCreate) ToMessage(appRecord repositories.AppRecord, packageRecord repositories.PackageRecord) repositories.CreateBuildMessage {
+func (c *BuildCreate) ToMessage(appRecord repositories.AppRecord) repositories.CreateBuildMessage {
 	toReturn := repositories.CreateBuildMessage{
 		AppGUID:         appRecord.GUID,
 		PackageGUID:     c.Package.GUID,
@@ -24,12 +22,6 @@ func (c *BuildCreate) ToMessage(appRecord repositories.AppRecord, packageRecord 
 		Lifecycle:       appRecord.Lifecycle,
 		Labels:          c.Metadata.Labels,
 		Annotations:     c.Metadata.Annotations,
-		OwnerRef: metav1.OwnerReference{
-			APIVersion: repositories.APIVersion,
-			Kind:       "CFPackage",
-			Name:       packageRecord.GUID,
-			UID:        packageRecord.UID,
-		},
 	}
 
 	return toReturn

--- a/api/payloads/package.go
+++ b/api/payloads/package.go
@@ -3,8 +3,6 @@ package payloads
 import (
 	"strings"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"code.cloudfoundry.org/korifi/api/repositories"
 )
 
@@ -22,12 +20,6 @@ func (m PackageCreate) ToMessage(record repositories.AppRecord) repositories.Cre
 		Type:      m.Type,
 		AppGUID:   record.GUID,
 		SpaceGUID: record.SpaceGUID,
-		OwnerRef: metav1.OwnerReference{
-			APIVersion: repositories.APIVersion,
-			Kind:       "CFApp",
-			Name:       record.GUID,
-			UID:        record.EtcdUID,
-		},
 	}
 }
 

--- a/api/repositories/build_repository.go
+++ b/api/repositories/build_repository.go
@@ -213,7 +213,6 @@ func (b *BuildRepo) CreateBuild(ctx context.Context, authInfo authorization.Info
 
 type CreateBuildMessage struct {
 	AppGUID         string
-	OwnerRef        metav1.OwnerReference
 	PackageGUID     string
 	SpaceGUID       string
 	StagingMemoryMB int
@@ -231,9 +230,6 @@ func (m CreateBuildMessage) toCFBuild() korifiv1alpha1.CFBuild {
 			Namespace:   m.SpaceGUID,
 			Labels:      m.Labels,
 			Annotations: m.Annotations,
-			OwnerReferences: []metav1.OwnerReference{
-				m.OwnerRef,
-			},
 		},
 		Spec: korifiv1alpha1.CFBuildSpec{
 			PackageRef: corev1.LocalObjectReference{

--- a/api/repositories/build_repository_test.go
+++ b/api/repositories/build_repository_test.go
@@ -361,7 +361,6 @@ var _ = Describe("BuildRepository", func() {
 	Describe("CreateBuild", func() {
 		const (
 			appGUID     = "the-app-guid"
-			packageUID  = "the-package-uid"
 			packageGUID = "the-package-guid"
 
 			buildStagingState = "STAGING"
@@ -403,12 +402,6 @@ var _ = Describe("BuildRepository", func() {
 				},
 				Labels:      buildCreateLabels,
 				Annotations: buildCreateAnnotations,
-				OwnerRef: metav1.OwnerReference{
-					APIVersion: repositories.APIVersion,
-					Kind:       "CFPackage",
-					Name:       packageGUID,
-					UID:        packageUID,
-				},
 			}
 		})
 
@@ -483,18 +476,7 @@ var _ = Describe("BuildRepository", func() {
 
 			It("should eventually create a new Build CR", func() {
 				cfBuildLookupKey := types.NamespacedName{Name: buildCreateRecord.GUID, Namespace: spaceGUID}
-				createdCFBuild := new(korifiv1alpha1.CFBuild)
-				err := k8sClient.Get(ctx, cfBuildLookupKey, createdCFBuild)
-				Expect(err).NotTo(HaveOccurred())
-
-				Expect(createdCFBuild.ObjectMeta.OwnerReferences).To(ConsistOf([]metav1.OwnerReference{
-					{
-						APIVersion: "korifi.cloudfoundry.org/v1alpha1",
-						Kind:       "CFPackage",
-						Name:       packageGUID,
-						UID:        packageUID,
-					},
-				}))
+				Expect(k8sClient.Get(ctx, cfBuildLookupKey, &korifiv1alpha1.CFBuild{})).To(Succeed())
 			})
 		})
 

--- a/api/repositories/package_repository.go
+++ b/api/repositories/package_repository.go
@@ -67,7 +67,6 @@ type CreatePackageMessage struct {
 	Type      string
 	AppGUID   string
 	SpaceGUID string
-	OwnerRef  metav1.OwnerReference
 }
 
 func (message CreatePackageMessage) toCFPackage() korifiv1alpha1.CFPackage {
@@ -78,9 +77,8 @@ func (message CreatePackageMessage) toCFPackage() korifiv1alpha1.CFPackage {
 			APIVersion: korifiv1alpha1.GroupVersion.Identifier(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            guid,
-			Namespace:       message.SpaceGUID,
-			OwnerReferences: []metav1.OwnerReference{message.OwnerRef},
+			Name:      guid,
+			Namespace: message.SpaceGUID,
 		},
 		Spec: korifiv1alpha1.CFPackageSpec{
 			Type: korifiv1alpha1.PackageType(message.Type),

--- a/api/repositories/package_repository_test.go
+++ b/api/repositories/package_repository_test.go
@@ -45,12 +45,6 @@ var _ = Describe("PackageRepository", func() {
 				Type:      "bits",
 				AppGUID:   appGUID,
 				SpaceGUID: space.Name,
-				OwnerRef: metav1.OwnerReference{
-					APIVersion: "korifi.cloudfoundry.org/v1alpha1",
-					Kind:       "CFApp",
-					Name:       appGUID,
-					UID:        appUID,
-				},
 			}
 		})
 
@@ -92,15 +86,6 @@ var _ = Describe("PackageRepository", func() {
 				Expect(createdCFPackage.Namespace).To(Equal(space.Name))
 				Expect(createdCFPackage.Spec.Type).To(Equal(korifiv1alpha1.PackageType("bits")))
 				Expect(createdCFPackage.Spec.AppRef.Name).To(Equal(appGUID))
-				Expect(createdCFPackage.ObjectMeta.OwnerReferences).To(Equal(
-					[]metav1.OwnerReference{
-						{
-							APIVersion: "korifi.cloudfoundry.org/v1alpha1",
-							Kind:       "CFApp",
-							Name:       appGUID,
-							UID:        appUID,
-						},
-					}))
 			})
 		})
 	})

--- a/api/repositories/package_repository_test.go
+++ b/api/repositories/package_repository_test.go
@@ -19,7 +19,6 @@ import (
 
 var _ = Describe("PackageRepository", func() {
 	const appGUID = "the-app-guid"
-	const appUID = "the-app-uid"
 
 	var (
 		packageRepo *repositories.PackageRepo

--- a/api/repositories/service_binding_repository.go
+++ b/api/repositories/service_binding_repository.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
 
 	"code.cloudfoundry.org/korifi/api/apierrors"
 	"code.cloudfoundry.org/korifi/api/authorization"
@@ -18,7 +17,6 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 const (
@@ -122,11 +120,6 @@ func (r *ServiceBindingRepo) CreateServiceBinding(ctx context.Context, authInfo 
 				apierrors.ForbiddenError{},
 				apierrors.NotFoundError{},
 			)
-	}
-
-	err = controllerutil.SetOwnerReference(cfApp, cfServiceBinding, scheme.Scheme)
-	if err != nil {
-		return ServiceBindingRecord{}, apierrors.FromK8sError(err, ServiceBindingResourceType)
 	}
 
 	err = userClient.Create(ctx, cfServiceBinding)

--- a/api/repositories/service_binding_repository_test.go
+++ b/api/repositories/service_binding_repository_test.go
@@ -195,10 +195,6 @@ var _ = Describe("ServiceBindingRepo", func() {
 						},
 					},
 				))
-				Expect(serviceBinding.GetOwnerReferences()).To(ConsistOf(MatchFields(IgnoreExtras, Fields{
-					"Kind": Equal("CFApp"),
-					"Name": Equal(appGUID),
-				})))
 			})
 
 			When("the app does not exist", func() {

--- a/controllers/controllers/services/cfserviceinstance_controller.go
+++ b/controllers/controllers/services/cfserviceinstance_controller.go
@@ -18,15 +18,12 @@ package services
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
-	"code.cloudfoundry.org/korifi/controllers/controllers/shared"
 	"code.cloudfoundry.org/korifi/tools/k8s"
 
 	"sigs.k8s.io/controller-runtime/pkg/builder"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -38,10 +35,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-)
-
-const (
-	CFServiceInstanceFinalizerName = "cfServiceInstance.korifi.cloudfoundry.org"
 )
 
 // CFServiceInstanceReconciler reconciles a CFServiceInstance object
@@ -62,15 +55,8 @@ func NewCFServiceInstanceReconciler(
 
 //+kubebuilder:rbac:groups=korifi.cloudfoundry.org,resources=cfserviceinstances,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=korifi.cloudfoundry.org,resources=cfserviceinstances/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=korifi.cloudfoundry.org,resources=cfserviceinstances/finalizers,verbs=update
 
 func (r *CFServiceInstanceReconciler) ReconcileResource(ctx context.Context, cfServiceInstance *korifiv1alpha1.CFServiceInstance) (ctrl.Result, error) {
-	r.addFinalizer(ctx, cfServiceInstance)
-
-	if !cfServiceInstance.GetDeletionTimestamp().IsZero() {
-		return r.finalizeCFServiceInstance(ctx, cfServiceInstance)
-	}
-
 	secret := new(corev1.Secret)
 	err := r.k8sClient.Get(ctx, types.NamespacedName{Name: cfServiceInstance.Spec.SecretName, Namespace: cfServiceInstance.Namespace}, secret)
 	if err != nil {
@@ -123,44 +109,4 @@ func bindSecretUnavailableStatus(cfServiceInstance *korifiv1alpha1.CFServiceInst
 func (r *CFServiceInstanceReconciler) SetupWithManager(mgr ctrl.Manager) *builder.Builder {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&korifiv1alpha1.CFServiceInstance{})
-}
-
-func (r *CFServiceInstanceReconciler) addFinalizer(ctx context.Context, cfServiceInstance *korifiv1alpha1.CFServiceInstance) {
-	if controllerutil.ContainsFinalizer(cfServiceInstance, CFServiceInstanceFinalizerName) {
-		return
-	}
-
-	controllerutil.AddFinalizer(cfServiceInstance, CFServiceInstanceFinalizerName)
-	r.log.Info(fmt.Sprintf("Finalizer added to CFServiceInstance/%s", cfServiceInstance.Name))
-}
-
-func (r *CFServiceInstanceReconciler) finalizeCFServiceInstance(ctx context.Context, cfServiceInstance *korifiv1alpha1.CFServiceInstance) (ctrl.Result, error) {
-	logger := r.log.WithValues("cfServiceInstanceName", cfServiceInstance.Name, "cfServiceInstanceNamespace", cfServiceInstance.Namespace)
-	logger.Info("Reconciling deletion of CFServiceInstance")
-
-	if !controllerutil.ContainsFinalizer(cfServiceInstance, CFServiceInstanceFinalizerName) {
-		return ctrl.Result{}, nil
-	}
-
-	cfServiceBindingList := &korifiv1alpha1.CFServiceBindingList{}
-	err := r.k8sClient.List(ctx, cfServiceBindingList,
-		client.InNamespace(cfServiceInstance.Namespace),
-		client.MatchingFields{shared.IndexServiceBindingServiceInstanceGUID: cfServiceInstance.Name},
-	)
-	if err != nil {
-		logger.Error(err, "Error listing service bindings")
-		return ctrl.Result{}, err
-	}
-
-	for i, cfServiceBinding := range cfServiceBindingList.Items {
-		err = r.k8sClient.Delete(ctx, &cfServiceBindingList.Items[i])
-		if err != nil {
-			logger.Error(err, fmt.Sprintf("Error deleting %s", cfServiceBinding.Name))
-			return ctrl.Result{}, err
-		}
-	}
-
-	controllerutil.RemoveFinalizer(cfServiceInstance, CFServiceInstanceFinalizerName)
-
-	return ctrl.Result{}, nil
 }

--- a/controllers/controllers/services/cfserviceinstance_controller_test.go
+++ b/controllers/controllers/services/cfserviceinstance_controller_test.go
@@ -3,10 +3,6 @@ package services_test
 import (
 	"context"
 	"errors"
-	"time"
-
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -27,25 +23,19 @@ import (
 
 var _ = Describe("CFServiceInstance.Reconcile", func() {
 	var (
-		cfServiceInstance       *korifiv1alpha1.CFServiceInstance
-		cfServiceInstanceSecret *corev1.Secret
-
-		getCFServiceInstanceError         error
-		getCFServiceInstanceSecretError   error
-		patchCFServiceInstanceStatusError error
+		cfServiceInstance               *korifiv1alpha1.CFServiceInstance
+		cfServiceInstanceSecret         *corev1.Secret
+		getCFServiceInstanceSecretError error
 
 		cfServiceInstanceReconciler *k8s.PatchingReconciler[korifiv1alpha1.CFServiceInstance, *korifiv1alpha1.CFServiceInstance]
 		ctx                         context.Context
 		req                         ctrl.Request
 
-		reconcileResult ctrl.Result
-		reconcileErr    error
+		reconcileErr error
 	)
 
 	BeforeEach(func() {
-		getCFServiceInstanceError = nil
 		getCFServiceInstanceSecretError = nil
-		patchCFServiceInstanceStatusError = nil
 
 		cfServiceInstance = new(korifiv1alpha1.CFServiceInstance)
 		cfServiceInstanceSecret = new(corev1.Secret)
@@ -54,17 +44,13 @@ var _ = Describe("CFServiceInstance.Reconcile", func() {
 			switch obj := obj.(type) {
 			case *korifiv1alpha1.CFServiceInstance:
 				cfServiceInstance.DeepCopyInto(obj)
-				return getCFServiceInstanceError
+				return nil
 			case *corev1.Secret:
 				cfServiceInstanceSecret.DeepCopyInto(obj)
 				return getCFServiceInstanceSecretError
 			default:
 				panic("TestClient Get provided an unexpected object type")
 			}
-		}
-
-		fakeStatusWriter.PatchStub = func(ctx context.Context, obj client.Object, patch client.Patch, option ...client.PatchOption) error {
-			return patchCFServiceInstanceStatusError
 		}
 
 		Expect(korifiv1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
@@ -84,157 +70,29 @@ var _ = Describe("CFServiceInstance.Reconcile", func() {
 	})
 
 	JustBeforeEach(func() {
-		reconcileResult, reconcileErr = cfServiceInstanceReconciler.Reconcile(ctx, req)
+		_, reconcileErr = cfServiceInstanceReconciler.Reconcile(ctx, req)
 	})
 
-	When("the CFServiceInstance is being created", func() {
-		When("on the happy path", func() {
-			It("returns an empty result and does not return error, also updates cfServiceInstance status", func() {
-				Expect(reconcileResult).To(Equal(ctrl.Result{}))
-				Expect(reconcileErr).NotTo(HaveOccurred())
-
-				Expect(fakeStatusWriter.PatchCallCount()).To(Equal(1))
-				_, serviceInstanceObj, _, _ := fakeStatusWriter.PatchArgsForCall(0)
-				updatedCFServiceInstance, ok := serviceInstanceObj.(*korifiv1alpha1.CFServiceInstance)
-				Expect(ok).To(BeTrue())
-				Expect(updatedCFServiceInstance.Status.Binding.Name).To(Equal(cfServiceInstanceSecret.Name))
-				Expect(updatedCFServiceInstance.Status.Conditions).To(ContainElement(MatchFields(IgnoreExtras, Fields{
-					"Type":    Equal("BindingSecretAvailable"),
-					"Status":  Equal(metav1.ConditionTrue),
-					"Reason":  Equal("SecretFound"),
-					"Message": Equal(""),
-				})))
-			})
-		})
-		When("the secret isn't found", func() {
-			BeforeEach(func() {
-				getCFServiceInstanceSecretError = apierrors.NewNotFound(schema.GroupResource{}, cfServiceInstanceSecret.Name)
-			})
-
-			It("requeues the request", func() {
-				Expect(reconcileResult).To(Equal(ctrl.Result{RequeueAfter: 2 * time.Second}))
-				Expect(reconcileErr).NotTo(HaveOccurred())
-
-				Expect(fakeStatusWriter.PatchCallCount()).To(Equal(1))
-				_, serviceInstanceObj, _, _ := fakeStatusWriter.PatchArgsForCall(0)
-				updatedCFServiceInstance, ok := serviceInstanceObj.(*korifiv1alpha1.CFServiceInstance)
-				Expect(ok).To(BeTrue())
-
-				Expect(updatedCFServiceInstance.Status.Binding).To(BeZero())
-				Expect(updatedCFServiceInstance.Status.Conditions).To(ContainElement(MatchFields(IgnoreExtras, Fields{
-					"Type":    Equal("BindingSecretAvailable"),
-					"Status":  Equal(metav1.ConditionFalse),
-					"Reason":  Equal("SecretNotFound"),
-					"Message": Equal("Binding secret does not exist"),
-				})))
-			})
-		})
-		When("the API errors fetching the secret", func() {
-			BeforeEach(func() {
-				getCFServiceInstanceSecretError = errors.New("some random error")
-			})
-
-			It("errors, and updates status", func() {
-				Expect(reconcileErr).To(HaveOccurred())
-
-				Expect(fakeStatusWriter.PatchCallCount()).To(Equal(1))
-				_, serviceInstanceObj, _, _ := fakeStatusWriter.PatchArgsForCall(0)
-				updatedCFServiceInstance, ok := serviceInstanceObj.(*korifiv1alpha1.CFServiceInstance)
-				Expect(ok).To(BeTrue())
-
-				Expect(updatedCFServiceInstance.Status.Binding).To(BeZero())
-				Expect(updatedCFServiceInstance.Status.Conditions).To(ContainElement(MatchFields(IgnoreExtras, Fields{
-					"Type":    Equal("BindingSecretAvailable"),
-					"Status":  Equal(metav1.ConditionFalse),
-					"Reason":  Equal("UnknownError"),
-					"Message": Equal("Error occurred while fetching secret: " + getCFServiceInstanceSecretError.Error()),
-				})))
-			})
-		})
-		When("The API errors setting status on the CFServiceInstance", func() {
-			BeforeEach(func() {
-				patchCFServiceInstanceStatusError = errors.New("some random error")
-			})
-
-			It("errors", func() {
-				Expect(reconcileErr).To(HaveOccurred())
-			})
-		})
-		When("adding the finalizer to the CFRoute returns an error", func() {
-			BeforeEach(func() {
-				fakeClient.PatchReturns(errors.New("failed to patch CFServiceInstance"))
-			})
-
-			It("returns the error", func() {
-				Expect(reconcileErr).To(MatchError("failed to patch CFServiceInstance"))
-			})
-		})
-	})
-
-	When("the CFServiceInstance is being deleted", func() {
-		var (
-			cfServiceBindingList    korifiv1alpha1.CFServiceBindingList
-			listCFServiceBindingErr error
-		)
+	When("the API errors fetching the secret", func() {
 		BeforeEach(func() {
-			cfServiceInstance = &korifiv1alpha1.CFServiceInstance{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "",
-					Namespace: "",
-					Finalizers: []string{
-						"cfServiceInstance.korifi.cloudfoundry.org",
-					},
-					DeletionTimestamp: &metav1.Time{
-						Time: time.Now(),
-					},
-				},
-				Spec: korifiv1alpha1.CFServiceInstanceSpec{
-					DisplayName: "",
-					SecretName:  "",
-					Type:        "",
-				},
-			}
-
-			cfServiceBindingList = korifiv1alpha1.CFServiceBindingList{
-				Items: []korifiv1alpha1.CFServiceBinding{{}},
-			}
-			listCFServiceBindingErr = nil
-
-			fakeClient.ListStub = func(ctx context.Context, list client.ObjectList, option ...client.ListOption) error {
-				switch list := list.(type) {
-				case *korifiv1alpha1.CFServiceBindingList:
-					cfServiceBindingList.DeepCopyInto(list)
-					return listCFServiceBindingErr
-				default:
-					panic("TestClient List provided a weird obj")
-				}
-			}
-		})
-		When("listing the associated CFServiceBindings fails", func() {
-			BeforeEach(func() {
-				listCFServiceBindingErr = errors.New("fail list on purpose")
-			})
-			It("returns the error", func() {
-				Expect(reconcileErr).To(MatchError(listCFServiceBindingErr))
-			})
-		})
-		When("delete the CFServiceBinding fails", func() {
-			BeforeEach(func() {
-				fakeClient.DeleteReturns(errors.New("delete service binding failed"))
-			})
-			It("returns the error", func() {
-				Expect(reconcileErr).To(MatchError("delete service binding failed"))
-			})
+			getCFServiceInstanceSecretError = errors.New("some random error")
 		})
 
-		When("removing the finalizer from the CFRoute fails", func() {
-			BeforeEach(func() {
-				fakeClient.PatchReturns(errors.New("failed to patch CFServiceInstance"))
-			})
+		It("errors, and updates status", func() {
+			Expect(reconcileErr).To(HaveOccurred())
 
-			It("returns the error", func() {
-				Expect(reconcileErr).To(MatchError("failed to patch CFServiceInstance"))
-			})
+			Expect(fakeStatusWriter.PatchCallCount()).To(Equal(1))
+			_, serviceInstanceObj, _, _ := fakeStatusWriter.PatchArgsForCall(0)
+			updatedCFServiceInstance, ok := serviceInstanceObj.(*korifiv1alpha1.CFServiceInstance)
+			Expect(ok).To(BeTrue())
+
+			Expect(updatedCFServiceInstance.Status.Binding).To(BeZero())
+			Expect(updatedCFServiceInstance.Status.Conditions).To(ContainElement(MatchFields(IgnoreExtras, Fields{
+				"Type":    Equal("BindingSecretAvailable"),
+				"Status":  Equal(metav1.ConditionFalse),
+				"Reason":  Equal("UnknownError"),
+				"Message": Equal("Error occurred while fetching secret: " + getCFServiceInstanceSecretError.Error()),
+			})))
 		})
 	})
 })

--- a/controllers/controllers/services/integration/cfserviceinstance_integration_test.go
+++ b/controllers/controllers/services/integration/cfserviceinstance_integration_test.go
@@ -46,6 +46,7 @@ var _ = Describe("CFServiceInstance", func() {
 				DisplayName: "service-instance-name",
 				Type:        "user-provided",
 				Tags:        []string{},
+				SecretName:  secret.Name,
 			},
 		}
 	})
@@ -54,25 +55,57 @@ var _ = Describe("CFServiceInstance", func() {
 		Expect(k8sClient.Delete(context.Background(), namespace)).To(Succeed())
 	})
 
-	Describe("Create", func() {
-		JustBeforeEach(func() {
-			Expect(k8sClient.Create(context.Background(), cfServiceInstance)).To(Succeed())
+	JustBeforeEach(func() {
+		Expect(k8sClient.Create(context.Background(), cfServiceInstance)).To(Succeed())
+	})
+
+	It("sets the BindingSecretAvailable condition to true in the CFServiceInstance status", func() {
+		Eventually(func(g Gomega) {
+			updatedCFServiceInstance := new(korifiv1alpha1.CFServiceInstance)
+			serviceInstanceNamespacedName := client.ObjectKeyFromObject(cfServiceInstance)
+			err := k8sClient.Get(context.Background(), serviceInstanceNamespacedName, updatedCFServiceInstance)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			g.Expect(updatedCFServiceInstance.Status.Binding.Name).To(Equal("secret-name"))
+			g.Expect(updatedCFServiceInstance.Status.Conditions).To(ContainElement(MatchFields(IgnoreExtras, Fields{
+				"Type":    Equal("BindingSecretAvailable"),
+				"Status":  Equal(metav1.ConditionTrue),
+				"Reason":  Equal("SecretFound"),
+				"Message": Equal(""),
+			})))
+		}).Should(Succeed())
+	})
+
+	When("the referenced secret does not exist", func() {
+		BeforeEach(func() {
+			cfServiceInstance.Spec.SecretName = "other-secret-name"
 		})
 
-		It("adds a finalizer", func() {
+		It("sets the BindingSecretAvailable condition to false in the CFServiceInstance status", func() {
 			Eventually(func(g Gomega) {
 				updatedCFServiceInstance := new(korifiv1alpha1.CFServiceInstance)
 				serviceInstanceNamespacedName := client.ObjectKeyFromObject(cfServiceInstance)
 				err := k8sClient.Get(context.Background(), serviceInstanceNamespacedName, updatedCFServiceInstance)
 				g.Expect(err).NotTo(HaveOccurred())
 
-				g.Expect(updatedCFServiceInstance.ObjectMeta.Finalizers).To(ConsistOf("cfServiceInstance.korifi.cloudfoundry.org"))
+				g.Expect(updatedCFServiceInstance.Status.Binding).To(BeZero())
+				g.Expect(updatedCFServiceInstance.Status.Conditions).To(ContainElement(MatchFields(IgnoreExtras, Fields{
+					"Type":    Equal("BindingSecretAvailable"),
+					"Status":  Equal(metav1.ConditionFalse),
+					"Reason":  Equal("SecretNotFound"),
+					"Message": Equal("Binding secret does not exist"),
+				})))
 			}).Should(Succeed())
 		})
 
-		When("the secret exists", func() {
+		When("the referenced secret is created afterwards", func() {
 			BeforeEach(func() {
-				cfServiceInstance.Spec.SecretName = secret.Name
+				Expect(k8sClient.Create(context.Background(), &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "other-secret-name",
+						Namespace: namespace.Name,
+					},
+				})).To(Succeed())
 			})
 
 			It("sets the BindingSecretAvailable condition to true in the CFServiceInstance status", func() {
@@ -82,7 +115,7 @@ var _ = Describe("CFServiceInstance", func() {
 					err := k8sClient.Get(context.Background(), serviceInstanceNamespacedName, updatedCFServiceInstance)
 					g.Expect(err).NotTo(HaveOccurred())
 
-					g.Expect(updatedCFServiceInstance.Status.Binding.Name).To(Equal("secret-name"))
+					g.Expect(updatedCFServiceInstance.Status.Binding.Name).To(Equal("other-secret-name"))
 					g.Expect(updatedCFServiceInstance.Status.Conditions).To(ContainElement(MatchFields(IgnoreExtras, Fields{
 						"Type":    Equal("BindingSecretAvailable"),
 						"Status":  Equal(metav1.ConditionTrue),
@@ -91,104 +124,6 @@ var _ = Describe("CFServiceInstance", func() {
 					})))
 				}).Should(Succeed())
 			})
-		})
-
-		When("the referenced secret does not exist", func() {
-			BeforeEach(func() {
-				cfServiceInstance.Spec.SecretName = "other-secret-name"
-			})
-
-			It("sets the BindingSecretAvailable condition to false in the CFServiceInstance status", func() {
-				Eventually(func(g Gomega) {
-					updatedCFServiceInstance := new(korifiv1alpha1.CFServiceInstance)
-					serviceInstanceNamespacedName := client.ObjectKeyFromObject(cfServiceInstance)
-					err := k8sClient.Get(context.Background(), serviceInstanceNamespacedName, updatedCFServiceInstance)
-					g.Expect(err).NotTo(HaveOccurred())
-
-					g.Expect(updatedCFServiceInstance.Status.Binding).To(BeZero())
-					g.Expect(updatedCFServiceInstance.Status.Conditions).To(ContainElement(MatchFields(IgnoreExtras, Fields{
-						"Type":    Equal("BindingSecretAvailable"),
-						"Status":  Equal(metav1.ConditionFalse),
-						"Reason":  Equal("SecretNotFound"),
-						"Message": Equal("Binding secret does not exist"),
-					})))
-				}).Should(Succeed())
-			})
-
-			When("the referenced secret is created afterwards", func() {
-				BeforeEach(func() {
-					Expect(k8sClient.Create(context.Background(), &corev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "other-secret-name",
-							Namespace: namespace.Name,
-						},
-					})).To(Succeed())
-				})
-
-				It("sets the BindingSecretAvailable condition to true in the CFServiceInstance status", func() {
-					Eventually(func(g Gomega) {
-						updatedCFServiceInstance := new(korifiv1alpha1.CFServiceInstance)
-						serviceInstanceNamespacedName := client.ObjectKeyFromObject(cfServiceInstance)
-						err := k8sClient.Get(context.Background(), serviceInstanceNamespacedName, updatedCFServiceInstance)
-						g.Expect(err).NotTo(HaveOccurred())
-
-						g.Expect(updatedCFServiceInstance.Status.Binding.Name).To(Equal("other-secret-name"))
-						g.Expect(updatedCFServiceInstance.Status.Conditions).To(ContainElement(MatchFields(IgnoreExtras, Fields{
-							"Type":    Equal("BindingSecretAvailable"),
-							"Status":  Equal(metav1.ConditionTrue),
-							"Reason":  Equal("SecretFound"),
-							"Message": Equal(""),
-						})))
-					}).Should(Succeed())
-				})
-			})
-		})
-	})
-
-	Describe("Delete", func() {
-		BeforeEach(func() {
-			cfServiceInstance.Spec.SecretName = secret.Name
-			Expect(k8sClient.Create(context.Background(), cfServiceInstance)).To(Succeed())
-
-			Eventually(func(g Gomega) {
-				updatedCFServiceInstance := new(korifiv1alpha1.CFServiceInstance)
-				serviceInstanceNamespacedName := client.ObjectKeyFromObject(cfServiceInstance)
-				err := k8sClient.Get(context.Background(), serviceInstanceNamespacedName, updatedCFServiceInstance)
-				g.Expect(err).NotTo(HaveOccurred())
-
-				g.Expect(updatedCFServiceInstance.ObjectMeta.Finalizers).To(ConsistOf("cfServiceInstance.korifi.cloudfoundry.org"))
-			}).Should(Succeed())
-
-			cfServiceBinding := &korifiv1alpha1.CFServiceBinding{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      GenerateGUID(),
-					Namespace: namespace.Name,
-				},
-				Spec: korifiv1alpha1.CFServiceBindingSpec{
-					Service: corev1.ObjectReference{
-						Kind:       "ServiceInstance",
-						Name:       cfServiceInstance.Name,
-						APIVersion: "korifi.cloudfoundry.org/v1alpha1",
-					},
-					AppRef: corev1.LocalObjectReference{
-						Name: "",
-					},
-				},
-			}
-			Expect(k8sClient.Create(context.Background(), cfServiceBinding)).To(Succeed())
-		})
-
-		JustBeforeEach(func() {
-			Expect(k8sClient.Delete(context.Background(), cfServiceInstance)).To(Succeed())
-		})
-
-		It("deletes associated ServiceBindings", func() {
-			Eventually(func(g Gomega) {
-				cfServiceBindingList := new(korifiv1alpha1.CFServiceBindingList)
-				g.Expect(k8sClient.List(context.Background(), cfServiceBindingList, client.InNamespace(namespace.Name))).To(Succeed())
-
-				g.Expect(cfServiceBindingList.Items).To(BeEmpty())
-			}).Should(Succeed())
 		})
 	})
 })

--- a/controllers/controllers/workloads/cfapp_controller.go
+++ b/controllers/controllers/workloads/cfapp_controller.go
@@ -255,11 +255,6 @@ func (r *CFAppReconciler) finalizeCFApp(ctx context.Context, cfApp *korifiv1alph
 		return err
 	}
 
-	err = r.finalizeCFAppTasks(ctx, cfApp)
-	if err != nil {
-		return err
-	}
-
 	err = r.finalizeCFServiceBindings(ctx, cfApp)
 	if err != nil {
 		return err
@@ -278,23 +273,6 @@ func (r *CFAppReconciler) finalizeCFAppRoutes(ctx context.Context, cfApp *korifi
 	err = r.updateRouteDestinations(ctx, cfApp.Name, cfRoutes)
 	if err != nil {
 		return err
-	}
-
-	return nil
-}
-
-func (r *CFAppReconciler) finalizeCFAppTasks(ctx context.Context, cfApp *korifiv1alpha1.CFApp) error {
-	tasksList := korifiv1alpha1.CFTaskList{}
-	err := r.k8sClient.List(ctx, &tasksList, client.InNamespace(cfApp.Namespace), client.MatchingFields{shared.IndexAppTasks: cfApp.Name})
-	if err != nil {
-		return err
-	}
-
-	for i := range tasksList.Items {
-		err = r.k8sClient.Delete(ctx, &tasksList.Items[i])
-		if err != nil {
-			return err
-		}
 	}
 
 	return nil

--- a/controllers/controllers/workloads/cfapp_controller_test.go
+++ b/controllers/controllers/workloads/cfapp_controller_test.go
@@ -46,8 +46,6 @@ var _ = Describe("CFAppReconciler", func() {
 		cfRoutePatchErr           error
 		cfRouteListErr            error
 		cfProcessListErr          error
-		cfTaskListErr             error
-		cfTaskDeleteErr           error
 		cfServiceBindingListErr   error
 		cfServiceBindingDeleteErr error
 
@@ -148,15 +146,6 @@ var _ = Describe("CFAppReconciler", func() {
 			},
 		}
 
-		cfTaskListErr = nil
-		cfTaskList := korifiv1alpha1.CFTaskList{
-			Items: []korifiv1alpha1.CFTask{{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "cfTaskGUID",
-					Namespace: defaultNamespace,
-				},
-			}},
-		}
 		cfServiceBindingListErr = nil
 		cfServiceBindingList := korifiv1alpha1.CFServiceBindingList{
 			Items: []korifiv1alpha1.CFServiceBinding{{
@@ -174,9 +163,6 @@ var _ = Describe("CFAppReconciler", func() {
 			case *korifiv1alpha1.CFRouteList:
 				cfRouteList.DeepCopyInto(list)
 				return cfRouteListErr
-			case *korifiv1alpha1.CFTaskList:
-				cfTaskList.DeepCopyInto(list)
-				return cfTaskListErr
 			case *korifiv1alpha1.CFServiceBindingList:
 				cfServiceBindingList.DeepCopyInto(list)
 				return cfServiceBindingListErr
@@ -198,12 +184,9 @@ var _ = Describe("CFAppReconciler", func() {
 			}
 		}
 
-		cfTaskDeleteErr = nil
 		cfServiceBindingDeleteErr = nil
 		fakeClient.DeleteStub = func(ctx context.Context, object client.Object, option ...client.DeleteOption) error {
 			switch object.(type) {
-			case *korifiv1alpha1.CFTask:
-				return cfTaskDeleteErr
 			case *korifiv1alpha1.CFServiceBinding:
 				return cfServiceBindingDeleteErr
 			default:
@@ -528,26 +511,6 @@ var _ = Describe("CFAppReconciler", func() {
 
 				It("return the error", func() {
 					Expect(reconcileErr).To(MatchError("failed to patch CFRoute"))
-				})
-			})
-
-			When("listing the app tasks fails", func() {
-				BeforeEach(func() {
-					cfTaskListErr = errors.New("failed to list CFTask")
-				})
-
-				It("return the error", func() {
-					Expect(reconcileErr).To(MatchError("failed to list CFTask"))
-				})
-			})
-
-			When("deleting an app task fails", func() {
-				BeforeEach(func() {
-					cfTaskDeleteErr = errors.New("failed to delete CFTask")
-				})
-
-				It("return the error", func() {
-					Expect(reconcileErr).To(MatchError("failed to delete CFTask"))
 				})
 			})
 

--- a/controllers/controllers/workloads/cfbuild_controller.go
+++ b/controllers/controllers/workloads/cfbuild_controller.go
@@ -83,6 +83,12 @@ func (r *CFBuildReconciler) ReconcileResource(ctx context.Context, cfBuild *kori
 		return ctrl.Result{}, err
 	}
 
+	err = controllerutil.SetOwnerReference(cfPackage, cfBuild, r.scheme)
+	if err != nil {
+		r.log.Error(err, "unable to set owner reference on CFBuild")
+		return ctrl.Result{}, err
+	}
+
 	stagingStatus := getConditionOrSetAsUnknown(&cfBuild.Status.Conditions, korifiv1alpha1.StagingConditionType)
 	succeededStatus := getConditionOrSetAsUnknown(&cfBuild.Status.Conditions, korifiv1alpha1.SucceededConditionType)
 

--- a/controllers/controllers/workloads/cfbuild_controller.go
+++ b/controllers/controllers/workloads/cfbuild_controller.go
@@ -70,12 +70,6 @@ func (r *CFBuildReconciler) ReconcileResource(ctx context.Context, cfBuild *kori
 		return ctrl.Result{}, err
 	}
 
-	err = controllerutil.SetOwnerReference(cfApp, cfBuild, r.scheme)
-	if err != nil {
-		r.log.Error(err, "unable to set owner reference on CFBuild")
-		return ctrl.Result{}, err
-	}
-
 	cfPackage := new(korifiv1alpha1.CFPackage)
 	err = r.k8sClient.Get(ctx, types.NamespacedName{Name: cfBuild.Spec.PackageRef.Name, Namespace: cfBuild.Namespace}, cfPackage)
 	if err != nil {

--- a/controllers/controllers/workloads/cfbuild_controller.go
+++ b/controllers/controllers/workloads/cfbuild_controller.go
@@ -58,7 +58,6 @@ func NewCFBuildReconciler(k8sClient client.Client, scheme *runtime.Scheme, log l
 
 //+kubebuilder:rbac:groups=korifi.cloudfoundry.org,resources=cfbuilds,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=korifi.cloudfoundry.org,resources=cfbuilds/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=korifi.cloudfoundry.org,resources=cfbuilds/finalizers,verbs=update
 
 //+kubebuilder:rbac:groups=korifi.cloudfoundry.org,resources=buildworkloads,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=korifi.cloudfoundry.org,resources=buildworkloads/status,verbs=get

--- a/controllers/controllers/workloads/cfpackage_controller.go
+++ b/controllers/controllers/workloads/cfpackage_controller.go
@@ -45,7 +45,6 @@ func NewCFPackageReconciler(client client.Client, scheme *runtime.Scheme, log lo
 
 //+kubebuilder:rbac:groups=korifi.cloudfoundry.org,resources=cfpackages,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=korifi.cloudfoundry.org,resources=cfpackages/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=korifi.cloudfoundry.org,resources=cfpackages/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/controllers/controllers/workloads/cfprocess_controller.go
+++ b/controllers/controllers/workloads/cfprocess_controller.go
@@ -72,7 +72,6 @@ func NewCFProcessReconciler(
 
 //+kubebuilder:rbac:groups=korifi.cloudfoundry.org,resources=cfprocesses,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=korifi.cloudfoundry.org,resources=cfprocesses/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=korifi.cloudfoundry.org,resources=cfprocesses/finalizers,verbs=update
 //+kubebuilder:rbac:groups=korifi.cloudfoundry.org,resources=appworkloads,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;patch
 

--- a/controllers/controllers/workloads/cftask_controller.go
+++ b/controllers/controllers/workloads/cftask_controller.go
@@ -88,7 +88,6 @@ func NewCFTaskReconciler(
 
 //+kubebuilder:rbac:groups=korifi.cloudfoundry.org,resources=cftasks,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=korifi.cloudfoundry.org,resources=cftasks/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=korifi.cloudfoundry.org,resources=cftasks/finalizers,verbs=update
 //+kubebuilder:rbac:groups=korifi.cloudfoundry.org,resources=taskworkloads,verbs=get;list;watch;create;patch;delete
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 

--- a/controllers/controllers/workloads/cftask_controller.go
+++ b/controllers/controllers/workloads/cftask_controller.go
@@ -111,6 +111,11 @@ func (r *CFTaskReconciler) ReconcileResource(ctx context.Context, cfTask *korifi
 		return ctrl.Result{}, err
 	}
 
+	err = controllerutil.SetOwnerReference(cfApp, cfTask, r.scheme)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
 	cfDroplet, err := r.getDroplet(ctx, cfTask, cfApp)
 	if err != nil {
 		return ctrl.Result{}, err

--- a/controllers/controllers/workloads/integration/cfapp_controller_integration_test.go
+++ b/controllers/controllers/workloads/integration/cfapp_controller_integration_test.go
@@ -600,32 +600,6 @@ var _ = Describe("CFAppReconciler Integration Tests", func() {
 			}))
 		})
 
-		When("the app is referenced by tasks", func() {
-			BeforeEach(func() {
-				cfTask := korifiv1alpha1.CFTask{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      PrefixedGUID("task"),
-						Namespace: namespaceGUID,
-					},
-					Spec: korifiv1alpha1.CFTaskSpec{
-						Command: "sleep 1000",
-						AppRef: corev1.LocalObjectReference{
-							Name: cfAppGUID,
-						},
-					},
-				}
-				Expect(k8sClient.Create(context.Background(), &cfTask)).To(Succeed())
-			})
-
-			It("deletes the referencing tasks", func() {
-				Eventually(func(g Gomega) {
-					tasksList := korifiv1alpha1.CFTaskList{}
-					g.Expect(k8sClient.List(context.Background(), &tasksList, client.InNamespace(namespaceGUID))).To(Succeed())
-					g.Expect(tasksList.Items).To(BeEmpty())
-				}).Should(Succeed())
-			})
-		})
-
 		When("the app is referenced by service bindings", func() {
 			BeforeEach(func() {
 				cfServiceBinding := korifiv1alpha1.CFServiceBinding{

--- a/controllers/controllers/workloads/integration/cfbuild_controller_integration_test.go
+++ b/controllers/controllers/workloads/integration/cfbuild_controller_integration_test.go
@@ -109,12 +109,6 @@ var _ = Describe("CFBuildReconciler Integration Tests", func() {
 				g.Expect(createdCFBuild.GetOwnerReferences()).To(ConsistOf(
 					metav1.OwnerReference{
 						APIVersion: korifiv1alpha1.GroupVersion.Identifier(),
-						Kind:       "CFApp",
-						Name:       desiredCFApp.Name,
-						UID:        desiredCFApp.UID,
-					},
-					metav1.OwnerReference{
-						APIVersion: korifiv1alpha1.GroupVersion.Identifier(),
 						Kind:       "CFPackage",
 						Name:       desiredCFPackage.Name,
 						UID:        desiredCFPackage.UID,

--- a/docs/architecture-decisions/0014-resource-ownership.md
+++ b/docs/architecture-decisions/0014-resource-ownership.md
@@ -1,0 +1,61 @@
+# Korifi resource ownership
+
+Date: 2022-11-10
+
+## Status
+
+Accepted
+
+## Context
+
+Korifi defines a network of kubernetes resources in order to model the CF api
+on top of kubernetes. Sometimes one resource that we are going to call the
+parent is the logical owner of another resource which we are going to call the
+child. The reconciler of the parent object is responsible of cleaning up all
+child resources associated with the parent resource that is being deleted. This
+cleanup is usually impemented by setting an [owner
+ref](https://kubernetes.io/docs/concepts/overview/working-with-objects/owners-dependents/)
+on the child.
+
+There are generally two options for who to set these owner refs:
+
+### The child creator
+
+This approach follows the good practice of the creator being responsible for
+the deletion of the objects it creates. In this case deletion is determined by
+the owner reference and the implied cascading delete. However there are some
+drawbacks:
+
+-   In order to set owner reference in kubernetes you have to first lookup the
+    parent object. This violates the declarative nature of the kubernetes
+    client as it cannot just apply a collection of resources at once. This does
+    not apply when the collection of objects being created is self contained,
+    i.e there are no references to previously created objects.
+-   There is a potential race when the creator client cache is stale and does not
+    know about the parent yet. This race can be mitigated by a retry loop, but
+    this introduces unnecessary complexity in the client.
+
+### The child reconciler
+
+This approach mitigates the drawbacks of the child creator approach as
+reconciliation runs in a loop anyway.
+
+This approach however is only applicable when the child object already holds
+some reference to its parent, e.g. `LocalObjectReference`. For example the
+`CFApp` owns a secret that describes its environment. The buitin kubernetes
+secret kind has no way of referring to and app, so no reconciler would be able
+to set this owner reference.
+
+A drawback of this approach is tha owner references are being set implicitly
+without the knowledge of potential kubectl users and may come as a surprise to
+them. We believe that korifi resources are not general purpose ones, so this
+automation is unlikely to get in the way. Also korifi child resources such as
+`CFServiceBinding` do not make much sense without being owned by their parent.
+
+## Decision
+
+We favour setting owner references in the child's reconciliation loop unless
+that is impossible. In this case the owner ref should be set by the creator. An
+example of this is the service instance creation, where a secret containing the
+service instance sensitive data is created along with the service instance
+itself and an owner ref is set by the creator.

--- a/helm/controllers/templates/role.yaml
+++ b/helm/controllers/templates/role.yaml
@@ -341,12 +341,6 @@ rules:
 - apiGroups:
   - korifi.cloudfoundry.org
   resources:
-  - cfservicebindings/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - korifi.cloudfoundry.org
-  resources:
   - cfservicebindings/status
   verbs:
   - get
@@ -364,12 +358,6 @@ rules:
   - patch
   - update
   - watch
-- apiGroups:
-  - korifi.cloudfoundry.org
-  resources:
-  - cfserviceinstances/finalizers
-  verbs:
-  - update
 - apiGroups:
   - korifi.cloudfoundry.org
   resources:

--- a/helm/controllers/templates/role.yaml
+++ b/helm/controllers/templates/role.yaml
@@ -200,12 +200,6 @@ rules:
 - apiGroups:
   - korifi.cloudfoundry.org
   resources:
-  - cfbuilds/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - korifi.cloudfoundry.org
-  resources:
   - cfbuilds/status
   verbs:
   - get
@@ -263,12 +257,6 @@ rules:
 - apiGroups:
   - korifi.cloudfoundry.org
   resources:
-  - cfpackages/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - korifi.cloudfoundry.org
-  resources:
   - cfpackages/status
   verbs:
   - get
@@ -286,12 +274,6 @@ rules:
   - patch
   - update
   - watch
-- apiGroups:
-  - korifi.cloudfoundry.org
-  resources:
-  - cfprocesses/finalizers
-  verbs:
-  - update
 - apiGroups:
   - korifi.cloudfoundry.org
   resources:
@@ -404,12 +386,6 @@ rules:
   - patch
   - update
   - watch
-- apiGroups:
-  - korifi.cloudfoundry.org
-  resources:
-  - cftasks/finalizers
-  verbs:
-  - update
 - apiGroups:
   - korifi.cloudfoundry.org
   resources:

--- a/helm/job-task-runner/templates/role.yaml
+++ b/helm/job-task-runner/templates/role.yaml
@@ -34,12 +34,6 @@ rules:
 - apiGroups:
   - korifi.cloudfoundry.org
   resources:
-  - taskworkloads/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - korifi.cloudfoundry.org
-  resources:
   - taskworkloads/status
   verbs:
   - get

--- a/helm/kpack-image-builder/templates/role.yaml
+++ b/helm/kpack-image-builder/templates/role.yaml
@@ -36,12 +36,6 @@ rules:
 - apiGroups:
   - korifi.cloudfoundry.org
   resources:
-  - builderinfos/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - korifi.cloudfoundry.org
-  resources:
   - builderinfos/status
   verbs:
   - get
@@ -57,12 +51,6 @@ rules:
   - list
   - patch
   - watch
-- apiGroups:
-  - korifi.cloudfoundry.org
-  resources:
-  - buildworkloads/finalizers
-  verbs:
-  - update
 - apiGroups:
   - korifi.cloudfoundry.org
   resources:
@@ -95,12 +83,6 @@ rules:
   - list
   - patch
   - watch
-- apiGroups:
-  - kpack.io
-  resources:
-  - images/finalizers
-  verbs:
-  - update
 - apiGroups:
   - kpack.io
   resources:

--- a/helm/statefulset-runner/templates/role.yaml
+++ b/helm/statefulset-runner/templates/role.yaml
@@ -29,12 +29,6 @@ rules:
 - apiGroups:
   - korifi.cloudfoundry.org
   resources:
-  - appworkloads/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - korifi.cloudfoundry.org
-  resources:
   - appworkloads/status
   verbs:
   - get

--- a/job-task-runner/controllers/taskworkload_controller.go
+++ b/job-task-runner/controllers/taskworkload_controller.go
@@ -60,7 +60,6 @@ type TaskWorkloadReconciler struct {
 
 //+kubebuilder:rbac:groups=korifi.cloudfoundry.org,resources=taskworkloads,verbs=get;list;watch;patch
 //+kubebuilder:rbac:groups=korifi.cloudfoundry.org,resources=taskworkloads/status,verbs=get;patch
-//+kubebuilder:rbac:groups=korifi.cloudfoundry.org,resources=taskworkloads/finalizers,verbs=update
 //+kubebuilder:rbac:groups=batch,resources=jobs,verbs=create;get;list;watch
 //+kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
 

--- a/kpack-image-builder/controllers/builderinfo_controller.go
+++ b/kpack-image-builder/controllers/builderinfo_controller.go
@@ -72,7 +72,6 @@ type BuilderInfoReconciler struct {
 
 //+kubebuilder:rbac:groups=korifi.cloudfoundry.org,resources=builderinfos,verbs=get;list;watch;create;patch;delete
 //+kubebuilder:rbac:groups=korifi.cloudfoundry.org,resources=builderinfos/status,verbs=get;patch
-//+kubebuilder:rbac:groups=korifi.cloudfoundry.org,resources=builderinfos/finalizers,verbs=update
 
 //+kubebuilder:rbac:groups=kpack.io,resources=clusterbuilders,verbs=get;list;watch
 //+kubebuilder:rbac:groups=kpack.io,resources=clusterbuilders/status,verbs=get

--- a/kpack-image-builder/controllers/buildworkload_controller.go
+++ b/kpack-image-builder/controllers/buildworkload_controller.go
@@ -117,11 +117,9 @@ type BuildWorkloadReconciler struct {
 
 //+kubebuilder:rbac:groups=korifi.cloudfoundry.org,resources=buildworkloads,verbs=get;list;watch;create;patch;delete
 //+kubebuilder:rbac:groups=korifi.cloudfoundry.org,resources=buildworkloads/status,verbs=get;patch
-//+kubebuilder:rbac:groups=korifi.cloudfoundry.org,resources=buildworkloads/finalizers,verbs=update
 
 //+kubebuilder:rbac:groups=kpack.io,resources=images,verbs=get;list;watch;create;patch;delete
 //+kubebuilder:rbac:groups=kpack.io,resources=images/status,verbs=get;patch
-//+kubebuilder:rbac:groups=kpack.io,resources=images/finalizers,verbs=update
 
 //+kubebuilder:rbac:groups="",resources=serviceaccounts;secrets,verbs=get;list;watch;patch
 //+kubebuilder:rbac:groups="",resources=serviceaccounts/status;secrets/status,verbs=get

--- a/statefulset-runner/controllers/appworkload_controller.go
+++ b/statefulset-runner/controllers/appworkload_controller.go
@@ -108,7 +108,6 @@ func NewAppWorkloadReconciler(
 
 //+kubebuilder:rbac:groups=korifi.cloudfoundry.org,resources=appworkloads,verbs=get;list;watch;create;patch;delete
 //+kubebuilder:rbac:groups=korifi.cloudfoundry.org,resources=appworkloads/status,verbs=get;patch
-//+kubebuilder:rbac:groups=korifi.cloudfoundry.org,resources=appworkloads/finalizers,verbs=update
 //+kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=create;patch;get;list;watch
 //+kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=create;patch;deletecollection
 


### PR DESCRIPTION
## Is there a related GitHub Issue?
https://github.com/cloudfoundry/korifi/issues/1876
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
* Use owner references to clean up dependent resources instead of doing that in finalizers wherever possible
* The app finalizer makes best effort to delete related service bindings
* Favour setting owner references in controllers' reconcile log
* ADR to record our decision about managing owner references

<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
N/A
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@georgethebeatle
