### PR TITLE
Handle changing process commands across builds

### DIFF
--- a/api/repositories/process_repository.go
+++ b/api/repositories/process_repository.go
@@ -326,7 +326,7 @@ func cfProcessToProcessRecord(cfProcess korifiv1alpha1.CFProcess) ProcessRecord 
 
 	cmd := cfProcess.Spec.Command
 	if cmd == "" {
-		cmd = cfProcess.Spec.DropletCommand
+		cmd = cfProcess.Spec.DetectedCommand
 	}
 
 	return ProcessRecord{

--- a/api/repositories/process_repository.go
+++ b/api/repositories/process_repository.go
@@ -324,12 +324,17 @@ func returnProcesses(processes []korifiv1alpha1.CFProcess) ([]ProcessRecord, err
 func cfProcessToProcessRecord(cfProcess korifiv1alpha1.CFProcess) ProcessRecord {
 	updatedAtTime, _ := getTimeLastUpdatedTimestamp(&cfProcess.ObjectMeta)
 
+	cmd := cfProcess.Spec.Command
+	if cmd == "" {
+		cmd = cfProcess.Spec.DropletCommand
+	}
+
 	return ProcessRecord{
 		GUID:             cfProcess.Name,
 		SpaceGUID:        cfProcess.Namespace,
 		AppGUID:          cfProcess.Spec.AppRef.Name,
 		Type:             cfProcess.Spec.ProcessType,
-		Command:          cfProcess.Spec.Command,
+		Command:          cmd,
 		DesiredInstances: *cfProcess.Spec.DesiredInstances,
 		MemoryMB:         cfProcess.Spec.MemoryMB,
 		DiskQuotaMB:      cfProcess.Spec.DiskQuotaMB,

--- a/controllers/api/v1alpha1/cfprocess_types.go
+++ b/controllers/api/v1alpha1/cfprocess_types.go
@@ -40,7 +40,7 @@ type CFProcessSpec struct {
 	Command string `json:"command,omitempty"`
 
 	// The default command for this process as defined by the build. This field is ignored when the Command field is set
-	DropletCommand string `json:"dropletCommand,omitempty"`
+	DetectedCommand string `json:"detectedCommand,omitempty"`
 
 	// Used to build the Liveness and Readiness Probes for the process' AppWorkload.
 	HealthCheck HealthCheck `json:"healthCheck"`

--- a/controllers/api/v1alpha1/cfprocess_types.go
+++ b/controllers/api/v1alpha1/cfprocess_types.go
@@ -39,6 +39,9 @@ type CFProcessSpec struct {
 	// Command string used to run this process on the app image. This is analogous to command in k8s and ENTRYPOINT in Docker
 	Command string `json:"command,omitempty"`
 
+	// The default command for this process as defined by the build. This field is ignored when the Command field is set
+	DropletCommand string `json:"dropletCommand,omitempty"`
+
 	// Used to build the Liveness and Readiness Probes for the process' AppWorkload.
 	HealthCheck HealthCheck `json:"healthCheck"`
 

--- a/controllers/controllers/workloads/cfapp_controller.go
+++ b/controllers/controllers/workloads/cfapp_controller.go
@@ -174,12 +174,8 @@ func addWebIfMissing(processTypes []korifiv1alpha1.ProcessType) []korifiv1alpha1
 }
 
 func (r *CFAppReconciler) updateCFProcessCommand(ctx context.Context, process *korifiv1alpha1.CFProcess, command string) error {
-	if process.Spec.Command != "" {
-		return nil
-	}
-
 	return k8s.Patch(ctx, r.k8sClient, process, func() {
-		process.Spec.Command = command
+		process.Spec.DropletCommand = command
 	})
 }
 
@@ -193,10 +189,10 @@ func (r *CFAppReconciler) createCFProcess(ctx context.Context, process korifiv1a
 			},
 		},
 		Spec: korifiv1alpha1.CFProcessSpec{
-			AppRef:      corev1.LocalObjectReference{Name: cfApp.Name},
-			ProcessType: process.Type,
-			Command:     process.Command,
-			Ports:       ports,
+			AppRef:         corev1.LocalObjectReference{Name: cfApp.Name},
+			ProcessType:    process.Type,
+			DropletCommand: process.Command,
+			Ports:          ports,
 		},
 	}
 	desiredCFProcess.SetStableName(cfApp.Name)

--- a/controllers/controllers/workloads/cfapp_controller.go
+++ b/controllers/controllers/workloads/cfapp_controller.go
@@ -175,7 +175,7 @@ func addWebIfMissing(processTypes []korifiv1alpha1.ProcessType) []korifiv1alpha1
 
 func (r *CFAppReconciler) updateCFProcessCommand(ctx context.Context, process *korifiv1alpha1.CFProcess, command string) error {
 	return k8s.Patch(ctx, r.k8sClient, process, func() {
-		process.Spec.DropletCommand = command
+		process.Spec.DetectedCommand = command
 	})
 }
 
@@ -189,10 +189,10 @@ func (r *CFAppReconciler) createCFProcess(ctx context.Context, process korifiv1a
 			},
 		},
 		Spec: korifiv1alpha1.CFProcessSpec{
-			AppRef:         corev1.LocalObjectReference{Name: cfApp.Name},
-			ProcessType:    process.Type,
-			DropletCommand: process.Command,
-			Ports:          ports,
+			AppRef:          corev1.LocalObjectReference{Name: cfApp.Name},
+			ProcessType:     process.Type,
+			DetectedCommand: process.Command,
+			Ports:           ports,
 		},
 	}
 	desiredCFProcess.SetStableName(cfApp.Name)

--- a/controllers/controllers/workloads/cfprocess_controller.go
+++ b/controllers/controllers/workloads/cfprocess_controller.go
@@ -330,13 +330,17 @@ func generateEnvVars(port int, commonEnv []corev1.EnvVar) []corev1.EnvVar {
 }
 
 func commandForProcess(process *korifiv1alpha1.CFProcess, app *korifiv1alpha1.CFApp) []string {
-	if process.Spec.Command == "" {
-		return []string{}
-	} else if app.Spec.Lifecycle.Type == korifiv1alpha1.BuildpackLifecycle {
-		return []string{"/cnb/lifecycle/launcher", process.Spec.Command}
-	} else {
-		return []string{"/bin/sh", "-c", process.Spec.Command}
+	cmd := process.Spec.Command
+	if cmd == "" {
+		cmd = process.Spec.DropletCommand
 	}
+	if cmd == "" {
+		return []string{}
+	}
+	if app.Spec.Lifecycle.Type == korifiv1alpha1.BuildpackLifecycle {
+		return []string{"/cnb/lifecycle/launcher", cmd}
+	}
+	return []string{"/bin/sh", "-c", cmd}
 }
 
 func makeProbeHandler(cfProcess *korifiv1alpha1.CFProcess, port int) corev1.ProbeHandler {

--- a/controllers/controllers/workloads/cfprocess_controller.go
+++ b/controllers/controllers/workloads/cfprocess_controller.go
@@ -332,7 +332,7 @@ func generateEnvVars(port int, commonEnv []corev1.EnvVar) []corev1.EnvVar {
 func commandForProcess(process *korifiv1alpha1.CFProcess, app *korifiv1alpha1.CFApp) []string {
 	cmd := process.Spec.Command
 	if cmd == "" {
-		cmd = process.Spec.DropletCommand
+		cmd = process.Spec.DetectedCommand
 	}
 	if cmd == "" {
 		return []string{}

--- a/controllers/controllers/workloads/cfprocess_controller_test.go
+++ b/controllers/controllers/workloads/cfprocess_controller_test.go
@@ -69,7 +69,7 @@ var _ = Describe("CFProcessReconciler Unit Tests", func() {
 		cfBuild = BuildCFBuildObject(testBuildGUID, testNamespace, testPackageGUID, testAppGUID)
 		UpdateCFBuildWithDropletStatus(cfBuild)
 		cfBuildError = nil
-		cfProcess = BuildCFProcessCRObject(testProcessGUID, testNamespace, testAppGUID, testProcessType, testProcessCommand)
+		cfProcess = BuildCFProcessCRObject(testProcessGUID, testNamespace, testAppGUID, testProcessType, testProcessCommand, "")
 		cfProcessError = nil
 
 		appWorkload = nil

--- a/controllers/controllers/workloads/integration/cfapp_controller_integration_test.go
+++ b/controllers/controllers/workloads/integration/cfapp_controller_integration_test.go
@@ -269,7 +269,7 @@ var _ = Describe("CFAppReconciler Integration Tests", func() {
 						return cfProcessList.Items
 					}).Should(HaveLen(1), "expected CFProcess to eventually be created")
 					createdCFProcess := cfProcessList.Items[0]
-					Expect(createdCFProcess.Spec.DropletCommand).To(Equal(process.Command), "cfprocess command does not match with droplet command")
+					Expect(createdCFProcess.Spec.DetectedCommand).To(Equal(process.Command), "cfprocess command does not match with droplet command")
 					Expect(createdCFProcess.Spec.AppRef.Name).To(Equal(cfAppGUID), "cfprocess app ref does not match app-guid")
 					Expect(createdCFProcess.Spec.Ports).To(Equal(droplet.Ports), "cfprocess ports does not match ports on droplet")
 
@@ -370,10 +370,10 @@ var _ = Describe("CFAppReconciler Integration Tests", func() {
 				})
 			})
 
-			It("sets the dropletCommand on the web process to the droplet value for the web process if empty", func() {
+			It("sets the detectedCommand on the web process to the droplet value for the web process if empty", func() {
 				Eventually(func(g Gomega) {
 					proc := findProcessWithType(cfApp, processTypeWeb)
-					g.Expect(proc.Spec.DropletCommand).To(Equal(processTypeWebCommand))
+					g.Expect(proc.Spec.DetectedCommand).To(Equal(processTypeWebCommand))
 				}).Should(Succeed())
 			})
 
@@ -384,10 +384,10 @@ var _ = Describe("CFAppReconciler Integration Tests", func() {
 					})).To(Succeed())
 				})
 
-				It("should save the dropletCommand but not change the command", func() {
+				It("should save the detectedCommand but not change the command", func() {
 					Eventually(func(g Gomega) {
 						proc := findProcessWithType(cfApp, processTypeWeb)
-						g.Expect(proc.Spec.DropletCommand).To(Equal(processTypeWebCommand))
+						g.Expect(proc.Spec.DetectedCommand).To(Equal(processTypeWebCommand))
 					}).Should(Succeed())
 					Consistently(func(g Gomega) {
 						proc := findProcessWithType(cfApp, processTypeWeb)
@@ -420,7 +420,7 @@ var _ = Describe("CFAppReconciler Integration Tests", func() {
 					webProcess := webProcessesList.Items[0]
 					Expect(webProcess.Spec.AppRef.Name).To(Equal(cfAppGUID))
 					Expect(webProcess.Spec.Command).To(Equal(""))
-					Expect(webProcess.Spec.DropletCommand).To(Equal(""))
+					Expect(webProcess.Spec.DetectedCommand).To(Equal(""))
 				})
 			})
 

--- a/controllers/controllers/workloads/integration/cfapp_controller_integration_test.go
+++ b/controllers/controllers/workloads/integration/cfapp_controller_integration_test.go
@@ -269,7 +269,7 @@ var _ = Describe("CFAppReconciler Integration Tests", func() {
 						return cfProcessList.Items
 					}).Should(HaveLen(1), "expected CFProcess to eventually be created")
 					createdCFProcess := cfProcessList.Items[0]
-					Expect(createdCFProcess.Spec.Command).To(Equal(process.Command), "cfprocess command does not match with droplet command")
+					Expect(createdCFProcess.Spec.DropletCommand).To(Equal(process.Command), "cfprocess command does not match with droplet command")
 					Expect(createdCFProcess.Spec.AppRef.Name).To(Equal(cfAppGUID), "cfprocess app ref does not match app-guid")
 					Expect(createdCFProcess.Spec.Ports).To(Equal(droplet.Ports), "cfprocess ports does not match ports on droplet")
 
@@ -359,7 +359,7 @@ var _ = Describe("CFAppReconciler Integration Tests", func() {
 			BeforeEach(func() {
 				beforeCtx := context.Background()
 				cfProcessForTypeWebGUID = GenerateGUID()
-				cfProcessForTypeWeb = BuildCFProcessCRObject(cfProcessForTypeWebGUID, namespaceGUID, cfAppGUID, processTypeWeb, processTypeWebCommand)
+				cfProcessForTypeWeb = BuildCFProcessCRObject(cfProcessForTypeWebGUID, namespaceGUID, cfAppGUID, processTypeWeb, processTypeWebCommand, "")
 				cfProcessForTypeWeb.Spec.Command = ""
 				Expect(k8sClient.Create(beforeCtx, cfProcessForTypeWeb)).To(Succeed())
 			})
@@ -370,10 +370,10 @@ var _ = Describe("CFAppReconciler Integration Tests", func() {
 				})
 			})
 
-			It("sets the command on the web process to the droplet value for the web process if empty", func() {
+			It("sets the dropletCommand on the web process to the droplet value for the web process if empty", func() {
 				Eventually(func(g Gomega) {
 					proc := findProcessWithType(cfApp, processTypeWeb)
-					g.Expect(proc.Spec.Command).To(Equal(processTypeWebCommand))
+					g.Expect(proc.Spec.DropletCommand).To(Equal(processTypeWebCommand))
 				}).Should(Succeed())
 			})
 
@@ -384,7 +384,11 @@ var _ = Describe("CFAppReconciler Integration Tests", func() {
 					})).To(Succeed())
 				})
 
-				It("should not change the command", func() {
+				It("should save the dropletCommand but not change the command", func() {
+					Eventually(func(g Gomega) {
+						proc := findProcessWithType(cfApp, processTypeWeb)
+						g.Expect(proc.Spec.DropletCommand).To(Equal(processTypeWebCommand))
+					}).Should(Succeed())
 					Consistently(func(g Gomega) {
 						proc := findProcessWithType(cfApp, processTypeWeb)
 						Expect(proc.Spec.Command).To(Equal("something else"))
@@ -416,6 +420,7 @@ var _ = Describe("CFAppReconciler Integration Tests", func() {
 					webProcess := webProcessesList.Items[0]
 					Expect(webProcess.Spec.AppRef.Name).To(Equal(cfAppGUID))
 					Expect(webProcess.Spec.Command).To(Equal(""))
+					Expect(webProcess.Spec.DropletCommand).To(Equal(""))
 				})
 			})
 
@@ -423,7 +428,7 @@ var _ = Describe("CFAppReconciler Integration Tests", func() {
 				var existingWebProcess *korifiv1alpha1.CFProcess
 
 				BeforeEach(func() {
-					existingWebProcess = BuildCFProcessCRObject(GenerateGUID(), namespaceGUID, cfAppGUID, processTypeWeb, processTypeWebCommand)
+					existingWebProcess = BuildCFProcessCRObject(GenerateGUID(), namespaceGUID, cfAppGUID, processTypeWeb, processTypeWebCommand, "")
 					Expect(
 						k8sClient.Create(context.Background(), existingWebProcess),
 					).To(Succeed())

--- a/controllers/controllers/workloads/testutils/shared_test_utils.go
+++ b/controllers/controllers/workloads/testutils/shared_test_utils.go
@@ -198,7 +198,7 @@ func BuildServiceAccount(name, namespace, imagePullSecretName string) *corev1.Se
 	}
 }
 
-func BuildCFProcessCRObject(cfProcessGUID, namespace, cfAppGUID, processType, processCommand, processDropletCommand string) *korifiv1alpha1.CFProcess {
+func BuildCFProcessCRObject(cfProcessGUID, namespace, cfAppGUID, processType, processCommand, processDetectedCommand string) *korifiv1alpha1.CFProcess {
 	return &korifiv1alpha1.CFProcess{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cfProcessGUID,
@@ -210,10 +210,10 @@ func BuildCFProcessCRObject(cfProcessGUID, namespace, cfAppGUID, processType, pr
 			},
 		},
 		Spec: korifiv1alpha1.CFProcessSpec{
-			AppRef:         corev1.LocalObjectReference{Name: cfAppGUID},
-			ProcessType:    processType,
-			Command:        processCommand,
-			DropletCommand: processDropletCommand,
+			AppRef:          corev1.LocalObjectReference{Name: cfAppGUID},
+			ProcessType:     processType,
+			Command:         processCommand,
+			DetectedCommand: processDetectedCommand,
 			HealthCheck: korifiv1alpha1.HealthCheck{
 				Type: "process",
 				Data: korifiv1alpha1.HealthCheckData{

--- a/controllers/controllers/workloads/testutils/shared_test_utils.go
+++ b/controllers/controllers/workloads/testutils/shared_test_utils.go
@@ -198,7 +198,7 @@ func BuildServiceAccount(name, namespace, imagePullSecretName string) *corev1.Se
 	}
 }
 
-func BuildCFProcessCRObject(cfProcessGUID string, namespace string, cfAppGUID string, processType string, processCommand string) *korifiv1alpha1.CFProcess {
+func BuildCFProcessCRObject(cfProcessGUID, namespace, cfAppGUID, processType, processCommand, processDropletCommand string) *korifiv1alpha1.CFProcess {
 	return &korifiv1alpha1.CFProcess{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cfProcessGUID,
@@ -210,9 +210,10 @@ func BuildCFProcessCRObject(cfProcessGUID string, namespace string, cfAppGUID st
 			},
 		},
 		Spec: korifiv1alpha1.CFProcessSpec{
-			AppRef:      corev1.LocalObjectReference{Name: cfAppGUID},
-			ProcessType: processType,
-			Command:     processCommand,
+			AppRef:         corev1.LocalObjectReference{Name: cfAppGUID},
+			ProcessType:    processType,
+			Command:        processCommand,
+			DropletCommand: processDropletCommand,
 			HealthCheck: korifiv1alpha1.HealthCheck{
 				Type: "process",
 				Data: korifiv1alpha1.HealthCheckData{

--- a/helm/controllers/templates/crds/korifi.cloudfoundry.org_cfprocesses.yaml
+++ b/helm/controllers/templates/crds/korifi.cloudfoundry.org_cfprocesses.yaml
@@ -52,14 +52,14 @@ spec:
               desiredInstances:
                 description: The desired number of replicas to deploy
                 type: integer
+              detectedCommand:
+                description: The default command for this process as defined by the
+                  build. This field is ignored when the Command field is set
+                type: string
               diskQuotaMB:
                 description: The disk limit in MiB
                 format: int64
                 type: integer
-              dropletCommand:
-                description: The default command for this process as defined by the
-                  build. This field is ignored when the Command field is set
-                type: string
               healthCheck:
                 description: Used to build the Liveness and Readiness Probes for the
                   process' AppWorkload.

--- a/helm/controllers/templates/crds/korifi.cloudfoundry.org_cfprocesses.yaml
+++ b/helm/controllers/templates/crds/korifi.cloudfoundry.org_cfprocesses.yaml
@@ -56,6 +56,10 @@ spec:
                 description: The disk limit in MiB
                 format: int64
                 type: integer
+              dropletCommand:
+                description: The default command for this process as defined by the
+                  build. This field is ignored when the Command field is set
+                type: string
               healthCheck:
                 description: Used to build the Liveness and Readiness Probes for the
                   process' AppWorkload.


### PR DESCRIPTION
## Is there a related GitHub Issue?
[#1869]

## What is this change about?
- Prior to this change, when an app was re-pushed with source that caused the `command` to change for a CFProcess, we'd ignore the change.
- For example pushing a node app, and then pushing java code to the same app name would leave the `node` start command, which would then fail.
- This commit adds a separate `dropletCommand` field to store the command from the built image. If no `command` is explicitly set on the process, the `dropletCommand` is used.
- For apps that explictly set a `command` for the process (for example in a manifest) the `command` overrides the droplet command.

![image](https://user-images.githubusercontent.com/8484092/201227183-f8fdae01-9d7f-4c50-8638-80fc8f7da0e9.png)

## Does this PR introduce a breaking change?
No

## Acceptance Steps
[#1869]

## Tag your pair, your PM, and/or team
@tcdowney PTAL. I'm especially open to different suggestions for the field name `dropletCommand`