### PR TITLE
Fix duplicate app log lines

### DIFF
--- a/api/repositories/pod_repository.go
+++ b/api/repositories/pod_repository.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"strconv"
+	"strings"
 	"time"
 
 	"code.cloudfoundry.org/korifi/api/apierrors"
@@ -397,6 +398,9 @@ func lineToAppLogRecord(line []byte) LogRecord {
 	logLine := string(line)
 	var logTime int64
 	logLine, logTime, _ = parseRFC3339NanoTime(logLine)
+
+	// trim trailing newlines so that the CLI doesn't render extra log lines for them
+	logLine = strings.TrimRight(logLine, "\r\n")
 
 	logRecord := LogRecord{
 		Message:   logLine,


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
[#1902]<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
- log lines for app logs were getting returned with a trailing newline for each log line.
- As a result, the CLI would render a blank line after each line of output.
- this commit trims off newlines from the log output to keep that from happening.

<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No. <!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
[#1902]<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@acosta11 <!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->
