### PR TITLE
Change ginkgo slow-spec-threshold to poll-progress-after

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -35,7 +35,7 @@ if ! grep -q e2e <(echo "$@"); then
     source <(setup-envtest use -p env --bin-dir "${ENVTEST_ASSETS_DIR}")
   fi
 
-  extra_args+=("--skip-package=e2e" "--coverprofile=cover.out" "--coverpkg=code.cloudfoundry.org/korifi/...")
+  extra_args+=("--poll-progress-after=60s" "--skip-package=e2e" "--coverprofile=cover.out" "--coverpkg=code.cloudfoundry.org/korifi/...")
 else
   export ROOT_NAMESPACE="${ROOT_NAMESPACE:-cf}"
   export APP_FQDN="${APP_FQDN:-vcap.me}"
@@ -49,7 +49,7 @@ else
   # creates user keys/certs and service accounts and exports vars for them
   source "$SCRIPT_DIR/account-creation.sh" "${SCRIPT_DIR}"
 
-  extra_args+=("--slow-spec-threshold=30s")
+  extra_args+=("--poll-progress-after=3m30s")
 
   echo "waiting for ClusterBuilder to be ready..."
   kubectl wait --for=condition=ready clusterbuilder --all=true --timeout=15m


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
--slow-spec-threshold is deprecated, so take the recommendation and use --poll-progress-after. This prints a stack trace if a test takes a long time, so we can see what it's up to.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
No ginkgo deprecation warnings when running tests

## Tag your pair, your PM, and/or team
@kieron-dev

