### PR TITLE
support process metadata patching

### DIFF
--- a/api/payloads/process.go
+++ b/api/payloads/process.go
@@ -11,8 +11,9 @@ type ProcessScale struct {
 }
 
 type ProcessPatch struct {
-	Command     *string      `json:"command"`
-	HealthCheck *HealthCheck `json:"health_check"`
+	Metadata    *MetadataPatch `json:"metadata"`
+	Command     *string        `json:"command"`
+	HealthCheck *HealthCheck   `json:"health_check"`
 }
 
 type HealthCheck struct {
@@ -62,6 +63,13 @@ func (p ProcessPatch) ToProcessPatchMessage(processGUID, spaceGUID string) repos
 			message.HealthCheckHTTPEndpoint = p.HealthCheck.Data.Endpoint
 			message.HealthCheckTimeoutSeconds = p.HealthCheck.Data.Timeout
 			message.HealthCheckInvocationTimeoutSeconds = p.HealthCheck.Data.InvocationTimeout
+		}
+	}
+
+	if p.Metadata != nil {
+		message.MetadataPatch = &repositories.MetadataPatch{
+			Annotations: p.Metadata.Annotations,
+			Labels:      p.Metadata.Labels,
 		}
 	}
 

--- a/api/repositories/process_repository_test.go
+++ b/api/repositories/process_repository_test.go
@@ -435,7 +435,7 @@ var _ = Describe("ProcessRepo", func() {
 							TimeoutSeconds:           0,
 						},
 					}),
-					"Labels":      BeEmpty(),
+					"Labels":      HaveKeyWithValue("korifi.cloudfoundry.org/app-guid", app1GUID),
 					"Annotations": BeEmpty(),
 					"CreatedAt":   Not(BeEmpty()),
 					"UpdatedAt":   Not(BeEmpty()),
@@ -522,6 +522,7 @@ var _ = Describe("ProcessRepo", func() {
 
 				When("all fields are set", func() {
 					BeforeEach(func() {
+						barValue := "bar"
 						message = repositories.PatchProcessMessage{
 							ProcessGUID:                         process1GUID,
 							SpaceGUID:                           space.Name,
@@ -533,6 +534,10 @@ var _ = Describe("ProcessRepo", func() {
 							DesiredInstances:                    tools.PtrTo(42),
 							MemoryMB:                            tools.PtrTo(int64(456)),
 							DiskQuotaMB:                         tools.PtrTo(int64(123)),
+							MetadataPatch: &repositories.MetadataPatch{
+								Labels:      map[string]*string{"foo": &barValue},
+								Annotations: map[string]*string{"foo": &barValue},
+							},
 						}
 					})
 
@@ -549,6 +554,8 @@ var _ = Describe("ProcessRepo", func() {
 						Expect(updatedProcessRecord.DesiredInstances).To(Equal(*message.DesiredInstances))
 						Expect(updatedProcessRecord.MemoryMB).To(Equal(*message.MemoryMB))
 						Expect(updatedProcessRecord.DiskQuotaMB).To(Equal(*message.DiskQuotaMB))
+						Expect(updatedProcessRecord.Labels).To(HaveKey("foo"))
+						Expect(updatedProcessRecord.Annotations).To(HaveKey("foo"))
 
 						var process korifiv1alpha1.CFProcess
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Name: process1GUID, Namespace: space.Name}, &process)).To(Succeed())
@@ -569,6 +576,8 @@ var _ = Describe("ProcessRepo", func() {
 							DiskQuotaMB:      123,
 							Ports:            []int32{8080},
 						}))
+						Expect(process.Labels).To(HaveKey("foo"))
+						Expect(process.Annotations).To(HaveKey("foo"))
 					})
 				})
 

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -230,6 +230,15 @@ type processResource struct {
 	Instances int    `json:"instances"`
 }
 
+type metadataPatch struct {
+	Annotations *map[string]string `json:"annotations,omitempty"`
+	Labels      *map[string]string `json:"labels,omitempty"`
+}
+
+type metadataResource struct {
+	Metadata *metadataPatch `json:"metadata,omitempty"`
+}
+
 type cfErr struct {
 	Detail string `json:"detail"`
 	Title  string `json:"title"`


### PR DESCRIPTION
## Is there a related GitHub Issue?
[#1444]

## What is this change about?
- Add new optional `metadata` field to /v3/processes/<GUID> PATCH requests.
- plumb metadata down to the repository layer and set labels and annotations on the underlying CFProcess object.

## Does this PR introduce a breaking change?
no

## Acceptance Steps
[#1444]

## Tag your pair, your PM, and/or team
I was soloing on this. Anyone feel free to take a look.
