### PR TITLE
Fix finalizer persistence race

### DIFF
--- a/tools/k8s/finalizer.go
+++ b/tools/k8s/finalizer.go
@@ -1,0 +1,26 @@
+package k8s
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+func AddFinalizer[T any, PT ObjectWithDeepCopy[T]](
+	ctx context.Context,
+	log logr.Logger,
+	k8sClient client.Client,
+	obj PT,
+	finalizerName string,
+) error {
+	origObj := PT(obj.DeepCopy())
+	if controllerutil.AddFinalizer(obj, finalizerName) {
+		return k8sClient.Patch(ctx, obj, client.MergeFrom(origObj))
+	}
+
+	log.Info("Finalizer added")
+
+	return nil
+}

--- a/tools/k8s/finalizer_test.go
+++ b/tools/k8s/finalizer_test.go
@@ -1,0 +1,57 @@
+package k8s_test
+
+import (
+	"context"
+
+	"code.cloudfoundry.org/korifi/tools/k8s"
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("AddFinalizer", func() {
+	var (
+		log    logr.Logger
+		secret *corev1.Secret
+		ctx    context.Context
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		log = logr.New(logr.Discard().GetSink())
+		secret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-secret", Namespace: testNamespace.Name},
+			StringData: map[string]string{"foo": "bar"},
+		}
+		Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+	})
+
+	JustBeforeEach(func() {
+		Expect(k8s.AddFinalizer(ctx, log, k8sClient, secret, "foo.com/bar")).To(Succeed())
+	})
+
+	It("has the finalizer set", func() {
+		Eventually(func(g Gomega) {
+			var fetchedSecret corev1.Secret
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(secret), &fetchedSecret)).To(Succeed())
+			g.Expect(fetchedSecret.Finalizers).To(ConsistOf("foo.com/bar"))
+		}).Should(Succeed())
+	})
+
+	When("adding the same finalizer again", func() {
+		BeforeEach(func() {
+			Expect(k8s.AddFinalizer(ctx, log, k8sClient, secret, "foo.com/bar")).To(Succeed())
+		})
+
+		It("still has the finalizer set", func() {
+			Consistently(func(g Gomega) {
+				var fetchedSecret corev1.Secret
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(secret), &fetchedSecret)).To(Succeed())
+				g.Expect(fetchedSecret.Finalizers).To(ConsistOf("foo.com/bar"))
+			}).Should(Succeed())
+		})
+	})
+})


### PR DESCRIPTION
## Is there a related GitHub Issue?

#1930

## What is this change about?

Commit immediately after setting finalizer in controllers

There is a potential race when deleting a resource with a finalizer
when the finalizer is not immediately persisted. E.g. for a CFSpace:

1. Create the CFSpace
2. Wait for namespace to appear
3. Delete the CFSpace.

However, the reconciler could well be in the code between creating that
namespace and propagating service accounts / secrets, and nothing has
yet been saved.

When the big 'patch' call finally occurs, the CFSpace has already been
deleted, since it didn't actually have a saved finalizer on it.

All resources created by the reconciliation are now orphaned and will
not be cleaned up.

(We also tidied up logs in the touched files)

## Does this PR introduce a breaking change?

No

## Acceptance Steps

We stop seeing flakes saying 'Eventually deletes the namespace'

## Tag your pair, your PM, and/or team

@kieron-dev

## Things to remember

<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
