### PR TITLE
Allow switching cluster stack build and run images

### DIFF
--- a/README.helm.md
+++ b/README.helm.md
@@ -68,6 +68,8 @@ Here are all the values that can be set for the chart:
   - `image` (_String_): Reference to the `kpack-image-builder` container image.
   - `dropletRepositoryPrefix` (_String_): Prefix of the container image repository where droplets will be stored. For DockerHub, this should be `index.docker.io/<username>`.
   - `clusterBuilderName` (_String_): The name of the `ClusterBuilder` Kpack has been configured with. Leave blank to let `kpack-image-builder` create an example `ClusterBuilder`.
+  - `clusterStackBuildImage` (_String_): The image to use for building defined in the `ClusterStack`. Used when `kpack-image-builder` is blank.
+  - `clusterStackRunImage` (_String_): The image to use for running defined in the `ClusterStack`. Used when `kpack-image-builder` is blank.
   - `builderRepository` (_String_): Container image repository to store the `ClusterBuilder` image. Required when `clusterBuilderName` is not provided.
 * `statefulset-runner`:
   - `include` (_Boolean_): Deploy the `statefulset-runner` component.

--- a/helm/kpack-image-builder/templates/cluster-builder.yaml
+++ b/helm/kpack-image-builder/templates/cluster-builder.yaml
@@ -19,9 +19,9 @@ metadata:
 spec:
   id: "io.buildpacks.stacks.bionic"
   buildImage:
-    image: "paketobuildpacks/build:full-cnb"
+    image: {{ .Values.clusterStackBuildImage | quote }}
   runImage:
-    image: "paketobuildpacks/run:full-cnb"
+    image: {{ .Values.clusterStackRunImage | quote }}
 
 ---
 apiVersion: kpack.io/v1alpha2

--- a/helm/kpack-image-builder/values.schema.json
+++ b/helm/kpack-image-builder/values.schema.json
@@ -74,6 +74,14 @@
       "description": "If blank, let korifi create a default cluster builder. If not blank, this is the name of the cluster builder that has been created outside of korifi",
       "type": "string"
     },
+    "clusterStackBuildImage": {
+      "description": "build image",
+      "type": "string"
+    },
+    "clusterStackRunImage": {
+      "description": "run image",
+      "type": "string"
+    },
     "builderRepository": {
       "description": "The name to use for the cluster builder docker image path when korifi is creating the cluster builder",
       "type": "string"

--- a/helm/kpack-image-builder/values.yaml
+++ b/helm/kpack-image-builder/values.yaml
@@ -17,4 +17,6 @@ image: cloudfoundry/korifi-kpack-image-builder:latest
 
 dropletRepositoryPrefix:
 clusterBuilderName:
+clusterStackBuildImage: paketobuildpacks/build:full-cnb
+clusterStackRunImage: paketobuildpacks/run:full-cnb
 builderRepository:

--- a/scripts/assets/values-template.yaml
+++ b/scripts/assets/values-template.yaml
@@ -22,6 +22,8 @@ kpack-image-builder:
   image: cloudfoundry/korifi-kpack-image-builder:latest
   dropletRepositoryPrefix: localregistry-docker-registry.default.svc.cluster.local:30050/droplets
   builderRepository: localregistry-docker-registry.default.svc.cluster.local:30050/kpack-builder
+  clusterStackBuildImage: paketobuildpacks/build:base-cnb
+  clusterStackRunImage: paketobuildpacks/run:base-cnb
 
 statefulset-runner:
   image: cloudfoundry/korifi-statefulset-runner:latest


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
The full-cnb stack is expensive for image creation. Allow changing this to base-cnb in the helm chart.

Default to the existing values.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
`make test e2e` still works, as does all CI

## Tag your pair, your PM, and/or team
@kieron-dev

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
