### PR TITLE
Use configured dropletRepository as given

### DIFF
--- a/INSTALL.kind.md
+++ b/INSTALL.kind.md
@@ -56,7 +56,7 @@ No changes here. If using DockerHub as recommended above, set the following valu
 
 -   `api.packageRepository`: `index.docker.io/<username>/packages`;
 -   `kpack-image-builder.builderRepository`: `index.docker.io/<username>/kpack-builder`;
--   `kpack-image-builder.dropletRepositoryPrefix`: `index.docker.io/<username>`.
+-   `kpack-image-builder.dropletRepository`: `index.docker.io/<username>/droplets`.
 
 If `$KORIFI_NAMESPACE` doesn't exist yet, you can add the `--create-namespace` flag to the `helm` invocation.
 

--- a/INSTALL.kind.md
+++ b/INSTALL.kind.md
@@ -54,7 +54,7 @@ No changes here. For the container registry credentials `Secret`, we recommend y
 
 No changes here. If using DockerHub as recommended above, set the following values:
 
--   `api.packageRepositoryPrefix`: `index.docker.io/<username>`;
+-   `api.packageRepository`: `index.docker.io/<username>/packages`;
 -   `kpack-image-builder.builderRepository`: `index.docker.io/<username>/kpack-builder`;
 -   `kpack-image-builder.dropletRepositoryPrefix`: `index.docker.io/<username>`.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -126,7 +126,7 @@ helm install korifi https://github.com/cloudfoundry/korifi/releases/download/v<V
     --set=adminUserName="$ADMIN_USERNAME" \
     --set=api.apiServer.url="api.$BASE_DOMAIN" \
     --set=global.defaultAppDomainName="apps.$BASE_DOMAIN" \
-    --set=api.packageRepositoryPrefix=europe-west1-docker.pkg.dev/my-project/korifi/packages \
+    --set=api.packageRepository=europe-west1-docker.pkg.dev/my-project/korifi/packages \
     --set=kpack-image-builder.builderRepository=europe-west1-docker.pkg.dev/my-project/korifi/kpack-builder \
     --set=kpack-image-builder.dropletRepositoryPrefix=europe-west1-docker.pkg.dev/my-project/korifi/droplets
 ```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -128,7 +128,7 @@ helm install korifi https://github.com/cloudfoundry/korifi/releases/download/v<V
     --set=global.defaultAppDomainName="apps.$BASE_DOMAIN" \
     --set=api.packageRepository=europe-west1-docker.pkg.dev/my-project/korifi/packages \
     --set=kpack-image-builder.builderRepository=europe-west1-docker.pkg.dev/my-project/korifi/kpack-builder \
-    --set=kpack-image-builder.dropletRepositoryPrefix=europe-west1-docker.pkg.dev/my-project/korifi/droplets
+    --set=kpack-image-builder.dropletRepository=europe-west1-docker.pkg.dev/my-project/korifi/droplets
 ```
 
 The chart provides various other values that can be set. See [`README.helm.md`](./README.helm.md) for details.

--- a/README.helm.md
+++ b/README.helm.md
@@ -66,7 +66,7 @@ Here are all the values that can be set for the chart:
   - `replicas` (_Integer_): Number of replicas.
   - `resources` (_Object_): The [`ResourceRequirements`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#resourcerequirements-v1-core) for the `kpack-image-builder`.
   - `image` (_String_): Reference to the `kpack-image-builder` container image.
-  - `dropletRepositoryPrefix` (_String_): Prefix of the container image repository where droplets will be stored. For DockerHub, this should be `index.docker.io/<username>`.
+  - `dropletRepository` (_String_): The container image repository where droplets will be stored. For DockerHub, this might be `index.docker.io/<username>/droplets`.
   - `clusterBuilderName` (_String_): The name of the `ClusterBuilder` Kpack has been configured with. Leave blank to let `kpack-image-builder` create an example `ClusterBuilder`.
   - `clusterStackBuildImage` (_String_): The image to use for building defined in the `ClusterStack`. Used when `kpack-image-builder` is blank.
   - `clusterStackRunImage` (_String_): The image to use for running defined in the `ClusterStack`. Used when `kpack-image-builder` is blank.

--- a/README.helm.md
+++ b/README.helm.md
@@ -37,7 +37,7 @@ Here are all the values that can be set for the chart:
       - `memoryMB` (_Integer_)
       - `diskMB` (_Integer_)
   - `builderName` (_String_): ID of the builder used to build apps. Defaults to `kpack-image-builder`.
-  - `packageRepositoryPrefix` (_String_): Prefix of the container image repository where app source packages will be stored. For DockerHub, this should be `index.docker.io/<username>`.
+  - `packageRepository` (_String_): The container image repository where app source packages will be stored. For DockerHub, this might be `index.docker.io/<username>/packages`.
   - `userCertificateExpirationWarningDuration` (_String_): Issue a warning if the user certificate provided for login has a long expiry. See [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration) for details on the format.
   - `authProxy`: Needed if using a cluster authentication proxy, e.g. [Pinniped](https://pinniped.dev/).
     - `host` (_String_): Must be a host string, a host:port pair, or a URL to the base of the apiserver.

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -27,7 +27,7 @@ type APIConfig struct {
 
 	RootNamespace                            string                 `yaml:"rootNamespace"`
 	BuilderName                              string                 `yaml:"builderName"`
-	PackageRegistryBase                      string                 `yaml:"packageRegistryBase"`
+	PackageRepository                        string                 `yaml:"packageRepository"`
 	PackageRegistrySecretName                string                 `yaml:"packageRegistrySecretName"`
 	DefaultDomainName                        string                 `yaml:"defaultDomainName"`
 	UserCertificateExpirationWarningDuration string                 `yaml:"userCertificateExpirationWarningDuration"`

--- a/api/handlers/package_handler.go
+++ b/api/handlers/package_handler.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"path"
 
 	"code.cloudfoundry.org/korifi/api/apierrors"
 	"code.cloudfoundry.org/korifi/api/authorization"
@@ -53,7 +52,7 @@ type PackageHandler struct {
 	dropletRepo        CFDropletRepository
 	imageRepo          ImageRepository
 	requestValidator   RequestJSONValidator
-	registryBase       string
+	packageRepository  string
 	registrySecretName string
 }
 
@@ -64,7 +63,7 @@ func NewPackageHandler(
 	dropletRepo CFDropletRepository,
 	imageRepo ImageRepository,
 	requestValidator RequestJSONValidator,
-	registryBase string,
+	packageRepository string,
 	registrySecretName string,
 ) *PackageHandler {
 	return &PackageHandler{
@@ -74,7 +73,7 @@ func NewPackageHandler(
 		appRepo:            appRepo,
 		dropletRepo:        dropletRepo,
 		imageRepo:          imageRepo,
-		registryBase:       registryBase,
+		packageRepository:  packageRepository,
 		registrySecretName: registrySecretName,
 		requestValidator:   requestValidator,
 	}
@@ -175,8 +174,7 @@ func (h PackageHandler) packageUploadHandler(ctx context.Context, logger logr.Lo
 		return nil, apierrors.LogAndReturn(logger, apierrors.NewPackageBitsAlreadyUploadedError(err), "Error, cannot call package upload state was not AWAITING_UPLOAD", "packageGUID", packageGUID)
 	}
 
-	imageRef := path.Join(h.registryBase, packageGUID)
-	uploadedImageRef, err := h.imageRepo.UploadSourceImage(r.Context(), authInfo, imageRef, bitsFile, record.SpaceGUID)
+	uploadedImageRef, err := h.imageRepo.UploadSourceImage(r.Context(), authInfo, h.packageRepository, bitsFile, record.SpaceGUID)
 	if err != nil {
 		return nil, apierrors.LogAndReturn(logger, err, "Error calling uploadSourceImage")
 	}

--- a/api/handlers/package_handler_test.go
+++ b/api/handlers/package_handler_test.go
@@ -31,7 +31,7 @@ var _ = Describe("PackageHandler", func() {
 		dropletRepo                *fake.CFDropletRepository
 		imageRepo                  *fake.ImageRepository
 		requestJSONValidator       *fake.RequestJSONValidator
-		packageRegistryBase        string
+		packageRepository          string
 		packageImagePullSecretName string
 
 		packageGUID string
@@ -47,7 +47,7 @@ var _ = Describe("PackageHandler", func() {
 		dropletRepo = new(fake.CFDropletRepository)
 		imageRepo = new(fake.ImageRepository)
 		requestJSONValidator = new(fake.RequestJSONValidator)
-		packageRegistryBase = "some-org"
+		packageRepository = "some-org"
 		packageImagePullSecretName = "package-image-pull-secret"
 
 		packageGUID = generateGUID("package")
@@ -63,7 +63,7 @@ var _ = Describe("PackageHandler", func() {
 			dropletRepo,
 			imageRepo,
 			requestJSONValidator,
-			packageRegistryBase,
+			packageRepository,
 			packageImagePullSecretName,
 		)
 
@@ -864,7 +864,7 @@ var _ = Describe("PackageHandler", func() {
 			Expect(imageRepo.UploadSourceImageCallCount()).To(Equal(1))
 			_, actualAuthInfo, imageRef, srcFile, actualSpaceGUID := imageRepo.UploadSourceImageArgsForCall(0)
 			Expect(actualAuthInfo).To(Equal(authInfo))
-			Expect(imageRef).To(Equal(fmt.Sprintf("%s/%s", packageRegistryBase, packageGUID)))
+			Expect(imageRef).To(Equal(packageRepository))
 			actualSrcContents, err := io.ReadAll(srcFile)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(actualSrcContents)).To(Equal("the-src-file-contents"))

--- a/api/main.go
+++ b/api/main.go
@@ -216,7 +216,7 @@ func main() {
 			dropletRepo,
 			imageRepo,
 			decoderValidator,
-			config.PackageRegistryBase,
+			config.PackageRepository,
 			config.PackageRegistrySecretName,
 		),
 		handlers.NewBuildHandler(

--- a/helm/api/templates/configmap.yaml
+++ b/helm/api/templates/configmap.yaml
@@ -19,7 +19,7 @@ data:
       stack: {{ .Values.lifecycle.stack }}
       stagingMemoryMB: {{ .Values.lifecycle.stagingRequirements.memoryMB }}
       stagingDiskMB: {{ .Values.lifecycle.stagingRequirements.diskMB }}
-    packageRegistryBase: {{ .Values.packageRepositoryPrefix }}
+    packageRepository: {{ .Values.packageRepository }}
     packageRegistrySecretName: {{ .Values.global.containerRegistrySecret }}
     defaultDomainName: {{ .Values.global.defaultAppDomainName }}
     userCertificateExpirationWarningDuration: {{ .Values.userCertificateExpirationWarningDuration }}

--- a/helm/api/values.schema.json
+++ b/helm/api/values.schema.json
@@ -151,8 +151,8 @@
       "description": "name of the component to use for building droplets",
       "type": "string"
     },
-    "packageRepositoryPrefix": {
-      "description": "prefix of full path to docker image used to store package",
+    "packageRepository": {
+      "description": "Repository path in container registry used to store source package images",
       "type": "string"
     },
     "userCertificateExpirationWarningDuration": {
@@ -180,7 +180,7 @@
     "image",
     "lifecycle",
     "builderName",
-    "packageRepositoryPrefix",
+    "packageRepository",
     "userCertificateExpirationWarningDuration"
   ],
   "title": "Values",

--- a/helm/api/values.yaml
+++ b/helm/api/values.yaml
@@ -36,7 +36,7 @@ lifecycle:
     diskMB: 1024
 
 builderName: kpack-image-builder
-packageRepositoryPrefix:
+packageRepository:
 userCertificateExpirationWarningDuration: 168h
 
 authProxy:

--- a/helm/kpack-image-builder/templates/configmap.yaml
+++ b/helm/kpack-image-builder/templates/configmap.yaml
@@ -7,4 +7,4 @@ data:
   kpack_build_controllers_config.yaml: |
     cfRootNamespace: {{ .Values.global.rootNamespace }}
     clusterBuilderName: {{ default "cf-kpack-cluster-builder" .Values.clusterBuilderName }}
-    kpackImageTag: {{ .Values.dropletRepositoryPrefix }}
+    dropletRepository: {{ .Values.dropletRepository }}

--- a/helm/kpack-image-builder/values.schema.json
+++ b/helm/kpack-image-builder/values.schema.json
@@ -66,8 +66,8 @@
       "description": "docker image",
       "type": "string"
     },
-    "dropletRepositoryPrefix": {
-      "description": "prefix to the docker path used to store droplet images",
+    "dropletRepository": {
+      "description": "container repository used to store droplet images",
       "type": "string"
     },
     "clusterBuilderName": {
@@ -87,7 +87,7 @@
       "type": "string"
     }
   },
-  "required": ["global", "include", "image", "dropletRepositoryPrefix"],
+  "required": ["global", "include", "image", "dropletRepository"],
   "title": "Values",
   "type": "object"
 }

--- a/helm/kpack-image-builder/values.yaml
+++ b/helm/kpack-image-builder/values.yaml
@@ -15,7 +15,7 @@ resources:
 
 image: cloudfoundry/korifi-kpack-image-builder:latest
 
-dropletRepositoryPrefix:
+dropletRepository:
 clusterBuilderName:
 clusterStackBuildImage: paketobuildpacks/build:full-cnb
 clusterStackRunImage: paketobuildpacks/run:full-cnb

--- a/kpack-image-builder/config/config.go
+++ b/kpack-image-builder/config/config.go
@@ -11,7 +11,7 @@ import (
 
 type ControllerConfig struct {
 	CFRootNamespace    string `yaml:"cfRootNamespace"`
-	KpackImageTag      string `yaml:"kpackImageTag"`
+	DropletRepository  string `yaml:"dropletRepository"`
 	ClusterBuilderName string `yaml:"clusterBuilderName"`
 }
 

--- a/kpack-image-builder/controllers/buildworkload_controller.go
+++ b/kpack-image-builder/controllers/buildworkload_controller.go
@@ -26,7 +26,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"path"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"code.cloudfoundry.org/korifi/kpack-image-builder/config"
@@ -209,7 +208,6 @@ func (r *BuildWorkloadReconciler) ensureKpackImageRequirements(ctx context.Conte
 
 func (r *BuildWorkloadReconciler) createKpackImageAndUpdateStatus(ctx context.Context, buildWorkload *korifiv1alpha1.BuildWorkload) error {
 	serviceAccountName := kpackServiceAccount
-	kpackImageTag := path.Join(r.controllerConfig.KpackImageTag, buildWorkload.Name)
 	kpackImageName := buildWorkload.Name
 	kpackImageNamespace := buildWorkload.Namespace
 	desiredKpackImage := buildv1alpha2.Image{
@@ -221,7 +219,7 @@ func (r *BuildWorkloadReconciler) createKpackImageAndUpdateStatus(ctx context.Co
 			},
 		},
 		Spec: buildv1alpha2.ImageSpec{
-			Tag: kpackImageTag,
+			Tag: r.controllerConfig.DropletRepository,
 			Builder: corev1.ObjectReference{
 				Kind:       clusterBuilderKind,
 				Name:       r.controllerConfig.ClusterBuilderName,

--- a/kpack-image-builder/controllers/suite_test.go
+++ b/kpack-image-builder/controllers/suite_test.go
@@ -113,7 +113,7 @@ var _ = BeforeSuite(func() {
 	controllerConfig := &config.ControllerConfig{
 		CFRootNamespace:    PrefixedGUID("cf"),
 		ClusterBuilderName: "cf-kpack-builder",
-		KpackImageTag:      "image/registry/tag",
+		DropletRepository:  "image/registry/tag",
 	}
 
 	registryAuthFetcherClient, err := k8sclient.NewForConfig(cfg)

--- a/scripts/assets/values-template.yaml
+++ b/scripts/assets/values-template.yaml
@@ -8,7 +8,7 @@ api:
   apiServer:
     url: localhost
   image: cloudfoundry/korifi-api:latest
-  packageRepositoryPrefix: localregistry-docker-registry.default.svc.cluster.local:30050/sources
+  packageRepository: localregistry-docker-registry.default.svc.cluster.local:30050/packages
 
 controllers:
   taskTTL: 5s

--- a/scripts/assets/values-template.yaml
+++ b/scripts/assets/values-template.yaml
@@ -20,7 +20,7 @@ job-task-runner:
 
 kpack-image-builder:
   image: cloudfoundry/korifi-kpack-image-builder:latest
-  dropletRepositoryPrefix: localregistry-docker-registry.default.svc.cluster.local:30050/droplets
+  dropletRepository: localregistry-docker-registry.default.svc.cluster.local:30050/droplets
   builderRepository: localregistry-docker-registry.default.svc.cluster.local:30050/kpack-builder
   clusterStackBuildImage: paketobuildpacks/build:base-cnb
   clusterStackRunImage: paketobuildpacks/run:base-cnb

--- a/scripts/deploy-on-kind.sh
+++ b/scripts/deploy-on-kind.sh
@@ -17,7 +17,7 @@ flags:
       - DOCKER_SERVER
       - DOCKER_USERNAME
       - DOCKER_PASSWORD
-      - PACKAGE_REPOSITORY_PREFIX
+      - PACKAGE_REPOSITORY
       - DROPLET_REPOSITORY_PREFIX
       - KPACK_BUILDER_REPOSITORY
 
@@ -47,7 +47,7 @@ while [[ $# -gt 0 ]]; do
     -r | --use-custom-registry)
       use_custom_registry="true"
       # blow up if required vars not set
-      echo "$DOCKER_SERVER $DOCKER_USERNAME $DOCKER_PASSWORD $PACKAGE_REPOSITORY_PREFIX $DROPLET_REPOSITORY_PREFIX $KPACK_BUILDER_REPOSITORY" >/dev/null
+      echo "$DOCKER_SERVER $DOCKER_USERNAME $DOCKER_PASSWORD $PACKAGE_REPOSITORY $DROPLET_REPOSITORY_PREFIX $KPACK_BUILDER_REPOSITORY" >/dev/null
       shift
       ;;
     -D | --debug)
@@ -148,7 +148,7 @@ function deploy_korifi() {
         --create-namespace \
         --values=scripts/assets/values.yaml \
         --set=global.debug="$doDebug" \
-        --set=api.packageRepositoryPrefix="$PACKAGE_REPOSITORY_PREFIX" \
+        --set=api.packageRepository="$PACKAGE_REPOSITORY" \
         --set=kpack-image-builder.dropletRepositoryPrefix="$DROPLET_REPOSITORY_PREFIX" \
         --set=kpack-image-builder.builderRepository="$KPACK_BUILDER_REPOSITORY" \
         --wait

--- a/scripts/deploy-on-kind.sh
+++ b/scripts/deploy-on-kind.sh
@@ -18,7 +18,7 @@ flags:
       - DOCKER_USERNAME
       - DOCKER_PASSWORD
       - PACKAGE_REPOSITORY
-      - DROPLET_REPOSITORY_PREFIX
+      - DROPLET_REPOSITORY
       - KPACK_BUILDER_REPOSITORY
 
   -v, --verbose
@@ -47,7 +47,7 @@ while [[ $# -gt 0 ]]; do
     -r | --use-custom-registry)
       use_custom_registry="true"
       # blow up if required vars not set
-      echo "$DOCKER_SERVER $DOCKER_USERNAME $DOCKER_PASSWORD $PACKAGE_REPOSITORY $DROPLET_REPOSITORY_PREFIX $KPACK_BUILDER_REPOSITORY" >/dev/null
+      echo "$DOCKER_SERVER $DOCKER_USERNAME $DOCKER_PASSWORD $PACKAGE_REPOSITORY $DROPLET_REPOSITORY $KPACK_BUILDER_REPOSITORY" >/dev/null
       shift
       ;;
     -D | --debug)
@@ -149,7 +149,7 @@ function deploy_korifi() {
         --values=scripts/assets/values.yaml \
         --set=global.debug="$doDebug" \
         --set=api.packageRepository="$PACKAGE_REPOSITORY" \
-        --set=kpack-image-builder.dropletRepositoryPrefix="$DROPLET_REPOSITORY_PREFIX" \
+        --set=kpack-image-builder.dropletRepository="$DROPLET_REPOSITORY" \
         --set=kpack-image-builder.builderRepository="$KPACK_BUILDER_REPOSITORY" \
         --wait
     else


### PR DESCRIPTION
## Is there a related GitHub Issue?
#1914

## What is this change about?
Do not append a suffix, as this means we cannot support registries which disallow dynamic repository creation on push (e.g. ECR).

Rename some config values to make this clear to operators:

- Helm value in kpack-image-builder:
  - `dropletRepositoryPrefix` --> `dropletRepository`
- kpack-image-builder config map property
  - `kpackImageTag` --> `dropletRepository`

Finally, update docs.

## Does this PR introduce a breaking change?
Yes. Korifi packagers and users should note the two renames above.

## Acceptance Steps
1. Deploy korifi successfully using the new helm value in the kpack-image-builder chart.
2. Successfully push an app.

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
