### PR TITLE
Pre-delete helm hook service account permission fix

### DIFF
--- a/helm/kpack-image-builder/templates/pre-delete-builderinfo.yaml
+++ b/helm/kpack-image-builder/templates/pre-delete-builderinfo.yaml
@@ -65,6 +65,12 @@ metadata:
     helm.sh/hook-weight: "-10"
 rules:
 - apiGroups:
+  - "apiextensions.k8s.io"
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+- apiGroups:
   - "korifi.cloudfoundry.org"
   resources:
   - builderinfos


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
In the pre-delete helm hook to delete the builder info, we check the builder info CRD exists. This adds permission to get CRDs so that the check doesn't always fail.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
See the builder info is deleted when you `helm delete` korifi

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
