### PR TITLE
Rename helm packageRegistrySecret to containerRegistrySecret

### DIFF
--- a/README.helm.md
+++ b/README.helm.md
@@ -15,7 +15,7 @@ Here are all the values that can be set for the chart:
   - `debug` (_Boolean_): Enables remote debugging with [Delve](https://github.com/go-delve/delve).
   - `defaultAppDomainName` (_String_): Base domain name for application URLs.
   - `generateIngressCertificates` (_Boolean_): Use `cert-manager` to generate self-signed certificates for the API and app endpoints.
-  - `packageRegistrySecret` (_String_): Name of the `Secret` to use when pushing source and droplet images to the container registry.
+  - `containerRegistrySecret` (_String_): Name of the `Secret` to use when pushing or pulling from package, droplet and kpack-build repositories
 * `api`:
   - `include` (_Boolean_): Deploy the API component.
   - `replicas` (_Integer_): Number of replicas.

--- a/helm/api/templates/configmap.yaml
+++ b/helm/api/templates/configmap.yaml
@@ -20,7 +20,7 @@ data:
       stagingMemoryMB: {{ .Values.lifecycle.stagingRequirements.memoryMB }}
       stagingDiskMB: {{ .Values.lifecycle.stagingRequirements.diskMB }}
     packageRegistryBase: {{ .Values.packageRepositoryPrefix }}
-    packageRegistrySecretName: {{ .Values.global.packageRegistrySecret }}
+    packageRegistrySecretName: {{ .Values.global.containerRegistrySecret }}
     defaultDomainName: {{ .Values.global.defaultAppDomainName }}
     userCertificateExpirationWarningDuration: {{ .Values.userCertificateExpirationWarningDuration }}
     {{- if .Values.authProxy }}

--- a/helm/api/values.schema.json
+++ b/helm/api/values.schema.json
@@ -20,15 +20,15 @@
           "description": "create self-signed certificates for ingress using cert-manager",
           "type": "boolean"
         },
-        "packageRegistrySecret": {
-          "description": "name of the secret containing credentials to access the package registry",
+        "containerRegistrySecret": {
+          "description": "name of the secret containing credentials to access the container registry",
           "type": "string"
         }
       },
       "required": [
         "rootNamespace",
         "defaultAppDomainName",
-        "packageRegistrySecret"
+        "containerRegistrySecret"
       ],
       "type": "object"
     },

--- a/helm/api/values.yaml
+++ b/helm/api/values.yaml
@@ -3,7 +3,7 @@ global:
   debug: false
   defaultAppDomainName:
   generateIngressCertificates: false
-  packageRegistrySecret: image-registry-credentials
+  containerRegistrySecret: image-registry-credentials
 
 include: true
 replicas: 1

--- a/helm/controllers/templates/configmap.yaml
+++ b/helm/controllers/templates/configmap.yaml
@@ -11,7 +11,7 @@ data:
       memoryMB: {{ .Values.processDefaults.memoryMB }}
       diskQuotaMB: {{ .Values.processDefaults.diskQuotaMB }}
     cfRootNamespace: {{ .Values.global.rootNamespace }}
-    packageRegistrySecretName: {{ .Values.global.packageRegistrySecret }}
+    packageRegistrySecretName: {{ .Values.global.containerRegistrySecret }}
     taskTTL: {{ .Values.taskTTL }}
     workloads_tls_secret_name: {{ .Values.workloadsTLSSecret }}
     workloads_tls_secret_namespace: {{ .Release.Namespace }}

--- a/helm/controllers/values.schema.json
+++ b/helm/controllers/values.schema.json
@@ -20,15 +20,15 @@
           "description": "create self-signed certificates for ingress using cert-manager",
           "type": "boolean"
         },
-        "packageRegistrySecret": {
-          "description": "name of the secret containing credentials to access the package registry",
+        "containerRegistrySecret": {
+          "description": "name of the secret containing credentials to access the container registry",
           "type": "string"
         }
       },
       "required": [
         "rootNamespace",
         "defaultAppDomainName",
-        "packageRegistrySecret"
+        "containerRegistrySecret"
       ],
       "type": "object"
     },

--- a/helm/controllers/values.yaml
+++ b/helm/controllers/values.yaml
@@ -3,7 +3,7 @@ global:
   debug: false
   defaultAppDomainName: apps.my-cf-domain.com
   generateIngressCertificates: false
-  packageRegistrySecret: image-registry-credentials
+  containerRegistrySecret: image-registry-credentials
 
 include: true
 replicas: 1

--- a/helm/korifi/values.yaml
+++ b/helm/korifi/values.yaml
@@ -3,7 +3,7 @@ global:
   debug: false
   defaultAppDomainName: apps.my-cf-domain.com
   generateIngressCertificates: false
-  packageRegistrySecret: image-registry-credentials
+  containerRegistrySecret: image-registry-credentials
 
 adminUserName:
 

--- a/helm/kpack-image-builder/templates/service-account.yaml
+++ b/helm/kpack-image-builder/templates/service-account.yaml
@@ -6,6 +6,6 @@ metadata:
   annotations:
     cloudfoundry.org/propagate-service-account: "true"
 secrets:
-  - name: {{ .Values.global.packageRegistrySecret }}
+  - name: {{ .Values.global.containerRegistrySecret }}
 imagePullSecrets:
-  - name: {{ .Values.global.packageRegistrySecret }}
+  - name: {{ .Values.global.containerRegistrySecret }}

--- a/helm/kpack-image-builder/values.schema.json
+++ b/helm/kpack-image-builder/values.schema.json
@@ -12,12 +12,12 @@
           "description": "run the dlv command and expose debugging ports",
           "type": "boolean"
         },
-        "packageRegistrySecret": {
-          "description": "name of the secret containing credentials to access the package registry",
+        "containerRegistrySecret": {
+          "description": "name of the secret containing credentials to access the container registry",
           "type": "string"
         }
       },
-      "required": ["rootNamespace", "packageRegistrySecret"],
+      "required": ["rootNamespace", "containerRegistrySecret"],
       "type": "object"
     },
     "include": {

--- a/helm/kpack-image-builder/values.yaml
+++ b/helm/kpack-image-builder/values.yaml
@@ -1,7 +1,7 @@
 global:
   rootNamespace: cf
   debug: false
-  packageRegistrySecret: image-registry-credentials
+  containerRegistrySecret: image-registry-credentials
 
 include: true
 replicas: 1


### PR DESCRIPTION
## Is there a related GitHub Issue?
#1923

## What is this change about?
The global value is used as package, droplet and kpack-build repository
secrets, so it makes sense to call it containerRegistrySecret.

## Does this PR introduce a breaking change?
Yes - helm chart value is renamed

## Acceptance Steps
Install korifi helm chart using the new name for the global registry secret and check you can push an app.

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
