### PR TITLE
Avoid create-new-user.sh for AWS

### DIFF
--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -40,7 +40,9 @@ echo "**************************"
 echo " Creating 'cf-admin' user"
 echo "**************************"
 
-"$SCRIPT_DIR/create-new-user.sh" cf-admin
+if [[ "${CLUSTER_TYPE:-}" != "EKS" ]]; then
+  "$SCRIPT_DIR/create-new-user.sh" cf-admin
+fi
 
 echo "*************************"
 echo " Installing Cert Manager"


### PR DESCRIPTION
## Is there a related GitHub Issue?
#1922

## What is this change about?
EKS does not support signing user certs, so we cannot run this script with an EKS cluster targeted

## Does this PR introduce a breaking change?
No

## Acceptance Steps
`deploy-on-kind.sh` works, as does CI

## Tag your pair, your PM, and/or team
@davewalter
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
