### PR TITLE
Fix race condition when deleting CFSpaces

### DIFF
--- a/controllers/controllers/workloads/shared.go
+++ b/controllers/controllers/workloads/shared.go
@@ -12,7 +12,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/pod-security-admission/api"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -161,26 +160,6 @@ func reconcileRoleBindings(ctx context.Context, kClient client.Client, log logr.
 		}
 	}
 	return nil
-}
-
-func finalize(ctx context.Context, kClient client.Client, log logr.Logger, orgOrSpace client.Object, finalizerName string) (ctrl.Result, error) {
-	log = log.WithName("finalize")
-
-	if !controllerutil.ContainsFinalizer(orgOrSpace, finalizerName) {
-		return ctrl.Result{}, nil
-	}
-
-	err := kClient.Delete(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: orgOrSpace.GetName()}})
-	if err != nil {
-		log.Error(err, "Failed to delete namespace")
-		return ctrl.Result{}, err
-	}
-
-	if controllerutil.RemoveFinalizer(orgOrSpace, finalizerName) {
-		log.Info("finalizer removed")
-	}
-
-	return ctrl.Result{}, nil
 }
 
 func getNamespace(ctx context.Context, log logr.Logger, client client.Client, namespaceName string) (*corev1.Namespace, bool) {


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
When Korifi is deployed with custom runner & builder implementations, deleting the namespace causes resources to be deleted in an adhoc fashion causing a few resources to hang forever in their finalizer blocks. Deleting CFApps before NSes makes sure the resources required in finalizer blocks live around long enough for the whole operation to succeed.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
All tests pass

## Tag your pair, your PM, and/or team
@akrishna90 