### PR TITLE
Expand on race condition fix when deleting CFSpace

### DIFF
--- a/controllers/controllers/workloads/cfbuild_controller.go
+++ b/controllers/controllers/workloads/cfbuild_controller.go
@@ -58,6 +58,9 @@ func NewCFBuildReconciler(k8sClient client.Client, scheme *runtime.Scheme, log l
 
 //+kubebuilder:rbac:groups=korifi.cloudfoundry.org,resources=cfbuilds,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=korifi.cloudfoundry.org,resources=cfbuilds/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=korifi.cloudfoundry.org,resources=cfbuilds/finalizers,verbs=update
+
+//+kubebuilder:rbac:groups=korifi.cloudfoundry.org,resources=cfpackages/finalizers,verbs=update
 
 //+kubebuilder:rbac:groups=korifi.cloudfoundry.org,resources=buildworkloads,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=korifi.cloudfoundry.org,resources=buildworkloads/status,verbs=get
@@ -77,7 +80,7 @@ func (r *CFBuildReconciler) ReconcileResource(ctx context.Context, cfBuild *kori
 		return ctrl.Result{}, err
 	}
 
-	err = controllerutil.SetOwnerReference(cfPackage, cfBuild, r.scheme)
+	err = controllerutil.SetControllerReference(cfPackage, cfBuild, r.scheme)
 	if err != nil {
 		r.log.Error(err, "unable to set owner reference on CFBuild")
 		return ctrl.Result{}, err
@@ -185,7 +188,7 @@ func (r *CFBuildReconciler) createBuildWorkload(ctx context.Context, cfBuild *ko
 	}
 	desiredWorkload.Spec.Env = imageEnvironment
 
-	err = controllerutil.SetOwnerReference(cfBuild, &desiredWorkload, r.scheme)
+	err = controllerutil.SetControllerReference(cfBuild, &desiredWorkload, r.scheme)
 	if err != nil {
 		r.log.Error(err, "failed to set OwnerRef on BuildWorkload")
 		return fmt.Errorf("failed to set OwnerRef on BuildWorkload: %w", err)

--- a/controllers/controllers/workloads/cfbuild_controller_test.go
+++ b/controllers/controllers/workloads/cfbuild_controller_test.go
@@ -3,6 +3,8 @@ package workloads_test
 import (
 	"context"
 
+	"code.cloudfoundry.org/korifi/tools"
+
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	. "code.cloudfoundry.org/korifi/controllers/controllers/workloads/testutils"
 	"code.cloudfoundry.org/korifi/tools/k8s"
@@ -108,10 +110,12 @@ var _ = Describe("CFBuildReconciler Integration Tests", func() {
 				g.Expect(k8sClient.Get(context.Background(), lookupKey, &createdCFBuild)).To(Succeed())
 				g.Expect(createdCFBuild.GetOwnerReferences()).To(ConsistOf(
 					metav1.OwnerReference{
-						APIVersion: korifiv1alpha1.GroupVersion.Identifier(),
-						Kind:       "CFPackage",
-						Name:       desiredCFPackage.Name,
-						UID:        desiredCFPackage.UID,
+						APIVersion:         korifiv1alpha1.GroupVersion.Identifier(),
+						Kind:               "CFPackage",
+						Name:               desiredCFPackage.Name,
+						UID:                desiredCFPackage.UID,
+						Controller:         tools.PtrTo(true),
+						BlockOwnerDeletion: tools.PtrTo(true),
 					},
 				))
 			}).Should(Succeed())
@@ -170,10 +174,12 @@ var _ = Describe("CFBuildReconciler Integration Tests", func() {
 					createdWorkload := new(korifiv1alpha1.BuildWorkload)
 					g.Expect(k8sClient.Get(context.Background(), lookupKey, createdWorkload)).To(Succeed())
 					g.Expect(createdWorkload.GetOwnerReferences()).To(ConsistOf(metav1.OwnerReference{
-						UID:        desiredCFBuild.UID,
-						Kind:       "CFBuild",
-						APIVersion: "korifi.cloudfoundry.org/v1alpha1",
-						Name:       desiredCFBuild.Name,
+						UID:                desiredCFBuild.UID,
+						Kind:               "CFBuild",
+						APIVersion:         "korifi.cloudfoundry.org/v1alpha1",
+						Name:               desiredCFBuild.Name,
+						Controller:         tools.PtrTo(true),
+						BlockOwnerDeletion: tools.PtrTo(true),
 					}))
 				}).Should(Succeed())
 			})

--- a/controllers/controllers/workloads/cfpackage_controller.go
+++ b/controllers/controllers/workloads/cfpackage_controller.go
@@ -63,7 +63,7 @@ func (r *CFPackageReconciler) ReconcileResource(ctx context.Context, cfPackage *
 		return ctrl.Result{}, err
 	}
 
-	err = controllerutil.SetOwnerReference(&cfApp, cfPackage, r.scheme)
+	err = controllerutil.SetControllerReference(&cfApp, cfPackage, r.scheme)
 	if err != nil {
 		r.log.Error(err, "unable to set owner reference on CFPackage")
 		return ctrl.Result{}, err

--- a/controllers/controllers/workloads/cfpackage_controller_test.go
+++ b/controllers/controllers/workloads/cfpackage_controller_test.go
@@ -3,6 +3,8 @@ package workloads_test
 import (
 	"context"
 
+	"code.cloudfoundry.org/korifi/tools"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -53,10 +55,12 @@ var _ = Describe("CFPackageReconciler Integration Tests", func() {
 				}
 				return createdCFPackage.GetOwnerReferences()
 			}).Should(ConsistOf(metav1.OwnerReference{
-				APIVersion: korifiv1alpha1.GroupVersion.Identifier(),
-				Kind:       "CFApp",
-				Name:       cfApp.Name,
-				UID:        cfApp.UID,
+				APIVersion:         korifiv1alpha1.GroupVersion.Identifier(),
+				Kind:               "CFApp",
+				Name:               cfApp.Name,
+				UID:                cfApp.UID,
+				Controller:         tools.PtrTo(true),
+				BlockOwnerDeletion: tools.PtrTo(true),
 			}))
 		})
 	})

--- a/helm/controllers/templates/role.yaml
+++ b/helm/controllers/templates/role.yaml
@@ -200,6 +200,12 @@ rules:
 - apiGroups:
   - korifi.cloudfoundry.org
   resources:
+  - cfbuilds/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
   - cfbuilds/status
   verbs:
   - get
@@ -255,6 +261,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - cfpackages/finalizers
+  verbs:
+  - update
 - apiGroups:
   - korifi.cloudfoundry.org
   resources:


### PR DESCRIPTION
## Is there a related GitHub Issue?
no

## What is this change about?
Expands on the previously added fix for a race condition when Korifi is deployed with custom runner & builder implementations. The previous fix deleted any associated CFApps before deleting the namespace in the CFSpace finalizer since that caused resources to hang forever in their finalizer blocks. Making the owner references in the CFApp ownership chain set BlockOwnerDeletion to true ensures the child resources are fully removed before the CFApp is removed and therefore deletion of the namespace will not be blocked.

## Does this PR introduce a breaking change?
no

## Acceptance Steps
All tests pass

## Tag your pair, your PM, and/or team
@akrishna90 @acosta11 
