### PR TITLE
Fix CFRoute deletion finalizer bug

### DIFF
--- a/controllers/controllers/networking/cfroute_controller.go
+++ b/controllers/controllers/networking/cfroute_controller.go
@@ -197,7 +197,7 @@ func (r *CFRouteReconciler) finalizeCFRoute(ctx context.Context, log logr.Logger
 }
 
 func (r *CFRouteReconciler) finalizeFQDNProxy(ctx context.Context, log logr.Logger, cfRouteName string, fqdnProxy *contourv1.HTTPProxy) error {
-	return k8s.Patch(ctx, r.client, fqdnProxy, func() {
+	return k8s.PatchResource(ctx, r.client, fqdnProxy, func() {
 		var retainedIncludes []contourv1.Include
 		for _, include := range fqdnProxy.Spec.Includes {
 			if include.Name != cfRouteName {

--- a/tests/e2e/routes_test.go
+++ b/tests/e2e/routes_test.go
@@ -301,7 +301,7 @@ var _ = Describe("Routes", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("succeeds with a job redirect", func() {
+		It("deletes the route and redirects to a deletion job", func() {
 			Expect(resp).To(HaveRestyStatusCode(http.StatusAccepted))
 			Expect(resp).To(HaveRestyHeaderWithValue("Location", SatisfyAll(
 				HavePrefix(apiServerRoot),
@@ -313,6 +313,12 @@ var _ = Describe("Routes", func() {
 				jobResp, err := client.R().Get(jobURL)
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(string(jobResp.Body())).To(ContainSubstring("COMPLETE"))
+			}).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				getRouteResp, err := client.R().Get("/v3/routes/" + routeGUID)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(getRouteResp).To(HaveRestyStatusCode(http.StatusNotFound))
 			}).Should(Succeed())
 		})
 


### PR DESCRIPTION
## Is there a related GitHub Issue?
Issue: https://github.com/cloudfoundry/korifi/issues/1986

## What is this change about?
Fixes a bug where a route could not be deleted since the controller did not have permission to update the Status of an HTTPProxy resource. This updates the implementation to use the PatchResource function instead which doesn't attempt to update the Status and backfills some tests.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
You should no longer be able to reproduce the issue in https://github.com/cloudfoundry/korifi/issues/1986.

```
cf create-route apps-127-0-0-1.nip.io --hostname foo
cf routes # and see the route
cf delete-route apps-127-0-0-1.nip.io --hostname foo
cf routes # and see the route WAS deleted
```

## Tag your pair, your PM, and/or team
@kieron-dev 

