### PR TITLE
Take EKS ECR Role ARN rather than service account name

### DIFF
--- a/helm/api/templates/configmap.yaml
+++ b/helm/api/templates/configmap.yaml
@@ -20,8 +20,8 @@ data:
       stagingMemoryMB: {{ .Values.lifecycle.stagingRequirements.memoryMB }}
       stagingDiskMB: {{ .Values.lifecycle.stagingRequirements.diskMB }}
     packageRepository: {{ .Values.packageRepository }}
-    {{- if not .Values.global.containerRegistryServiceAccount }}
-    packageRegistrySecretName: {{ required "containerRegistrySecret is required when global.containerRegistryServiceAccount is not set" .Values.global.containerRegistrySecret }}
+    {{- if not .Values.global.eksContainerRegistryRoleARN }}
+    packageRegistrySecretName: {{ required "containerRegistrySecret is required when global.eksContainerRegistryRoleARN is not set" .Values.global.containerRegistrySecret }}
     {{- end }}
     defaultDomainName: {{ .Values.global.defaultAppDomainName }}
     userCertificateExpirationWarningDuration: {{ .Values.userCertificateExpirationWarningDuration }}

--- a/helm/api/templates/deployment.yaml
+++ b/helm/api/templates/deployment.yaml
@@ -50,7 +50,7 @@ spec:
           name: korifi-tls-config
           readOnly: true
       {{- include "korifi.podSecurityContext" . | indent 6 }}
-      serviceAccountName: {{ .Values.global.containerRegistryServiceAccount | default "korifi-api-system-serviceaccount" }}
+      serviceAccountName: korifi-api-system-serviceaccount
       volumes:
       - configMap:
           name: korifi-api-config

--- a/helm/api/templates/rbac.yaml
+++ b/helm/api/templates/rbac.yaml
@@ -1,10 +1,12 @@
-{{- if not .Values.global.containerRegistryServiceAccount }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: korifi-api-system-serviceaccount
   namespace: {{ .Release.Namespace }}
-{{- end }}
+  {{- if .Values.global.eksContainerRegistryRoleARN }}
+  annotations:
+    eks.amazonaws.com/role-arn: {{ .Values.global.eksContainerRegistryRoleARN }}
+  {{- end }}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -17,7 +19,7 @@ roleRef:
   name: korifi-api-system-role
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.global.containerRegistryServiceAccount | default "korifi-api-system-serviceaccount" }}
+  name: korifi-api-system-serviceaccount
   namespace: {{ .Release.Namespace }}
 
 ---
@@ -32,5 +34,5 @@ roleRef:
   name: korifi-api-system-role
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.global.containerRegistryServiceAccount | default "korifi-api-system-serviceaccount" }}
+  name: korifi-api-system-serviceaccount
   namespace: {{ .Release.Namespace }}

--- a/helm/api/values.schema.json
+++ b/helm/api/values.schema.json
@@ -21,11 +21,11 @@
           "type": "boolean"
         },
         "containerRegistrySecret": {
-          "description": "name of the secret containing credentials to access the container registry. Required if containerRegistryServiceAccount not set. Ignored if containerRegistryServiceAccount is set",
+          "description": "name of the secret containing credentials to access the container registry. Required if eksContainerRegistryRoleARN not set. Ignored if eksContainerRegistryRoleARN is set",
           "type": "string"
         },
-        "containerRegistryServiceAccount": {
-          "description": "name of the service account which should be used to run pods accessing the container registry. Required if containerRegistrySecret not set",
+        "eksContainerRegistryRoleARN": {
+          "description": "amazon resource name (ARN) of the IAM role to use to access the container registry. Required if containerRegistrySecret not set",
           "type": "string"
         }
       },

--- a/helm/api/values.yaml
+++ b/helm/api/values.yaml
@@ -4,7 +4,7 @@ global:
   defaultAppDomainName:
   generateIngressCertificates: false
   containerRegistrySecret: image-registry-credentials
-  # containerRegistryServiceAccount:
+  eksContainerRegistryRoleARN: ""
 
 include: true
 replicas: 1

--- a/helm/controllers/templates/configmap.yaml
+++ b/helm/controllers/templates/configmap.yaml
@@ -11,7 +11,7 @@ data:
       memoryMB: {{ .Values.processDefaults.memoryMB }}
       diskQuotaMB: {{ .Values.processDefaults.diskQuotaMB }}
     cfRootNamespace: {{ .Values.global.rootNamespace }}
-    {{- if not .Values.global.containerRegistryServiceAccount }}
+    {{- if not .Values.global.eksContainerRegistryRoleARN }}
     containerRegistrySecretName: {{ .Values.global.containerRegistrySecret | quote }}
     {{- end }}
     taskTTL: {{ .Values.taskTTL }}

--- a/helm/controllers/values.schema.json
+++ b/helm/controllers/values.schema.json
@@ -21,11 +21,11 @@
           "type": "boolean"
         },
         "containerRegistrySecret": {
-          "description": "name of the secret containing credentials to access the container registry. Required if containerRegistryServiceAccount not set. Ignored if containerRegistryServiceAccount is set",
+          "description": "name of the secret containing credentials to access the container registry. Required if eksContainerRegistryRoleARN not set. Ignored if eksContainerRegistryRoleARN is set",
           "type": "string"
         },
-        "containerRegistryServiceAccount": {
-          "description": "name of the service account which should be used to run pods accessing the container registry. Required if containerRegistrySecret not set",
+        "eksContainerRegistryRoleARN": {
+          "description": "amazon resource name (ARN) of the IAM role to use to access the container registry. Required if containerRegistrySecret not set",
           "type": "string"
         }
       },

--- a/helm/controllers/values.yaml
+++ b/helm/controllers/values.yaml
@@ -4,7 +4,7 @@ global:
   defaultAppDomainName: apps.my-cf-domain.com
   generateIngressCertificates: false
   containerRegistrySecret: image-registry-credentials
-  # containerRegistryServiceAccount:
+  eksContainerRegistryRoleARN: ""
 
 include: true
 replicas: 1

--- a/helm/korifi/values.yaml
+++ b/helm/korifi/values.yaml
@@ -4,7 +4,7 @@ global:
   defaultAppDomainName: apps.my-cf-domain.com
   generateIngressCertificates: false
   containerRegistrySecret: image-registry-credentials
-  # containerRegistryServiceAccount:
+  eksContainerRegistryRoleARN: ""
 
 adminUserName:
 

--- a/helm/kpack-image-builder/templates/cluster-builder.yaml
+++ b/helm/kpack-image-builder/templates/cluster-builder.yaml
@@ -30,7 +30,7 @@ metadata:
   name: cf-kpack-cluster-builder
 spec:
   serviceAccountRef:
-    name: {{ .Values.global.containerRegistryServiceAccount | default "kpack-service-account" }}
+    name: kpack-service-account
     namespace: {{ .Values.global.rootNamespace }}
   tag: {{ required "builderRepository is required when clusterBuilderName is unset" .Values.builderRepository }}
   stack:

--- a/helm/kpack-image-builder/templates/configmap.yaml
+++ b/helm/kpack-image-builder/templates/configmap.yaml
@@ -8,4 +8,4 @@ data:
     cfRootNamespace: {{ .Values.global.rootNamespace }}
     clusterBuilderName: {{ .Values.clusterBuilderName | default "cf-kpack-cluster-builder" }}
     dropletRepository: {{ .Values.dropletRepository }}
-    builderServiceAccount: {{ .Values.global.containerRegistryServiceAccount | default "kpack-service-account" }}
+    builderServiceAccount: kpack-service-account

--- a/helm/kpack-image-builder/templates/deployment.yaml
+++ b/helm/kpack-image-builder/templates/deployment.yaml
@@ -73,7 +73,7 @@ spec:
           name: korifi-kpack-build-config
           readOnly: true
       {{- include "korifi.podSecurityContext" . | indent 6 }}
-      serviceAccountName: {{ .Values.global.containerRegistryServiceAccount | default "korifi-kpack-build-controller-manager" }}
+      serviceAccountName: korifi-kpack-build-controller-manager
       terminationGracePeriodSeconds: 10
       volumes:
       - name: cert

--- a/helm/kpack-image-builder/templates/post-install-builderinfo.yaml
+++ b/helm/kpack-image-builder/templates/post-install-builderinfo.yaml
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name | quote }}
         helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     spec:
-      serviceAccountName: {{ .Values.global.containerRegistryServiceAccount | default "korifi-kpack-build-controller-manager" }}
+      serviceAccountName: korifi-kpack-build-controller-manager
       restartPolicy: Never
       {{- include "korifi.podSecurityContext" . | indent 6 }}
       containers:

--- a/helm/kpack-image-builder/templates/rbac.yaml
+++ b/helm/kpack-image-builder/templates/rbac.yaml
@@ -1,10 +1,12 @@
-{{- if not .Values.global.containerRegistryServiceAccount }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: korifi-kpack-build-controller-manager
   namespace: {{ .Release.Namespace }}
-{{- end }}
+  {{- if .Values.global.eksContainerRegistryRoleARN }}
+  annotations:
+    eks.amazonaws.com/role-arn: {{ .Values.global.eksContainerRegistryRoleARN }}
+  {{- end }}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -57,7 +59,7 @@ roleRef:
   name: korifi-kpack-build-leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.global.containerRegistryServiceAccount | default "korifi-kpack-build-controller-manager" }}
+  name: korifi-kpack-build-controller-manager
   namespace: {{ .Release.Namespace }}
 
 ---
@@ -71,5 +73,5 @@ roleRef:
   name: korifi-kpack-build-manager-role
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.global.containerRegistryServiceAccount | default "korifi-kpack-build-controller-manager" }}
+  name: korifi-kpack-build-controller-manager
   namespace: {{ .Release.Namespace }}

--- a/helm/kpack-image-builder/templates/service-account.yaml
+++ b/helm/kpack-image-builder/templates/service-account.yaml
@@ -1,4 +1,3 @@
-{{- if not .Values.global.containerRegistryServiceAccount }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -6,6 +5,10 @@ metadata:
   namespace: {{ .Values.global.rootNamespace }}
   annotations:
     cloudfoundry.org/propagate-service-account: "true"
+    {{- if .Values.global.eksContainerRegistryRoleARN }}
+    eks.amazonaws.com/role-arn: {{ .Values.global.eksContainerRegistryRoleARN }}
+    {{- end }}
+{{- if not .Values.global.eksContainerRegistryRoleARN }}
 secrets:
   - name: {{ .Values.global.containerRegistrySecret }}
 imagePullSecrets:

--- a/helm/kpack-image-builder/values.schema.json
+++ b/helm/kpack-image-builder/values.schema.json
@@ -13,11 +13,11 @@
           "type": "boolean"
         },
         "containerRegistrySecret": {
-          "description": "name of the secret containing credentials to access the container registry. Required if containerRegistryServiceAccount not set. Ignored if containerRegistryServiceAccount is set",
+          "description": "name of the secret containing credentials to access the container registry. Required if eksContainerRegistryRoleARN not set. Ignored if eksContainerRegistryRoleARN is set",
           "type": "string"
         },
-        "containerRegistryServiceAccount": {
-          "description": "name of the service account which should be used to run pods accessing the container registry. Required if containerRegistrySecret not set",
+        "eksContainerRegistryRoleARN": {
+          "description": "amazon resource name (ARN) of the IAM role to use to access the container registry. Required if containerRegistrySecret not set",
           "type": "string"
         }
       },

--- a/helm/kpack-image-builder/values.yaml
+++ b/helm/kpack-image-builder/values.yaml
@@ -2,7 +2,7 @@ global:
   rootNamespace: cf
   debug: false
   containerRegistrySecret: image-registry-credentials
-  # containerRegistryServiceAccount:
+  eksContainerRegistryRoleARN: ""
 
 include: true
 replicas: 1


### PR DESCRIPTION
## Is there a related GitHub Issue?
#1922

## What is this change about?
It is simpler to take the ARN of role granting ECR access and k8s
service account role mapping, than to require external service account
creeation by the user.

## Does this PR introduce a breaking change?
Helm values have changed

## Acceptance Steps
You can push an app on EKS with ECR container registry configured

## Tag your pair, your PM, and/or team
@davewalter

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
