### PR TITLE
Remove `gorilla/schema`

### DIFF
--- a/api/actions/app_logs.go
+++ b/api/actions/app_logs.go
@@ -52,8 +52,8 @@ func (a *AppLogs) Read(ctx context.Context, logger logr.Logger, authInfo authori
 	}
 
 	logLimit := int64(defaultLogLimit)
-	if read.Limit != nil {
-		logLimit = *read.Limit
+	if read.Limit != 0 {
+		logLimit = read.Limit
 	}
 
 	runtimeLogs, err := a.podRepo.GetRuntimeLogsForApp(ctx, logger, authInfo, repositories.RuntimeLogsMessage{
@@ -73,18 +73,18 @@ func (a *AppLogs) Read(ctx context.Context, logger logr.Logger, authInfo authori
 	})
 
 	// ensure that we didn't exceed the log limit
-	if read.Limit != nil && int64(len(logs)) > *read.Limit {
-		first := int64(len(logs)) - *read.Limit
+	if read.Limit != 0 && int64(len(logs)) > read.Limit {
+		first := int64(len(logs)) - read.Limit
 		logs = logs[first:]
 	}
 
 	// filter any entries from before the start time
-	if read.StartTime != nil {
-		first := sort.Search(len(logs), func(i int) bool { return *read.StartTime <= logs[i].Timestamp })
+	if read.StartTime != 0 {
+		first := sort.Search(len(logs), func(i int) bool { return read.StartTime <= logs[i].Timestamp })
 		logs = logs[first:]
 	}
 
-	if read.Descending != nil && *read.Descending {
+	if read.Descending {
 		for i, j := 0, len(logs)-1; i < j; i, j = i+1, j-1 {
 			logs[i], logs[j] = logs[j], logs[i]
 		}

--- a/api/actions/app_logs_test.go
+++ b/api/actions/app_logs_test.go
@@ -85,13 +85,7 @@ var _ = Describe("ReadAppLogs", func() {
 		}
 		podRepo.GetRuntimeLogsForAppReturns(logs, nil)
 
-		requestPayload = payloads.LogRead{
-			StartTime:     nil,
-			EndTime:       nil,
-			EnvelopeTypes: nil,
-			Limit:         nil,
-			Descending:    nil,
-		}
+		requestPayload = payloads.LogRead{}
 		authInfo = authorization.Info{Token: "a-token"}
 	})
 
@@ -112,8 +106,7 @@ var _ = Describe("ReadAppLogs", func() {
 
 	When("the limit is lower than the total number of logs available", func() {
 		BeforeEach(func() {
-			limit := int64(2)
-			requestPayload.Limit = &limit
+			requestPayload.Limit = 2
 		})
 
 		It("gives us the most recent logs up to the limit", func() {
@@ -125,8 +118,8 @@ var _ = Describe("ReadAppLogs", func() {
 
 		When("the start time is set to the beginning of unix time according to the CF CLI", func() {
 			BeforeEach(func() {
-				theBigBang := int64(-6795364578871345152) // this is some date in 1754, which is what the CLI defaults to
-				requestPayload.StartTime = &theBigBang
+				// this is some date in 1754, which is what the CLI defaults to
+				requestPayload.StartTime = int64(-6795364578871345152)
 			})
 			It("gives us the latest logs up to the log limit", func() {
 				Expect(returnedErr).NotTo(HaveOccurred())
@@ -151,8 +144,7 @@ var _ = Describe("ReadAppLogs", func() {
 
 	When("the descending flag in the request is set to true", func() {
 		BeforeEach(func() {
-			descending := true
-			requestPayload.Descending = &descending
+			requestPayload.Descending = true
 		})
 
 		It("returns the logs in the reverse order", func() {
@@ -165,8 +157,7 @@ var _ = Describe("ReadAppLogs", func() {
 
 	When("the start time is newer than any of the log entries", func() {
 		BeforeEach(func() {
-			startTime := time.Now().Add(time.Minute).UnixNano()
-			requestPayload.StartTime = &startTime
+			requestPayload.StartTime = time.Now().Add(time.Minute).UnixNano()
 		})
 
 		It("returns an empty list", func() {
@@ -177,8 +168,7 @@ var _ = Describe("ReadAppLogs", func() {
 
 	When("the start time is the same as the latest log entry", func() {
 		BeforeEach(func() {
-			startTime := logs[1].Timestamp
-			requestPayload.StartTime = &startTime
+			requestPayload.StartTime = logs[1].Timestamp
 		})
 
 		It("returns only the latest entry", func() {

--- a/api/handlers/app_handler_test.go
+++ b/api/handlers/app_handler_test.go
@@ -565,18 +565,6 @@ var _ = Describe("AppHandler", func() {
 				})
 			})
 
-			When("Query Parameters are provided", func() {
-				BeforeEach(func() {
-					var err error
-					req, err = http.NewRequestWithContext(ctx, "GET", "/v3/apps?order_by=name", nil)
-					Expect(err).NotTo(HaveOccurred())
-				})
-
-				It("returns status 200 OK", func() {
-					Expect(rr.Code).Should(Equal(http.StatusOK), "Matching HTTP response code:")
-				})
-			})
-
 			It("invokes the repository with the provided auth info", func() {
 				Expect(appRepo.ListAppsCallCount()).To(Equal(1))
 				_, actualAuthInfo, _ := appRepo.ListAppsArgsForCall(0)
@@ -588,6 +576,10 @@ var _ = Describe("AppHandler", func() {
 					var err error
 					req, err = http.NewRequestWithContext(ctx, "GET", "/v3/apps?names=app1,app2&space_guids=space1,space2", nil)
 					Expect(err).NotTo(HaveOccurred())
+				})
+
+				It("returns status 200 OK", func() {
+					Expect(rr.Code).Should(Equal(http.StatusOK), "Matching HTTP response code:")
 				})
 
 				It("passes them to the repository", func() {

--- a/api/handlers/route_handler_test.go
+++ b/api/handlers/route_handler_test.go
@@ -440,9 +440,8 @@ var _ = Describe("RouteHandler", func() {
 				It("calls route with expected parameters", func() {
 					Expect(routeRepo.ListRoutesCallCount()).To(Equal(1))
 					_, _, message := routeRepo.ListRoutesArgsForCall(0)
-					Expect(message.AppGUIDs).To(HaveLen(0))
-					Expect(message.Hosts).To(HaveLen(1))
-					Expect(message.Hosts[0]).To(Equal(""))
+					Expect(message.AppGUIDs).To(BeEmpty())
+					Expect(message.Hosts).To(BeEmpty())
 				})
 			})
 

--- a/api/handlers/service_binding_handler.go
+++ b/api/handlers/service_binding_handler.go
@@ -111,7 +111,7 @@ func (h *ServiceBindingHandler) listHandler(ctx context.Context, logger logr.Log
 	}
 
 	var appRecords []repositories.AppRecord
-	if listFilter.Include != nil && len(serviceBindingList) > 0 {
+	if listFilter.Include != "" && len(serviceBindingList) > 0 {
 		listAppsMessage := repositories.ListAppsMessage{}
 
 		for _, serviceBinding := range serviceBindingList {

--- a/api/payloads/app.go
+++ b/api/payloads/app.go
@@ -2,6 +2,7 @@ package payloads
 
 import (
 	"fmt"
+	"net/url"
 
 	"code.cloudfoundry.org/korifi/api/config"
 	"code.cloudfoundry.org/korifi/api/repositories"
@@ -55,10 +56,9 @@ type AppSetCurrentDroplet struct {
 }
 
 type AppList struct {
-	Names      *string `schema:"names"`
-	GUIDs      *string `schema:"guids"`
-	SpaceGuids *string `schema:"space_guids"`
-	OrderBy    string  `schema:"order_by"`
+	Names      string
+	GUIDs      string
+	SpaceGuids string
 }
 
 func (a *AppList) ToMessage() repositories.ListAppsMessage {
@@ -71,6 +71,13 @@ func (a *AppList) ToMessage() repositories.ListAppsMessage {
 
 func (a *AppList) SupportedKeys() []string {
 	return []string{"names", "guids", "space_guids", "order_by"}
+}
+
+func (a *AppList) DecodeFromURLValues(values url.Values) error {
+	a.Names = values.Get("names")
+	a.GUIDs = values.Get("guids")
+	a.SpaceGuids = values.Get("space_guids")
+	return nil
 }
 
 type AppPatchEnvVars struct {

--- a/api/payloads/app_test.go
+++ b/api/payloads/app_test.go
@@ -1,0 +1,27 @@
+package payloads_test
+
+import (
+	"net/url"
+
+	"code.cloudfoundry.org/korifi/api/payloads"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("AppList", func() {
+	Describe("DecodeFromURLValues", func() {
+		appList := payloads.AppList{}
+		err := appList.DecodeFromURLValues(url.Values{
+			"names":       []string{"name"},
+			"guids":       []string{"guid"},
+			"space_guids": []string{"space_guid"},
+		})
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(appList).To(Equal(payloads.AppList{
+			Names:      "name",
+			GUIDs:      "guid",
+			SpaceGuids: "space_guid",
+		}))
+	})
+})

--- a/api/payloads/buildpack.go
+++ b/api/payloads/buildpack.go
@@ -1,9 +1,13 @@
 package payloads
 
-type BuildpackList struct {
-	OrderBy string `schema:"order_by"`
-}
+import "net/url"
+
+type BuildpackList struct{}
 
 func (d *BuildpackList) SupportedKeys() []string {
 	return []string{"order_by"}
+}
+
+func (d *BuildpackList) DecodeFromURLValues(values url.Values) error {
+	return nil
 }

--- a/api/payloads/decode_test.go
+++ b/api/payloads/decode_test.go
@@ -2,6 +2,8 @@ package payloads_test
 
 import (
 	"net/http"
+	"net/url"
+	"strconv"
 
 	"code.cloudfoundry.org/korifi/api/apierrors"
 	"code.cloudfoundry.org/korifi/api/payloads"
@@ -58,7 +60,9 @@ var _ = Describe("Decode", func() {
 		})
 
 		It("returns an error", func() {
-			Expect(decodeErr).To(MatchError(ContainSubstring("unable to decode request query parameters")))
+			Expect(decodeErr).To(HaveOccurred())
+			_, ok := decodeErr.(apierrors.MessageParseError)
+			Expect(ok).To(BeTrue())
 		})
 	})
 
@@ -82,9 +86,15 @@ var _ = Describe("Decode", func() {
 })
 
 type DecodeTestPayload struct {
-	Key int `schema:"key,required"`
+	Key int
 }
 
 func (p *DecodeTestPayload) SupportedKeys() []string {
 	return []string{"key"}
+}
+
+func (p *DecodeTestPayload) DecodeFromURLValues(values url.Values) error {
+	var err error
+	p.Key, err = strconv.Atoi(values.Get("key"))
+	return err
 }

--- a/api/payloads/domain.go
+++ b/api/payloads/domain.go
@@ -2,6 +2,7 @@ package payloads
 
 import (
 	"errors"
+	"net/url"
 
 	"code.cloudfoundry.org/korifi/api/repositories"
 )
@@ -46,7 +47,7 @@ func (c *DomainUpdate) ToMessage(domainGUID string) repositories.UpdateDomainMes
 }
 
 type DomainList struct {
-	Names *string `schema:"names"`
+	Names string
 }
 
 func (d *DomainList) ToMessage() repositories.ListDomainsMessage {
@@ -57,4 +58,9 @@ func (d *DomainList) ToMessage() repositories.ListDomainsMessage {
 
 func (d *DomainList) SupportedKeys() []string {
 	return []string{"names"}
+}
+
+func (d *DomainList) DecodeFromURLValues(values url.Values) error {
+	d.Names = values.Get("names")
+	return nil
 }

--- a/api/payloads/domain_test.go
+++ b/api/payloads/domain_test.go
@@ -215,69 +215,24 @@ var _ = Describe("DomainUpdate", func() {
 })
 
 var _ = Describe("DomainList", func() {
-	var payload payloads.DomainList
-
-	Describe("Decode", func() {
-		var (
-			form      url.Values
-			decodeErr error
-		)
-
-		BeforeEach(func() {
-			payload = payloads.DomainList{}
-			form = url.Values{}
-		})
-
-		JustBeforeEach(func() {
-			decodeErr = payloads.Decode(&payload, form)
-		})
-
+	Describe("DecodeFromURLValues", func() {
 		It("succeeds", func() {
-			Expect(decodeErr).NotTo(HaveOccurred())
-			Expect(payload.Names).To(BeNil())
-		})
-
-		When("the form has valid keys", func() {
-			BeforeEach(func() {
-				form = url.Values{
-					"names": []string{"foo,bar"},
-				}
+			domainList := payloads.DomainList{}
+			err := domainList.DecodeFromURLValues(url.Values{
+				"names": []string{"foo,bar"},
 			})
 
-			It("succeeds", func() {
-				Expect(decodeErr).NotTo(HaveOccurred())
-				Expect(payload.Names).To(gstruct.PointTo(Equal("foo,bar")))
-			})
-		})
-
-		When("the form is invalid", func() {
-			BeforeEach(func() {
-				form = url.Values{
-					"bananas": []string{"foo", "bar"},
-				}
-			})
-
-			It("errors", func() {
-				expectUnknownKeyError(decodeErr, "The query parameter is invalid")
-			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(domainList.Names).To(Equal("foo,bar"))
 		})
 	})
 
 	Describe("ToMessage", func() {
-		var listDomainsMessage repositories.ListDomainsMessage
-
-		BeforeEach(func() {
-			payload = payloads.DomainList{
-				Names: tools.PtrTo("foo,bar"),
-			}
-		})
-
-		JustBeforeEach(func() {
-			listDomainsMessage = payload.ToMessage()
-		})
-
 		It("splits names to strings", func() {
-			Expect(listDomainsMessage.Names).To(ConsistOf("foo", "bar"))
+			domainList := payloads.DomainList{
+				Names: "foo,bar",
+			}
+			Expect(domainList.ToMessage().Names).To(ConsistOf("foo", "bar"))
 		})
 	})
 })

--- a/api/payloads/log.go
+++ b/api/payloads/log.go
@@ -1,13 +1,31 @@
 package payloads
 
+import (
+	"net/url"
+)
+
 type LogRead struct {
-	StartTime     *int64   `schema:"start_time"`
-	EndTime       *int64   `schema:"end_time"`
-	EnvelopeTypes []string `schema:"envelope_types" validate:"dive,eq=LOG|eq=COUNTER|eq=GAUGE|eq=TIMER|eq=EVENT"`
-	Limit         *int64   `schema:"limit"`
-	Descending    *bool    `schema:"descending"`
+	StartTime     int64
+	EnvelopeTypes []string `validate:"dive,eq=LOG|eq=COUNTER|eq=GAUGE|eq=TIMER|eq=EVENT"`
+	Limit         int64
+	Descending    bool
 }
 
 func (l *LogRead) SupportedKeys() []string {
 	return []string{"start_time", "end_time", "envelope_types", "limit", "descending"}
+}
+
+func (l *LogRead) DecodeFromURLValues(values url.Values) error {
+	var err error
+	if l.StartTime, err = getInt(values, "start_time"); err != nil {
+		return err
+	}
+	l.EnvelopeTypes = values["envelope_types"]
+	if l.Limit, err = getInt(values, "limit"); err != nil {
+		return err
+	}
+	if l.Descending, err = getBool(values, "descending"); err != nil {
+		return err
+	}
+	return nil
 }

--- a/api/payloads/log_test.go
+++ b/api/payloads/log_test.go
@@ -1,0 +1,41 @@
+package payloads_test
+
+import (
+	"net/url"
+
+	"code.cloudfoundry.org/korifi/api/payloads"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("LogRead", func() {
+	DescribeTable("DecodeFromURLValues",
+		func(query string, logRead payloads.LogRead, err string) {
+			actualLogRead := payloads.LogRead{}
+			values, parseErr := url.ParseQuery(query)
+			Expect(parseErr).NotTo(HaveOccurred())
+
+			decodeErr := actualLogRead.DecodeFromURLValues(values)
+
+			if err == "" {
+				Expect(decodeErr).NotTo(HaveOccurred())
+				Expect(actualLogRead).To(Equal(logRead))
+			} else {
+				Expect(decodeErr).To(MatchError(ContainSubstring(err)))
+			}
+		},
+		Entry("all fields valid", "start_time=123&envelope_types=one&envelope_types=two&limit=456&descending=true", payloads.LogRead{
+			StartTime:     123,
+			EnvelopeTypes: []string{"one", "two"},
+			Limit:         456,
+			Descending:    true,
+		}, ""),
+		Entry("all fields missing", "", payloads.LogRead{}, ""),
+		Entry("invalid start_time", "start_time=foo", payloads.LogRead{}, "invalid syntax"),
+		Entry("empty start_time", "start_time=", payloads.LogRead{}, ""),
+		Entry("invalid limit", "limit=foo", payloads.LogRead{}, "invalid syntax"),
+		Entry("empty limit", "limit=", payloads.LogRead{}, ""),
+		Entry("invalid descending", "descending=foo", payloads.LogRead{}, "invalid syntax"),
+		Entry("empty descending", "descending=", payloads.LogRead{}, ""),
+	)
+})

--- a/api/payloads/package_test.go
+++ b/api/payloads/package_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"net/http"
+	"net/url"
 
 	"code.cloudfoundry.org/korifi/api/payloads"
 	"code.cloudfoundry.org/korifi/tools"
@@ -218,5 +219,23 @@ var _ = Describe("PackageUpdate", func() {
 				"bar": nil,
 			}))
 		})
+	})
+})
+
+var _ = Describe("PackageListQueryParameters", func() {
+	Describe("DecodeFromURLValues", func() {
+		packageList := payloads.PackageListQueryParameters{}
+		err := packageList.DecodeFromURLValues(url.Values{
+			"app_guids": []string{"app_guid"},
+			"states":    []string{"state"},
+			"order_by":  []string{"order"},
+		})
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(packageList).To(Equal(payloads.PackageListQueryParameters{
+			AppGUIDs: "app_guid",
+			States:   "state",
+			OrderBy:  "order",
+		}))
 	})
 })

--- a/api/payloads/payloads_suite_test.go
+++ b/api/payloads/payloads_suite_test.go
@@ -27,9 +27,3 @@ func expectUnprocessableEntityError(err error, detail string) {
 	Expect(err).To(BeAssignableToTypeOf(apierrors.UnprocessableEntityError{}))
 	Expect(err.(apierrors.UnprocessableEntityError).Detail()).To(ContainSubstring(detail))
 }
-
-func expectUnknownKeyError(err error, detail string) {
-	Expect(err).To(HaveOccurred())
-	Expect(err).To(BeAssignableToTypeOf(apierrors.UnknownKeyError{}))
-	Expect(err.(apierrors.UnknownKeyError).Detail()).To(ContainSubstring(detail))
-}

--- a/api/payloads/process.go
+++ b/api/payloads/process.go
@@ -1,6 +1,8 @@
 package payloads
 
 import (
+	"net/url"
+
 	"code.cloudfoundry.org/korifi/api/repositories"
 )
 
@@ -36,7 +38,7 @@ func (p ProcessScale) ToRecord() repositories.ProcessScaleValues {
 }
 
 type ProcessList struct {
-	AppGUIDs *string `schema:"app_guids"`
+	AppGUIDs string
 }
 
 func (p *ProcessList) ToMessage() repositories.ListProcessesMessage {
@@ -47,6 +49,11 @@ func (p *ProcessList) ToMessage() repositories.ListProcessesMessage {
 
 func (p *ProcessList) SupportedKeys() []string {
 	return []string{"app_guids"}
+}
+
+func (p *ProcessList) DecodeFromURLValues(values url.Values) error {
+	p.AppGUIDs = values.Get("app_guids")
+	return nil
 }
 
 func (p ProcessPatch) ToProcessPatchMessage(processGUID, spaceGUID string) repositories.PatchProcessMessage {

--- a/api/payloads/process_test.go
+++ b/api/payloads/process_test.go
@@ -1,0 +1,23 @@
+package payloads_test
+
+import (
+	"net/url"
+
+	"code.cloudfoundry.org/korifi/api/payloads"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ProcessList", func() {
+	Describe("DecodeFromURLValues", func() {
+		processList := payloads.ProcessList{}
+		err := processList.DecodeFromURLValues(url.Values{
+			"app_guids": []string{"app_guid"},
+		})
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(processList).To(Equal(payloads.ProcessList{
+			AppGUIDs: "app_guid",
+		}))
+	})
+})

--- a/api/payloads/route.go
+++ b/api/payloads/route.go
@@ -1,6 +1,8 @@
 package payloads
 
 import (
+	"net/url"
+
 	"code.cloudfoundry.org/korifi/api/repositories"
 )
 
@@ -30,11 +32,11 @@ func (p RouteCreate) ToMessage(domainNamespace, domainName string) repositories.
 }
 
 type RouteList struct {
-	AppGUIDs    *string `schema:"app_guids"`
-	SpaceGUIDs  *string `schema:"space_guids"`
-	DomainGUIDs *string `schema:"domain_guids"`
-	Hosts       *string `schema:"hosts"`
-	Paths       *string `schema:"paths"`
+	AppGUIDs    string
+	SpaceGUIDs  string
+	DomainGUIDs string
+	Hosts       string
+	Paths       string
 }
 
 func (p *RouteList) ToMessage() repositories.ListRoutesMessage {
@@ -49,6 +51,15 @@ func (p *RouteList) ToMessage() repositories.ListRoutesMessage {
 
 func (p *RouteList) SupportedKeys() []string {
 	return []string{"app_guids", "space_guids", "domain_guids", "hosts", "paths"}
+}
+
+func (p *RouteList) DecodeFromURLValues(values url.Values) error {
+	p.AppGUIDs = values.Get("app_guids")
+	p.SpaceGUIDs = values.Get("space_guids")
+	p.DomainGUIDs = values.Get("domain_guids")
+	p.Hosts = values.Get("hosts")
+	p.Paths = values.Get("paths")
+	return nil
 }
 
 type RoutePatch struct {

--- a/api/payloads/route_test.go
+++ b/api/payloads/route_test.go
@@ -1,0 +1,31 @@
+package payloads_test
+
+import (
+	"net/url"
+
+	"code.cloudfoundry.org/korifi/api/payloads"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("RouteList", func() {
+	Describe("DecodeFromURLValues", func() {
+		routeList := payloads.RouteList{}
+		err := routeList.DecodeFromURLValues(url.Values{
+			"app_guids":    []string{"app_guid"},
+			"space_guids":  []string{"space_guid"},
+			"domain_guids": []string{"domain_guid"},
+			"hosts":        []string{"host"},
+			"paths":        []string{"path"},
+		})
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(routeList).To(Equal(payloads.RouteList{
+			AppGUIDs:    "app_guid",
+			SpaceGUIDs:  "space_guid",
+			DomainGUIDs: "domain_guid",
+			Hosts:       "host",
+			Paths:       "path",
+		}))
+	})
+})

--- a/api/payloads/service_binding.go
+++ b/api/payloads/service_binding.go
@@ -1,6 +1,8 @@
 package payloads
 
 import (
+	"net/url"
+
 	"code.cloudfoundry.org/korifi/api/repositories"
 )
 
@@ -25,10 +27,9 @@ func (p ServiceBindingCreate) ToMessage(spaceGUID string) repositories.CreateSer
 }
 
 type ServiceBindingList struct {
-	AppGUIDs             *string `schema:"app_guids"`
-	ServiceInstanceGUIDs *string `schema:"service_instance_guids"`
-	Include              *string `schema:"include" validate:"oneof=app"`
-	Type                 *string `schema:"type" validate:"oneof=app"`
+	AppGUIDs             string
+	ServiceInstanceGUIDs string
+	Include              string
 }
 
 func (l *ServiceBindingList) ToMessage() repositories.ListServiceBindingsMessage {
@@ -39,5 +40,12 @@ func (l *ServiceBindingList) ToMessage() repositories.ListServiceBindingsMessage
 }
 
 func (l *ServiceBindingList) SupportedKeys() []string {
-	return []string{"app_guids, service_instance_guids, include, type"}
+	return []string{"app_guids", "service_instance_guids", "include", "type"}
+}
+
+func (l *ServiceBindingList) DecodeFromURLValues(values url.Values) error {
+	l.AppGUIDs = values.Get("app_guids")
+	l.ServiceInstanceGUIDs = values.Get("service_instance_guids")
+	l.Include = values.Get("include")
+	return nil
 }

--- a/api/payloads/service_binding_test.go
+++ b/api/payloads/service_binding_test.go
@@ -1,0 +1,27 @@
+package payloads_test
+
+import (
+	"net/url"
+
+	"code.cloudfoundry.org/korifi/api/payloads"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ServiceBindingList", func() {
+	Describe("DecodeFromURLValues", func() {
+		serviceBindingList := payloads.ServiceBindingList{}
+		err := serviceBindingList.DecodeFromURLValues(url.Values{
+			"app_guids":              []string{"app_guid"},
+			"service_instance_guids": []string{"service_instance_guid"},
+			"include":                []string{"include"},
+		})
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(serviceBindingList).To(Equal(payloads.ServiceBindingList{
+			AppGUIDs:             "app_guid",
+			ServiceInstanceGUIDs: "service_instance_guid",
+			Include:              "include",
+		}))
+	})
+})

--- a/api/payloads/service_instance.go
+++ b/api/payloads/service_instance.go
@@ -1,6 +1,7 @@
 package payloads
 
 import (
+	"net/url"
 	"strings"
 
 	"code.cloudfoundry.org/korifi/api/repositories"
@@ -32,9 +33,9 @@ func (p ServiceInstanceCreate) ToServiceInstanceCreateMessage() repositories.Cre
 }
 
 type ServiceInstanceList struct {
-	Names      *string `schema:"names"`
-	SpaceGuids *string `schema:"space_guids"`
-	OrderBy    string  `schema:"order_by"`
+	Names      string
+	SpaceGuids string
+	OrderBy    string
 }
 
 func (l *ServiceInstanceList) ToMessage() repositories.ListServiceInstanceMessage {
@@ -48,4 +49,11 @@ func (l *ServiceInstanceList) ToMessage() repositories.ListServiceInstanceMessag
 
 func (l *ServiceInstanceList) SupportedKeys() []string {
 	return []string{"names", "space_guids", "fields", "order_by", "per_page"}
+}
+
+func (l *ServiceInstanceList) DecodeFromURLValues(values url.Values) error {
+	l.Names = values.Get("names")
+	l.SpaceGuids = values.Get("space_guids")
+	l.OrderBy = values.Get("order_by")
+	return nil
 }

--- a/api/payloads/service_instance_test.go
+++ b/api/payloads/service_instance_test.go
@@ -1,0 +1,27 @@
+package payloads_test
+
+import (
+	"net/url"
+
+	"code.cloudfoundry.org/korifi/api/payloads"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ServiceInstanceList", func() {
+	Describe("DecodeFromURLValues", func() {
+		serviceInstanceList := payloads.ServiceInstanceList{}
+		err := serviceInstanceList.DecodeFromURLValues(url.Values{
+			"names":       []string{"name"},
+			"space_guids": []string{"space_guid"},
+			"order_by":    []string{"order"},
+		})
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(serviceInstanceList).To(Equal(payloads.ServiceInstanceList{
+			Names:      "name",
+			SpaceGuids: "space_guid",
+			OrderBy:    "order",
+		}))
+	})
+})

--- a/api/payloads/shared.go
+++ b/api/payloads/shared.go
@@ -1,6 +1,10 @@
 package payloads
 
-import "strings"
+import (
+	"net/url"
+	"strconv"
+	"strings"
+)
 
 type Lifecycle struct {
 	Type string        `json:"type" validate:"required"`
@@ -20,12 +24,12 @@ type RelationshipData struct {
 	GUID string `json:"guid" validate:"required"`
 }
 
-func ParseArrayParam(arrayParam *string) []string {
-	if arrayParam == nil {
+func ParseArrayParam(arrayParam string) []string {
+	if arrayParam == "" {
 		return []string{}
 	}
 
-	elements := strings.Split(*arrayParam, ",")
+	elements := strings.Split(arrayParam, ",")
 	for i, e := range elements {
 		elements[i] = strings.TrimSpace(e)
 	}
@@ -41,4 +45,26 @@ type Metadata struct {
 type MetadataPatch struct {
 	Annotations map[string]*string `json:"annotations" validate:"metadatavalidator"`
 	Labels      map[string]*string `json:"labels" validate:"metadatavalidator"`
+}
+
+func getInt(values url.Values, key string) (int64, error) {
+	if !values.Has(key) {
+		return 0, nil
+	}
+	s := values.Get(key)
+	if s == "" {
+		return 0, nil
+	}
+	return strconv.ParseInt(s, 10, 64)
+}
+
+func getBool(values url.Values, key string) (bool, error) {
+	if !values.Has(key) {
+		return false, nil
+	}
+	s := values.Get(key)
+	if s == "" {
+		return false, nil
+	}
+	return strconv.ParseBool(s)
 }

--- a/api/payloads/shared_test.go
+++ b/api/payloads/shared_test.go
@@ -9,28 +9,19 @@ import (
 var _ = Describe("ParseArrayParam", func() {
 	When("a nil value is specified", func() {
 		It("returns an empty array", func() {
-			Expect(ParseArrayParam(nil)).To(Equal([]string{}))
-		})
-	})
-
-	When("an empty value is specified", func() {
-		It("returns an array with a single empty string", func() {
-			value := ""
-			Expect(ParseArrayParam(&value)).To(Equal([]string{""}))
+			Expect(ParseArrayParam("")).To(Equal([]string{}))
 		})
 	})
 
 	When("an single value is specified", func() {
 		It("returns an array with the value specified", func() {
-			value := "foo"
-			Expect(ParseArrayParam(&value)).To(Equal([]string{"foo"}))
+			Expect(ParseArrayParam("foo")).To(Equal([]string{"foo"}))
 		})
 	})
 
 	When("multiple values are specified in a CSV", func() {
 		It("returns an array with the value split on commas and all white-space removed from each value", func() {
-			value := " foo,   bar    ,   baz"
-			Expect(ParseArrayParam(&value)).To(Equal([]string{"foo", "bar", "baz"}))
+			Expect(ParseArrayParam(" foo,   bar    ,   baz")).To(Equal([]string{"foo", "bar", "baz"}))
 		})
 	})
 })

--- a/api/payloads/task.go
+++ b/api/payloads/task.go
@@ -1,6 +1,10 @@
 package payloads
 
 import (
+	"net/url"
+	"strconv"
+	"strings"
+
 	"code.cloudfoundry.org/korifi/api/repositories"
 )
 
@@ -17,7 +21,7 @@ func (p TaskCreate) ToMessage(appRecord repositories.AppRecord) repositories.Cre
 }
 
 type TaskList struct {
-	SequenceIDs []int64 `schema:"sequence_ids"`
+	SequenceIDs []int64
 }
 
 func (t *TaskList) ToMessage() repositories.ListTaskMessage {
@@ -28,4 +32,23 @@ func (t *TaskList) ToMessage() repositories.ListTaskMessage {
 
 func (t *TaskList) SupportedKeys() []string {
 	return []string{"sequence_ids"}
+}
+
+func (a *TaskList) DecodeFromURLValues(values url.Values) error {
+	idsStr := values.Get("sequence_ids")
+
+	var ids []int64
+	for _, idStr := range strings.Split(idsStr, ",") {
+		if idStr == "" {
+			continue
+		}
+		id, err := strconv.ParseInt(idStr, 10, 64)
+		if err != nil {
+			return err
+		}
+		ids = append(ids, id)
+	}
+
+	a.SequenceIDs = ids
+	return nil
 }

--- a/api/payloads/task_test.go
+++ b/api/payloads/task_test.go
@@ -1,0 +1,33 @@
+package payloads_test
+
+import (
+	"net/url"
+
+	"code.cloudfoundry.org/korifi/api/payloads"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("TaskList", func() {
+	DescribeTable("DecodeFromURLValues",
+		func(query string, taskList payloads.TaskList, err string) {
+			actualTaskList := payloads.TaskList{}
+			values, parseErr := url.ParseQuery(query)
+			Expect(parseErr).NotTo(HaveOccurred())
+
+			decodeErr := actualTaskList.DecodeFromURLValues(values)
+
+			if err == "" {
+				Expect(decodeErr).NotTo(HaveOccurred())
+				Expect(actualTaskList).To(Equal(taskList))
+			} else {
+				Expect(decodeErr).To(MatchError(ContainSubstring(err)))
+			}
+		},
+		Entry("valid sequence_ids", "sequence_ids=1,2,3", payloads.TaskList{SequenceIDs: []int64{1, 2, 3}}, ""),
+		Entry("missing sequence_ids", "", payloads.TaskList{}, ""),
+		Entry("empty sequence_ids", "sequence_ids=", payloads.TaskList{}, ""),
+		Entry("empty sequence_id", "sequence_ids=1,,3", payloads.TaskList{SequenceIDs: []int64{1, 3}}, ""),
+		Entry("invalid sequence_ids", "sequence_ids=1,two,3", payloads.TaskList{}, "invalid syntax"),
+	)
+})

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,6 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.8.0
-	github.com/gorilla/schema v1.2.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.5.0
 	github.com/mileusna/useragent v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -329,8 +329,6 @@ github.com/gorilla/handlers v1.5.1 h1:9lRY6j8DEeeBT10CvO9hGW0gmky0BprnvDI5vfhUHH
 github.com/gorilla/handlers v1.5.1/go.mod h1:t8XrUpc4KVXb7HGyJ4/cEnwQiaxrX/hz1Zv/4g96P1Q=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
-github.com/gorilla/schema v1.2.0 h1:YufUaxZYCKGFuAq3c96BOhjgd5nmXiOY9NGzF247Tsc=
-github.com/gorilla/schema v1.2.0/go.mod h1:kgLaKoK1FELgZqMAVxx/5cbj0kT+57qxUrAlIO2eleU=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=


### PR DESCRIPTION
## Is there a related GitHub Issue?

#2010 

## What is this change about?

This replaces the `gorilla/schema` with a custom implementation. It consists of adding a `DecodeFromURLValues` to every payload type, and use it in `payloads.Decode`.

This also gets rid of pointer fields on payload structs, as we didn't find any reason to have them. In some places we were treating a list parameter as an empty slice when not passed, and as a slice containing a single empty string when passed empty: we didn't think this distinction was useful, so we treat both cases as empty slices now.

## Does this PR introduce a breaking change?

Some minor changes in behaviour, e.g. the handling of the `hosts` param in the routes handler. Also some minor changes in error messages.

/cc @davewalter 