### PR TITLE
Ensure child resources are deleted for CFApps

### DIFF
--- a/controllers/controllers/workloads/cfapp_controller.go
+++ b/controllers/controllers/workloads/cfapp_controller.go
@@ -205,7 +205,7 @@ func (r *CFAppReconciler) createCFProcess(ctx context.Context, log logr.Logger, 
 	}
 	desiredCFProcess.SetStableName(cfApp.Name)
 
-	if err := controllerutil.SetOwnerReference(cfApp, desiredCFProcess, r.scheme); err != nil {
+	if err := controllerutil.SetControllerReference(cfApp, desiredCFProcess, r.scheme); err != nil {
 		log.Error(err, "failed to set OwnerRef on CFProcess")
 		return err
 	}

--- a/controllers/controllers/workloads/cfapp_controller_test.go
+++ b/controllers/controllers/workloads/cfapp_controller_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	"code.cloudfoundry.org/korifi/tools"
+
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"code.cloudfoundry.org/korifi/controllers/controllers/workloads"
 	. "code.cloudfoundry.org/korifi/controllers/controllers/workloads/testutils"
@@ -275,10 +277,12 @@ var _ = Describe("CFAppReconciler Integration Tests", func() {
 
 					Expect(createdCFProcess.ObjectMeta.OwnerReferences).To(ConsistOf([]metav1.OwnerReference{
 						{
-							APIVersion: "korifi.cloudfoundry.org/v1alpha1",
-							Kind:       "CFApp",
-							Name:       cfApp.Name,
-							UID:        cfApp.GetUID(),
+							APIVersion:         "korifi.cloudfoundry.org/v1alpha1",
+							Kind:               "CFApp",
+							Name:               cfApp.Name,
+							UID:                cfApp.GetUID(),
+							Controller:         tools.PtrTo(true),
+							BlockOwnerDeletion: tools.PtrTo(true),
 						},
 					}))
 				}

--- a/controllers/controllers/workloads/cfprocess_controller.go
+++ b/controllers/controllers/workloads/cfprocess_controller.go
@@ -71,6 +71,7 @@ func NewCFProcessReconciler(
 
 //+kubebuilder:rbac:groups=korifi.cloudfoundry.org,resources=cfprocesses,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=korifi.cloudfoundry.org,resources=cfprocesses/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=korifi.cloudfoundry.org,resources=cfprocesses/finalizers,verbs=update
 //+kubebuilder:rbac:groups=korifi.cloudfoundry.org,resources=appworkloads,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;patch
 
@@ -82,7 +83,7 @@ func (r *CFProcessReconciler) ReconcileResource(ctx context.Context, cfProcess *
 		return ctrl.Result{}, err
 	}
 
-	err = controllerutil.SetOwnerReference(cfApp, cfProcess, r.scheme)
+	err = controllerutil.SetControllerReference(cfApp, cfProcess, r.scheme)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -246,7 +247,7 @@ func (r *CFProcessReconciler) generateAppWorkload(actualAppWorkload *korifiv1alp
 	desiredAppWorkload.Spec.LivenessProbe = livenessProbe(cfProcess, appPort)
 	desiredAppWorkload.Spec.RunnerName = r.controllerConfig.RunnerName
 
-	err := controllerutil.SetOwnerReference(cfProcess, &desiredAppWorkload, r.scheme)
+	err := controllerutil.SetControllerReference(cfProcess, &desiredAppWorkload, r.scheme)
 	if err != nil {
 		return nil, err
 	}

--- a/controllers/controllers/workloads/cfprocess_controller_test.go
+++ b/controllers/controllers/workloads/cfprocess_controller_test.go
@@ -110,10 +110,12 @@ var _ = Describe("CFProcessReconciler Integration Tests", func() {
 				}
 				return createdCFProcess.GetOwnerReferences()
 			}).Should(ConsistOf(metav1.OwnerReference{
-				APIVersion: korifiv1alpha1.GroupVersion.Identifier(),
-				Kind:       "CFApp",
-				Name:       cfApp.Name,
-				UID:        cfApp.UID,
+				APIVersion:         korifiv1alpha1.GroupVersion.Identifier(),
+				Kind:               "CFApp",
+				Name:               cfApp.Name,
+				UID:                cfApp.UID,
+				Controller:         tools.PtrTo(true),
+				BlockOwnerDeletion: tools.PtrTo(true),
 			}))
 		})
 	})
@@ -129,9 +131,14 @@ var _ = Describe("CFProcessReconciler Integration Tests", func() {
 				var updatedCFApp korifiv1alpha1.CFApp
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cfApp), &updatedCFApp)).To(Succeed())
 
-				g.Expect(appWorkload.OwnerReferences).To(HaveLen(1), "expected length of ownerReferences to be 1")
-				g.Expect(appWorkload.OwnerReferences[0].Name).To(Equal(cfProcess.Name))
-
+				g.Expect(appWorkload.OwnerReferences).To(ConsistOf(metav1.OwnerReference{
+					APIVersion:         korifiv1alpha1.GroupVersion.Identifier(),
+					Kind:               "CFProcess",
+					Name:               cfProcess.Name,
+					UID:                cfProcess.UID,
+					Controller:         tools.PtrTo(true),
+					BlockOwnerDeletion: tools.PtrTo(true),
+				}))
 				g.Expect(appWorkload.ObjectMeta.Labels).To(HaveKeyWithValue(CFAppGUIDLabelKey, testAppGUID))
 				g.Expect(appWorkload.ObjectMeta.Labels).To(HaveKeyWithValue(cfAppRevisionKey, cfApp.Annotations[cfAppRevisionKey]))
 				g.Expect(appWorkload.ObjectMeta.Labels).To(HaveKeyWithValue(CFProcessGUIDLabelKey, testProcessGUID))

--- a/helm/controllers/templates/role.yaml
+++ b/helm/controllers/templates/role.yaml
@@ -290,6 +290,12 @@ rules:
 - apiGroups:
   - korifi.cloudfoundry.org
   resources:
+  - cfprocesses/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
   - cfprocesses/status
   verbs:
   - get


### PR DESCRIPTION
## Is there a related GitHub Issue?
no

## What is this change about?
Make the owner references in the CFApp AppWorkload ownership chain set BlockOwnerDeletion to true to ensure that the child resources are fully removed before removing the CFApp

## Does this PR introduce a breaking change?
No

## Acceptance Steps
All tests pass

## Tag your pair, your PM, and/or team
@julian-hj @Birdrock 
