### PR TITLE
Fix logging on webhook TLS errors

### DIFF
--- a/controllers/main.go
+++ b/controllers/main.go
@@ -17,8 +17,10 @@ limitations under the License.
 package main
 
 import (
+	"code.cloudfoundry.org/korifi/tools"
 	"flag"
 	"fmt"
+	"log"
 	"os"
 	"time"
 
@@ -93,6 +95,7 @@ func main() {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	klog.SetLogger(ctrl.Log)
+	log.SetOutput(&tools.LogrWriter{Logger: ctrl.Log, Message: "HTTP server error"})
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,

--- a/kpack-image-builder/main.go
+++ b/kpack-image-builder/main.go
@@ -17,8 +17,10 @@ limitations under the License.
 package main
 
 import (
+	"code.cloudfoundry.org/korifi/tools"
 	"flag"
 	"fmt"
+	"log"
 	"os"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
@@ -79,6 +81,7 @@ func main() {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	klog.SetLogger(ctrl.Log)
+	log.SetOutput(&tools.LogrWriter{Logger: ctrl.Log, Message: "HTTP server error"})
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,

--- a/statefulset-runner/main.go
+++ b/statefulset-runner/main.go
@@ -17,7 +17,9 @@ limitations under the License.
 package main
 
 import (
+	"code.cloudfoundry.org/korifi/tools"
 	"flag"
+	"log"
 	"os"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
@@ -79,6 +81,7 @@ func main() {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	klog.SetLogger(ctrl.Log)
+	log.SetOutput(&tools.LogrWriter{Logger: ctrl.Log, Message: "HTTP server error"})
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,

--- a/tools/logr_writer.go
+++ b/tools/logr_writer.go
@@ -1,0 +1,18 @@
+package tools
+
+import (
+	"errors"
+
+	"github.com/go-logr/logr"
+)
+
+// LogrWriter implements io.Writer and converts Write calls to logr.Logger.Error() calls
+type LogrWriter struct {
+	Logger  logr.Logger
+	Message string
+}
+
+func (w *LogrWriter) Write(msg []byte) (int, error) {
+	w.Logger.Error(errors.New(string(msg)), w.Message)
+	return len(msg), nil
+}


### PR DESCRIPTION
 
## Is there a related GitHub Issue?
#2025

## What is this change about?
- the HTTP server used by controller manager runtime for webhooks uses the golang `log` package for logging.
- we can't control the creation of that HTTP server, so this change uses `log.SetOutput` to direct low level log lines to a LogrWriter with our zapr logger.
- this change also moves the LogrWriter to the tools package and makes it public since we are using it across executables.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
#2025

