### PR TITLE
Pre-release fixes for v0.5

### DIFF
--- a/INSTALL.EKS.md
+++ b/INSTALL.EKS.md
@@ -232,7 +232,6 @@ Follow the instructions in the [main installation guide](INSTALL.md), making the
     --set=adminUserName="${ADMIN_USERNAME}" \
     --set=api.apiServer.url="api.${BASE_DOMAIN}" \
     --set=global.defaultAppDomainName="apps.${BASE_DOMAIN}" \
-    --set=api.packageRepository="${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${CLUSTER_NAME}/packages" \
-    --set=kpack-image-builder.builderRepository="${KPACK_BUILDER_REPO}" \
-    --set=kpack-image-builder.dropletRepository=${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${CLUSTER_NAME}/droplets
+    --set=global.containerRepositoryPrefix="${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${CLUSTER_NAME}/" \
+    --set=kpack-image-builder.builderRepository="${KPACK_BUILDER_REPO}"
   ```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -33,10 +33,10 @@ The following environment variables will be needed throughout this guide:
 Here are the example values we'll use in this guide:
 
 ```sh
-export ROOT_NAMESPACE="cf"
-export KORIFI_NAMESPACE="korifi"
-export ADMIN_USERNAME="cf-admin"
-export BASE_DOMAIN="korifi.example.org"
+ROOT_NAMESPACE="cf"
+KORIFI_NAMESPACE="korifi"
+ADMIN_USERNAME="cf-admin"
+BASE_DOMAIN="korifi.example.org"
 ```
 
 ### Registries with Custom CA
@@ -55,7 +55,7 @@ DockerHub allows only one private repository per free account. In case the Docke
 
 ### Kpack
 
-[Kpack](https://github.com/pivotal/kpack) is used to build runnable applications from source code using [Cloud Native Buildpacks](https://buildpacks.io/). Follow the [instructions](https://github.com/pivotal/kpack/blob/main/docs/install.md) to install the latest version.
+[Kpack](https://github.com/pivotal/kpack) is used to build runnable applications from source code using [Cloud Native Buildpacks](https://buildpacks.io/). Follow the [instructions](https://github.com/pivotal/kpack/releases/latest) to install the latest version.
 
 The Helm chart will create an example Kpack `ClusterBuilder` (with the associated `ClusterStore` and `ClusterStack`) by default. To use your own `ClusterBuilder`, specify the `kpack-image-builder.clusterBuilderName` value. See the [Kpack documentation](https://github.com/pivotal/kpack/blob/main/docs/builders.md) for details on how to set up your own `ClusterBuilder`.
 
@@ -102,7 +102,8 @@ EOF
 
 ### Container registry credentials `Secret`
 
-(Not required when using ECR on an EKS deployment)
+> **Warning**
+> This is not required when using ECR on an EKS deployment.
 
 Use the following command to create a `Secret` that Korifi and Kpack will use to connect to your container registry:
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -138,23 +138,21 @@ helm install korifi https://github.com/cloudfoundry/korifi/releases/download/v<V
     --set=adminUserName="$ADMIN_USERNAME" \
     --set=api.apiServer.url="api.$BASE_DOMAIN" \
     --set=global.defaultAppDomainName="apps.$BASE_DOMAIN" \
-    --set=global.containerRegistryBase=europe-west1-docker.pkg.dev/my-project \
-    --set=global.containerRepositoryPrefix=korifi/ \
+    --set=global.containerRepositoryPrefix=europe-west1-docker.pkg.dev/my-project/korifi/ \
     --set=kpack-image-builder.builderRepository=europe-west1-docker.pkg.dev/my-project/korifi/kpack-builder \
 ```
 
-The `global.containerRegistryBase` and `global.containerRepositoryPrefix` are used to determine the image refs for the package and droplet images produced by korifi.
-The values depend on the target container registry.
-The app GUID and image type (packages or droplets) are appended to form the image ref.
+`global.containerRepositoryPrefix` is used to determine the container repository for the package and droplet images produced by Korifi.
+In particular, the app GUID and image type (`packages` or `droplets`) are appended to form the name of the repository.
 For example:
 
-| Registry  | containerRegistryBase                        | containerRepositoryPrefix | Resultant Image Ref                                                             | Notes                                                                                                    |
-| --------- | -------------------------------------------- | ------------------------- | ------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| ACR       | \<projectID>.azurecr.io                      | foo/bar/korifi-           | \<projectID>.azurecr.io/foo/bar/korifi-\<appGUID>-packages                      | Repositories are created dynamically during push by ACR                                                  |
-| DockerHub | index.docker.io/\<dockerOrganisation>        | [empty]                   | index.docker.io/\<dockerOrganisation>/\<appGUID>-packages                       | Docker does not support nested repositories                                                              |
-| ECR       | \<projectID>.dkr.ecr.\<region>.amazonaws.com | foo/bar/korifi-           | \<projectID>.dkr.ecr.\<region>.amazonaws.com/foo/bar/korifi-\<appGUID>-packages | Korifi will create the repository before pushing, as dynamic repository creation is not posssible on ECR |
-| GAR       | \<region>-docker.pkg.dev/\<projectID>        | foo/bar/korifi-           | \<region>-docker.pkg.dev/\<projectID>/foo/bar/korifi-\<appGUID>-packages        | The `foo` repository must already exist in GAR                                                           |
-| GCR       | gcr.io/\<projectID>                          | foo/bar/korifi-           | gcr.io/\<projectID>/foo/bar/korifi-\<appGUID>-packages                          | Repositories are created dynamically during push by GCR                                                  |
+| Registry  | containerRepositoryPrefix                                    | Resultant Image Ref                                                             | Notes                                                                                                    |
+| --------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| ACR       | \<projectID>.azurecr.io/foo/bar/korifi-                      | \<projectID>.azurecr.io/foo/bar/korifi-\<appGUID>-packages                      | Repositories are created dynamically during push by ACR                                                  |
+| DockerHub | index.docker.io/\<dockerOrganisation>/                       | index.docker.io/\<dockerOrganisation>/\<appGUID>-packages                       | Docker does not support nested repositories                                                              |
+| ECR       | \<projectID>.dkr.ecr.\<region>.amazonaws.com/foo/bar/korifi- | \<projectID>.dkr.ecr.\<region>.amazonaws.com/foo/bar/korifi-\<appGUID>-packages | Korifi will create the repository before pushing, as dynamic repository creation is not posssible on ECR |
+| GAR       | \<region>-docker.pkg.dev/\<projectID>/foo/bar/korifi-        | \<region>-docker.pkg.dev/\<projectID>/foo/bar/korifi-\<appGUID>-packages        | The `foo` repository must already exist in GAR                                                           |
+| GCR       | gcr.io/\<projectID>/foo/bar/korifi-                          | gcr.io/\<projectID>/foo/bar/korifi-\<appGUID>-packages                          | Repositories are created dynamically during push by GCR                                                  |
 
 The chart provides various other values that can be set. See [`README.helm.md`](./README.helm.md) for details.
 

--- a/README.helm.md
+++ b/README.helm.md
@@ -11,9 +11,8 @@ Here are all the values that can be set for the chart:
 
 - `adminUserName` (_String_): Name of the admin user that will be bound to the Cloud Foundry Admin role.
 - `global`: Global values that are shared between Korifi and its subcharts.
-  - `containerRegistryBase` (_String_): The part of the container registry image reference identifying the registry used for package and droplet images.
   - `containerRegistrySecret` (_String_): Name of the `Secret` to use when pushing or pulling from package, droplet and kpack-build repositories. Required if eksContainerRegistryRoleARN not set. Ignored if eksContainerRegistryRoleARN is set.
-  - `containerRepositoryPrefix` (_String_): The repository prefix of the image repository where package and droplet images are pushed to. This is added to the containerRegistryBase, and is suffixed with appGUID and `-packages` or `-droplets`.
+  - `containerRepositoryPrefix` (_String_): The prefix of the container repository where package and droplet images will be pushed. This is suffixed with the app GUID and `-packages` or `-droplets`. For example, a value of `index.docker.io/korifi/` will result in `index.docker.io/korifi/<appGUID>-packages` and `index.docker.io/korifi/<appGUID>-droplets` being pushed.
   - `debug` (_Boolean_): Enables remote debugging with [Delve](https://github.com/go-delve/delve).
   - `defaultAppDomainName` (_String_): Base domain name for application URLs.
   - `eksContainerRegistryRoleARN` (_String_): Amazon Resource Name (ARN) of the IAM role to use to access the ECR registry from an EKS deployed Korifi. Required if containerRegistrySecret not set.

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -27,7 +27,6 @@ type APIConfig struct {
 
 	RootNamespace                            string                 `yaml:"rootNamespace"`
 	BuilderName                              string                 `yaml:"builderName"`
-	ContainerRegistryBase                    string                 `yaml:"containerRegistryBase"`
 	ContainerRepositoryPrefix                string                 `yaml:"containerRepositoryPrefix"`
 	ContainerRegistryType                    string                 `yaml:"containerRegistryType"`
 	PackageRegistrySecretName                string                 `yaml:"packageRegistrySecretName"`

--- a/api/config/config_test.go
+++ b/api/config/config_test.go
@@ -35,8 +35,7 @@ var _ = Describe("Config", func() {
 
 			"rootNamespace":                            "root-ns",
 			"builderName":                              "my-builder",
-			"containerRegistryBase":                    "container.registry",
-			"containerRepositoryPrefix":                "my-prefix",
+			"containerRepositoryPrefix":                "container.registry/my-prefix",
 			"packageRegistrySecretName":                "package-registry-secret",
 			"defaultDomainName":                        "default.domain",
 			"userCertificateExpirationWarningDuration": "10s",
@@ -78,8 +77,7 @@ var _ = Describe("Config", func() {
 		Expect(cfg.ServerURL).To(Equal("https://api.foo"))
 		Expect(cfg.RootNamespace).To(Equal("root-ns"))
 		Expect(cfg.BuilderName).To(Equal("my-builder"))
-		Expect(cfg.ContainerRegistryBase).To(Equal("container.registry"))
-		Expect(cfg.ContainerRepositoryPrefix).To(Equal("my-prefix"))
+		Expect(cfg.ContainerRepositoryPrefix).To(Equal("container.registry/my-prefix"))
 		Expect(cfg.PackageRegistrySecretName).To(Equal("package-registry-secret"))
 		Expect(cfg.DefaultDomainName).To(Equal("default.domain"))
 		Expect(cfg.UserCertificateExpirationWarningDuration).To(Equal("10s"))

--- a/api/main.go
+++ b/api/main.go
@@ -165,7 +165,7 @@ func main() {
 		namespaceRetriever,
 		nsPermissions,
 		toolsregistry.NewRegistryCreator(config.ContainerRegistryType),
-		toolsregistry.NewContainerRegistryMeta(config.ContainerRegistryBase, config.ContainerRepositoryPrefix),
+		toolsregistry.NewContainerRegistryMeta(config.ContainerRepositoryPrefix),
 	)
 	serviceInstanceRepo := repositories.NewServiceInstanceRepo(
 		namespaceRetriever,

--- a/api/repositories/image_repository.go
+++ b/api/repositories/image_repository.go
@@ -20,7 +20,6 @@ import (
 
 	authv1 "k8s.io/api/authorization/v1"
 	k8sclient "k8s.io/client-go/kubernetes"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 //+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get,namespace=ROOT_NAMESPACE
@@ -130,13 +129,9 @@ func (r *ImageRepository) getCredentials(ctx context.Context) (remote.Option, er
 	var keychain authn.Keychain
 	var err error
 
-	logger := logf.Log.WithName("FOOLogger")
-
 	if r.registrySecretName == "" {
-		logger.Info("Registry Secret Name is empty")
 		keychain, err = k8schain.NewNoClient(ctx)
 	} else {
-		logger.Info("Registry Secret Name is not empty", "registrySecretName", r.registrySecretName)
 		keychain, err = k8schain.New(ctx, r.privilegedK8sClient, k8schain.Options{
 			Namespace:        r.rootNamespace,
 			ImagePullSecrets: []string{r.registrySecretName},

--- a/api/repositories/package_repository.go
+++ b/api/repositories/package_repository.go
@@ -128,7 +128,7 @@ func (r *PackageRepo) CreatePackage(ctx context.Context, authInfo authorization.
 		return PackageRecord{}, apierrors.FromK8sError(err, PackageResourceType)
 	}
 
-	err = r.repositoryCreator.CreateRepository(ctx, r.containerRegistryMeta.PackageRepoName(message.AppGUID))
+	err = r.repositoryCreator.CreateRepository(ctx, r.containerRegistryMeta.PackageRepoPath(message.AppGUID))
 	if err != nil {
 		return PackageRecord{}, fmt.Errorf("failed to create package repository: %w", err)
 	}
@@ -303,7 +303,7 @@ func (r *PackageRepo) cfPackageToPackageRecord(cfPackage korifiv1alpha1.CFPackag
 		UpdatedAt:   updatedAtTime,
 		Labels:      cfPackage.Labels,
 		Annotations: cfPackage.Annotations,
-		ImageRef:    r.containerRegistryMeta.PackageImageRef(cfPackage.Spec.AppRef.Name),
+		ImageRef:    r.containerRegistryMeta.PackageRepoName(cfPackage.Spec.AppRef.Name),
 	}
 }
 

--- a/api/repositories/package_repository_test.go
+++ b/api/repositories/package_repository_test.go
@@ -40,7 +40,7 @@ var _ = Describe("PackageRepository", func() {
 			namespaceRetriever,
 			nsPerms,
 			repoCreator,
-			registry.NewContainerRegistryMeta("container.registry/foo", "my/prefix-"),
+			registry.NewContainerRegistryMeta("container.registry/foo/my/prefix-"),
 		)
 		org = createOrgWithCleanup(ctx, prefixedGUID("org"))
 		space = createSpaceWithCleanup(ctx, org.Name, prefixedGUID("space"))
@@ -118,7 +118,7 @@ var _ = Describe("PackageRepository", func() {
 			It("creates a package repository", func() {
 				Expect(repoCreator.CreateRepositoryCallCount()).To(Equal(1))
 				_, repoName := repoCreator.CreateRepositoryArgsForCall(0)
-				Expect(repoName).To(Equal("my/prefix-" + appGUID + "-packages"))
+				Expect(repoName).To(Equal("foo/my/prefix-" + appGUID + "-packages"))
 			})
 
 			When("repo creation errors", func() {

--- a/helm/api/templates/configmap.yaml
+++ b/helm/api/templates/configmap.yaml
@@ -19,7 +19,6 @@ data:
       stack: {{ .Values.lifecycle.stack }}
       stagingMemoryMB: {{ .Values.lifecycle.stagingRequirements.memoryMB }}
       stagingDiskMB: {{ .Values.lifecycle.stagingRequirements.diskMB }}
-    containerRegistryBase: {{ .Values.global.containerRegistryBase | quote }}
     containerRepositoryPrefix: {{ .Values.global.containerRepositoryPrefix | quote }}
     {{- if not .Values.global.eksContainerRegistryRoleARN }}
     packageRegistrySecretName: {{ required "packageRegistrySecretName is required when global.eksContainerRegistryRoleARN is not set" .Values.global.containerRegistrySecret }}

--- a/helm/api/templates/configmap.yaml
+++ b/helm/api/templates/configmap.yaml
@@ -21,7 +21,7 @@ data:
       stagingDiskMB: {{ .Values.lifecycle.stagingRequirements.diskMB }}
     containerRepositoryPrefix: {{ .Values.global.containerRepositoryPrefix | quote }}
     {{- if not .Values.global.eksContainerRegistryRoleARN }}
-    packageRegistrySecretName: {{ required "packageRegistrySecretName is required when global.eksContainerRegistryRoleARN is not set" .Values.global.containerRegistrySecret }}
+    packageRegistrySecretName: {{ required "global.containerRegistrySecret is required when global.eksContainerRegistryRoleARN is not set" .Values.global.containerRegistrySecret }}
     {{- end }}
     defaultDomainName: {{ .Values.global.defaultAppDomainName }}
     userCertificateExpirationWarningDuration: {{ .Values.userCertificateExpirationWarningDuration }}

--- a/helm/api/values.yaml
+++ b/helm/api/values.yaml
@@ -3,8 +3,6 @@ global:
   debug: false
   defaultAppDomainName:
   generateIngressCertificates: false
-  containerRegistryBase: ""
-  containerRepositoryPrefix: ""
   containerRegistrySecret: image-registry-credentials
   eksContainerRegistryRoleARN: ""
 

--- a/helm/korifi/values.schema.json
+++ b/helm/korifi/values.schema.json
@@ -20,12 +20,8 @@
           "description": "Use `cert-manager` to generate self-signed certificates for the API and app endpoints.",
           "type": "boolean"
         },
-        "containerRegistryBase": {
-          "description": "The part of the container registry image reference identifying the registry used for package and droplet images.",
-          "type": "string"
-        },
         "containerRepositoryPrefix": {
-          "description": "The repository prefix of the image repository where package and droplet images are pushed to. This is added to the containerRegistryBase, and is suffixed with appGUID and `-packages` or `-droplets`.",
+          "description": "The prefix of the container repository where package and droplet images will be pushed. This is suffixed with the app GUID and `-packages` or `-droplets`. For example, a value of `index.docker.io/korifi/` will result in `index.docker.io/korifi/<appGUID>-packages` and `index.docker.io/korifi/<appGUID>-droplets` being pushed.",
           "type": "string"
         },
         "containerRegistrySecret": {
@@ -39,7 +35,7 @@
       },
       "required": [
         "rootNamespace",
-        "containerRegistryBase",
+        "containerRepositoryPrefix",
         "defaultAppDomainName"
       ],
       "type": "object"

--- a/helm/korifi/values.yaml
+++ b/helm/korifi/values.yaml
@@ -3,8 +3,6 @@ global:
   debug: false
   defaultAppDomainName: apps.my-cf-domain.com
   generateIngressCertificates: false
-  containerRegistryBase: ""
-  containerRepositoryPrefix: ""
   containerRegistrySecret: image-registry-credentials
   eksContainerRegistryRoleARN: ""
 

--- a/helm/kpack-image-builder/templates/configmap.yaml
+++ b/helm/kpack-image-builder/templates/configmap.yaml
@@ -7,7 +7,6 @@ data:
   kpack_build_controllers_config.yaml: |
     cfRootNamespace: {{ .Values.global.rootNamespace }}
     clusterBuilderName: {{ .Values.clusterBuilderName | default "cf-kpack-cluster-builder" }}
-    containerRegistryBase: {{ .Values.global.containerRegistryBase | quote }}
     containerRepositoryPrefix: {{ .Values.global.containerRepositoryPrefix | quote }}
     builderServiceAccount: kpack-service-account
     {{- if .Values.global.eksContainerRegistryRoleARN }}

--- a/helm/kpack-image-builder/values.yaml
+++ b/helm/kpack-image-builder/values.yaml
@@ -1,8 +1,6 @@
 global:
   rootNamespace: cf
   debug: false
-  containerRegistryBase: ""
-  containerRepositoryPrefix: ""
   containerRegistrySecret: image-registry-credentials
   eksContainerRegistryRoleARN: ""
 

--- a/kpack-image-builder/config/config.go
+++ b/kpack-image-builder/config/config.go
@@ -13,7 +13,6 @@ type ControllerConfig struct {
 	CFRootNamespace           string `yaml:"cfRootNamespace"`
 	ClusterBuilderName        string `yaml:"clusterBuilderName"`
 	BuilderServiceAccount     string `yaml:"builderServiceAccount"`
-	ContainerRegistryBase     string `yaml:"containerRegistryBase"`
 	ContainerRepositoryPrefix string `yaml:"containerRepositoryPrefix"`
 	ContainerRegistryType     string `yaml:"containerRegistryType"`
 }

--- a/kpack-image-builder/controllers/buildworkload_controller.go
+++ b/kpack-image-builder/controllers/buildworkload_controller.go
@@ -224,7 +224,7 @@ func (r *BuildWorkloadReconciler) createKpackImageAndUpdateStatus(ctx context.Co
 	appGUID := buildWorkload.Labels[korifiv1alpha1.CFAppGUIDLabelKey]
 	kpackImageName := buildWorkload.Name
 	kpackImageNamespace := buildWorkload.Namespace
-	kpackImageTag := r.containerRegistryMeta.DropletImageRef(appGUID)
+	kpackImageTag := r.containerRegistryMeta.DropletRepoName(appGUID)
 	desiredKpackImage := buildv1alpha2.Image{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      kpackImageName,
@@ -280,7 +280,7 @@ func (r *BuildWorkloadReconciler) createKpackImageIfNotExists(ctx context.Contex
 	err := r.k8sClient.Get(ctx, client.ObjectKeyFromObject(&desiredKpackImage), &foundKpackImage)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			if err = r.imageRepoCreator.CreateRepository(ctx, r.containerRegistryMeta.DropletRepoName(appGUID)); err != nil {
+			if err = r.imageRepoCreator.CreateRepository(ctx, r.containerRegistryMeta.DropletRepoPath(appGUID)); err != nil {
 				r.log.Error(err, "failed to create image repository")
 				return err
 			}

--- a/kpack-image-builder/controllers/suite_test.go
+++ b/kpack-image-builder/controllers/suite_test.go
@@ -133,7 +133,7 @@ var _ = BeforeSuite(func() {
 		controllers.NewRegistryAuthFetcher(registryAuthFetcherClient, controllerConfig.BuilderServiceAccount),
 		registryCAPath,
 		fakeImageProcessFetcherInfocation,
-		registry.NewContainerRegistryMeta("my.repository", "my-prefix/"),
+		registry.NewContainerRegistryMeta("my.repository/my-prefix/"),
 		imageRepoCreator,
 	)
 	err = (buildWorkloadReconciler).SetupWithManager(k8sManager)

--- a/kpack-image-builder/main.go
+++ b/kpack-image-builder/main.go
@@ -17,11 +17,12 @@ limitations under the License.
 package main
 
 import (
-	"code.cloudfoundry.org/korifi/tools"
 	"flag"
 	"fmt"
 	"log"
 	"os"
+
+	"code.cloudfoundry.org/korifi/tools"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"code.cloudfoundry.org/korifi/kpack-image-builder/api/v1alpha1"
@@ -130,7 +131,7 @@ func main() {
 		controllers.NewRegistryAuthFetcher(k8sClient, controllerConfig.BuilderServiceAccount),
 		registryCAPath,
 		cfBuildImageProcessFetcher.Fetch,
-		registry.NewContainerRegistryMeta(controllerConfig.ContainerRegistryBase, controllerConfig.ContainerRepositoryPrefix),
+		registry.NewContainerRegistryMeta(controllerConfig.ContainerRepositoryPrefix),
 		registry.NewRegistryCreator(controllerConfig.ContainerRegistryType),
 	).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "BuildWorkload")

--- a/scripts/assets/values-template.yaml
+++ b/scripts/assets/values-template.yaml
@@ -3,7 +3,7 @@ adminUserName: cf-admin
 global:
   defaultAppDomainName: apps-127-0-0-1.nip.io
   generateIngressCertificates: true
-  containerRegistryBase: localregistry-docker-registry.default.svc.cluster.local:30050/
+  containerRepositoryPrefix: localregistry-docker-registry.default.svc.cluster.local:30050/
 
 api:
   apiServer:

--- a/scripts/deploy-on-kind.sh
+++ b/scripts/deploy-on-kind.sh
@@ -17,7 +17,6 @@ flags:
       - DOCKER_SERVER
       - DOCKER_USERNAME
       - DOCKER_PASSWORD
-      - REGISTRY_BASE
       - REPOSITORY_PREFIX
       - KPACK_BUILDER_REPOSITORY
 
@@ -51,7 +50,7 @@ while [[ $# -gt 0 ]]; do
     -r | --use-custom-registry)
       use_custom_registry="true"
       # blow up if required vars not set
-      echo "$DOCKER_SERVER $DOCKER_USERNAME $DOCKER_PASSWORD $REGISTRY_BASE $REPOSITORY_PREFIX $KPACK_BUILDER_REPOSITORY" >/dev/null
+      echo "$DOCKER_SERVER $DOCKER_USERNAME $DOCKER_PASSWORD $REPOSITORY_PREFIX $KPACK_BUILDER_REPOSITORY" >/dev/null
       shift
       ;;
     -D | --debug)
@@ -161,7 +160,6 @@ function deploy_korifi() {
         --namespace korifi \
         --values=scripts/assets/values.yaml \
         --set=global.debug="$doDebug" \
-        --set=global.containerRegistryBase="$REGISTRY_BASE" \
         --set=global.containerRepositoryPrefix="$REPOSITORY_PREFIX" \
         --set=kpack-image-builder.builderRepository="$KPACK_BUILDER_REPOSITORY" \
         --wait

--- a/tools/registry/meta.go
+++ b/tools/registry/meta.go
@@ -1,31 +1,34 @@
 package registry
 
-import "path"
+import (
+	"strings"
+)
 
 type ContainerRegistryMeta struct {
 	registryBase string
 	repoPrefix   string
 }
 
-func NewContainerRegistryMeta(registryBase, repoPrefix string) *ContainerRegistryMeta {
+func NewContainerRegistryMeta(repoPrefix string) *ContainerRegistryMeta {
+	base, prefix, _ := strings.Cut(repoPrefix, "/")
 	return &ContainerRegistryMeta{
-		registryBase: registryBase,
-		repoPrefix:   repoPrefix,
+		registryBase: base,
+		repoPrefix:   prefix,
 	}
 }
 
-func (r *ContainerRegistryMeta) PackageRepoName(appGUID string) string {
+func (r *ContainerRegistryMeta) PackageRepoPath(appGUID string) string {
 	return r.repoPrefix + appGUID + "-packages"
 }
 
-func (r *ContainerRegistryMeta) PackageImageRef(appGUID string) string {
-	return path.Join(r.registryBase, r.PackageRepoName(appGUID))
+func (r *ContainerRegistryMeta) PackageRepoName(appGUID string) string {
+	return r.registryBase + "/" + r.PackageRepoPath(appGUID)
 }
 
-func (r *ContainerRegistryMeta) DropletRepoName(appGUID string) string {
+func (r *ContainerRegistryMeta) DropletRepoPath(appGUID string) string {
 	return r.repoPrefix + appGUID + "-droplets"
 }
 
-func (r *ContainerRegistryMeta) DropletImageRef(appGUID string) string {
-	return path.Join(r.registryBase, r.DropletRepoName(appGUID))
+func (r *ContainerRegistryMeta) DropletRepoName(appGUID string) string {
+	return r.registryBase + "/" + r.DropletRepoPath(appGUID)
 }

--- a/tools/registry/meta_test.go
+++ b/tools/registry/meta_test.go
@@ -10,22 +10,44 @@ var _ = Describe("ContainerRegistryMeta", func() {
 	var containerRegistryMeta *registry.ContainerRegistryMeta
 
 	BeforeEach(func() {
-		containerRegistryMeta = registry.NewContainerRegistryMeta("my-repo-prefix.foo/bar", "plus-some/more-")
+		containerRegistryMeta = registry.NewContainerRegistryMeta("my-repo-prefix.foo/bar/plus-some/more-")
 	})
 
-	It("returns package repo name", func() {
-		Expect(containerRegistryMeta.PackageRepoName("my-app")).To(Equal("plus-some/more-my-app-packages"))
+	It("returns the package repository path", func() {
+		Expect(containerRegistryMeta.PackageRepoPath("my-app")).To(Equal("bar/plus-some/more-my-app-packages"))
 	})
 
-	It("returns package image ref", func() {
-		Expect(containerRegistryMeta.PackageImageRef("my-app")).To(Equal("my-repo-prefix.foo/bar/plus-some/more-my-app-packages"))
+	It("returns the package repository name", func() {
+		Expect(containerRegistryMeta.PackageRepoName("my-app")).To(Equal("my-repo-prefix.foo/bar/plus-some/more-my-app-packages"))
 	})
 
-	It("returns droplet repo name", func() {
-		Expect(containerRegistryMeta.DropletRepoName("my-app")).To(Equal("plus-some/more-my-app-droplets"))
+	It("returns the droplet repository path", func() {
+		Expect(containerRegistryMeta.DropletRepoPath("my-app")).To(Equal("bar/plus-some/more-my-app-droplets"))
 	})
 
-	It("returns package image ref", func() {
-		Expect(containerRegistryMeta.DropletImageRef("my-app")).To(Equal("my-repo-prefix.foo/bar/plus-some/more-my-app-droplets"))
+	It("returns the droplet repository name", func() {
+		Expect(containerRegistryMeta.DropletRepoName("my-app")).To(Equal("my-repo-prefix.foo/bar/plus-some/more-my-app-droplets"))
+	})
+
+	When("the repository path is just a slash", func() {
+		BeforeEach(func() {
+			containerRegistryMeta = registry.NewContainerRegistryMeta("my-repo-prefix.foo/")
+		})
+
+		It("parses the prefix correctly", func() {
+			Expect(containerRegistryMeta.DropletRepoPath("my-app")).To(Equal("my-app-droplets"))
+			Expect(containerRegistryMeta.DropletRepoName("my-app")).To(Equal("my-repo-prefix.foo/my-app-droplets"))
+		})
+	})
+
+	When("the repository path is empty", func() {
+		BeforeEach(func() {
+			containerRegistryMeta = registry.NewContainerRegistryMeta("my-repo-prefix.foo")
+		})
+
+		It("parses the prefix correctly", func() {
+			Expect(containerRegistryMeta.DropletRepoPath("my-app")).To(Equal("my-app-droplets"))
+			Expect(containerRegistryMeta.DropletRepoName("my-app")).To(Equal("my-repo-prefix.foo/my-app-droplets"))
+		})
 	})
 })


### PR DESCRIPTION
## Is there a related GitHub Issue?

No.

## What is this change about?

- Consolidate registry config values so that users only have to specify `global.containerRepositoryPrefix`.
- Remove some leftover debug logs.
- Improve the error message when `global.containerRegistrySecret` is missing.
- Fix the docs.

## Does this PR introduce a breaking change?

Yes: the container repository prefix values have been consolidated into the single `global.containerRepositoryPrefix`.

## Tag your pair, your PM, and/or team

@davewalter
