### PR TITLE
Stabilize app revision

### DIFF
--- a/controllers/main.go
+++ b/controllers/main.go
@@ -17,12 +17,13 @@ limitations under the License.
 package main
 
 import (
-	"code.cloudfoundry.org/korifi/tools"
 	"flag"
 	"fmt"
 	"log"
 	"os"
 	"time"
+
+	"code.cloudfoundry.org/korifi/tools"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"code.cloudfoundry.org/korifi/controllers/config"

--- a/statefulset-runner/main.go
+++ b/statefulset-runner/main.go
@@ -17,10 +17,11 @@ limitations under the License.
 package main
 
 import (
-	"code.cloudfoundry.org/korifi/tools"
 	"flag"
 	"log"
 	"os"
+
+	"code.cloudfoundry.org/korifi/tools"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	v1 "code.cloudfoundry.org/korifi/statefulset-runner/api/v1"


### PR DESCRIPTION
## Is there a related GitHub Issue?
https://github.com/cloudfoundry/korifi/issues/1912
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
The app revision used to be set/incremented un the cf app webhook
according to nontrivial logic that was trying to guess whether the app
is being stopped which was error prone and unpredictable because there
are no guaranteed how many times the hook will execute

This WIP is an attempt to move the logic from the webhook to the app
handler, or to be more exact, to eliminate it, since the app handler
knows with certainty if the app is being stopped or started. The handler
will bump the app  rev when the app stop endpoint is triggered. This
makes the app rev predictable by the user, since it no longer happens in
the reconciliation loop.
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
See story
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@danail-branekov
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
