### PR TITLE
Operator can avoid exposing the Korifi API via Contour

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -205,6 +205,13 @@ It may take some time before the address is available. Retry this until you see 
 
 The type of DNS records to create will differ based on the type of the endpoint: `ip` endpoints (e.g. the ones created by GKE) will need an `A` record, while `hostname` endpoints (e.g. on EKS) a `CNAME` record.
 
+#### Custom Ingress
+
+If you want to expose the API server using a means other than Contour, you can
+switch off the default contour api-server ingress by setting the `api.expose`
+value to `false` in the `helm install` command above. Make sure your ingress
+targets a service with name `korifi-api-svc` and port `443`.
+
 ## Test Korifi
 
 ```sh

--- a/README.helm.md
+++ b/README.helm.md
@@ -32,6 +32,7 @@ Here are all the values that can be set for the chart:
     - `caCert` (_String_): Proxy's PEM-encoded CA certificate (*not* as Base64).
     - `host` (_String_): Must be a host string, a host:port pair, or a URL to the base of the apiserver.
   - `builderName` (_String_): ID of the builder used to build apps. Defaults to `kpack-image-builder`.
+  - `expose` (_Boolean_): Expose the API component via Contour. Set to false if you want to expose the API using other means.
   - `image` (_String_): Reference to the API container image.
   - `include` (_Boolean_): Deploy the API component.
   - `lifecycle`: Default lifecycle for apps.

--- a/helm/api/templates/ingress.yaml
+++ b/helm/api/templates/ingress.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.expose }}
 apiVersion: projectcontour.io/v1
 kind: HTTPProxy
 metadata:
@@ -21,3 +22,4 @@ spec:
     fqdn: {{ .Values.apiServer.url }}
     tls:
       secretName: korifi-api-ingress-cert
+{{- end }}

--- a/helm/api/values.schema.json
+++ b/helm/api/values.schema.json
@@ -5,6 +5,10 @@
       "description": "Deploy the API component.",
       "type": "boolean"
     },
+    "expose": {
+      "description": "Expose the API component via Contour. Set to false if you want to expose the API using other means.",
+      "type": "boolean"
+    },
     "replicas": {
       "description": "Number of replicas.",
       "type": "integer"
@@ -143,6 +147,7 @@
   },
   "required": [
     "include",
+    "expose",
     "apiServer",
     "image",
     "lifecycle",

--- a/helm/api/values.yaml
+++ b/helm/api/values.yaml
@@ -8,6 +8,7 @@ global:
   containerRegistryCACertSecret:
 
 include: true
+expose: true
 replicas: 1
 resources:
   requests:


### PR DESCRIPTION
## Is there a related GitHub Issue?
Issue: https://github.com/cloudfoundry/korifi/issues/1843
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
- This is a first step towards support of non-Contour routing for Korifi.
- The ability to have self-signed certificates issued by cert manager is
  left intact, as certs are useful regardless of the networking
  techology being used, and it can be switched off using the global
  `generateIngressCertificates` flag
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
See issue
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@eirini
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
