### PR TITLE
Introduce the controllers.namespaceLabels value

### DIFF
--- a/README.helm.md
+++ b/README.helm.md
@@ -53,6 +53,7 @@ Here are all the values that can be set for the chart:
 - `controllers`:
   - `image` (_String_): Reference to the controllers container image.
   - `include` (_Boolean_): Deploy the controllers component.
+  - `namespaceLabels`: Key value pairs that are going to be set as labels in the workload namespaces created by Korifi
   - `processDefaults`:
     - `diskQuotaMB` (_Integer_): Default disk quota for the `web` process.
     - `memoryMB` (_Integer_): Default memory limit for the `web` process.

--- a/controllers/config/config.go
+++ b/controllers/config/config.go
@@ -16,6 +16,7 @@ type ControllerConfig struct {
 	WorkloadsTLSSecretNamespace string            `yaml:"workloads_tls_secret_namespace"`
 	BuilderName                 string            `yaml:"builderName"`
 	RunnerName                  string            `yaml:"runnerName"`
+	NamespaceLabels             map[string]string `yaml:"namespaceLabels"`
 }
 
 type CFProcessDefaults struct {

--- a/controllers/config/config_test.go
+++ b/controllers/config/config_test.go
@@ -72,6 +72,7 @@ var _ = Describe("LoadFromPath", func() {
 			WorkloadsTLSSecretNamespace: "workloadsTLSSecretNamespace",
 			BuilderName:                 "buildReconciler",
 			RunnerName:                  "statefulset-runner",
+			NamespaceLabels:             map[string]string{},
 		}))
 	})
 

--- a/controllers/controllers/workloads/cfspace_controller_test.go
+++ b/controllers/controllers/workloads/cfspace_controller_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"time"
 
+	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
+	. "code.cloudfoundry.org/korifi/controllers/controllers/workloads/testutils"
+	"code.cloudfoundry.org/korifi/tools/k8s"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
@@ -15,10 +18,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/pod-security-admission/api"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
-	. "code.cloudfoundry.org/korifi/controllers/controllers/workloads/testutils"
-	"code.cloudfoundry.org/korifi/tools/k8s"
 )
 
 var _ = Describe("CFSpaceReconciler Integration Tests", func() {

--- a/controllers/controllers/workloads/labels/compiler.go
+++ b/controllers/controllers/workloads/labels/compiler.go
@@ -1,0 +1,44 @@
+package labels
+
+// Compiler is a reusable map composer. It persists a set of defaults, which
+// can be overridden when calling Compile() to produce the combined map.
+type Compiler struct {
+	defaults map[string]string
+}
+
+func NewCompiler() Compiler {
+	return Compiler{
+		defaults: map[string]string{},
+	}
+}
+
+func (o Compiler) Defaults(defaults map[string]string) Compiler {
+	defaultsCopy := copyMap(o.defaults)
+	for k, v := range defaults {
+		defaultsCopy[k] = v
+	}
+	return Compiler{
+		defaults: defaultsCopy,
+	}
+}
+
+func (o Compiler) Compile(overrides map[string]string) map[string]string {
+	res := map[string]string{}
+	for k, v := range o.defaults {
+		res[k] = v
+	}
+	for k, v := range overrides {
+		res[k] = v
+	}
+
+	return res
+}
+
+func copyMap(src map[string]string) map[string]string {
+	dst := map[string]string{}
+	for k, v := range src {
+		dst[k] = v
+	}
+
+	return dst
+}

--- a/controllers/controllers/workloads/labels/compiler_suite_test.go
+++ b/controllers/controllers/workloads/labels/compiler_suite_test.go
@@ -1,0 +1,13 @@
+package labels_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestLabels(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Labels Suite")
+}

--- a/controllers/controllers/workloads/labels/compiler_test.go
+++ b/controllers/controllers/workloads/labels/compiler_test.go
@@ -1,0 +1,84 @@
+package labels_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"code.cloudfoundry.org/korifi/controllers/controllers/workloads/labels"
+)
+
+var _ = Describe("Labels", func() {
+	var (
+		compiler labels.Compiler
+		override map[string]string
+		output   map[string]string
+	)
+
+	BeforeEach(func() {
+		override = nil
+		compiler = labels.NewCompiler()
+	})
+
+	JustBeforeEach(func() {
+		output = compiler.Compile(override)
+	})
+
+	It("will return empty if no defaults or override given", func() {
+		Expect(output).To(BeEmpty())
+	})
+
+	When("default values are provided", func() {
+		BeforeEach(func() {
+			compiler = compiler.Defaults(map[string]string{
+				"foo": "bar",
+			})
+		})
+
+		It("puts the default in the output", func() {
+			Expect(output).To(HaveKeyWithValue("foo", "bar"))
+		})
+	})
+
+	When("default values are provided twice", func() {
+		var oldCompiler labels.Compiler
+
+		BeforeEach(func() {
+			oldCompiler = compiler.Defaults(map[string]string{
+				"foo":   "bar",
+				"hello": "there",
+			})
+			compiler = oldCompiler.Defaults(map[string]string{
+				"foo": "baz",
+			})
+		})
+
+		It("puts the latest default in the output", func() {
+			Expect(output).To(HaveKeyWithValue("foo", "baz"))
+			Expect(output).To(HaveKeyWithValue("hello", "there"))
+		})
+
+		It("is immutable", func() {
+			Expect(oldCompiler.Compile(nil)).To(HaveKeyWithValue("foo", "bar"))
+			Expect(oldCompiler.Compile(nil)).To(HaveKeyWithValue("hello", "there"))
+		})
+	})
+
+	When("a default value is overridden", func() {
+		BeforeEach(func() {
+			compiler = compiler.Defaults(map[string]string{
+				"foo": "bar",
+			})
+			override = map[string]string{
+				"foo": "baz",
+			}
+		})
+
+		It("will use overridden value", func() {
+			Expect(output).To(HaveKeyWithValue("foo", "baz"))
+		})
+
+		It("will not accidently store the override", func() {
+			Expect(compiler.Compile(nil)).To(HaveKeyWithValue("foo", "bar"))
+		})
+	})
+})

--- a/controllers/controllers/workloads/shared.go
+++ b/controllers/controllers/workloads/shared.go
@@ -11,13 +11,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/pod-security-admission/api"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
-
 func createOrPatchNamespace(ctx context.Context, client client.Client, log logr.Logger, orgOrSpace client.Object, labels map[string]string) error {
 	log = log.WithName("createOrPatchNamespace")
 
@@ -35,8 +33,6 @@ func createOrPatchNamespace(ctx context.Context, client client.Client, log logr.
 		for key, value := range labels {
 			namespace.Labels[key] = value
 		}
-		namespace.Labels[api.EnforceLevelLabel] = string(api.LevelRestricted)
-		namespace.Labels[api.AuditLevelLabel] = string(api.LevelRestricted)
 
 		return nil
 	})
@@ -168,14 +164,14 @@ func reconcileRoleBindings(ctx context.Context, kClient client.Client, log logr.
 	return nil
 }
 
-func getNamespace(ctx context.Context, log logr.Logger, client client.Client, namespaceName string) (*corev1.Namespace, bool) {
+func getNamespace(ctx context.Context, log logr.Logger, client client.Client, namespaceName string) error {
 	log = log.WithValues("namespace", namespaceName)
 
 	namespace := new(corev1.Namespace)
 	err := client.Get(ctx, types.NamespacedName{Name: namespaceName}, namespace)
 	if err != nil {
 		log.Error(err, "failed to get namespace")
-		return nil, false
+		return err
 	}
-	return namespace, true
+	return nil
 }

--- a/helm/controllers/templates/configmap.yaml
+++ b/helm/controllers/templates/configmap.yaml
@@ -17,3 +17,7 @@ data:
     taskTTL: {{ .Values.taskTTL }}
     workloads_tls_secret_name: {{ .Values.workloadsTLSSecret }}
     workloads_tls_secret_namespace: {{ .Release.Namespace }}
+    namespaceLabels:
+    {{- range $key, $value := .Values.namespaceLabels }}
+      {{ $key }}: {{ $value }}
+    {{- end }}

--- a/helm/controllers/values.schema.json
+++ b/helm/controllers/values.schema.json
@@ -82,6 +82,11 @@
     "workloadsTLSSecret": {
       "description": "TLS secret used when setting up an app routes.",
       "type": "string"
+    },
+    "namespaceLabels": {
+      "description": "Key value pairs that are going to be set as labels in the workload namespaces created by Korifi",
+      "type": "object",
+      "properties": {}
     }
   },
   "required": [

--- a/helm/controllers/values.yaml
+++ b/helm/controllers/values.yaml
@@ -25,3 +25,5 @@ processDefaults:
   diskQuotaMB: 1024
 taskTTL: 30d
 workloadsTLSSecret: korifi-workloads-ingress-cert
+
+namespaceLabels: {}


### PR DESCRIPTION
## Is there a related GitHub Issue?

https://github.com/cloudfoundry/korifi/issues/1844

<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?

-   This lets the operator set custom labels on korifi space namespaces
-   For instance disabling istio sidecar injection or changing the
pod-security-admission levels
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No

<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
See issue

<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@kieron-dev

<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

## Things to remember

<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
