### PR TITLE
Add `--wait` to helm install in docs

### DIFF
--- a/INSTALL.EKS.md
+++ b/INSTALL.EKS.md
@@ -264,7 +264,8 @@ helm install korifi https://github.com/cloudfoundry/korifi/releases/download/v<V
   --set=global.containerRepositoryPrefix="${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${CLUSTER_NAME}/" \
   --set=global.containerRegistrySecret="" \
   --set=global.eksContainerRegistryRoleARN="${ECR_ROLE_ARN}" \
-  --set=kpack-image-builder.builderRepository="${KPACK_BUILDER_REPO}"
+  --set=kpack-image-builder.builderRepository="${KPACK_BUILDER_REPO}" \
+  --wait
 ```
 
 ## Test Korifi

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -163,6 +163,7 @@ helm install korifi https://github.com/cloudfoundry/korifi/releases/download/v<V
     --set=global.defaultAppDomainName="apps.$BASE_DOMAIN" \
     --set=global.containerRepositoryPrefix=europe-west1-docker.pkg.dev/my-project/korifi/ \
     --set=kpack-image-builder.builderRepository=europe-west1-docker.pkg.dev/my-project/korifi/kpack-builder \
+    --wait
 ```
 
 `global.containerRepositoryPrefix` is used to determine the container repository for the package and droplet images produced by Korifi.


### PR DESCRIPTION
## Is there a related GitHub Issue?
#2045

## What is this change about?
There is an obscure dependency between post-install templates and the `--wait` flag. Post-install templates only wait for the main installation to be _ready_ if the `--wait` flag is specified in install or upgrade command.

Our scripts all use `--wait`, but our docs did not reflect that.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
See issue

## Tag your pair, your PM, and/or team

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
