### PR TITLE
Change CFOrg and CFSpace display name validation to match CAPI

### DIFF
--- a/controllers/api/v1alpha1/cforg_types.go
+++ b/controllers/api/v1alpha1/cforg_types.go
@@ -33,7 +33,7 @@ type CFOrgSpec struct {
 	// Important: Run "make" to regenerate code after modifying this file
 
 	// The mutable, user-friendly name of the CFOrg. Unlike metadata.name, the user can change this field.
-	// +kubebuilder:validation:Pattern="^[-\\w]+$"
+	// +kubebuilder:validation:Pattern="^[[:alnum:][:punct:][:print:]]+$"
 	DisplayName string `json:"displayName"`
 }
 

--- a/controllers/api/v1alpha1/cforg_types_test.go
+++ b/controllers/api/v1alpha1/cforg_types_test.go
@@ -1,0 +1,58 @@
+package v1alpha1_test
+
+import (
+	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("CF Org", func() {
+	Describe("display name validation", func() {
+		var (
+			cfOrg     *korifiv1alpha1.CFOrg
+			createErr error
+		)
+
+		BeforeEach(func() {
+			cfOrg = &korifiv1alpha1.CFOrg{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      uuid.NewString(),
+				},
+				Spec: korifiv1alpha1.CFOrgSpec{
+					DisplayName: "org-name",
+				},
+			}
+		})
+
+		JustBeforeEach(func() {
+			createErr = k8sClient.Create(ctx, cfOrg)
+		})
+
+		It("accepts a valid name", func() {
+			Expect(createErr).NotTo(HaveOccurred())
+		})
+
+		When("name contains a space", func() {
+			BeforeEach(func() {
+				cfOrg.Spec.DisplayName = "hello there"
+			})
+
+			It("is allowed", func() {
+				Expect(createErr).NotTo(HaveOccurred())
+			})
+		})
+
+		When("display name contains disallowed characters", func() {
+			BeforeEach(func() {
+				cfOrg.Spec.DisplayName = "Nope\t\n\n"
+			})
+
+			It("fails", func() {
+				Expect(createErr).To(HaveOccurred())
+			})
+		})
+	})
+})

--- a/controllers/api/v1alpha1/cfspace_types.go
+++ b/controllers/api/v1alpha1/cfspace_types.go
@@ -27,7 +27,7 @@ const (
 // CFSpaceSpec defines the desired state of CFSpace
 type CFSpaceSpec struct {
 	// The mutable, user-friendly name of the space. Unlike metadata.name, the user can change this field
-	// +kubebuilder:validation:Pattern="^[-\\w]+$"
+	// +kubebuilder:validation:Pattern="^[[:alnum:][:punct:][:print:]]+$"
 	DisplayName string `json:"displayName"`
 }
 

--- a/controllers/api/v1alpha1/cfspace_types_test.go
+++ b/controllers/api/v1alpha1/cfspace_types_test.go
@@ -1,0 +1,75 @@
+package v1alpha1_test
+
+import (
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("CF Space", func() {
+	Describe("display name validation", func() {
+		var (
+			cfSpace   *korifiv1alpha1.CFSpace
+			createErr error
+		)
+
+		BeforeEach(func() {
+			cfOrg := &korifiv1alpha1.CFOrg{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      uuid.NewString(),
+				},
+				Spec: korifiv1alpha1.CFOrgSpec{
+					DisplayName: uuid.NewString(),
+				},
+			}
+			Expect(k8sClient.Create(ctx, cfOrg)).To(Succeed())
+
+			Expect(k8sClient.Create(ctx, &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: cfOrg.Name},
+			})).To(Succeed())
+
+			cfSpace = &korifiv1alpha1.CFSpace{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: cfOrg.Name,
+					Name:      uuid.NewString(),
+				},
+				Spec: korifiv1alpha1.CFSpaceSpec{
+					DisplayName: "space-name",
+				},
+			}
+		})
+
+		JustBeforeEach(func() {
+			createErr = k8sClient.Create(ctx, cfSpace)
+		})
+
+		It("accepts a valid name", func() {
+			Expect(createErr).NotTo(HaveOccurred())
+		})
+
+		When("name contains a space", func() {
+			BeforeEach(func() {
+				cfSpace.Spec.DisplayName = "hello there"
+			})
+
+			It("is allowed", func() {
+				Expect(createErr).NotTo(HaveOccurred())
+			})
+		})
+
+		When("display name contains disallowed characters", func() {
+			BeforeEach(func() {
+				cfSpace.Spec.DisplayName = "Nope\t\n\n"
+			})
+
+			It("fails", func() {
+				Expect(createErr).To(HaveOccurred())
+			})
+		})
+	})
+})

--- a/controllers/api/v1alpha1/webhook_suite_test.go
+++ b/controllers/api/v1alpha1/webhook_suite_test.go
@@ -133,6 +133,14 @@ var _ = BeforeSuite(func() {
 
 	Expect((&korifiv1alpha1.CFBuild{}).SetupWebhookWithManager(mgr)).To(Succeed())
 
+	orgNameDuplicateValidator := webhooks.NewDuplicateValidator(coordination.NewNameRegistry(mgr.GetClient(), workloads.CFOrgEntityType))
+	orgPlacementValidator := webhooks.NewPlacementValidator(mgr.GetClient(), namespace)
+	Expect(workloads.NewCFOrgValidator(orgNameDuplicateValidator, orgPlacementValidator).SetupWebhookWithManager(mgr)).To(Succeed())
+
+	spaceNameDuplicateValidator := webhooks.NewDuplicateValidator(coordination.NewNameRegistry(mgr.GetClient(), workloads.CFSpaceEntityType))
+	spacePlacementValidator := webhooks.NewPlacementValidator(mgr.GetClient(), namespace)
+	Expect(workloads.NewCFSpaceValidator(spaceNameDuplicateValidator, spacePlacementValidator).SetupWebhookWithManager(mgr)).To(Succeed())
+
 	//+kubebuilder:scaffold:webhook
 
 	go func() {

--- a/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cforgs.yaml
+++ b/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cforgs.yaml
@@ -45,7 +45,7 @@ spec:
               displayName:
                 description: The mutable, user-friendly name of the CFOrg. Unlike
                   metadata.name, the user can change this field.
-                pattern: ^[-\w]+$
+                pattern: ^[[:alnum:][:punct:][:print:]]+$
                 type: string
             required:
             - displayName

--- a/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfspaces.yaml
+++ b/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfspaces.yaml
@@ -45,7 +45,7 @@ spec:
               displayName:
                 description: The mutable, user-friendly name of the space. Unlike
                   metadata.name, the user can change this field
-                pattern: ^[-\w]+$
+                pattern: ^[[:alnum:][:punct:][:print:]]+$
                 type: string
             required:
             - displayName


### PR DESCRIPTION
## Is there a related GitHub Issue?
#1717

## What is this change about?
Use the same regexp for validating Org and Space display names as is used in CAPI

## Does this PR introduce a breaking change?
No

## Acceptance Steps
E.g. create an org called "My Org". The space in the name is now accepted

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
