### PR TITLE
Introduce flag to exclude contour routing for apps

### DIFF
--- a/README.helm.md
+++ b/README.helm.md
@@ -50,6 +50,8 @@ Here are all the values that can be set for the chart:
       - `cpu` (_String_): CPU request.
       - `memory` (_String_): Memory request.
   - `userCertificateExpirationWarningDuration` (_String_): Issue a warning if the user certificate provided for login has a long expiry. See [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration) for details on the format.
+- `contourRouter`:
+  - `include` (_Boolean_): Deploy the `contour-router` component.
 - `controllers`:
   - `image` (_String_): Reference to the controllers container image.
   - `namespaceLabels`: Key value pairs that are going to be set as labels in the workload namespaces created by Korifi

--- a/controllers/config/config.go
+++ b/controllers/config/config.go
@@ -12,6 +12,7 @@ type ControllerConfig struct {
 	IncludeKpackImageBuilder bool `yaml:"includeKpackImageBuilder"`
 	IncludeJobTaskRunner     bool `yaml:"includeJobTaskRunner"`
 	IncludeStatefulsetRunner bool `yaml:"includeStatefulsetRunner"`
+	IncludeContourRouter     bool `yaml:"includeContourRouter"`
 
 	// core controllers
 	CFProcessDefaults           CFProcessDefaults `yaml:"cfProcessDefaults"`

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -178,16 +178,6 @@ func main() {
 			os.Exit(1)
 		}
 
-		if err = (networkingcontrollers.NewCFRouteReconciler(
-			mgr.GetClient(),
-			mgr.GetScheme(),
-			ctrl.Log.WithName("controllers").WithName("CFRoute"),
-			controllerConfig,
-		)).SetupWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create controller", "controller", "CFRoute")
-			os.Exit(1)
-		}
-
 		if err = (servicescontrollers.NewCFServiceInstanceReconciler(
 			mgr.GetClient(),
 			mgr.GetScheme(),
@@ -326,6 +316,19 @@ func main() {
 				os.Exit(1)
 			}
 		}
+
+		if controllerConfig.IncludeContourRouter {
+			if err = (networkingcontrollers.NewCFRouteReconciler(
+				mgr.GetClient(),
+				mgr.GetScheme(),
+				ctrl.Log.WithName("controllers").WithName("CFRoute"),
+				controllerConfig,
+			)).SetupWithManager(mgr); err != nil {
+				setupLog.Error(err, "unable to create controller", "controller", "CFRoute")
+				os.Exit(1)
+			}
+		}
+
 	}
 
 	// Setup webhooks with manager

--- a/helm/korifi/controllers/configmap.yaml
+++ b/helm/korifi/controllers/configmap.yaml
@@ -8,6 +8,7 @@ data:
     includeKpackImageBuilder: {{ .Values.kpackImageBuilder.include }}
     includeJobTaskRunner: {{ .Values.jobTaskRunner.include }}
     includeStatefulsetRunner: {{ .Values.statefulsetRunner.include }}
+    includeContourRouter: {{ .Values.contourRouter.include }}
   korifi_controllers_config.yaml: |-
     builderName: {{ .Values.controllers.reconcilers.build }}
     runnerName: {{ .Values.controllers.reconcilers.app }}

--- a/helm/korifi/values.schema.json
+++ b/helm/korifi/values.schema.json
@@ -453,6 +453,16 @@
       },
       "required": ["include", "jobTTL"],
       "type": "object"
+    },
+    "contourRouter": {
+      "properties": {
+        "include": {
+          "description": "Deploy the `contour-router` component.",
+          "type": "boolean"
+        }
+      },
+      "required": ["include"],
+      "type": "object"
     }
   },
   "required": [

--- a/helm/korifi/values.yaml
+++ b/helm/korifi/values.yaml
@@ -111,3 +111,6 @@ jobTaskRunner:
       memory: 64Mi
 
   jobTTL: 24h
+
+contourRouter:
+  include: true


### PR DESCRIPTION
## Is there a related GitHub Issue?
#1841

## What is this change about?
New helm value `contourRouter.include` controls inclusion of the
CFRouteReconciler in controllers.

When false, no services or contour HTTPProxies will be created for apps,
allowing a different reconciler to create the appropriate routing based
on the CFRoute resource.


## Does this PR introduce a breaking change?
No - unless you turn the component off. In which case, you will need to provide an alternative CFRoute reconciler.

## Acceptance Steps
See story

## Tag your pair, your PM, and/or team
@georgethebeatle

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
