### PR TITLE
Don't attempt to add finalizers to deleted resources

### DIFF
--- a/controllers/controllers/networking/cfdomain_controller.go
+++ b/controllers/controllers/networking/cfdomain_controller.go
@@ -57,13 +57,14 @@ func NewCFDomainReconciler(
 func (r *CFDomainReconciler) ReconcileResource(ctx context.Context, cfDomain *korifiv1alpha1.CFDomain) (ctrl.Result, error) {
 	log := r.log.WithValues("namespace", cfDomain.Namespace, "name", cfDomain.Name)
 
-	if err := k8s.AddFinalizer(ctx, log, r.client, cfDomain, CFDomainFinalizerName); err != nil {
-		log.Error(err, "Error adding finalizer")
-		return ctrl.Result{}, err
-	}
-
 	if !cfDomain.GetDeletionTimestamp().IsZero() {
 		return r.finalizeCFDomain(ctx, log, cfDomain)
+	}
+
+	err := k8s.AddFinalizer(ctx, log, r.client, cfDomain, CFDomainFinalizerName)
+	if err != nil {
+		log.Error(err, "Error adding finalizer")
+		return ctrl.Result{}, err
 	}
 
 	return ctrl.Result{}, nil

--- a/controllers/controllers/workloads/cfapp_controller.go
+++ b/controllers/controllers/workloads/cfapp_controller.go
@@ -60,17 +60,18 @@ func NewCFAppReconciler(k8sClient client.Client, scheme *runtime.Scheme, log log
 func (r *CFAppReconciler) ReconcileResource(ctx context.Context, cfApp *korifiv1alpha1.CFApp) (ctrl.Result, error) {
 	log := r.log.WithValues("namespace", cfApp.Namespace, "name", cfApp.Name)
 
-	if err := k8s.AddFinalizer(ctx, log, r.k8sClient, cfApp, cfAppFinalizerName); err != nil {
-		log.Error(err, "Error adding finalizer")
-		return ctrl.Result{}, err
-	}
-
 	if !cfApp.GetDeletionTimestamp().IsZero() {
 		err := r.finalizeCFApp(ctx, log, cfApp)
 		return ctrl.Result{}, err
 	}
 
-	err := r.reconcileVCAPServicesSecret(ctx, log, cfApp)
+	err := k8s.AddFinalizer(ctx, log, r.k8sClient, cfApp, cfAppFinalizerName)
+	if err != nil {
+		log.Error(err, "Error adding finalizer")
+		return ctrl.Result{}, err
+	}
+
+	err = r.reconcileVCAPServicesSecret(ctx, log, cfApp)
 	if err != nil {
 		log.Error(err, "unable to create CFApp VCAP Services secret")
 		return ctrl.Result{}, err


### PR DESCRIPTION
## Is there a related GitHub Issue?
No.

## What is this change about?
While deploying Korifi from HEAD of main, Clint and I noticed errors in the korifi-controllers logs indicating a failure to add finalizers to certain resources because they were being deleted. This PR updates the reconcilers for resources that require a finalizer to check if the resource is being deleted before attempting to add a finalizer.

## Does this PR introduce a breaking change?
No.

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@clintyoshimura 