### PR TITLE
Apply `namespaceLabels` to org namespaces too

### DIFF
--- a/README.helm.md
+++ b/README.helm.md
@@ -54,7 +54,7 @@ Here are all the values that can be set for the chart:
   - `include` (_Boolean_): Deploy the `contour-router` component.
 - `controllers`:
   - `image` (_String_): Reference to the controllers container image.
-  - `namespaceLabels`: Key value pairs that are going to be set as labels in the workload namespaces created by Korifi
+  - `namespaceLabels`: Key-value pairs that are going to be set as labels on the namespaces created by Korifi
   - `processDefaults`:
     - `diskQuotaMB` (_Integer_): Default disk quota for the `web` process.
     - `memoryMB` (_Integer_): Default memory limit for the `web` process.

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -196,10 +196,12 @@ func main() {
 			os.Exit(1)
 		}
 
-		labelCompiler := labels.NewCompiler().Defaults(map[string]string{
-			admission.EnforceLevelLabel: string(admission.LevelRestricted),
-			admission.AuditLevelLabel:   string(admission.LevelRestricted),
-		})
+		labelCompiler := labels.NewCompiler().
+			Defaults(map[string]string{
+				admission.EnforceLevelLabel: string(admission.LevelRestricted),
+				admission.AuditLevelLabel:   string(admission.LevelRestricted),
+			}).
+			Defaults(controllerConfig.NamespaceLabels)
 
 		if err = workloadscontrollers.NewCFOrgReconciler(
 			mgr.GetClient(),
@@ -218,7 +220,7 @@ func main() {
 			ctrl.Log.WithName("controllers").WithName("CFSpace"),
 			controllerConfig.ContainerRegistrySecretName,
 			controllerConfig.CFRootNamespace,
-			labelCompiler.Defaults(controllerConfig.NamespaceLabels),
+			labelCompiler,
 		).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "CFSpace")
 			os.Exit(1)

--- a/helm/korifi/values.schema.json
+++ b/helm/korifi/values.schema.json
@@ -282,7 +282,7 @@
           "type": "string"
         },
         "namespaceLabels": {
-          "description": "Key value pairs that are going to be set as labels in the workload namespaces created by Korifi",
+          "description": "Key-value pairs that are going to be set as labels on the namespaces created by Korifi",
           "type": "object",
           "properties": {}
         }


### PR DESCRIPTION
## Is there a related GitHub Issue?
#1844

## What is this change about?
This applies the `namespaceLabels` to org namespaces in addition to space namespaces. In the future we might consider having separate configurations for orgs and spaces, but in the meantime this should do.

## Does this PR introduce a breaking change?
No.
