### PR TITLE
Support CF-compatible display names for orgs and spaces

### DIFF
--- a/api/authorization/namespace_permissions.go
+++ b/api/authorization/namespace_permissions.go
@@ -34,11 +34,11 @@ func NewNamespacePermissions(privilegedClient client.Client, identityProvider Id
 }
 
 func (o *NamespacePermissions) GetAuthorizedOrgNamespaces(ctx context.Context, info Info) (map[string]bool, error) {
-	return o.getAuthorizedNamespaces(ctx, info, korifiv1alpha1.OrgNameLabel, "Org")
+	return o.getAuthorizedNamespaces(ctx, info, korifiv1alpha1.OrgNameKey, "Org")
 }
 
 func (o *NamespacePermissions) GetAuthorizedSpaceNamespaces(ctx context.Context, info Info) (map[string]bool, error) {
-	return o.getAuthorizedNamespaces(ctx, info, korifiv1alpha1.SpaceNameLabel, "Space")
+	return o.getAuthorizedNamespaces(ctx, info, korifiv1alpha1.SpaceNameKey, "Space")
 }
 
 func (o *NamespacePermissions) getAuthorizedNamespaces(ctx context.Context, info Info, orgSpaceLabel, resourceType string) (map[string]bool, error) {

--- a/api/authorization/namespace_permissions_test.go
+++ b/api/authorization/namespace_permissions_test.go
@@ -118,8 +118,8 @@ var _ = Describe("Namespace Permissions", func() {
 
 	Describe("Get Authorized Org Namespaces", func() {
 		BeforeEach(func() {
-			org1NS = createNamespace("org1", map[string]string{korifiv1alpha1.OrgNameLabel: "org1"})
-			org2NS = createNamespace("org2", map[string]string{korifiv1alpha1.OrgNameLabel: "org2"})
+			org1NS = createNamespace("org1", map[string]string{korifiv1alpha1.OrgNameKey: "org1"})
+			org2NS = createNamespace("org2", map[string]string{korifiv1alpha1.OrgNameKey: "org2"})
 
 			createRoleBindingForUser(userName, roleName1, org1NS)
 			createRoleBindingForUser(userName, roleName2, org1NS)
@@ -184,8 +184,8 @@ var _ = Describe("Namespace Permissions", func() {
 
 	Describe("Get Authorized Space Namespaces", func() {
 		BeforeEach(func() {
-			space1NS = createNamespace("space1", map[string]string{korifiv1alpha1.SpaceNameLabel: "space1"})
-			space2NS = createNamespace("space2", map[string]string{korifiv1alpha1.SpaceNameLabel: "space2"})
+			space1NS = createNamespace("space1", map[string]string{korifiv1alpha1.SpaceNameKey: "space1"})
+			space2NS = createNamespace("space2", map[string]string{korifiv1alpha1.SpaceNameKey: "space2"})
 
 			createRoleBindingForUser(userName, roleName1, space1NS)
 			createRoleBindingForUser("some-other-user", roleName1, space2NS)
@@ -222,8 +222,8 @@ var _ = Describe("Namespace Permissions", func() {
 
 	Describe("Authorized In", func() {
 		BeforeEach(func() {
-			org1NS = createNamespace("org1", map[string]string{korifiv1alpha1.OrgNameLabel: "org1"})
-			org2NS = createNamespace("org2", map[string]string{korifiv1alpha1.OrgNameLabel: "org2"})
+			org1NS = createNamespace("org1", map[string]string{korifiv1alpha1.OrgNameKey: "org1"})
+			org2NS = createNamespace("org2", map[string]string{korifiv1alpha1.OrgNameKey: "org2"})
 
 			createRoleBindingForUser(userName, roleName1, org1NS)
 			createRoleBindingForUser("some-other-user", roleName1, org2NS)

--- a/api/repositories/org_repository_test.go
+++ b/api/repositories/org_repository_test.go
@@ -76,7 +76,7 @@ var _ = Describe("OrgRepository", func() {
 				return
 			}
 
-			createNamespace(ctx, anchorNamespace, org.Name, map[string]string{korifiv1alpha1.OrgNameLabel: org.Spec.DisplayName})
+			createNamespace(ctx, anchorNamespace, org.Name, map[string]string{korifiv1alpha1.OrgNameKey: org.Spec.DisplayName})
 
 			meta.SetStatusCondition(&(org.Status.Conditions), metav1.Condition{
 				Type:    "Ready",

--- a/api/repositories/repositories_suite_test.go
+++ b/api/repositories/repositories_suite_test.go
@@ -157,7 +157,7 @@ func createOrgWithCleanup(ctx context.Context, displayName string) *korifiv1alph
 		ObjectMeta: metav1.ObjectMeta{
 			Name: cfOrg.Name,
 			Labels: map[string]string{
-				korifiv1alpha1.OrgNameLabel: cfOrg.Spec.DisplayName,
+				korifiv1alpha1.OrgNameKey: cfOrg.Spec.DisplayName,
 			},
 		},
 	}
@@ -197,7 +197,7 @@ func createSpaceWithCleanup(ctx context.Context, orgGUID, name string) *korifiv1
 		ObjectMeta: metav1.ObjectMeta{
 			Name: cfSpace.Name,
 			Labels: map[string]string{
-				korifiv1alpha1.SpaceNameLabel: cfSpace.Spec.DisplayName,
+				korifiv1alpha1.SpaceNameKey: cfSpace.Spec.DisplayName,
 			},
 		},
 	}

--- a/api/repositories/space_repository_test.go
+++ b/api/repositories/space_repository_test.go
@@ -80,7 +80,7 @@ var _ = Describe("SpaceRepository", func() {
 				return
 			}
 
-			createNamespace(ctx, anchorNamespace, space.Name, map[string]string{korifiv1alpha1.SpaceNameLabel: space.Spec.DisplayName})
+			createNamespace(ctx, anchorNamespace, space.Name, map[string]string{korifiv1alpha1.SpaceNameKey: space.Spec.DisplayName})
 
 			meta.SetStatusCondition(&(space.Status.Conditions), metav1.Condition{
 				Type:    "Ready",

--- a/controllers/api/v1alpha1/cforg_types.go
+++ b/controllers/api/v1alpha1/cforg_types.go
@@ -21,7 +21,9 @@ import (
 )
 
 const (
-	OrgNameLabel = "cloudfoundry.org/org-name"
+	OrgNameKey             = "cloudfoundry.org/org-name"
+	OrgGUIDKey             = "cloudfoundry.org/org-guid"
+	OrgSpaceDeprecatedName = "XXX-deprecated-XXX"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!

--- a/controllers/api/v1alpha1/cfspace_types.go
+++ b/controllers/api/v1alpha1/cfspace_types.go
@@ -21,7 +21,8 @@ import (
 )
 
 const (
-	SpaceNameLabel = "cloudfoundry.org/space-name"
+	SpaceNameKey = "cloudfoundry.org/space-name"
+	SpaceGUIDKey = "cloudfoundry.org/space-guid"
 )
 
 // CFSpaceSpec defines the desired state of CFSpace

--- a/controllers/controllers/workloads/cforg_controller.go
+++ b/controllers/controllers/workloads/cforg_controller.go
@@ -123,8 +123,11 @@ func (r *CFOrgReconciler) ReconcileResource(ctx context.Context, cfOrg *korifiv1
 	getConditionOrSetAsUnknown(&cfOrg.Status.Conditions, korifiv1alpha1.ReadyConditionType)
 
 	err = createOrPatchNamespace(ctx, r.client, log, cfOrg, r.labelCompiler.Compile(map[string]string{
-		korifiv1alpha1.OrgNameLabel: cfOrg.Spec.DisplayName,
-	}))
+		korifiv1alpha1.OrgNameKey: korifiv1alpha1.OrgSpaceDeprecatedName,
+		korifiv1alpha1.OrgGUIDKey: cfOrg.Name,
+	}), map[string]string{
+		korifiv1alpha1.OrgNameKey: cfOrg.Spec.DisplayName,
+	})
 	if err != nil {
 		log.Error(err, "Error creating namespace")
 		return ctrl.Result{}, err

--- a/controllers/controllers/workloads/cfspace_controller.go
+++ b/controllers/controllers/workloads/cfspace_controller.go
@@ -110,8 +110,11 @@ func (r *CFSpaceReconciler) ReconcileResource(ctx context.Context, cfSpace *kori
 	getConditionOrSetAsUnknown(&cfSpace.Status.Conditions, korifiv1alpha1.ReadyConditionType)
 
 	err = createOrPatchNamespace(ctx, r.client, log, cfSpace, r.labelCompiler.Compile(map[string]string{
-		korifiv1alpha1.SpaceNameLabel: cfSpace.Spec.DisplayName,
-	}))
+		korifiv1alpha1.SpaceNameKey: korifiv1alpha1.OrgSpaceDeprecatedName,
+		korifiv1alpha1.SpaceGUIDKey: cfSpace.Name,
+	}), map[string]string{
+		korifiv1alpha1.SpaceNameKey: cfSpace.Spec.DisplayName,
+	})
 	if err != nil {
 		log.Error(err, "Error creating namespace")
 		return ctrl.Result{}, err

--- a/controllers/controllers/workloads/cfspace_controller_test.go
+++ b/controllers/controllers/workloads/cfspace_controller_test.go
@@ -84,7 +84,11 @@ var _ = Describe("CFSpaceReconciler Integration Tests", func() {
 			Eventually(func(g Gomega) {
 				var createdSpace corev1.Namespace
 				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: spaceGUID}, &createdSpace)).To(Succeed())
-				g.Expect(createdSpace.Labels).To(HaveKeyWithValue(korifiv1alpha1.SpaceNameLabel, spaceName))
+				g.Expect(createdSpace.Labels).To(SatisfyAll(
+					HaveKeyWithValue(korifiv1alpha1.SpaceNameKey, korifiv1alpha1.OrgSpaceDeprecatedName),
+					HaveKeyWithValue(korifiv1alpha1.SpaceGUIDKey, spaceGUID),
+				))
+				g.Expect(createdSpace.Annotations).To(HaveKeyWithValue(korifiv1alpha1.SpaceNameKey, cfSpace.Spec.DisplayName))
 			}).Should(Succeed())
 		})
 

--- a/controllers/controllers/workloads/shared.go
+++ b/controllers/controllers/workloads/shared.go
@@ -27,22 +27,8 @@ func createOrPatchNamespace(ctx context.Context, client client.Client, log logr.
 	}
 
 	result, err := controllerutil.CreateOrPatch(ctx, client, namespace, func() error {
-		if namespace.Labels == nil {
-			namespace.Labels = make(map[string]string)
-		}
-
-		for key, value := range labels {
-			namespace.Labels[key] = value
-		}
-
-		if namespace.Annotations == nil {
-			namespace.Annotations = make(map[string]string)
-		}
-
-		for key, value := range annotations {
-			namespace.Annotations[key] = value
-		}
-
+		updateMap(&namespace.Labels, labels)
+		updateMap(&namespace.Annotations, annotations)
 		return nil
 	})
 	if err != nil {
@@ -51,6 +37,16 @@ func createOrPatchNamespace(ctx context.Context, client client.Client, log logr.
 
 	log.Info("Namespace reconciled", "operation", result)
 	return nil
+}
+
+func updateMap(dest *map[string]string, values map[string]string) {
+	if *dest == nil {
+		*dest = make(map[string]string)
+	}
+
+	for key, value := range values {
+		(*dest)[key] = value
+	}
 }
 
 func propagateSecret(ctx context.Context, client client.Client, log logr.Logger, orgOrSpace client.Object, secretName string) error {

--- a/controllers/controllers/workloads/shared.go
+++ b/controllers/controllers/workloads/shared.go
@@ -16,7 +16,8 @@ import (
 )
 
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
-func createOrPatchNamespace(ctx context.Context, client client.Client, log logr.Logger, orgOrSpace client.Object, labels map[string]string) error {
+
+func createOrPatchNamespace(ctx context.Context, client client.Client, log logr.Logger, orgOrSpace client.Object, labels map[string]string, annotations map[string]string) error {
 	log = log.WithName("createOrPatchNamespace")
 
 	namespace := &corev1.Namespace{
@@ -32,6 +33,14 @@ func createOrPatchNamespace(ctx context.Context, client client.Client, log logr.
 
 		for key, value := range labels {
 			namespace.Labels[key] = value
+		}
+
+		if namespace.Annotations == nil {
+			namespace.Annotations = make(map[string]string)
+		}
+
+		for key, value := range annotations {
+			namespace.Annotations[key] = value
 		}
 
 		return nil

--- a/controllers/webhooks/workloads/cforg_validator.go
+++ b/controllers/webhooks/workloads/cforg_validator.go
@@ -2,6 +2,7 @@ package workloads
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -20,6 +21,7 @@ const (
 	OrgDecodingErrorType = "OrgDecodingError"
 	// Note: the cf cli expects the specfic text `Organization '.*' already exists.` in the error and ignores the error if it matches it.
 	duplicateOrgNameErrorMessage = "Organization '%s' already exists."
+	maxLabelLength               = 63
 )
 
 var cfOrgLog = logf.Log.WithName("cforg-validate")
@@ -51,6 +53,10 @@ func (v *CFOrgValidator) ValidateCreate(ctx context.Context, obj runtime.Object)
 	org, ok := obj.(*korifiv1alpha1.CFOrg)
 	if !ok {
 		return apierrors.NewBadRequest(fmt.Sprintf("expected a CFOrg but got a %T", obj))
+	}
+
+	if len(org.Name) > maxLabelLength {
+		return errors.New("org name cannot be longer than 63 chars")
 	}
 
 	err := v.placementValidator.ValidateOrgCreate(*org)

--- a/controllers/webhooks/workloads/cforg_validator_test.go
+++ b/controllers/webhooks/workloads/cforg_validator_test.go
@@ -55,7 +55,17 @@ var _ = Describe("CFOrgValidatingWebhook", func() {
 			})
 
 			It("should fail", func() {
-				Expect(createErr.Error()).To(ContainSubstring(fmt.Sprintf("Organization '%s' must be placed in the root 'cf' namespace", org1Name)))
+				Expect(createErr).To(MatchError(ContainSubstring(fmt.Sprintf("Organization '%s' must be placed in the root 'cf' namespace", org1Name))))
+			})
+		})
+
+		When("the CFOrg name would not be a valid label value (>63 chars)", func() {
+			BeforeEach(func() {
+				org1.Name = strings.Repeat("a", 64)
+			})
+
+			It("should fail", func() {
+				Expect(createErr).To(MatchError(ContainSubstring("org name cannot be longer than 63 chars")))
 			})
 		})
 

--- a/controllers/webhooks/workloads/cfspace_validator.go
+++ b/controllers/webhooks/workloads/cfspace_validator.go
@@ -2,6 +2,7 @@ package workloads
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -50,6 +51,10 @@ func (v *CFSpaceValidator) ValidateCreate(ctx context.Context, obj runtime.Objec
 	space, ok := obj.(*korifiv1alpha1.CFSpace)
 	if !ok {
 		return apierrors.NewBadRequest(fmt.Sprintf("expected a CFSpace but got a %T", obj))
+	}
+
+	if len(space.Name) > maxLabelLength {
+		return errors.New("space name cannot be longer than 63 chars")
 	}
 
 	duplicateErrorMessage := fmt.Sprintf(duplicateSpaceNameErrorMessage, space.Spec.DisplayName)


### PR DESCRIPTION
## Is there a related GitHub Issue?
#1717

## What is this change about?

This changes the way we manage org and space display names, according to [this comment](https://github.com/cloudfoundry/korifi/issues/1717#issuecomment-1386291322):

- we deprecated the `cloudfoundry.org/(org|space)-name` labels, now setting them as `XXX-deprecated-XXX`;
- we introduced the `cloudfoundry.org/(org|space)-name` annotations, which will accomodate any value that is valid for traditional CF;
- we introduced the `cloudfoundry.org/(org|space)-guid` labels, which will be useful to trace back namespaces to their org/name;
- validate org/space names to make sure that they're valid label values.

We also backfilled tests for org/space namespace metadata updating.

## Does this PR introduce a breaking change?
Yes: anything relying on the `cloudfoundry.org/(org|space)-name` label value won't be able to do that anymore.

## Tag your pair, your PM, and/or team
@kieron-dev
