### PR TITLE
Remove dangling code after order-by move PR

### DIFF
--- a/api/repositories/buildpack_repository.go
+++ b/api/repositories/buildpack_repository.go
@@ -30,10 +30,6 @@ type BuildpackRecord struct {
 	UpdatedAt string
 }
 
-type ListBuildpacksMessage struct {
-	OrderBy []string
-}
-
 func NewBuildpackRepository(builderName string, userClientFactory authorization.UserK8sClientFactory, rootNamespace string) *BuildpackRepository {
 	return &BuildpackRepository{
 		builderName:       builderName,

--- a/api/repositories/buildpack_repository_test.go
+++ b/api/repositories/buildpack_repository_test.go
@@ -33,7 +33,7 @@ var _ = Describe("BuildpackRepository", func() {
 				})
 			})
 
-			It("lists the buildpacks in order", func() {
+			It("returns all buildpacks", func() {
 				buildpackRecords, err := buildpackRepo.ListBuildpacks(context.Background(), authInfo)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(buildpackRecords).To(ConsistOf(

--- a/api/repositories/package_repository_test.go
+++ b/api/repositories/package_repository_test.go
@@ -250,9 +250,6 @@ var _ = Describe("PackageRepository", func() {
 				package1GUID = generateGUID()
 				createPackageCR(ctx, k8sClient, package1GUID, appGUID, space.Name, "")
 
-				// add a small delay to test ordering on created_by
-				time.Sleep(100 * time.Millisecond)
-
 				package2GUID = generateGUID()
 				createPackageCR(ctx, k8sClient, package2GUID, appGUID2, space2.Name, "my-image-url")
 
@@ -283,23 +280,6 @@ var _ = Describe("PackageRepository", func() {
 							"GUID": Equal(noPermissionsPackageGUID),
 						}),
 					))
-				})
-
-				It("orders the results in ascending created_at order by default", func() {
-					Expect(packageList).To(ConsistOf(
-						MatchFields(IgnoreExtras, Fields{
-							"GUID": Equal(package1GUID),
-						}),
-						MatchFields(IgnoreExtras, Fields{
-							"GUID": Equal(package2GUID),
-						}),
-					))
-
-					firstCreatedAt, err := time.Parse(time.RFC3339, packageList[0].CreatedAt)
-					Expect(err).NotTo(HaveOccurred())
-					secondCreatedAt, err := time.Parse(time.RFC3339, packageList[1].CreatedAt)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(firstCreatedAt).To(BeTemporally("<=", secondCreatedAt))
 				})
 
 				When("app_guids filter is provided", func() {


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
Ordering has moved from repositories to handlers, when explicit order_by params are used.

We remove the test remaining in repositories that was checking ordering no longer done there, and clean up some unused code.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Green CI

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
