### PR TITLE
Fix and improve docs

### DIFF
--- a/INSTALL.EKS.md
+++ b/INSTALL.EKS.md
@@ -137,7 +137,7 @@ cat >trust-relationships.json <<EOF
           "${OIDC_PROVIDER}:sub": [
             "system:serviceaccount:kpack:controller",
             "system:serviceaccount:korifi:korifi-api-system-serviceaccount",
-            "system:serviceaccount:korifi:korifi-kpack-build-controller-manager",
+            "system:serviceaccount:korifi:korifi-controllers-controller-manager",
             "system:serviceaccount:*:kpack-service-account"
           ]
         }

--- a/INSTALL.EKS.md
+++ b/INSTALL.EKS.md
@@ -40,7 +40,7 @@ eksctl create cluster \
   --with-oidc
 ```
 
-Your kubeconfig will be updated to be targetting the new cluster when this command completes.
+Your kubeconfig will be updated to be targeting the new cluster when this command completes.
 
 ### Install the EBS CSI addon
 
@@ -72,11 +72,9 @@ eksctl create addon \
 
 ### Setup IAM role for access to ECR
 
-The main difference when installing Korifi on EKS with ECR, as opposed to other container registries,
-is that ECR tokens issued by the AWS CLI expire in 12 hours.
+The main difference when installing Korifi on EKS with ECR, as opposed to other container registries, is that ECR tokens issued by the AWS CLI expire in 12 hours.
 This means they are not a good option for storing in Kubernetes secrets for Korifi to use.
-Instead, we must grant the ECR push and pull permissions in an IAM role
-and allow that role to be associated with various service accounts used by Korifi and Kpack.
+Instead, we must grant the ECR push and pull permissions in an IAM role and allow that role to be associated with various service accounts used by Korifi and Kpack.
 
 The [AWS docs](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)
 have more details about associating IAM roles with Kubernetes service accounts.

--- a/INSTALL.EKS.md
+++ b/INSTALL.EKS.md
@@ -266,6 +266,12 @@ helm install korifi https://github.com/cloudfoundry/korifi/releases/download/v<V
   --wait
 ```
 
+## Post-install Configuration
+
+### DNS
+
+Follow the [common instructions](./INSTALL.md#dns).
+
 ## Test Korifi
 
 First, let's create a CLI profile for your Korifi admin user:

--- a/INSTALL.EKS.md
+++ b/INSTALL.EKS.md
@@ -44,7 +44,7 @@ Your kubeconfig will be updated to be targeting the new cluster when this comman
 
 ### Install the EBS CSI addon
 
-Create the EBS CSI addon to allow PVCs (https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html).
+Create the [EBS CSI](https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html) addon to allow PVCs.
 
 First, set up the service account and role for the addon:
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -113,13 +113,13 @@ kubectl --namespace "$ROOT_NAMESPACE" create secret docker-registry image-regist
 Make sure the value of `--docker-server` is a valid [URI authority](https://datatracker.ietf.org/doc/html/rfc3986#section-3.2).
 
 -   If using **DockerHub**:
-    -   `--docker-server` should be `https://index.docker.io/v1/`;
+    -   `--docker-server` should be omitted;
     -   `--docker-username` should be your DockerHub user;
     -   `--docker-password` can be either your DockerHub password or a [generated personal access token](https://hub.docker.com/settings/security?generateToken=true).
--   If using **GCR**:
-    -   `--docker-server` should be `gcr.io`;
+-   If using **Google Artifact Registry**:
+    -   `--docker-server` should be `<region>-docker.pkg.dev`;
     -   `--docker-username` should be `_json_key`;
-    -   `--docker-password` should be the JSON-formatted access token for a service account that has permission to manage images in GCR.
+    -   `--docker-password` should be the JSON-formatted access token for a service account that has permission to manage images in Google Artifact Registry.
 
 ### TLS certificates
 
@@ -170,13 +170,13 @@ helm install korifi https://github.com/cloudfoundry/korifi/releases/download/v<V
 In particular, the app GUID and image type (`packages` or `droplets`) are appended to form the name of the repository.
 For example:
 
-| Registry  | containerRepositoryPrefix                                    | Resultant Image Ref                                                            | Notes                                                                                                    |
-| --------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------- |
-| ACR       | `<projectID>.azurecr.io/foo/bar/korifi-`                     | `<projectID>.azurecr.io/foo/bar/korifi-<appGUID>-packages`                     | Repositories are created dynamically during push by ACR                                                  |
-| DockerHub | `index.docker.io/<dockerOrganisation>/`                      | `index.docker.io/<dockerOrganisation>/<appGUID>-packages`                      | Docker does not support nested repositories                                                              |
-| ECR       | `<projectID>.dkr.ecr.<region>.amazonaws.com/foo/bar/korifi-` | `<projectID>.dkr.ecr.<region>.amazonaws.com/foo/bar/korifi-<appGUID>-packages` | Korifi will create the repository before pushing, as dynamic repository creation is not posssible on ECR |
-| GAR       | `<region>-docker.pkg.dev/<projectID>/foo/bar/korifi-`        | `<region>-docker.pkg.dev/<projectID>/foo/bar/korifi-<appGUID>-packages`        | The `foo` repository must already exist in GAR                                                           |
-| GCR       | `gcr.io/<projectID>/foo/bar/korifi-`                         | `gcr.io/<projectID>/foo/bar/korifi-<appGUID>-packages`                         | Repositories are created dynamically during push by GCR                                                  |
+| Registry                          | containerRepositoryPrefix                                    | Resultant Image Ref                                                            | Notes                                                                                                    |
+| --------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------- |
+| Azure Container Registry          | `<projectID>.azurecr.io/foo/bar/korifi-`                     | `<projectID>.azurecr.io/foo/bar/korifi-<appGUID>-packages`                     | Repositories are created dynamically during push by ACR                                                  |
+| DockerHub                         | `index.docker.io/<dockerOrganisation>/`                      | `index.docker.io/<dockerOrganisation>/<appGUID>-packages`                      | Docker does not support nested repositories                                                              |
+| Amazon Elastic Container Registry | `<projectID>.dkr.ecr.<region>.amazonaws.com/foo/bar/korifi-` | `<projectID>.dkr.ecr.<region>.amazonaws.com/foo/bar/korifi-<appGUID>-packages` | Korifi will create the repository before pushing, as dynamic repository creation is not posssible on ECR |
+| Google Artifact Registry          | `<region>-docker.pkg.dev/<projectID>/foo/bar/korifi-`        | `<region>-docker.pkg.dev/<projectID>/foo/bar/korifi-<appGUID>-packages`        | The `foo` repository must already exist in GAR                                                           |
+| Google Container Registry         | `gcr.io/<projectID>/foo/bar/korifi-`                         | `gcr.io/<projectID>/foo/bar/korifi-<appGUID>-packages`                         | Repositories are created dynamically during push by GCR                                                  |
 
 The chart provides various other values that can be set. See [`README.helm.md`](./README.helm.md) for details.
 


### PR DESCRIPTION
## Is there a related GitHub Issue?
No.

## What is this change about?

This:
- improves wording and formatting;
- uses links instead of plain URLs;
- adds the missing DNS section to the EKS install docs;
- improves instructions related to container registries to make them clearer and more useful;
- fixes a broken trust relationship in the EKS install docs.

## Does this PR introduce a breaking change?
No.

## Tag your pair, your PM, and/or team
@kieron-dev
