### PR TITLE
Implement list users as a stub

### DIFF
--- a/api/handlers/user.go
+++ b/api/handlers/user.go
@@ -1,0 +1,45 @@
+package handlers
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+
+	"code.cloudfoundry.org/korifi/api/presenter"
+	"code.cloudfoundry.org/korifi/api/routing"
+)
+
+const (
+	usersPath = "/v3/users"
+)
+
+type User struct {
+	apiBaseURL url.URL
+}
+
+func NewUser(apiBaseURL url.URL) User {
+	return User{
+		apiBaseURL: apiBaseURL,
+	}
+}
+
+func (h User) list(req *http.Request) (*routing.Response, error) {
+	usernames := req.URL.Query().Get("usernames")
+	users := []interface{}{}
+	if len(usernames) > 0 {
+		for _, username := range strings.Split(usernames, ",") {
+			users = append(users, presenter.ForUser(username))
+		}
+	}
+	return routing.NewResponse(http.StatusOK).WithBody(presenter.ForList(users, h.apiBaseURL, *req.URL)), nil
+}
+
+func (h User) UnauthenticatedRoutes() []routing.Route {
+	return nil
+}
+
+func (h User) AuthenticatedRoutes() []routing.Route {
+	return []routing.Route{
+		{Method: "GET", Pattern: usersPath, Handler: h.list},
+	}
+}

--- a/api/handlers/user_test.go
+++ b/api/handlers/user_test.go
@@ -1,0 +1,82 @@
+package handlers_test
+
+import (
+	"net/http"
+
+	"code.cloudfoundry.org/korifi/api/handlers"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("User", func() {
+	var query string
+
+	BeforeEach(func() {
+		query = ""
+		userHandler := handlers.NewUser(*serverURL)
+		routerBuilder.LoadRoutes(userHandler)
+	})
+
+	JustBeforeEach(func() {
+		req, err := http.NewRequestWithContext(ctx, "GET", "/v3/users"+query, nil)
+		Expect(err).NotTo(HaveOccurred())
+		routerBuilder.Build().ServeHTTP(rr, req)
+	})
+
+	Describe("GET /v3/users", func() {
+		When("no parameters are provided", func() {
+			It("returns an empty list", func() {
+				Expect(rr).To(HaveHTTPStatus(http.StatusOK))
+				Expect(rr).To(HaveHTTPHeaderWithValue("Content-Type", "application/json"))
+				Expect(rr).To(HaveHTTPBody(MatchJSON(`{
+					"pagination": {
+						"total_results": 0,
+						"total_pages": 1,
+						"first": {
+							"href": "https://api.example.org/v3/users"
+						},
+						"last": {
+							"href": "https://api.example.org/v3/users"
+						},
+						"next": null,
+						"previous": null
+					},
+					"resources": []
+				}`)))
+			})
+		})
+
+		When("usernames are passed", func() {
+			BeforeEach(func() {
+				query = "?usernames=foo,bar"
+			})
+
+			It("returns a list of users matching the usernames", func() {
+				Expect(rr).To(HaveHTTPStatus(http.StatusOK))
+				Expect(rr).To(HaveHTTPHeaderWithValue("Content-Type", "application/json"))
+				Expect(rr).To(HaveHTTPBody(MatchJSON(`{
+					"pagination": {
+						"total_results": 2,
+						"total_pages": 1,
+						"first": {
+							"href": "https://api.example.org/v3/users?usernames=foo,bar"
+						},
+						"last": {
+							"href": "https://api.example.org/v3/users?usernames=foo,bar"
+						},
+						"next": null,
+						"previous": null
+					},
+					"resources": [
+						{
+							"username": "foo"
+						},
+						{
+							"username": "bar"
+						}
+					]
+				}`)))
+			})
+		})
+	})
+})

--- a/api/main.go
+++ b/api/main.go
@@ -328,6 +328,7 @@ func main() {
 			decoderValidator,
 		),
 		handlers.NewWhoAmI(cachingIdentityProvider, *serverURL),
+		handlers.NewUser(*serverURL),
 		handlers.NewBuildpack(
 			*serverURL,
 			buildpackRepo,

--- a/api/presenter/user.go
+++ b/api/presenter/user.go
@@ -1,0 +1,9 @@
+package presenter
+
+type UserResponse struct {
+	Name string `json:"username"`
+}
+
+func ForUser(name string) UserResponse {
+	return UserResponse{Name: name}
+}


### PR DESCRIPTION
## Is there a related GitHub Issue?
https://github.com/cloudfoundry/korifi/issues/1239
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Implement `list users` as a stub - this (temporary) solution is needed to make
`cf unset-org|space-role` work.

When usernames are passed as a filter, this returns a list of resources
with username and guid containing those values.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
N/A

## Tag your pair, your PM, and/or team
@kieron-dev @gcapizzi

