### PR TITLE
Implement list roles

### DIFF
--- a/api/config/config.go
+++ b/api/config/config.go
@@ -10,48 +10,55 @@ import (
 )
 
 const (
-	defaultExternalProtocol = "https"
+	defaultExternalProtocol           = "https"
+	OrgRole                 RoleLevel = "org"
+	SpaceRole               RoleLevel = "space"
 )
 
-type APIConfig struct {
-	InternalPort      int `yaml:"internalPort"`
-	IdleTimeout       int `yaml:"idleTimeout"`
-	ReadTimeout       int `yaml:"readTimeout"`
-	ReadHeaderTimeout int `yaml:"readHeaderTimeout"`
-	WriteTimeout      int `yaml:"writeTimeout"`
+type (
+	APIConfig struct {
+		InternalPort      int `yaml:"internalPort"`
+		IdleTimeout       int `yaml:"idleTimeout"`
+		ReadTimeout       int `yaml:"readTimeout"`
+		ReadHeaderTimeout int `yaml:"readHeaderTimeout"`
+		WriteTimeout      int `yaml:"writeTimeout"`
 
-	ExternalFQDN string `yaml:"externalFQDN"`
-	ExternalPort int    `yaml:"externalPort"`
+		ExternalFQDN string `yaml:"externalFQDN"`
+		ExternalPort int    `yaml:"externalPort"`
 
-	ServerURL string
+		ServerURL string
 
-	RootNamespace                            string                 `yaml:"rootNamespace"`
-	BuilderName                              string                 `yaml:"builderName"`
-	ContainerRepositoryPrefix                string                 `yaml:"containerRepositoryPrefix"`
-	ContainerRegistryType                    string                 `yaml:"containerRegistryType"`
-	PackageRegistrySecretName                string                 `yaml:"packageRegistrySecretName"`
-	DefaultDomainName                        string                 `yaml:"defaultDomainName"`
-	UserCertificateExpirationWarningDuration string                 `yaml:"userCertificateExpirationWarningDuration"`
-	DefaultLifecycleConfig                   DefaultLifecycleConfig `yaml:"defaultLifecycleConfig"`
+		RootNamespace                            string                 `yaml:"rootNamespace"`
+		BuilderName                              string                 `yaml:"builderName"`
+		ContainerRepositoryPrefix                string                 `yaml:"containerRepositoryPrefix"`
+		ContainerRegistryType                    string                 `yaml:"containerRegistryType"`
+		PackageRegistrySecretName                string                 `yaml:"packageRegistrySecretName"`
+		DefaultDomainName                        string                 `yaml:"defaultDomainName"`
+		UserCertificateExpirationWarningDuration string                 `yaml:"userCertificateExpirationWarningDuration"`
+		DefaultLifecycleConfig                   DefaultLifecycleConfig `yaml:"defaultLifecycleConfig"`
 
-	RoleMappings map[string]Role `yaml:"roleMappings"`
+		RoleMappings map[string]Role `yaml:"roleMappings"`
 
-	AuthProxyHost   string `yaml:"authProxyHost"`
-	AuthProxyCACert string `yaml:"authProxyCACert"`
-}
+		AuthProxyHost   string `yaml:"authProxyHost"`
+		AuthProxyCACert string `yaml:"authProxyCACert"`
+	}
 
-type Role struct {
-	Name      string `yaml:"name"`
-	Propagate bool   `yaml:"propagate"`
-}
+	RoleLevel string
 
-// DefaultLifecycleConfig contains default values of the Lifecycle block of CFApps and Builds created by the Shim
-type DefaultLifecycleConfig struct {
-	Type            string `yaml:"type"`
-	Stack           string `yaml:"stack"`
-	StagingMemoryMB int    `yaml:"stagingMemoryMB"`
-	StagingDiskMB   int    `yaml:"stagingDiskMB"`
-}
+	Role struct {
+		Name      string    `yaml:"name"`
+		Level     RoleLevel `yaml:"level"`
+		Propagate bool      `yaml:"propagate"`
+	}
+
+	// DefaultLifecycleConfig contains default values of the Lifecycle block of CFApps and Builds created by the Shim
+	DefaultLifecycleConfig struct {
+		Type            string `yaml:"type"`
+		Stack           string `yaml:"stack"`
+		StagingMemoryMB int    `yaml:"stagingMemoryMB"`
+		StagingDiskMB   int    `yaml:"stagingDiskMB"`
+	}
+)
 
 func LoadFromPath(path string) (*APIConfig, error) {
 	var config APIConfig

--- a/api/handlers/fake/cfrole_repository.go
+++ b/api/handlers/fake/cfrole_repository.go
@@ -26,6 +26,20 @@ type CFRoleRepository struct {
 		result1 repositories.RoleRecord
 		result2 error
 	}
+	ListRolesStub        func(context.Context, authorization.Info) ([]repositories.RoleRecord, error)
+	listRolesMutex       sync.RWMutex
+	listRolesArgsForCall []struct {
+		arg1 context.Context
+		arg2 authorization.Info
+	}
+	listRolesReturns struct {
+		result1 []repositories.RoleRecord
+		result2 error
+	}
+	listRolesReturnsOnCall map[int]struct {
+		result1 []repositories.RoleRecord
+		result2 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -96,11 +110,78 @@ func (fake *CFRoleRepository) CreateRoleReturnsOnCall(i int, result1 repositorie
 	}{result1, result2}
 }
 
+func (fake *CFRoleRepository) ListRoles(arg1 context.Context, arg2 authorization.Info) ([]repositories.RoleRecord, error) {
+	fake.listRolesMutex.Lock()
+	ret, specificReturn := fake.listRolesReturnsOnCall[len(fake.listRolesArgsForCall)]
+	fake.listRolesArgsForCall = append(fake.listRolesArgsForCall, struct {
+		arg1 context.Context
+		arg2 authorization.Info
+	}{arg1, arg2})
+	stub := fake.ListRolesStub
+	fakeReturns := fake.listRolesReturns
+	fake.recordInvocation("ListRoles", []interface{}{arg1, arg2})
+	fake.listRolesMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *CFRoleRepository) ListRolesCallCount() int {
+	fake.listRolesMutex.RLock()
+	defer fake.listRolesMutex.RUnlock()
+	return len(fake.listRolesArgsForCall)
+}
+
+func (fake *CFRoleRepository) ListRolesCalls(stub func(context.Context, authorization.Info) ([]repositories.RoleRecord, error)) {
+	fake.listRolesMutex.Lock()
+	defer fake.listRolesMutex.Unlock()
+	fake.ListRolesStub = stub
+}
+
+func (fake *CFRoleRepository) ListRolesArgsForCall(i int) (context.Context, authorization.Info) {
+	fake.listRolesMutex.RLock()
+	defer fake.listRolesMutex.RUnlock()
+	argsForCall := fake.listRolesArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *CFRoleRepository) ListRolesReturns(result1 []repositories.RoleRecord, result2 error) {
+	fake.listRolesMutex.Lock()
+	defer fake.listRolesMutex.Unlock()
+	fake.ListRolesStub = nil
+	fake.listRolesReturns = struct {
+		result1 []repositories.RoleRecord
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *CFRoleRepository) ListRolesReturnsOnCall(i int, result1 []repositories.RoleRecord, result2 error) {
+	fake.listRolesMutex.Lock()
+	defer fake.listRolesMutex.Unlock()
+	fake.ListRolesStub = nil
+	if fake.listRolesReturnsOnCall == nil {
+		fake.listRolesReturnsOnCall = make(map[int]struct {
+			result1 []repositories.RoleRecord
+			result2 error
+		})
+	}
+	fake.listRolesReturnsOnCall[i] = struct {
+		result1 []repositories.RoleRecord
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *CFRoleRepository) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
 	fake.createRoleMutex.RLock()
 	defer fake.createRoleMutex.RUnlock()
+	fake.listRolesMutex.RLock()
+	defer fake.listRolesMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/api/handlers/role_test.go
+++ b/api/handlers/role_test.go
@@ -2,11 +2,12 @@ package handlers_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"strings"
-	"time"
 
 	"code.cloudfoundry.org/korifi/api/authorization"
 	"code.cloudfoundry.org/korifi/api/handlers"
@@ -26,11 +27,11 @@ var _ = Describe("Role", func() {
 	var (
 		apiHandler *handlers.Role
 		roleRepo   *fake.CFRoleRepository
-		now        time.Time
+		now        string
 	)
 
 	BeforeEach(func() {
-		now = time.Unix(1631892190, 0) // 2021-09-17T15:23:10Z
+		now = "2021-09-17T15:23:10Z"
 
 		roleRepo = new(fake.CFRoleRepository)
 		decoderValidator, err := handlers.NewDefaultDecoderValidator()
@@ -43,20 +44,20 @@ var _ = Describe("Role", func() {
 	DescribeTable("Role org / space combination validation",
 		func(role, orgOrSpace string, succeeds bool, errMsg string) {
 			createRoleRequestBody := fmt.Sprintf(`{
-                "type": "%s",
-                "relationships": {
-                    "user": {
-                        "data": {
-                            "username": "my-user"
-                        }
-                    },
-                    "%s": {
-                        "data": {
-                            "guid": "some-guid"
-                        }
-                    }
-                }
-            }`, role, orgOrSpace)
+				"type": "%s",
+				"relationships": {
+					"user": {
+						"data": {
+							"username": "my-user"
+						}
+					},
+					"%s": {
+						"data": {
+							"guid": "some-guid"
+						}
+					}
+				}
+			}`, role, orgOrSpace)
 
 			req, err := http.NewRequestWithContext(ctx, "POST", rolesBase, strings.NewReader(createRoleRequestBody))
 			Expect(err).NotTo(HaveOccurred())
@@ -111,20 +112,20 @@ var _ = Describe("Role", func() {
 			}
 
 			createRoleRequestBody = `{
-                "type": "space_developer",
-                "relationships": {
-                    "user": {
-                        "data": {
-                            "username": "my-user"
-                        }
-                    },
-                    "space": {
-                        "data": {
-                            "guid": "my-space"
-                        }
-                    }
-                }
-            }`
+				"type": "space_developer",
+				"relationships": {
+					"user": {
+						"data": {
+							"username": "my-user"
+						}
+					},
+					"space": {
+						"data": {
+							"guid": "my-space"
+						}
+					}
+				}
+			}`
 		})
 
 		makePostRequest := func() {
@@ -142,34 +143,37 @@ var _ = Describe("Role", func() {
 			Expect(rr).To(HaveHTTPStatus(http.StatusCreated))
 			Expect(rr).To(HaveHTTPHeaderWithValue("Content-Type", "application/json"))
 			Expect(rr).To(HaveHTTPBody(MatchJSON(fmt.Sprintf(`{
-                "guid": "t-h-e-r-o-l-e",
-                "created_at": "2021-09-17T15:23:10Z",
-                "updated_at": "2021-09-17T15:23:10Z",
-                "type": "space_developer",
-                "relationships": {
-                    "user": {
-                        "data":{
-                            "guid": "my-user"
-                        }
-                    },
-                    "space": {
-                        "data":{
-                            "guid": "my-space"
-                        }
-                    },
-                    "organization": {
-                        "data":null
-                    }
-                },
-                "links": {
-                    "self": {
-                        "href": "%[1]s/v3/roles/t-h-e-r-o-l-e"
-                    },
-                    "space": {
-                        "href": "%[1]s/v3/spaces/my-space"
-                    }
-                }
-            }`, defaultServerURL))))
+				"guid": "t-h-e-r-o-l-e",
+				"created_at": "2021-09-17T15:23:10Z",
+				"updated_at": "2021-09-17T15:23:10Z",
+				"type": "space_developer",
+				"relationships": {
+					"user": {
+						"data":{
+							"guid": "my-user"
+						}
+					},
+					"space": {
+						"data":{
+							"guid": "my-space"
+						}
+					},
+					"organization": {
+						"data":null
+					}
+				},
+				"links": {
+					"self": {
+						"href": "%[1]s/v3/roles/t-h-e-r-o-l-e"
+					},
+					"user": {
+						"href": "%[1]s/v3/users/my-user"
+					},
+					"space": {
+						"href": "%[1]s/v3/spaces/my-space"
+					}
+				}
+			}`, defaultServerURL))))
 		})
 
 		It("invokes the role repo create function with expected parameters", func() {
@@ -185,108 +189,114 @@ var _ = Describe("Role", func() {
 		When("username is passed in the guid field", func() {
 			BeforeEach(func() {
 				createRoleRequestBody = `{
-                    "type": "space_developer",
-                    "relationships": {
-                        "user": {
-                            "data": {
-                                "guid": "my-user"
-                            }
-                        },
-                        "space": {
-                            "data": {
-                                "guid": "my-space"
-                            }
-                        }
-                    }
-                }`
+					"type": "space_developer",
+					"relationships": {
+						"user": {
+							"data": {
+								"guid": "my-user"
+							}
+						},
+						"space": {
+							"data": {
+								"guid": "my-space"
+							}
+						}
+					}
+				}`
 			})
 
 			It("still works as guid and username are equivalent here", func() {
 				Expect(rr).To(HaveHTTPStatus(http.StatusCreated))
 				Expect(rr).To(HaveHTTPHeaderWithValue("Content-Type", "application/json"))
 				Expect(rr).To(HaveHTTPBody(MatchJSON(fmt.Sprintf(`{
-                    "guid": "t-h-e-r-o-l-e",
-                    "created_at": "2021-09-17T15:23:10Z",
-                    "updated_at": "2021-09-17T15:23:10Z",
-                    "type": "space_developer",
-                    "relationships": {
-                        "user": {
-                            "data":{
-                                "guid": "my-user"
-                            }
-                        },
-                        "space": {
-                            "data":{
-                                "guid": "my-space"
-                            }
-                        },
-                        "organization": {
-                            "data":null
-                        }
-                    },
-                    "links": {
-                        "self": {
-                            "href": "%[1]s/v3/roles/t-h-e-r-o-l-e"
-                        },
-                        "space": {
-                            "href": "%[1]s/v3/spaces/my-space"
-                        }
-                    }
-                }`, defaultServerURL))))
+					"guid": "t-h-e-r-o-l-e",
+					"created_at": "2021-09-17T15:23:10Z",
+					"updated_at": "2021-09-17T15:23:10Z",
+					"type": "space_developer",
+					"relationships": {
+						"user": {
+							"data":{
+								"guid": "my-user"
+							}
+						},
+						"space": {
+							"data":{
+								"guid": "my-space"
+							}
+						},
+						"organization": {
+							"data":null
+						}
+					},
+					"links": {
+						"self": {
+							"href": "%[1]s/v3/roles/t-h-e-r-o-l-e"
+						},
+						"user": {
+							"href": "%[1]s/v3/users/my-user"
+						},
+						"space": {
+							"href": "%[1]s/v3/spaces/my-space"
+						}
+					}
+				}`, defaultServerURL))))
 			})
 		})
 
 		When("the role is an organisation role", func() {
 			BeforeEach(func() {
 				createRoleRequestBody = `{
-                    "type": "organization_manager",
-                    "relationships": {
-                        "user": {
-                            "data": {
-                                "guid": "my-user"
-                            }
-                        },
-                        "organization": {
-                            "data": {
-                                "guid": "my-org"
-                            }
-                        }
-                    }
-                }`
+					"type": "organization_manager",
+					"relationships": {
+						"user": {
+							"data": {
+								"guid": "my-user"
+							}
+						},
+						"organization": {
+							"data": {
+								"guid": "my-org"
+							}
+						}
+					}
+				}`
 			})
 
 			It("returns 201 with appropriate success JSON", func() {
 				Expect(rr).To(HaveHTTPStatus(http.StatusCreated))
 				Expect(rr).To(HaveHTTPHeaderWithValue("Content-Type", "application/json"))
 				Expect(rr).To(HaveHTTPBody(MatchJSON(fmt.Sprintf(`{
-                    "guid": "t-h-e-r-o-l-e",
-                    "created_at": "2021-09-17T15:23:10Z",
-                    "updated_at": "2021-09-17T15:23:10Z",
-                    "type": "organization_manager",
-                    "relationships": {
-                        "user": {
-                            "data":{
-                                "guid": "my-user"
-                            }
-                        },
-                        "space": {
-                            "data": null
-                        },
-                        "organization": {
-                            "data": {
-                                "guid": "my-org"
-                            }
-                        }
-                    },
-                    "links": {
-                        "self": {
-                            "href": "%[1]s/v3/roles/t-h-e-r-o-l-e"
-                        },
-                        "organization": {
-                            "href": "%[1]s/v3/organizations/my-org"
-                        }
-                    }
-                }`, defaultServerURL))))
+					"guid": "t-h-e-r-o-l-e",
+					"created_at": "2021-09-17T15:23:10Z",
+					"updated_at": "2021-09-17T15:23:10Z",
+					"type": "organization_manager",
+					"relationships": {
+						"user": {
+							"data":{
+								"guid": "my-user"
+							}
+						},
+						"space": {
+							"data": null
+						},
+						"organization": {
+							"data": {
+								"guid": "my-org"
+							}
+						}
+					},
+					"links": {
+						"self": {
+							"href": "%[1]s/v3/roles/t-h-e-r-o-l-e"
+						},
+						"user": {
+							"href": "%[1]s/v3/users/my-user"
+						},
+						"organization": {
+							"href": "%[1]s/v3/organizations/my-org"
+						}
+					}
+				}`, defaultServerURL))))
 			})
 
 			It("invokes the role repo create function with expected parameters", func() {
@@ -301,20 +311,20 @@ var _ = Describe("Role", func() {
 		When("the kind is a service account", func() {
 			BeforeEach(func() {
 				createRoleRequestBody = `{
-                    "type": "organization_manager",
-                    "relationships": {
-                        "kubernetesServiceAccount": {
-                            "data": {
-                                "guid": "my-user"
-                            }
-                        },
-                        "organization": {
-                            "data": {
-                                "guid": "my-org"
-                            }
-                        }
-                    }
-                }`
+					"type": "organization_manager",
+					"relationships": {
+						"kubernetesServiceAccount": {
+							"data": {
+								"guid": "my-user"
+							}
+						},
+						"organization": {
+							"data": {
+								"guid": "my-org"
+							}
+						}
+					}
+				}`
 			})
 
 			It("creates a service account role binding", func() {
@@ -331,15 +341,15 @@ var _ = Describe("Role", func() {
 		When("the role does not contain a user or service account", func() {
 			BeforeEach(func() {
 				createRoleRequestBody = `{
-                    "type": "organization_manager",
-                    "relationships": {
-                        "organization": {
-                            "data": {
-                                "guid": "my-org"
-                            }
-                        }
-                    }
-                }`
+					"type": "organization_manager",
+					"relationships": {
+						"organization": {
+							"data": {
+								"guid": "my-org"
+							}
+						}
+					}
+				}`
 			})
 
 			It("returns an error", func() {
@@ -355,15 +365,15 @@ var _ = Describe("Role", func() {
 		When("the role does not contain a space or organisation relationship", func() {
 			BeforeEach(func() {
 				createRoleRequestBody = `{
-                    "type": "organization_manager",
-                    "relationships": {
-                        "user": {
-                            "data": {
-                                "guid": "my-user"
-                            }
-                        }
-                    }
-                }`
+					"type": "organization_manager",
+					"relationships": {
+						"user": {
+							"data": {
+								"guid": "my-user"
+							}
+						}
+					}
+				}`
 			})
 
 			It("returns an error", func() {
@@ -374,25 +384,25 @@ var _ = Describe("Role", func() {
 		When("the role does contains both a space and organization relationship", func() {
 			BeforeEach(func() {
 				createRoleRequestBody = `{
-                    "type": "organization_manager",
-                    "relationships": {
-                        "user": {
-                            "data": {
-                                "guid": "my-user"
-                            }
-                        },
-                        "space": {
-                            "data": {
-                                "guid": "my-space"
-                            }
-                        },
-                        "organization": {
-                            "data": {
-                                "guid": "my-org"
-                            }
-                        }
-                    }
-                }`
+					"type": "organization_manager",
+					"relationships": {
+						"user": {
+							"data": {
+								"guid": "my-user"
+							}
+						},
+						"space": {
+							"data": {
+								"guid": "my-space"
+							}
+						},
+						"organization": {
+							"data": {
+								"guid": "my-org"
+							}
+						}
+					}
+				}`
 			})
 
 			It("returns an error", func() {
@@ -419,14 +429,14 @@ var _ = Describe("Role", func() {
 				Expect(rr).To(HaveHTTPStatus(http.StatusBadRequest))
 				Expect(rr).To(HaveHTTPHeaderWithValue("Content-Type", "application/json"))
 				Expect(rr).To(HaveHTTPBody(MatchJSON(`{
-                    "errors": [
-                        {
-                            "title": "CF-MessageParseError",
-                            "detail": "Request invalid due to parse error: invalid request body",
-                            "code": 1001
-                        }
-                    ]
-                }`)))
+					"errors": [
+						{
+							"title": "CF-MessageParseError",
+							"detail": "Request invalid due to parse error: invalid request body",
+							"code": 1001
+						}
+					]
+				}`)))
 			})
 		})
 
@@ -439,65 +449,65 @@ var _ = Describe("Role", func() {
 				Expect(rr).To(HaveHTTPStatus(http.StatusUnprocessableEntity))
 				Expect(rr).To(HaveHTTPHeaderWithValue("Content-Type", "application/json"))
 				Expect(rr).To(HaveHTTPBody(MatchJSON(`{
-                    "errors": [
-                        {
-                            "title": "CF-UnprocessableEntity",
-                            "detail": "invalid request body: json: unknown field \"who-am-i\"",
-                            "code": 10008
-                        }
-                    ]
-                }`)))
+					"errors": [
+						{
+							"title": "CF-UnprocessableEntity",
+							"detail": "invalid request body: json: unknown field \"who-am-i\"",
+							"code": 10008
+						}
+					]
+				}`)))
 			})
 		})
 
 		When("the request body is invalid with missing required type field", func() {
 			BeforeEach(func() {
 				createRoleRequestBody = `{
-                    "relationships": {
-                        "user": {
-                            "data": {
-                                "guid": "my-user"
-                            }
-                        },
-                        "space": {
-                            "data": {
-                                "guid": "my-space"
-                            }
-                        }
-                    }
-                }`
+					"relationships": {
+						"user": {
+							"data": {
+								"guid": "my-user"
+							}
+						},
+						"space": {
+							"data": {
+								"guid": "my-space"
+							}
+						}
+					}
+				}`
 			})
 
 			It("returns a status 422 with appropriate error message json", func() {
 				Expect(rr).To(HaveHTTPStatus(http.StatusUnprocessableEntity))
 				Expect(rr).To(HaveHTTPHeaderWithValue("Content-Type", "application/json"))
 				Expect(rr).To(HaveHTTPBody(MatchJSON(`{
-                    "errors": [
-                        {
-                            "title": "CF-UnprocessableEntity",
-                            "detail": "Type is a required field",
-                            "code": 10008
-                        }
-                    ]
-                }`)))
+					"errors": [
+						{
+							"title": "CF-UnprocessableEntity",
+							"detail": "Type is a required field",
+							"code": 10008
+						}
+					]
+				}`)))
 			})
 		})
 
 		When("the request body has neither user name nor guid", func() {
 			BeforeEach(func() {
 				createRoleRequestBody = `{
-                    "type": "organization_manager",
-                    "relationships": {
-                        "user": {
-                            "data": {}
-                        },
-                        "space": {
-                            "data": {
-                                "guid": "my-space"
-                            }
-                        }
-                    }
-                }`
+					"type": "organization_manager",
+					"relationships": {
+						"user": {
+							"data": {}
+						},
+						"space": {
+							"data": {
+								"guid": "my-space"
+							}
+						}
+					}
+				}`
 			})
 
 			It("returns a status 422 with appropriate error message json", func() {
@@ -507,6 +517,239 @@ var _ = Describe("Role", func() {
 					ContainSubstring("Field validation for 'GUID' failed"),
 					ContainSubstring("Field validation for 'Username' failed"),
 				)))
+			})
+		})
+	})
+
+	Describe("List roles", func() {
+		var query string
+
+		BeforeEach(func() {
+			query = ""
+			roleRepo.ListRolesReturns([]repositories.RoleRecord{
+				{
+					GUID:      "org-role",
+					CreatedAt: now,
+					UpdatedAt: now,
+					Type:      "organization_manager",
+					Space:     "",
+					Org:       "the-org",
+					User:      "org-user",
+				},
+				{
+					GUID:      "space-role",
+					CreatedAt: now,
+					UpdatedAt: now,
+					Type:      "space_developer",
+					Space:     "the-space",
+					Org:       "",
+					User:      "space-user",
+				},
+			}, nil)
+		})
+
+		JustBeforeEach(func() {
+			req, err := http.NewRequestWithContext(ctx, "GET", rolesBase+query, nil)
+			Expect(err).NotTo(HaveOccurred())
+			routerBuilder.Build().ServeHTTP(rr, req)
+		})
+
+		It("calls the roles repo correctly", func() {
+			Expect(roleRepo.ListRolesCallCount()).To(Equal(1))
+			_, actualAuthInfo := roleRepo.ListRolesArgsForCall(0)
+			Expect(actualAuthInfo).To(Equal(authInfo))
+		})
+
+		It("lists roles", func() {
+			Expect(rr).To(HaveHTTPStatus(http.StatusOK))
+			Expect(rr).To(HaveHTTPHeaderWithValue("Content-Type", "application/json"))
+			Expect(rr).To(HaveHTTPBody(MatchJSON(fmt.Sprintf(`{
+				"pagination": {
+					"total_results": 2,
+					"total_pages": 1,
+					"first": {
+						"href": "%[1]s/v3/roles"
+					},
+					"last": {
+						"href": "%[1]s/v3/roles"
+					},
+					"next": null,
+					"previous": null
+				},
+				"resources": [
+					{
+						"guid": "org-role",
+						"created_at": "2021-09-17T15:23:10Z",
+						"updated_at": "2021-09-17T15:23:10Z",
+						"type": "organization_manager",
+						"relationships": {
+							"user": {
+								"data": {
+									"guid": "org-user"
+								}
+							},
+							"organization": {
+								"data": {
+									"guid": "the-org"
+								}
+							},
+							"space": {
+								"data": null
+							}
+						},
+						"links": {
+							"self": {
+								"href": "%[1]s/v3/roles/org-role"
+							},
+							"user": {
+								"href": "%[1]s/v3/users/org-user"
+							},
+							"organization": {
+								"href": "%[1]s/v3/organizations/the-org"
+							}
+						}
+					},
+					{
+						"guid": "space-role",
+						"created_at": "2021-09-17T15:23:10Z",
+						"updated_at": "2021-09-17T15:23:10Z",
+						"type": "space_developer",
+						"relationships": {
+							"user": {
+								"data": {
+									"guid": "space-user"
+								}
+							},
+							"organization": {
+								"data": null
+							},
+							"space": {
+								"data": {
+									"guid": "the-space"
+								}
+							}
+						},
+						"links": {
+							"self": {
+								"href": "%[1]s/v3/roles/space-role"
+							},
+							"user": {
+								"href": "%[1]s/v3/users/space-user"
+							},
+							"space": {
+								"href": "%[1]s/v3/spaces/the-space"
+							}
+						}
+					}
+				]
+			}`, defaultServerURL))))
+		})
+
+		When("include is specified", func() {
+			BeforeEach(func() {
+				query = "?include=user"
+			})
+
+			It("does not fail but has no effect on the result", func() {
+				Expect(rr).To(HaveHTTPStatus(http.StatusOK))
+				Expect(rr).To(HaveHTTPBody(SatisfyAll(
+					ContainSubstring("org-user"),
+					ContainSubstring("the-org"),
+					ContainSubstring("space-user"),
+					ContainSubstring("the-space"),
+				)))
+			})
+		})
+
+		type res struct {
+			GUID string `json:"guid"`
+		}
+		type resList struct {
+			Resources []res `json:"resources"`
+		}
+
+		DescribeTable("filtering", func(filter string, expectedGUIDs ...string) {
+			roleRepo.ListRolesReturns([]repositories.RoleRecord{
+				{GUID: "1", Type: "a", Space: "space1", Org: "", User: "user1"},
+				{GUID: "2", Type: "b", Space: "space2", Org: "", User: "user1"},
+				{GUID: "3", Type: "c", Space: "", Org: "org1", User: "user1"},
+				{GUID: "4", Type: "c", Space: "", Org: "org2", User: "user2"},
+			}, nil)
+			req, err := http.NewRequestWithContext(ctx, "GET", rolesBase+"?"+filter, nil)
+			Expect(err).NotTo(HaveOccurred())
+			rr = httptest.NewRecorder()
+			routerBuilder.Build().ServeHTTP(rr, req)
+			Expect(rr).To(HaveHTTPStatus(http.StatusOK))
+
+			var respList resList
+			err = json.Unmarshal(rr.Body.Bytes(), &respList)
+			Expect(err).NotTo(HaveOccurred())
+
+			var expectedRes []res
+			for _, guid := range expectedGUIDs {
+				expectedRes = append(expectedRes, res{GUID: guid})
+			}
+			Expect(respList.Resources).To(ConsistOf(expectedRes))
+		},
+			Entry("no filter", "", "1", "2", "3", "4"),
+			Entry("guids1", "guids=4", "4"),
+			Entry("guids2", "guids=1,3", "1", "3"),
+			Entry("types1", "types=a", "1"),
+			Entry("types2", "types=b,c", "2", "3", "4"),
+			Entry("space_guids1", "space_guids=space1", "1"),
+			Entry("space_guids2", "space_guids=space1,space2", "1", "2"),
+			Entry("organization_guids1", "organization_guids=org1", "3"),
+			Entry("organization_guids2", "organization_guids=org1,org2", "3", "4"),
+			Entry("user_guids1", "user_guids=user1", "1", "2", "3"),
+			Entry("user_guids2", "user_guids=user1,user2", "1", "2", "3", "4"),
+		)
+
+		DescribeTable("ordering", func(order string, expectedGUIDs ...string) {
+			roleRepo.ListRolesReturns([]repositories.RoleRecord{
+				{GUID: "1", CreatedAt: "2022-01-23T17:08:22", UpdatedAt: "2022-01-22T17:09:00"},
+				{GUID: "2", CreatedAt: "2022-01-24T17:08:22", UpdatedAt: "2022-01-21T17:09:00"},
+				{GUID: "3", CreatedAt: "2022-01-22T17:08:22", UpdatedAt: "2022-01-24T17:09:00"},
+				{GUID: "4", CreatedAt: "2022-01-21T17:08:22", UpdatedAt: "2022-01-23T17:09:00"},
+			}, nil)
+			req, err := http.NewRequestWithContext(ctx, "GET", rolesBase+"?order_by="+order, nil)
+			Expect(err).NotTo(HaveOccurred())
+			rr = httptest.NewRecorder()
+			routerBuilder.Build().ServeHTTP(rr, req)
+			Expect(rr).To(HaveHTTPStatus(http.StatusOK))
+
+			var respList resList
+			err = json.Unmarshal(rr.Body.Bytes(), &respList)
+			Expect(err).NotTo(HaveOccurred())
+
+			var expectedRes []res
+			for _, guid := range expectedGUIDs {
+				expectedRes = append(expectedRes, res{GUID: guid})
+			}
+			Expect(respList.Resources).To(Equal(expectedRes))
+		},
+			Entry("created_at ASC", "created_at", "4", "3", "1", "2"),
+			Entry("created_at DESC", "-created_at", "2", "1", "3", "4"),
+			Entry("updated_at ASC", "updated_at", "2", "1", "4", "3"),
+			Entry("updated_at DESC", "-updated_at", "3", "4", "1", "2"),
+		)
+
+		When("order_by is not a valid field", func() {
+			BeforeEach(func() {
+				query = "?order_by=not_valid"
+			})
+
+			It("returns an Unknown key error", func() {
+				expectUnknownKeyError("The query parameter is invalid: Order by can only be: 'created_at', 'updated_at'")
+			})
+		})
+
+		When("calling the repository fails", func() {
+			BeforeEach(func() {
+				roleRepo.ListRolesReturns(nil, errors.New("boom"))
+			})
+
+			It("returns the error", func() {
+				expectUnknownError()
 			})
 		})
 	})

--- a/api/handlers/user_test.go
+++ b/api/handlers/user_test.go
@@ -69,10 +69,12 @@ var _ = Describe("User", func() {
 					},
 					"resources": [
 						{
-							"username": "foo"
+							"username": "foo",
+							"guid": "foo"
 						},
 						{
-							"username": "bar"
+							"username": "bar",
+							"guid": "bar"
 						}
 					]
 				}`)))

--- a/api/main.go
+++ b/api/main.go
@@ -180,6 +180,7 @@ func main() {
 		userClientFactory,
 		spaceRepo,
 		authorization.NewNamespacePermissions(privilegedCRClient, cachingIdentityProvider),
+		authorization.NewNamespacePermissions(privilegedCRClient, cachingIdentityProvider),
 		config.RootNamespace,
 		config.RoleMappings,
 	)

--- a/api/payloads/role.go
+++ b/api/payloads/role.go
@@ -1,30 +1,43 @@
 package payloads
 
 import (
+	"net/url"
+	"strings"
+
 	"code.cloudfoundry.org/korifi/api/repositories"
 	rbacv1 "k8s.io/api/rbac/v1"
 )
 
-type RoleCreate struct {
-	Type          string            `json:"type" validate:"required"`
-	Relationships RoleRelationships `json:"relationships" validate:"required"`
-}
+type (
+	RoleCreate struct {
+		Type          string            `json:"type" validate:"required"`
+		Relationships RoleRelationships `json:"relationships" validate:"required"`
+	}
 
-type UserRelationship struct {
-	Data UserRelationshipData `json:"data" validate:"required"`
-}
+	UserRelationship struct {
+		Data UserRelationshipData `json:"data" validate:"required"`
+	}
 
-type UserRelationshipData struct {
-	Username string `json:"username" validate:"required_without=GUID"`
-	GUID     string `json:"guid" validate:"required_without=Username"`
-}
+	UserRelationshipData struct {
+		Username string `json:"username" validate:"required_without=GUID"`
+		GUID     string `json:"guid" validate:"required_without=Username"`
+	}
 
-type RoleRelationships struct {
-	User                     *UserRelationship `json:"user" validate:"required_without=KubernetesServiceAccount"`
-	KubernetesServiceAccount *Relationship     `json:"kubernetesServiceAccount" validate:"required_without=User"`
-	Space                    *Relationship     `json:"space"`
-	Organization             *Relationship     `json:"organization"`
-}
+	RoleRelationships struct {
+		User                     *UserRelationship `json:"user" validate:"required_without=KubernetesServiceAccount"`
+		KubernetesServiceAccount *Relationship     `json:"kubernetesServiceAccount" validate:"required_without=User"`
+		Space                    *Relationship     `json:"space"`
+		Organization             *Relationship     `json:"organization"`
+	}
+
+	RoleListFilter struct {
+		GUIDs      map[string]bool
+		Types      map[string]bool
+		SpaceGUIDs map[string]bool
+		OrgGUIDs   map[string]bool
+		UserGUIDs  map[string]bool
+	}
+)
 
 func (p RoleCreate) ToMessage() repositories.CreateRoleMessage {
 	record := repositories.CreateRoleMessage{
@@ -51,4 +64,30 @@ func (p RoleCreate) ToMessage() repositories.CreateRoleMessage {
 	}
 
 	return record
+}
+
+func (r *RoleListFilter) SupportedKeys() []string {
+	return []string{"guids", "types", "space_guids", "organization_guids", "user_guids", "order_by", "include"}
+}
+
+func (r *RoleListFilter) DecodeFromURLValues(values url.Values) error {
+	r.GUIDs = commaSepToSet(values.Get("guids"))
+	r.Types = commaSepToSet(values.Get("types"))
+	r.SpaceGUIDs = commaSepToSet(values.Get("space_guids"))
+	r.OrgGUIDs = commaSepToSet(values.Get("organization_guids"))
+	r.UserGUIDs = commaSepToSet(values.Get("user_guids"))
+	return nil
+}
+
+func commaSepToSet(in string) map[string]bool {
+	out := map[string]bool{}
+	if in == "" {
+		return out
+	}
+
+	for _, s := range strings.Split(in, ",") {
+		out[s] = true
+	}
+
+	return out
 }

--- a/api/presenter/role.go
+++ b/api/presenter/role.go
@@ -2,7 +2,6 @@ package presenter
 
 import (
 	"net/url"
-	"time"
 
 	"code.cloudfoundry.org/korifi/api/repositories"
 )
@@ -23,6 +22,7 @@ type RoleResponse struct {
 
 type RoleLinks struct {
 	Self         *Link `json:"self"`
+	User         *Link `json:"user"`
 	Space        *Link `json:"space,omitempty"`
 	Organization *Link `json:"organization,omitempty"`
 }
@@ -31,11 +31,20 @@ func ForCreateRole(role repositories.RoleRecord, apiBaseURL url.URL) RoleRespons
 	return toRoleResponse(role, apiBaseURL)
 }
 
+func ForRoleList(roles []repositories.RoleRecord, apiBaseURL, requestURL url.URL) ListResponse {
+	items := make([]any, len(roles))
+	for i := range items {
+		items[i] = toRoleResponse(roles[i], apiBaseURL)
+	}
+
+	return ForList(items, apiBaseURL, requestURL)
+}
+
 func toRoleResponse(role repositories.RoleRecord, apiBaseURL url.URL) RoleResponse {
 	resp := RoleResponse{
 		GUID:      role.GUID,
-		CreatedAt: role.CreatedAt.UTC().Format(time.RFC3339),
-		UpdatedAt: role.CreatedAt.UTC().Format(time.RFC3339),
+		CreatedAt: role.CreatedAt,
+		UpdatedAt: role.CreatedAt,
 		Type:      role.Type,
 		Relationships: Relationships{
 			"user":         Relationship{Data: &RelationshipData{GUID: role.User}},
@@ -45,6 +54,9 @@ func toRoleResponse(role repositories.RoleRecord, apiBaseURL url.URL) RoleRespon
 		Links: RoleLinks{
 			Self: &Link{
 				HRef: buildURL(apiBaseURL).appendPath(rolesBase, role.GUID).build(),
+			},
+			User: &Link{
+				HRef: buildURL(apiBaseURL).appendPath(usersBase, role.User).build(),
 			},
 		},
 	}

--- a/api/presenter/user.go
+++ b/api/presenter/user.go
@@ -1,9 +1,12 @@
 package presenter
 
+const usersBase = "/v3/users"
+
 type UserResponse struct {
 	Name string `json:"username"`
+	GUID string `json:"guid"`
 }
 
 func ForUser(name string) UserResponse {
-	return UserResponse{Name: name}
+	return UserResponse{Name: name, GUID: name}
 }

--- a/api/repositories/repositories_suite_test.go
+++ b/api/repositories/repositories_suite_test.go
@@ -238,11 +238,12 @@ func createClusterRole(ctx context.Context, filename string) *rbacv1.ClusterRole
 	return clusterRole
 }
 
-func createRoleBinding(ctx context.Context, userName, roleName, namespace string) {
+func createRoleBinding(ctx context.Context, userName, roleName, namespace string, labels ...string) {
 	roleBinding := rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      generateGUID(),
 			Namespace: namespace,
+			Labels:    map[string]string{},
 		},
 		Subjects: []rbacv1.Subject{{
 			Kind: rbacv1.UserKind,
@@ -253,5 +254,10 @@ func createRoleBinding(ctx context.Context, userName, roleName, namespace string
 			Name: roleName,
 		},
 	}
+
+	for i := 0; i < len(labels); i += 2 {
+		roleBinding.Labels[labels[i]] = labels[i+1]
+	}
+
 	Expect(k8sClient.Create(ctx, &roleBinding)).To(Succeed())
 }

--- a/helm/korifi/api/configmap.yaml
+++ b/helm/korifi/api/configmap.yaml
@@ -48,25 +48,33 @@ data:
         propagate: true
       organization_auditor:
         name: korifi-controllers-organization-auditor
+        level: org
         propagate: false
       organization_billing_manager:
         name: korifi-controllers-organization-billing-manager
+        level: org
         propagate: false
       organization_manager:
         name: korifi-controllers-organization-manager
+        level: org
         propagate: true
       organization_user:
         name: korifi-controllers-organization-user
+        level: org
         propagate: false
       space_auditor:
         name: korifi-controllers-space-auditor
+        level: space
         propagate: false
       space_developer:
         name: korifi-controllers-space-developer
+        level: space
         propagate: false
       space_manager:
         name: korifi-controllers-space-manager
+        level: space
         propagate: false
       space_supporter:
         name: korifi-controllers-space-supporter
+        level: space
         propagate: false

--- a/helm/korifi/controllers/cf_roles/cf_admin.yaml
+++ b/helm/korifi/controllers/cf_roles/cf_admin.yaml
@@ -171,6 +171,7 @@ rules:
   - rolebindings
   verbs:
   - create
+  - list
 
 - apiGroups:
   - metrics.k8s.io

--- a/helm/korifi/controllers/cf_roles/cf_org_user.yaml
+++ b/helm/korifi/controllers/cf_roles/cf_org_user.yaml
@@ -20,3 +20,10 @@ rules:
   verbs:
   - list
   - get
+
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - list

--- a/helm/korifi/controllers/cf_roles/cf_space_developer.yaml
+++ b/helm/korifi/controllers/cf_roles/cf_space_developer.yaml
@@ -97,6 +97,13 @@ rules:
     - watch
 
 - apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - list
+
+- apiGroups:
   - korifi.cloudfoundry.org
   resources:
   - cfroutes

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -116,6 +116,10 @@ type typedResource struct {
 	Metadata *metadata `json:"metadata,omitempty"`
 }
 
+type typedResourceList struct {
+	Resources []typedResource `json:"resources"`
+}
+
 type metadata struct {
 	Labels      map[string]string `json:"labels,omitempty"`
 	Annotations map[string]string `json:"annotations,omitempty"`

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -92,6 +92,11 @@ var _ = Describe("Smoke Tests", func() {
 				g.Expect(resp).To(HaveHTTPStatus(http.StatusOK))
 				g.Expect(resp).To(HaveHTTPBody(ContainSubstring("Hello World")))
 			}, 5*time.Minute, 30*time.Second).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				cfLogs := cf.Cf("logs", appName, "--recent")
+				g.Expect(string(cfLogs.Wait().Out.Contents())).To(ContainSubstring("Console output from test-node-app"))
+			}, 2*time.Minute, 2*time.Second).Should(Succeed())
 		})
 	})
 })


### PR DESCRIPTION
## Is there a related GitHub Issue?
https://github.com/cloudfoundry/korifi/issues/1239
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Implement listing roles (`GET /v3/roles`)

Invoked when unsetting org/space roles via the cf cli

<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
1. `cf set-org-role bob org1 OrgManager`
2. `cf curl "/v3/roles"` -> see `bob` has the OrgManager role assigned in org `org1 `
3. `cf set-space-role bob org1 space1 SpaceDeveloper`
4. `cf curl "/v3/roles"` -> see `bob` has the SpaceDeveloper role assigned in space `space1 `


<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@kieron-dev
