### PR TITLE
Implement DELETE /v3/roles/guid

### DIFF
--- a/api/handlers/fake/cfrole_repository.go
+++ b/api/handlers/fake/cfrole_repository.go
@@ -26,6 +26,34 @@ type CFRoleRepository struct {
 		result1 repositories.RoleRecord
 		result2 error
 	}
+	DeleteRoleStub        func(context.Context, authorization.Info, repositories.DeleteRoleMessage) error
+	deleteRoleMutex       sync.RWMutex
+	deleteRoleArgsForCall []struct {
+		arg1 context.Context
+		arg2 authorization.Info
+		arg3 repositories.DeleteRoleMessage
+	}
+	deleteRoleReturns struct {
+		result1 error
+	}
+	deleteRoleReturnsOnCall map[int]struct {
+		result1 error
+	}
+	GetRoleStub        func(context.Context, authorization.Info, string) (repositories.RoleRecord, error)
+	getRoleMutex       sync.RWMutex
+	getRoleArgsForCall []struct {
+		arg1 context.Context
+		arg2 authorization.Info
+		arg3 string
+	}
+	getRoleReturns struct {
+		result1 repositories.RoleRecord
+		result2 error
+	}
+	getRoleReturnsOnCall map[int]struct {
+		result1 repositories.RoleRecord
+		result2 error
+	}
 	ListRolesStub        func(context.Context, authorization.Info) ([]repositories.RoleRecord, error)
 	listRolesMutex       sync.RWMutex
 	listRolesArgsForCall []struct {
@@ -110,6 +138,135 @@ func (fake *CFRoleRepository) CreateRoleReturnsOnCall(i int, result1 repositorie
 	}{result1, result2}
 }
 
+func (fake *CFRoleRepository) DeleteRole(arg1 context.Context, arg2 authorization.Info, arg3 repositories.DeleteRoleMessage) error {
+	fake.deleteRoleMutex.Lock()
+	ret, specificReturn := fake.deleteRoleReturnsOnCall[len(fake.deleteRoleArgsForCall)]
+	fake.deleteRoleArgsForCall = append(fake.deleteRoleArgsForCall, struct {
+		arg1 context.Context
+		arg2 authorization.Info
+		arg3 repositories.DeleteRoleMessage
+	}{arg1, arg2, arg3})
+	stub := fake.DeleteRoleStub
+	fakeReturns := fake.deleteRoleReturns
+	fake.recordInvocation("DeleteRole", []interface{}{arg1, arg2, arg3})
+	fake.deleteRoleMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *CFRoleRepository) DeleteRoleCallCount() int {
+	fake.deleteRoleMutex.RLock()
+	defer fake.deleteRoleMutex.RUnlock()
+	return len(fake.deleteRoleArgsForCall)
+}
+
+func (fake *CFRoleRepository) DeleteRoleCalls(stub func(context.Context, authorization.Info, repositories.DeleteRoleMessage) error) {
+	fake.deleteRoleMutex.Lock()
+	defer fake.deleteRoleMutex.Unlock()
+	fake.DeleteRoleStub = stub
+}
+
+func (fake *CFRoleRepository) DeleteRoleArgsForCall(i int) (context.Context, authorization.Info, repositories.DeleteRoleMessage) {
+	fake.deleteRoleMutex.RLock()
+	defer fake.deleteRoleMutex.RUnlock()
+	argsForCall := fake.deleteRoleArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *CFRoleRepository) DeleteRoleReturns(result1 error) {
+	fake.deleteRoleMutex.Lock()
+	defer fake.deleteRoleMutex.Unlock()
+	fake.DeleteRoleStub = nil
+	fake.deleteRoleReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *CFRoleRepository) DeleteRoleReturnsOnCall(i int, result1 error) {
+	fake.deleteRoleMutex.Lock()
+	defer fake.deleteRoleMutex.Unlock()
+	fake.DeleteRoleStub = nil
+	if fake.deleteRoleReturnsOnCall == nil {
+		fake.deleteRoleReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.deleteRoleReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *CFRoleRepository) GetRole(arg1 context.Context, arg2 authorization.Info, arg3 string) (repositories.RoleRecord, error) {
+	fake.getRoleMutex.Lock()
+	ret, specificReturn := fake.getRoleReturnsOnCall[len(fake.getRoleArgsForCall)]
+	fake.getRoleArgsForCall = append(fake.getRoleArgsForCall, struct {
+		arg1 context.Context
+		arg2 authorization.Info
+		arg3 string
+	}{arg1, arg2, arg3})
+	stub := fake.GetRoleStub
+	fakeReturns := fake.getRoleReturns
+	fake.recordInvocation("GetRole", []interface{}{arg1, arg2, arg3})
+	fake.getRoleMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *CFRoleRepository) GetRoleCallCount() int {
+	fake.getRoleMutex.RLock()
+	defer fake.getRoleMutex.RUnlock()
+	return len(fake.getRoleArgsForCall)
+}
+
+func (fake *CFRoleRepository) GetRoleCalls(stub func(context.Context, authorization.Info, string) (repositories.RoleRecord, error)) {
+	fake.getRoleMutex.Lock()
+	defer fake.getRoleMutex.Unlock()
+	fake.GetRoleStub = stub
+}
+
+func (fake *CFRoleRepository) GetRoleArgsForCall(i int) (context.Context, authorization.Info, string) {
+	fake.getRoleMutex.RLock()
+	defer fake.getRoleMutex.RUnlock()
+	argsForCall := fake.getRoleArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *CFRoleRepository) GetRoleReturns(result1 repositories.RoleRecord, result2 error) {
+	fake.getRoleMutex.Lock()
+	defer fake.getRoleMutex.Unlock()
+	fake.GetRoleStub = nil
+	fake.getRoleReturns = struct {
+		result1 repositories.RoleRecord
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *CFRoleRepository) GetRoleReturnsOnCall(i int, result1 repositories.RoleRecord, result2 error) {
+	fake.getRoleMutex.Lock()
+	defer fake.getRoleMutex.Unlock()
+	fake.GetRoleStub = nil
+	if fake.getRoleReturnsOnCall == nil {
+		fake.getRoleReturnsOnCall = make(map[int]struct {
+			result1 repositories.RoleRecord
+			result2 error
+		})
+	}
+	fake.getRoleReturnsOnCall[i] = struct {
+		result1 repositories.RoleRecord
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *CFRoleRepository) ListRoles(arg1 context.Context, arg2 authorization.Info) ([]repositories.RoleRecord, error) {
 	fake.listRolesMutex.Lock()
 	ret, specificReturn := fake.listRolesReturnsOnCall[len(fake.listRolesArgsForCall)]
@@ -180,6 +337,10 @@ func (fake *CFRoleRepository) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.createRoleMutex.RLock()
 	defer fake.createRoleMutex.RUnlock()
+	fake.deleteRoleMutex.RLock()
+	defer fake.deleteRoleMutex.RUnlock()
+	fake.getRoleMutex.RLock()
+	defer fake.getRoleMutex.RUnlock()
 	fake.listRolesMutex.RLock()
 	defer fake.listRolesMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/api/handlers/job.go
+++ b/api/handlers/job.go
@@ -21,6 +21,7 @@ const (
 	routeDeletePrefix  = "route.delete"
 	spaceDeletePrefix  = "space.delete"
 	domainDeletePrefix = "domain.delete"
+	roleDeletePrefix   = "role.delete"
 )
 
 const JobResourceType = "Job"
@@ -55,7 +56,7 @@ func (h *Job) get(r *http.Request) (*routing.Response, error) {
 	switch jobType {
 	case syncSpacePrefix:
 		jobResponse = presenter.ForManifestApplyJob(jobGUID, resourceGUID, h.serverURL)
-	case appDeletePrefix, orgDeletePrefix, spaceDeletePrefix, routeDeletePrefix, domainDeletePrefix:
+	case appDeletePrefix, orgDeletePrefix, spaceDeletePrefix, routeDeletePrefix, domainDeletePrefix, roleDeletePrefix:
 		jobResponse = presenter.ForDeleteJob(jobGUID, jobType, h.serverURL)
 	default:
 		return nil, apierrors.LogAndReturn(

--- a/api/main.go
+++ b/api/main.go
@@ -183,6 +183,7 @@ func main() {
 		authorization.NewNamespacePermissions(privilegedCRClient, cachingIdentityProvider),
 		config.RootNamespace,
 		config.RoleMappings,
+		namespaceRetriever,
 	)
 	imageRepo := repositories.NewImageRepository(
 		privilegedK8sClient,

--- a/api/presenter/job.go
+++ b/api/presenter/job.go
@@ -14,6 +14,7 @@ const (
 	SpaceApplyManifestOperation = "space.apply_manifest"
 	SpaceDeleteOperation        = "space.delete"
 	DomainDeleteOperation       = "domain.delete"
+	RoleDeleteOperation         = "role.delete"
 )
 
 type JobResponse struct {

--- a/api/repositories/repositories_suite_test.go
+++ b/api/repositories/repositories_suite_test.go
@@ -238,7 +238,7 @@ func createClusterRole(ctx context.Context, filename string) *rbacv1.ClusterRole
 	return clusterRole
 }
 
-func createRoleBinding(ctx context.Context, userName, roleName, namespace string, labels ...string) {
+func createRoleBinding(ctx context.Context, userName, roleName, namespace string, labels ...string) rbacv1.RoleBinding {
 	roleBinding := rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      generateGUID(),
@@ -260,4 +260,5 @@ func createRoleBinding(ctx context.Context, userName, roleName, namespace string
 	}
 
 	Expect(k8sClient.Create(ctx, &roleBinding)).To(Succeed())
+	return roleBinding
 }

--- a/helm/korifi/controllers/cf_roles/cf_admin.yaml
+++ b/helm/korifi/controllers/cf_roles/cf_admin.yaml
@@ -172,6 +172,7 @@ rules:
   verbs:
   - create
   - list
+  - delete
 
 - apiGroups:
   - metrics.k8s.io

--- a/helm/korifi/controllers/cf_roles/cf_org_manager.yaml
+++ b/helm/korifi/controllers/cf_roles/cf_org_manager.yaml
@@ -21,3 +21,10 @@ rules:
     - get
     - list
     - watch
+
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - delete

--- a/helm/korifi/controllers/cf_roles/cf_space_manager.yaml
+++ b/helm/korifi/controllers/cf_roles/cf_space_manager.yaml
@@ -67,3 +67,10 @@ rules:
   verbs:
   - get
   - list
+
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - delete

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -448,7 +448,7 @@ func asyncCreateSpace(spaceName, orgGUID string, createdSpaceGUID *string, wg *s
 
 // createRole creates an org or space role
 // You should probably invoke this via createOrgRole or createSpaceRole
-func createRole(roleName, orgSpaceType, userName, orgSpaceGUID string) {
+func createRole(roleName, orgSpaceType, userName, orgSpaceGUID string) string {
 	rolesURL := apiServerRoot + "/v3/roles"
 
 	payload := typedResource{
@@ -462,21 +462,25 @@ func createRole(roleName, orgSpaceType, userName, orgSpaceGUID string) {
 	}
 
 	var resultErr cfErrs
+	var createdRole typedResource
 	resp, err := adminClient.R().
 		SetBody(payload).
+		SetResult(&createdRole).
 		SetError(&resultErr).
 		Post(rolesURL)
 
 	ExpectWithOffset(2, err).NotTo(HaveOccurred())
 	ExpectWithOffset(2, resp).To(HaveRestyStatusCode(http.StatusCreated))
+
+	return createdRole.GUID
 }
 
-func createOrgRole(roleName, userName, orgGUID string) {
-	createRole(roleName, "organization", userName, orgGUID)
+func createOrgRole(roleName, userName, orgGUID string) string {
+	return createRole(roleName, "organization", userName, orgGUID)
 }
 
-func createSpaceRole(roleName, userName, spaceGUID string) {
-	createRole(roleName, "space", userName, spaceGUID)
+func createSpaceRole(roleName, userName, spaceGUID string) string {
+	return createRole(roleName, "space", userName, spaceGUID)
 }
 
 func createApp(spaceGUID, name string) string {


### PR DESCRIPTION
## Is there a related GitHub Issue?
https://github.com/cloudfoundry/korifi/issues/1239
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Implement DELETE /v3/role/{guid}

Also fix listing functionality to read the role guid that gets returned
to the user from the CFRole metadata, as the CFRole name contains the
sha256 sum of the role name and the user name, so that optimistic
locking will prevent us from creating duplicate entries
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
See story
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@eirini
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
