### PR TITLE
Allow multiple apps in manifests

### DIFF
--- a/api/actions/manifest/normalizer.go
+++ b/api/actions/manifest/normalizer.go
@@ -73,14 +73,13 @@ func (n Normalizer) normalizeProcesses(appInfo payloads.ManifestApplication, app
 			break
 		}
 	}
+	if webProc == nil {
+		processes = append(processes, payloads.ManifestApplicationProcess{Type: korifiv1alpha1.ProcessTypeWeb})
+		webProc = &processes[len(processes)-1]
+	}
 
 	if appInfo.Memory != nil || appInfo.DiskQuota != nil || appInfo.Instances != nil || appInfo.Command != nil ||
 		appInfo.HealthCheckHTTPEndpoint != nil || appInfo.HealthCheckType != nil || appInfo.HealthCheckInvocationTimeout != nil || appInfo.Timeout != nil {
-
-		if webProc == nil {
-			processes = append(processes, payloads.ManifestApplicationProcess{Type: korifiv1alpha1.ProcessTypeWeb})
-			webProc = &processes[len(processes)-1]
-		}
 
 		webProc.Memory = procValIfSet(appInfo.Memory, webProc.Memory)
 		webProc.DiskQuota = procValIfSet(appInfo.DiskQuota, webProc.DiskQuota)

--- a/api/actions/manifest/normalizer_test.go
+++ b/api/actions/manifest/normalizer_test.go
@@ -117,8 +117,15 @@ var _ = Describe("Normalizer", func() {
 			}
 		})
 
+		It("always creates a web process", func() {
+			Expect(normalizedAppInfo.Processes).To(ContainElement(payloads.ManifestApplicationProcess{Type: "web"}))
+		})
+
 		It("preserves existing processes", func() {
-			Expect(normalizedAppInfo.Processes).To(ConsistOf(payloads.ManifestApplicationProcess{Type: "bob"}))
+			Expect(normalizedAppInfo.Processes).To(ConsistOf(
+				payloads.ManifestApplicationProcess{Type: "web"},
+				payloads.ManifestApplicationProcess{Type: "bob"},
+			))
 		})
 
 		DescribeTable("when app-level values are provided",
@@ -159,7 +166,7 @@ var _ = Describe("Normalizer", func() {
 				Expect(webProc.Timeout).To(Equal(effective.Timeout))
 			},
 
-			// without an existing web process
+			// without an explicit web process in the manifest
 			Entry("app-level command only",
 				appParams{Command: tools.PtrTo("echo boo")}, prcParams{},
 				expParams{Command: tools.PtrTo("echo boo")}),
@@ -188,7 +195,7 @@ var _ = Describe("Normalizer", func() {
 				appParams{Memory: tools.PtrTo("512M"), DiskQuota: tools.PtrTo("2G")}, prcParams{},
 				expParams{Memory: tools.PtrTo("512M"), DiskQuota: tools.PtrTo("2G")}),
 
-			// with an existing web process without the given value set
+			// with an explicit web process in the manifest, but without the app-level value set
 			Entry("empty proc with app memory",
 				appParams{Memory: tools.PtrTo("512M")},
 				prcParams{Instances: tools.PtrTo(3)},

--- a/api/handlers/app_test.go
+++ b/api/handlers/app_test.go
@@ -316,6 +316,27 @@ var _ = Describe("App", func() {
                 }`, defaultServerURL, appGUID, spaceGUID)), "Response body matches response:")
 		})
 
+		It("creates the `web` process", func() {
+			Expect(processRepo.CreateProcessCallCount()).To(Equal(1))
+			_, actualAuthInfo, actualMsg := processRepo.CreateProcessArgsForCall(0)
+			Expect(actualAuthInfo).To(Equal(authInfo))
+			Expect(actualMsg).To(Equal(repositories.CreateProcessMessage{
+				AppGUID:   appGUID,
+				SpaceGUID: spaceGUID,
+				Type:      "web",
+			}))
+		})
+
+		When("creating the process fails", func() {
+			BeforeEach(func() {
+				processRepo.CreateProcessReturns(errors.New("create-process-err"))
+			})
+
+			It("returns an error", func() {
+				expectUnknownError()
+			})
+		})
+
 		When("creating the app fails", func() {
 			BeforeEach(func() {
 				appRepo.CreateAppReturns(repositories.AppRecord{}, errors.New("create-app-err"))

--- a/api/handlers/fake/cfprocess_repository.go
+++ b/api/handlers/fake/cfprocess_repository.go
@@ -11,6 +11,19 @@ import (
 )
 
 type CFProcessRepository struct {
+	CreateProcessStub        func(context.Context, authorization.Info, repositories.CreateProcessMessage) error
+	createProcessMutex       sync.RWMutex
+	createProcessArgsForCall []struct {
+		arg1 context.Context
+		arg2 authorization.Info
+		arg3 repositories.CreateProcessMessage
+	}
+	createProcessReturns struct {
+		result1 error
+	}
+	createProcessReturnsOnCall map[int]struct {
+		result1 error
+	}
 	GetProcessStub        func(context.Context, authorization.Info, string) (repositories.ProcessRecord, error)
 	getProcessMutex       sync.RWMutex
 	getProcessArgsForCall []struct {
@@ -75,6 +88,69 @@ type CFProcessRepository struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *CFProcessRepository) CreateProcess(arg1 context.Context, arg2 authorization.Info, arg3 repositories.CreateProcessMessage) error {
+	fake.createProcessMutex.Lock()
+	ret, specificReturn := fake.createProcessReturnsOnCall[len(fake.createProcessArgsForCall)]
+	fake.createProcessArgsForCall = append(fake.createProcessArgsForCall, struct {
+		arg1 context.Context
+		arg2 authorization.Info
+		arg3 repositories.CreateProcessMessage
+	}{arg1, arg2, arg3})
+	stub := fake.CreateProcessStub
+	fakeReturns := fake.createProcessReturns
+	fake.recordInvocation("CreateProcess", []interface{}{arg1, arg2, arg3})
+	fake.createProcessMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *CFProcessRepository) CreateProcessCallCount() int {
+	fake.createProcessMutex.RLock()
+	defer fake.createProcessMutex.RUnlock()
+	return len(fake.createProcessArgsForCall)
+}
+
+func (fake *CFProcessRepository) CreateProcessCalls(stub func(context.Context, authorization.Info, repositories.CreateProcessMessage) error) {
+	fake.createProcessMutex.Lock()
+	defer fake.createProcessMutex.Unlock()
+	fake.CreateProcessStub = stub
+}
+
+func (fake *CFProcessRepository) CreateProcessArgsForCall(i int) (context.Context, authorization.Info, repositories.CreateProcessMessage) {
+	fake.createProcessMutex.RLock()
+	defer fake.createProcessMutex.RUnlock()
+	argsForCall := fake.createProcessArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *CFProcessRepository) CreateProcessReturns(result1 error) {
+	fake.createProcessMutex.Lock()
+	defer fake.createProcessMutex.Unlock()
+	fake.CreateProcessStub = nil
+	fake.createProcessReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *CFProcessRepository) CreateProcessReturnsOnCall(i int, result1 error) {
+	fake.createProcessMutex.Lock()
+	defer fake.createProcessMutex.Unlock()
+	fake.CreateProcessStub = nil
+	if fake.createProcessReturnsOnCall == nil {
+		fake.createProcessReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.createProcessReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *CFProcessRepository) GetProcess(arg1 context.Context, arg2 authorization.Info, arg3 string) (repositories.ProcessRecord, error) {
@@ -346,6 +422,8 @@ func (fake *CFProcessRepository) PatchProcessReturnsOnCall(i int, result1 reposi
 func (fake *CFProcessRepository) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.createProcessMutex.RLock()
+	defer fake.createProcessMutex.RUnlock()
 	fake.getProcessMutex.RLock()
 	defer fake.getProcessMutex.RUnlock()
 	fake.getProcessByAppTypeAndSpaceMutex.RLock()

--- a/api/handlers/process.go
+++ b/api/handlers/process.go
@@ -31,6 +31,7 @@ type CFProcessRepository interface {
 	ListProcesses(context.Context, authorization.Info, repositories.ListProcessesMessage) ([]repositories.ProcessRecord, error)
 	GetProcessByAppTypeAndSpace(context.Context, authorization.Info, string, string, string) (repositories.ProcessRecord, error)
 	PatchProcess(context.Context, authorization.Info, repositories.PatchProcessMessage) (repositories.ProcessRecord, error)
+	CreateProcess(context.Context, authorization.Info, repositories.CreateProcessMessage) error
 }
 
 //counterfeiter:generate -o fake -fake-name ProcessScaler . ProcessScaler

--- a/api/handlers/space_manifest_test.go
+++ b/api/handlers/space_manifest_test.go
@@ -128,25 +128,6 @@ var _ = Describe("SpaceManifest", func() {
 			})
 		})
 
-		When("the manifest contains multiple apps", func() {
-			BeforeEach(func() {
-				requestBody = strings.NewReader(`---
-                version: 1
-                applications:
-                - name: app1
-                - name: app2
-                `)
-			})
-
-			It("response with an unprocessable entity error", func() {
-				expectUnprocessableEntityError("Applications must contain at maximum 1 item")
-			})
-
-			It("doesn't call applyManifestAction", func() {
-				Expect(manifestApplier.ApplyCallCount()).To(Equal(0))
-			})
-		})
-
 		When("the application name is missing", func() {
 			BeforeEach(func() {
 				requestBody = strings.NewReader(`---
@@ -165,22 +146,33 @@ var _ = Describe("SpaceManifest", func() {
 			})
 		})
 
+		When("the application memory does not have a unit", func() {
+			BeforeEach(func() {
+				requestBody = strings.NewReader(`---
+                version: 1
+                applications:
+                - name: test-app
+                  memory: 1024
+                `)
+			})
+
+			It("response with an unprocessable entity error", func() {
+				expectUnprocessableEntityError("Memory must use a supported unit: B, K, KB, M, MB, G, GB, T, or TB")
+			})
+		})
+
 		When("the application memory is not a positive integer", func() {
 			BeforeEach(func() {
 				requestBody = strings.NewReader(`---
                 version: 1
                 applications:
                 - name: test-app
-                  memory: 0
+                  memory: 0M
                 `)
 			})
 
 			It("response with an unprocessable entity error", func() {
-				expectUnprocessableEntityError("Key: 'Manifest.Applications[0].Memory' Error:Field validation for 'Memory' failed on the 'megabytestring' tag")
-			})
-
-			It("doesn't call applyManifestAction", func() {
-				Expect(manifestApplier.ApplyCallCount()).To(Equal(0))
+				expectUnprocessableEntityError("Memory must be greater than 0MB")
 			})
 		})
 
@@ -225,6 +217,23 @@ var _ = Describe("SpaceManifest", func() {
 			})
 		})
 
+		When("the application process disk doesn't supply a unit", func() {
+			BeforeEach(func() {
+				requestBody = strings.NewReader(`---
+                version: 1
+                applications:
+                - name: test-app
+                  processes:
+                  - type: web
+                    disk_quota: 1024
+                `)
+			})
+
+			It("response with an unprocessable entity error", func() {
+				expectUnprocessableEntityError("DiskQuota must use a supported unit: B, K, KB, M, MB, G, GB, T, or TB")
+			})
+		})
+
 		When("the application process disk is not a positive integer", func() {
 			BeforeEach(func() {
 				requestBody = strings.NewReader(`---
@@ -233,16 +242,29 @@ var _ = Describe("SpaceManifest", func() {
                 - name: test-app
                   processes:
                   - type: web
-                    disk_quota: 0
+                    disk_quota: 0M
                 `)
 			})
 
 			It("response with an unprocessable entity error", func() {
-				expectUnprocessableEntityError("Key: 'Manifest.Applications[0].Processes[0].DiskQuota' Error:Field validation for 'DiskQuota' failed on the 'megabytestring' tag")
+				expectUnprocessableEntityError("DiskQuota must be greater than 0MB")
+			})
+		})
+
+		When("the application process memory doesn't supply a unit", func() {
+			BeforeEach(func() {
+				requestBody = strings.NewReader(`---
+                version: 1
+                applications:
+                - name: test-app
+                  processes:
+                  - type: web
+                    memory: 1024
+                `)
 			})
 
-			It("doesn't call applyManifestAction", func() {
-				Expect(manifestApplier.ApplyCallCount()).To(Equal(0))
+			It("response with an unprocessable entity error", func() {
+				expectUnprocessableEntityError("Memory must use a supported unit: B, K, KB, M, MB, G, GB, T, or TB")
 			})
 		})
 
@@ -254,12 +276,12 @@ var _ = Describe("SpaceManifest", func() {
                 - name: test-app
                   processes:
                   - type: web
-                    memory: 0
+                    memory: 0GB
                 `)
 			})
 
 			It("response with an unprocessable entity error", func() {
-				expectUnprocessableEntityError("Key: 'Manifest.Applications[0].Processes[0].Memory' Error:Field validation for 'Memory' failed on the 'megabytestring' tag")
+				expectUnprocessableEntityError("Memory must be greater than 0MB")
 			})
 
 			It("doesn't call applyManifestAction", func() {

--- a/api/payloads/manifest.go
+++ b/api/payloads/manifest.go
@@ -10,7 +10,7 @@ import (
 
 type Manifest struct {
 	Version      int                   `yaml:"version"`
-	Applications []ManifestApplication `yaml:"applications"`
+	Applications []ManifestApplication `yaml:"applications" validate:"dive"`
 }
 
 type ManifestApplication struct {
@@ -21,13 +21,13 @@ type ManifestApplication struct {
 	NoRoute      bool              `yaml:"no-route"`
 	Command      *string           `yaml:"command"`
 	Instances    *int              `yaml:"instances" validate:"omitempty,gte=0"`
-	Memory       *string           `yaml:"memory" validate:"megabytestring"`
-	DiskQuota    *string           `yaml:"disk_quota" validate:"megabytestring"`
+	Memory       *string           `yaml:"memory" validate:"amountWithUnit,positiveAmountWithUnit"`
+	DiskQuota    *string           `yaml:"disk_quota" validate:"amountWithUnit,positiveAmountWithUnit"`
 	// AltDiskQuota supports `disk-quota` with a hyphen for backwards compatibility.
 	// Do not set both DiskQuota and AltDiskQuota.
 	//
 	// Deprecated: Use DiskQuota instead
-	AltDiskQuota                 *string                      `yaml:"disk-quota" validate:"megabytestring"`
+	AltDiskQuota                 *string                      `yaml:"disk-quota" validate:"amountWithUnit,positiveAmountWithUnit"`
 	HealthCheckHTTPEndpoint      *string                      `yaml:"health-check-http-endpoint"`
 	HealthCheckInvocationTimeout *int64                       `yaml:"health-check-invocation-timeout" validate:"omitempty,gte=1"`
 	HealthCheckType              *string                      `yaml:"health-check-type" validate:"omitempty,oneof=none process port http"`
@@ -42,17 +42,17 @@ type ManifestApplication struct {
 type ManifestApplicationProcess struct {
 	Type      string  `yaml:"type" validate:"required"`
 	Command   *string `yaml:"command"`
-	DiskQuota *string `yaml:"disk_quota" validate:"megabytestring"`
+	DiskQuota *string `yaml:"disk_quota" validate:"amountWithUnit,positiveAmountWithUnit"`
 	// AltDiskQuota supports `disk-quota` with a hyphen for backwards compatibility.
 	// Do not set both DiskQuota and AltDiskQuota.
 	//
 	// Deprecated: Use DiskQuota instead
-	AltDiskQuota                 *string `yaml:"disk-quota" validate:"megabytestring"`
+	AltDiskQuota                 *string `yaml:"disk-quota" validate:"amountWithUnit,positiveAmountWithUnit"`
 	HealthCheckHTTPEndpoint      *string `yaml:"health-check-http-endpoint"`
 	HealthCheckInvocationTimeout *int64  `yaml:"health-check-invocation-timeout" validate:"omitempty,gte=1"`
 	HealthCheckType              *string `yaml:"health-check-type" validate:"omitempty,oneof=none process port http"`
 	Instances                    *int    `yaml:"instances" validate:"omitempty,gte=0"`
-	Memory                       *string `yaml:"memory" validate:"megabytestring"`
+	Memory                       *string `yaml:"memory" validate:"amountWithUnit,positiveAmountWithUnit"`
 	Timeout                      *int64  `yaml:"timeout" validate:"omitempty,gte=1"`
 }
 

--- a/api/payloads/manifest.go
+++ b/api/payloads/manifest.go
@@ -10,7 +10,7 @@ import (
 
 type Manifest struct {
 	Version      int                   `yaml:"version"`
-	Applications []ManifestApplication `yaml:"applications" validate:"max=1,dive"`
+	Applications []ManifestApplication `yaml:"applications"`
 }
 
 type ManifestApplication struct {

--- a/tests/e2e/apps_test.go
+++ b/tests/e2e/apps_test.go
@@ -233,7 +233,7 @@ var _ = Describe("Apps", func() {
 	})
 
 	Describe("List app processes", func() {
-		var result resourceList
+		var result typedResourceList
 
 		BeforeEach(func() {
 			createSpaceRole("space_developer", certUserName, space1GUID)
@@ -246,9 +246,10 @@ var _ = Describe("Apps", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("successfully lists the empty set of processes", func() {
+		It("successfully lists the default web process", func() {
 			Expect(resp).To(HaveRestyStatusCode(http.StatusOK))
-			Expect(result.Resources).To(BeEmpty())
+			Expect(result.Resources).To(HaveLen(1))
+			Expect(result.Resources[0].Type).To(Equal("web"))
 		})
 	})
 


### PR DESCRIPTION
## Is there a related GitHub Issue?
#1661

## What is this change about?
Allow the list of apps in a space manifest to have more than 1 entry.

Also fix the behaviour of creating a web process during manifest application or app creation to match cf on VMs. I.e. the web process is created at the same time as the app.

## Does this PR introduce a breaking change?
Note that the web app is created earlier now, rather than when starting the app.

## Acceptance Steps
See story

## Tag your pair, your PM, and/or team
@gcapizzi

