### PR TITLE
switched to `tr` because MacOSX base64 doesn’t support the` -w 0` option

### DIFF
--- a/scripts/account-creation.sh
+++ b/scripts/account-creation.sh
@@ -12,13 +12,13 @@ if [[ -z "${E2E_USER_NAME:=}" ]]; then
   export E2E_USER_NAME="e2e-cert-user"
   createCert "$E2E_USER_NAME" "$tmp/key.pem" "$tmp/cert.pem"
 
-  export E2E_USER_PEM="$(cat $tmp/cert.pem $tmp/key.pem | base64 -w0)"
+  export E2E_USER_PEM="$(cat $tmp/cert.pem $tmp/key.pem | base64 | tr -d '\n\r')"
 fi
 if [[ -z "${E2E_LONGCERT_USER_NAME:=}" ]]; then
   export E2E_LONGCERT_USER_NAME="e2e-longcert-user"
   createCert "$E2E_LONGCERT_USER_NAME" "$tmp/longkey.pem" "$tmp/longcert.pem" "365"
 
-  export E2E_LONGCERT_USER_PEM="$(cat $tmp/longcert.pem $tmp/longkey.pem | base64 -w0)"
+  export E2E_LONGCERT_USER_PEM="$(cat $tmp/longcert.pem $tmp/longkey.pem | base64 | tr -d '\n\r')"
 fi
 
 if [[ -z "${E2E_SERVICE_ACCOUNT:=}" ]]; then
@@ -53,9 +53,9 @@ fi
 
 if [[ -z "${CF_ADMIN_CERT:=}" ]]; then
   createCert "cf-admin" "$tmp/cf-admin-key.pem" "$tmp/cf-admin-cert.pem"
-  CF_ADMIN_CERT="$(base64 -w0 "$tmp/cf-admin-cert.pem")"
-  CF_ADMIN_KEY="$(base64 -w0 "$tmp/cf-admin-key.pem")"
-  CF_ADMIN_PEM="$(cat "$tmp/cf-admin-cert.pem" "$tmp/cf-admin-key.pem" | base64 -w0)"
+  CF_ADMIN_CERT="$(base64 "$tmp/cf-admin-cert.pem" | tr -d '\n\r')"
+  CF_ADMIN_KEY="$(base64 "$tmp/cf-admin-key.pem" | tr -d '\n\r')"
+  CF_ADMIN_PEM="$(cat "$tmp/cf-admin-cert.pem" "$tmp/cf-admin-key.pem" | base64 | tr -d '\n\r')"
   export CF_ADMIN_PEM CF_ADMIN_KEY CF_ADMIN_CERT
 fi
 


### PR DESCRIPTION
## What is this change about?
<!-- MacOSX base64  doesn't support `-w0` that cause `base64: illegal option -- w` during test run.  -->

## Acceptance Steps
<!-- make test -->

