### PR TITLE
Added support for GitHub Container Registry

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -177,6 +177,7 @@ For example:
 | Amazon Elastic Container Registry | `<projectID>.dkr.ecr.<region>.amazonaws.com/foo/bar/korifi-` | `<projectID>.dkr.ecr.<region>.amazonaws.com/foo/bar/korifi-<appGUID>-packages` | Korifi will create the repository before pushing, as dynamic repository creation is not posssible on ECR |
 | Google Artifact Registry          | `<region>-docker.pkg.dev/<projectID>/foo/bar/korifi-`        | `<region>-docker.pkg.dev/<projectID>/foo/bar/korifi-<appGUID>-packages`        | The `foo` repository must already exist in GAR                                                           |
 | Google Container Registry         | `gcr.io/<projectID>/foo/bar/korifi-`                         | `gcr.io/<projectID>/foo/bar/korifi-<appGUID>-packages`                         | Repositories are created dynamically during push by GCR                                                  |
+| GitHub Container Registry         | `ghcr.io/<githubUserName>/foo/bar/korifi-`                   | `ghcr.io/<githubUserName>/foo/bar/korifi-<appGUID>-package`                    | Repositories are created dynamically during push by GHCR                                                 |
 
 The chart provides various other values that can be set. See [`README.helm.md`](./README.helm.md) for details.
 


### PR DESCRIPTION
## Is there a related GitHub Issue?

No related Issue.

## What is this change about?

The GitHub container registry is a good place to try out korifi because private images are available for free.
So, I added a description of the GitHub container registry to the installation instructions.

## Does this PR introduce a breaking change?

No breaking change.

## Acceptance Steps

NA

## Tag your pair, your PM, and/or team

NA

## Things to remember

NA