### PR TITLE
Make the pod affinity term stable

### DIFF
--- a/statefulset-runner/controllers/appworkload_to_stset.go
+++ b/statefulset-runner/controllers/appworkload_to_stset.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
@@ -209,14 +210,18 @@ func truncateString(str string, num int) string {
 }
 
 func toLabelSelectorRequirements(selector *metav1.LabelSelector) []metav1.LabelSelectorRequirement {
-	labels := selector.MatchLabels
-	reqs := make([]metav1.LabelSelectorRequirement, 0, len(labels))
+	labels := make([]string, 0, len(selector.MatchLabels))
+	for k := range selector.MatchLabels {
+		labels = append(labels, k)
+	}
+	sort.Strings(labels)
 
-	for label, value := range labels {
+	reqs := make([]metav1.LabelSelectorRequirement, 0, len(labels))
+	for _, label := range labels {
 		reqs = append(reqs, metav1.LabelSelectorRequirement{
 			Key:      label,
 			Operator: metav1.LabelSelectorOpIn,
-			Values:   []string{value},
+			Values:   []string{selector.MatchLabels[label]},
 		})
 	}
 

--- a/statefulset-runner/controllers/appworkload_to_stset_test.go
+++ b/statefulset-runner/controllers/appworkload_to_stset_test.go
@@ -1,6 +1,8 @@
 package controllers_test
 
 import (
+	"fmt"
+
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"code.cloudfoundry.org/korifi/statefulset-runner/controllers"
 	"code.cloudfoundry.org/korifi/tools"
@@ -256,5 +258,15 @@ var _ = Describe("AppWorkload to StatefulSet Converter", func() {
 				}},
 			))
 		})
+	})
+
+	It("should produce a stable statefulset", func() {
+		for i := 0; i < 100; i++ {
+			ss, err := converter.Convert(appWorkload)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ss).To(Equal(statefulSet), func() string {
+				return fmt.Sprintf("failed on iteration %d", i)
+			})
+		}
 	})
 })


### PR DESCRIPTION
## Is there a related GitHub Issue?
#2132

## What is this change about?
This stops apps being randomly restarted when the statefulset-runner appworkload reconciler runs.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
See #2132

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
