### PR TITLE
Reflect the cluster builder ready status in the builder info status

### DIFF
--- a/controllers/api/v1alpha1/builderinfo_types.go
+++ b/controllers/api/v1alpha1/builderinfo_types.go
@@ -57,6 +57,8 @@ type BuilderInfoStatusBuildpack struct {
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 //+kubebuilder:resource:path=builderinfos
+//+kubebuilder:printcolumn:name="Age",type="date",JSONPath=`.metadata.creationTimestamp`
+//+kubebuilder:printcolumn:name="Ready",type="string",JSONPath=`.status.conditions[?(@.type=='Ready')].status`
 
 // BuilderInfo is the Schema for the builderinfos API
 type BuilderInfo struct {

--- a/helm/korifi/controllers/crds/korifi.cloudfoundry.org_builderinfos.yaml
+++ b/helm/korifi/controllers/crds/korifi.cloudfoundry.org_builderinfos.yaml
@@ -15,7 +15,17 @@ spec:
     singular: builderinfo
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.name
+      name: Builder name
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: BuilderInfo is the Schema for the builderinfos API


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
The builder info ready status condition should be true iff the cluster builder ready status condition is true

## Does this PR introduce a breaking change?
No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
