### PR TITLE
`BuildWorkload`s fail if the Kpack `ClusterBuilder` is not ready

### DIFF
--- a/kpack-image-builder/controllers/buildworkload_controller.go
+++ b/kpack-image-builder/controllers/buildworkload_controller.go
@@ -164,13 +164,21 @@ func (r *BuildWorkloadReconciler) ReconcileResource(ctx context.Context, buildWo
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	kpackReadyStatusCondition := kpackImage.Status.GetCondition(kpackReadyConditionType)
+	kpackReadyStatusCondition := kpackImage.Status.GetCondition(corev1alpha1.ConditionReady)
+	kpackBuilderReadyStatusCondition := kpackImage.Status.GetCondition(buildv1alpha2.ConditionBuilderReady)
 	if kpackReadyStatusCondition.IsFalse() {
 		meta.SetStatusCondition(&buildWorkload.Status.Conditions, metav1.Condition{
 			Type:    korifiv1alpha1.SucceededConditionType,
 			Status:  metav1.ConditionFalse,
 			Reason:  "BuildFailed",
 			Message: "Check build log output",
+		})
+	} else if kpackBuilderReadyStatusCondition.IsFalse() {
+		meta.SetStatusCondition(&buildWorkload.Status.Conditions, metav1.Condition{
+			Type:    korifiv1alpha1.SucceededConditionType,
+			Status:  metav1.ConditionFalse,
+			Reason:  "BuilderNotReady",
+			Message: "Check ClusterBuilder",
 		})
 	} else if kpackReadyStatusCondition.IsTrue() {
 		meta.SetStatusCondition(&buildWorkload.Status.Conditions, metav1.Condition{


### PR DESCRIPTION
## Is there a related GitHub Issue?

#1798

## What is this change about?

This allows `cf push` to fail quickly when the `ClusterBuilder` is not ready. We believe this condition will only occur right after installing Korifi or if the `ClusterBuilder` is misconfigured, so it is fair to fail builds on it instead of trying to be eventually consistent.

## Does this PR introduce a breaking change?
Yes. When using the default `kpack-image-builder`, `BuildWorkload`s (and thus `CFBuild`s) will now fail immediately if the configured `ClusterBuilder` is not ready, instead of waiting for it to get back to ready.

## Acceptance Steps
- Deploy Korifi;
- make the `ClusterBuilder` invalid;
- try to `cf push`.

## Tag your pair, your PM, and/or team
@gcapizzi 
