### PR TITLE
Fix linter warnings

### DIFF
--- a/api/actions/manifest/normalizer.go
+++ b/api/actions/manifest/normalizer.go
@@ -3,7 +3,6 @@ package manifest
 import (
 	"math/rand"
 	"strings"
-	"time"
 
 	"code.cloudfoundry.org/korifi/api/payloads"
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
@@ -131,7 +130,6 @@ func (n Normalizer) configureRandomRoute(appName string) payloads.ManifestRoute 
 }
 
 func generateRandomRoute() string {
-	rand.Seed(time.Now().Unix())
 	suffix := string('a'+rune(rand.Intn(26))) + string('a'+rune(rand.Intn(26)))
 	return adjectives[rand.Intn(len(adjectives))] + "-" + nouns[rand.Intn(len(nouns))] + "-" + suffix
 }

--- a/api/handlers/service_instance_test.go
+++ b/api/handlers/service_instance_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
-	"time"
 
 	apierrors "code.cloudfoundry.org/korifi/api/errors"
 	. "code.cloudfoundry.org/korifi/api/handlers"
@@ -744,7 +743,6 @@ var _ = Describe("ServiceInstance", func() {
 })
 
 func randomString(length int) string {
-	rand.Seed(time.Now().UnixNano())
 	b := make([]byte, length)
 	rand.Read(b)
 	return fmt.Sprintf("%x", b)[:length]


### PR DESCRIPTION
Fix linters

`rand.Seed()` is deprecated in go 1.20

## Tag your pair, your PM, and/or team
@kieron-dev
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

