### PR TITLE
Bump go version in github action tests

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        go-version: '^1.18'
+        go-version: '^1.20'
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
 
@@ -36,7 +36,7 @@ jobs:
 
     - uses: actions/setup-go@v3
       with:
-        go-version: '^1.18'
+        go-version: '^1.20'
 
     - name: Run Controllers tests
       run: make -C controllers test
@@ -57,7 +57,7 @@ jobs:
 
     - uses: actions/setup-go@v3
       with:
-        go-version: '^1.18'
+        go-version: '^1.20'
 
     - name: Run API unit tests
       run: make -C api test
@@ -79,7 +79,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: '^1.18'
+          go-version: '^1.20'
 
       - name: Run kpack-image-builder tests
         run: make -C kpack-image-builder test
@@ -101,7 +101,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: '^1.18'
+          go-version: '^1.20'
 
       - name: Run statefulset-runner tests
         run: make -C statefulset-runner test
@@ -123,7 +123,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: '^1.18'
+          go-version: '^1.20'
 
       - name: Run job-task-runner tests
         run: make -C job-task-runner test


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
We need to manually bump go-version in our github actions config.

We noticed this when the linter in concourse complained about rand.Seed() deprecated in go-1.20, but this wasn't picked up in the PR CI in github actions.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
