### PR TITLE
Use 'stable' for the go-version in github actions

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        go-version: '^1.20'
+        go-version: 'stable'
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
 
@@ -36,7 +36,7 @@ jobs:
 
     - uses: actions/setup-go@v3
       with:
-        go-version: '^1.20'
+        go-version: 'stable'
 
     - name: Run Controllers tests
       run: make -C controllers test
@@ -57,7 +57,7 @@ jobs:
 
     - uses: actions/setup-go@v3
       with:
-        go-version: '^1.20'
+        go-version: 'stable'
 
     - name: Run API unit tests
       run: make -C api test
@@ -79,7 +79,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: '^1.20'
+          go-version: 'stable'
 
       - name: Run kpack-image-builder tests
         run: make -C kpack-image-builder test
@@ -101,7 +101,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: '^1.20'
+          go-version: 'stable'
 
       - name: Run statefulset-runner tests
         run: make -C statefulset-runner test
@@ -123,7 +123,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: '^1.20'
+          go-version: 'stable'
 
       - name: Run job-task-runner tests
         run: make -C job-task-runner test


### PR DESCRIPTION
## Is there a related GitHub Issue?
#2154

## What is this change about?
That means we don't have to manually bump the go version in .github/workflows/test-pr.yml each time the minor version changes

## Does this PR introduce a breaking change?
No
