### PR TITLE
Remove double quotes surrounding a wildcard

### DIFF
--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -80,9 +80,9 @@ echo "************************************"
 echo " Installing Service Binding Runtime"
 echo "************************************"
 
-kubectl apply -f $VENDOR_DIR/service-binding/servicebinding-runtime-v*.yaml
+kubectl apply -f "$VENDOR_DIR/service-binding/servicebinding-runtime-v"*".yaml"
 kubectl -n servicebinding-system rollout status deployment/servicebinding-controller-manager --watch=true
-kubectl apply -f $VENDOR_DIR/service-binding/servicebinding-workloadresourcemappings-v*.yaml
+kubectl apply -f "$VENDOR_DIR/service-binding/servicebinding-workloadresourcemappings-v"*".yaml"
 
 if ! kubectl get apiservice v1beta1.metrics.k8s.io >/dev/null 2>&1; then
   if [[ -v INSECURE_TLS_METRICS_SERVER ]]; then

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -80,9 +80,9 @@ echo "************************************"
 echo " Installing Service Binding Runtime"
 echo "************************************"
 
-kubectl apply -f "$VENDOR_DIR/service-binding/servicebinding-runtime-v*.yaml"
+kubectl apply -f $VENDOR_DIR/service-binding/servicebinding-runtime-v*.yaml
 kubectl -n servicebinding-system rollout status deployment/servicebinding-controller-manager --watch=true
-kubectl apply -f "$VENDOR_DIR/service-binding/servicebinding-workloadresourcemappings-v*.yaml"
+kubectl apply -f $VENDOR_DIR/service-binding/servicebinding-workloadresourcemappings-v*.yaml
 
 if ! kubectl get apiservice v1beta1.metrics.k8s.io >/dev/null 2>&1; then
   if [[ -v INSECURE_TLS_METRICS_SERVER ]]; then


### PR DESCRIPTION
From `man bash`: Enclosing characters in double quotes preserves the literal value of all characters within the quotes, with the exception of $, `, \

In bash, this should not work. We would like to be able to point a wide range of users to the `deploy-on-kind.sh` script which calls this script. We would like to ensure the widest range of users do not run into issue with this.

## Is there a related GitHub Issue?

No

## What is this change about?

The script uses a wildcard inside double quotes. In bash, this should not work. We would like to be able to point a wide range of users to the `deploy-on-kind.sh` script which calls this script. We would like to ensure the widest range of users do not run into issue with this.

## Does this PR introduce a breaking change?

No

## Acceptance Steps

Run it in vanilla bash with no special settings.

## Tag your pair, your PM, and/or team

N/A
