### PR TITLE
Bump `app-rev` in a mutating webhook

### DIFF
--- a/api/handlers/app_test.go
+++ b/api/handlers/app_test.go
@@ -1455,32 +1455,6 @@ var _ = Describe("App", func() {
 				}`, defaultServerURL, appGUID, spaceGUID, appName)), "Response body matches response:")
 		})
 
-		It("bumps the app revision annotation", func() {
-			Expect(appRepo.PatchAppMetadataCallCount()).To(Equal(1))
-			_, _, actualPatchMsg := appRepo.PatchAppMetadataArgsForCall(0)
-			Expect(actualPatchMsg.Annotations).To(HaveKeyWithValue(AppRevisionKey, tools.PtrTo("1")))
-		})
-
-		When("bumping the app revision annotation fails", func() {
-			BeforeEach(func() {
-				appRepo.PatchAppMetadataReturns(repositories.AppRecord{}, errors.New("patch-app-rev-err"))
-			})
-
-			It("returns an error", func() {
-				expectUnprocessableEntityError("failed to update app revision")
-			})
-		})
-
-		When("the app revision cannot be parsed", func() {
-			BeforeEach(func() {
-				appRecord.Annotations[AppRevisionKey] = "nan"
-			})
-
-			It("returns an error", func() {
-				expectUnprocessableEntityError("failed to parse app revision")
-			})
-		})
-
 		When("fetching the app is forbidden", func() {
 			BeforeEach(func() {
 				appRepo.GetAppReturns(repositories.AppRecord{}, apierrors.NewForbiddenError(nil, "App"))

--- a/api/repositories/app_repository_test.go
+++ b/api/repositories/app_repository_test.go
@@ -1093,7 +1093,6 @@ var _ = Describe("AppRepository", func() {
 							Reason:             "staged",
 							Message:            "staged",
 						}},
-						ObservedDesiredState: "STOPPED",
 					}
 					g.Expect(k8sClient.Status().Patch(context.Background(), theAppCopy, client.MergeFrom(theApp))).To(Succeed())
 				}).Should(Succeed())
@@ -1532,7 +1531,6 @@ func createAppWithGUID(space, guid string) *korifiv1alpha1.CFApp {
 	Expect(k8sClient.Create(context.Background(), cfApp)).To(Succeed())
 
 	cfApp.Status.Conditions = []metav1.Condition{}
-	cfApp.Status.ObservedDesiredState = "STOPPED"
 	Expect(k8sClient.Status().Update(context.Background(), cfApp)).To(Succeed())
 
 	return cfApp

--- a/controllers/api/v1alpha1/cfapp_types.go
+++ b/controllers/api/v1alpha1/cfapp_types.go
@@ -30,6 +30,7 @@ type CFAppSpec struct {
 
 	// The user-requested state of the CFApp. The currently-applied state of the CFApp is in status.ObservedDesiredState.
 	// Allowed values are "STARTED", and "STOPPED".
+	// +kubebuilder:validation:Enum=STOPPED;STARTED
 	DesiredState DesiredState `json:"desiredState"`
 
 	// Specifies how to build images for the app
@@ -43,7 +44,6 @@ type CFAppSpec struct {
 }
 
 // DesiredState defines the desired state of CFApp.
-// +kubebuilder:validation:Enum=STOPPED;STARTED
 type DesiredState string
 
 // CFAppStatus defines the observed state of CFApp
@@ -51,7 +51,8 @@ type CFAppStatus struct {
 	// Conditions capture the current status of the App
 	Conditions []metav1.Condition `json:"conditions"`
 
-	// ObservedDesiredState specifies the currently-applied state of the CFApp (which may be different from spec.DesiredState)
+	// Deprecated: No longer used
+	// +kubebuilder:validation:Optional
 	ObservedDesiredState DesiredState `json:"observedDesiredState"`
 
 	// VCAPServicesSecretName contains the name of the CFApp's VCAP_SERVICES Secret, which should exist in the same namespace

--- a/controllers/api/v1alpha1/cfapp_webhook.go
+++ b/controllers/api/v1alpha1/cfapp_webhook.go
@@ -57,6 +57,7 @@ func (r *CFApp) defaultAnnotations(appAnnotations map[string]string) map[string]
 	if appAnnotations == nil {
 		appAnnotations = make(map[string]string)
 	}
+
 	_, hasRevAnnotation := appAnnotations[CFAppRevisionKey]
 	if !hasRevAnnotation {
 		appAnnotations[CFAppRevisionKey] = CFAppRevisionKeyDefault

--- a/controllers/controllers/services/cfservicebinding_controller_test.go
+++ b/controllers/controllers/services/cfservicebinding_controller_test.go
@@ -48,7 +48,6 @@ var _ = Describe("CFServiceBinding", func() {
 		Expect(k8s.Patch(context.Background(), k8sClient, desiredCFApp, func() {
 			desiredCFApp.Status = korifiv1alpha1.CFAppStatus{
 				Conditions:             nil,
-				ObservedDesiredState:   korifiv1alpha1.StoppedState,
 				VCAPServicesSecretName: "foo",
 			}
 			meta.SetStatusCondition(&desiredCFApp.Status.Conditions, metav1.Condition{

--- a/controllers/controllers/workloads/cfapp_controller.go
+++ b/controllers/controllers/workloads/cfapp_controller.go
@@ -77,10 +77,6 @@ func (r *CFAppReconciler) ReconcileResource(ctx context.Context, cfApp *korifiv1
 		return ctrl.Result{}, err
 	}
 
-	if cfApp.Status.ObservedDesiredState != cfApp.Spec.DesiredState {
-		cfApp.Status.ObservedDesiredState = cfApp.Spec.DesiredState
-	}
-
 	if cfApp.Status.Conditions == nil {
 		cfApp.Status.Conditions = make([]metav1.Condition, 0)
 	}

--- a/controllers/controllers/workloads/cfapp_controller_test.go
+++ b/controllers/controllers/workloads/cfapp_controller_test.go
@@ -154,7 +154,6 @@ var _ = Describe("CFAppReconciler Integration Tests", func() {
 				createdCFApp, err := getApp(namespaceGUID, cfAppGUID)
 				g.Expect(err).NotTo(HaveOccurred())
 
-				g.Expect(createdCFApp.Status.ObservedDesiredState).To(Equal(cfApp.Spec.DesiredState))
 				g.Expect(meta.IsStatusConditionTrue(createdCFApp.Status.Conditions, workloads.StatusConditionStaged)).To(BeFalse())
 				g.Expect(meta.IsStatusConditionTrue(createdCFApp.Status.Conditions, workloads.StatusConditionRunning)).To(BeFalse())
 			}).Should(Succeed())

--- a/controllers/controllers/workloads/env/builder_test.go
+++ b/controllers/controllers/workloads/env/builder_test.go
@@ -150,7 +150,6 @@ var _ = Describe("Builder", func() {
 			},
 			Status: korifiv1alpha1.CFAppStatus{
 				Conditions:             nil,
-				ObservedDesiredState:   korifiv1alpha1.StoppedState,
 				VCAPServicesSecretName: vcapServicesSecretName,
 			},
 		}

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -350,6 +350,8 @@ func main() {
 			os.Exit(1)
 		}
 
+		(&workloads.AppRevWebhook{}).SetupWebhookWithManager(mgr)
+
 		if err = (&korifiv1alpha1.CFPackage{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "CFPackage")
 			os.Exit(1)

--- a/controllers/webhooks/workloads/apprev_webhook.go
+++ b/controllers/webhooks/workloads/apprev_webhook.go
@@ -1,0 +1,68 @@
+package workloads
+
+//+kubebuilder:webhook:path=/mutate-korifi-cloudfoundry-org-v1alpha1-cfapp-apprev,mutating=true,failurePolicy=fail,sideEffects=None,groups=korifi.cloudfoundry.org,resources=cfapps,verbs=update,versions=v1alpha1,name=mcfapprev.korifi.cloudfoundry.org,admissionReviewVersions={v1,v1beta1}
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// AppRevWebhook does not implement the admission.Defaulter interface as we
+// need to access both oldObject and (new)Object to determine the actual state
+// change. So we use the lower-level admission.Handler interface
+type AppRevWebhook struct {
+	decoder *admission.Decoder
+}
+
+var apprevlog = logf.Log.WithName("apprev-webhook")
+
+func (r *AppRevWebhook) SetupWebhookWithManager(mgr ctrl.Manager) {
+	mgr.GetWebhookServer().Register("/mutate-korifi-cloudfoundry-org-v1alpha1-cfapp-apprev", &admission.Webhook{
+		Handler: r,
+	})
+}
+
+func (r *AppRevWebhook) InjectDecoder(d *admission.Decoder) error {
+	r.decoder = d
+	return nil
+}
+
+func (r *AppRevWebhook) Handle(ctx context.Context, req admission.Request) admission.Response {
+	var cfApp korifiv1alpha1.CFApp
+	if err := r.decoder.Decode(req, &cfApp); err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	var oldCFApp korifiv1alpha1.CFApp
+	if err := r.decoder.DecodeRaw(req.OldObject, &oldCFApp); err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	if cfApp.Spec.DesiredState == korifiv1alpha1.StoppedState && oldCFApp.Spec.DesiredState == korifiv1alpha1.StartedState {
+		cfApp.Annotations[korifiv1alpha1.CFAppRevisionKey] = bumpAppRev(cfApp.Annotations[korifiv1alpha1.CFAppRevisionKey])
+	}
+
+	marshalled, err := json.Marshal(cfApp)
+	if err != nil {
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+
+	return admission.PatchResponseFromRaw(req.Object.Raw, marshalled)
+}
+
+func bumpAppRev(currentRevValue string) string {
+	revValue, err := strconv.Atoi(currentRevValue)
+	if err != nil || revValue < 0 {
+		apprevlog.Info("setting-invalid-app-rev-to-zero", "app-rev", currentRevValue)
+		return korifiv1alpha1.CFAppRevisionKeyDefault
+	}
+
+	return strconv.Itoa(revValue + 1)
+}

--- a/controllers/webhooks/workloads/apprev_webhook_test.go
+++ b/controllers/webhooks/workloads/apprev_webhook_test.go
@@ -1,0 +1,85 @@
+package workloads_test
+
+import (
+	"context"
+
+	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("ApprevWebhook", func() {
+	var (
+		ctx         context.Context
+		namespace   string
+		app         *korifiv1alpha1.CFApp
+		originalApp *korifiv1alpha1.CFApp
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+
+		namespace = "ns-" + uuid.NewString()
+
+		Expect(k8sClient.Create(ctx, &v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespace,
+			},
+		})).To(Succeed())
+
+		app = makeCFApp(uuid.NewString(), namespace, uuid.NewString())
+		app.Annotations = map[string]string{
+			korifiv1alpha1.CFAppRevisionKey: "5",
+		}
+		app.Spec.DesiredState = korifiv1alpha1.StartedState
+		Expect(k8sClient.Create(ctx, app)).To(Succeed())
+		originalApp = app.DeepCopy()
+	})
+
+	JustBeforeEach(func() {
+		app.Spec.DisplayName = "changed-display-name"
+		Expect(k8sClient.Patch(ctx, app, client.MergeFrom(originalApp))).To(Succeed())
+	})
+
+	It("does not change the app rev", func() {
+		Expect(app.Annotations[korifiv1alpha1.CFAppRevisionKey]).To(Equal("5"))
+	})
+
+	When("desiredState changes from started to stopped", func() {
+		BeforeEach(func() {
+			app.Spec.DesiredState = korifiv1alpha1.StoppedState
+		})
+
+		It("increments the app rev", func() {
+			Expect(app.Annotations[korifiv1alpha1.CFAppRevisionKey]).To(Equal("6"))
+		})
+
+		When("the app rev is not a number", func() {
+			BeforeEach(func() {
+				app.Annotations[korifiv1alpha1.CFAppRevisionKey] = "a"
+				Expect(k8sClient.Patch(ctx, app, client.MergeFrom(originalApp))).To(Succeed())
+				originalApp = app.DeepCopy()
+			})
+
+			It("defaults the app rev to 0", func() {
+				Expect(app.Annotations[korifiv1alpha1.CFAppRevisionKey]).To(Equal("0"))
+			})
+		})
+
+		When("the app rev is negative", func() {
+			BeforeEach(func() {
+				app.Annotations[korifiv1alpha1.CFAppRevisionKey] = "-10"
+				Expect(k8sClient.Patch(ctx, app, client.MergeFrom(originalApp))).To(Succeed())
+				originalApp = app.DeepCopy()
+			})
+
+			It("sets the app rev to 0", func() {
+				Expect(app.Annotations[korifiv1alpha1.CFAppRevisionKey]).To(Equal("0"))
+			})
+		})
+	})
+})

--- a/controllers/webhooks/workloads/suite_integration_test.go
+++ b/controllers/webhooks/workloads/suite_integration_test.go
@@ -102,6 +102,8 @@ var _ = BeforeSuite(func() {
 
 	Expect((&korifiv1alpha1.CFApp{}).SetupWebhookWithManager(mgr)).To(Succeed())
 
+	(&workloads.AppRevWebhook{}).SetupWebhookWithManager(mgr)
+
 	appNameDuplicateValidator := webhooks.NewDuplicateValidator(coordination.NewNameRegistry(mgr.GetClient(), workloads.AppEntityType))
 	Expect(workloads.NewCFAppValidator(appNameDuplicateValidator).SetupWebhookWithManager(mgr)).To(Succeed())
 

--- a/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfapps.yaml
+++ b/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfapps.yaml
@@ -178,11 +178,7 @@ spec:
                   type: object
                 type: array
               observedDesiredState:
-                description: ObservedDesiredState specifies the currently-applied
-                  state of the CFApp (which may be different from spec.DesiredState)
-                enum:
-                - STOPPED
-                - STARTED
+                description: 'Deprecated: No longer used'
                 type: string
               vcapServicesSecretName:
                 description: VCAPServicesSecretName contains the name of the CFApp's
@@ -190,7 +186,6 @@ spec:
                 type: string
             required:
             - conditions
-            - observedDesiredState
             - vcapServicesSecretName
             type: object
         type: object

--- a/helm/korifi/controllers/manifests.yaml
+++ b/helm/korifi/controllers/manifests.yaml
@@ -119,6 +119,26 @@ webhooks:
       service:
         name: korifi-controllers-webhook-service
         namespace: '{{ .Release.Namespace }}'
+        path: /mutate-korifi-cloudfoundry-org-v1alpha1-cfapp-apprev
+    failurePolicy: Fail
+    name: mcfapprev.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - UPDATE
+        resources:
+          - cfapps
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-controllers-webhook-service
+        namespace: '{{ .Release.Namespace }}'
         path: /mutate-korifi-cloudfoundry-org-v1alpha1-cftask
     failurePolicy: Fail
     name: mcftask.korifi.cloudfoundry.org


### PR DESCRIPTION
## Is there a related GitHub Issue?
https://github.com/cloudfoundry/korifi/issues/2040
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
- Bump app-rev on app stop via a mutating webhook
- Deprecate `CFApp.Status.ObservedDesiredState`
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
`CFApp.Status.ObservedDesiredState` is no longer used and is deprecated
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
No functional change, stable e2e tests
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@kieron-dev
