### PR TITLE
Move masking of the Forbidden error to the handler

### DIFF
--- a/api/handlers/service_binding.go
+++ b/api/handlers/service_binding.go
@@ -92,7 +92,7 @@ func (h *ServiceBinding) delete(r *http.Request) (*routing.Response, error) {
 
 	err := h.serviceBindingRepo.DeleteServiceBinding(r.Context(), authInfo, serviceBindingGUID)
 	if err != nil {
-		return nil, apierrors.LogAndReturn(logger, err, "error when deleting service binding", "guid", serviceBindingGUID)
+		return nil, apierrors.LogAndReturn(logger, apierrors.ForbiddenAsNotFound(err), "error when deleting service binding", "guid", serviceBindingGUID)
 	}
 
 	return routing.NewResponse(http.StatusNoContent), nil

--- a/api/handlers/service_binding_test.go
+++ b/api/handlers/service_binding_test.go
@@ -528,6 +528,16 @@ var _ = Describe("ServiceBinding", func() {
 			_, _, guid := serviceBindingRepo.DeleteServiceBindingArgsForCall(0)
 			Expect(guid).To(Equal(serviceBindingGUID))
 		})
+
+		When("the user is not authorized to delete service bindings", func() {
+			BeforeEach(func() {
+				serviceBindingRepo.DeleteServiceBindingReturns(apierrors.NewForbiddenError(nil, "CFServiceBinding"))
+			})
+
+			It("returns 404 NotFound", func() {
+				expectNotFoundError("CFServiceBinding not found")
+			})
+		})
 	})
 
 	Describe("PATCH /v3/service_credential_bindings/:guid", func() {

--- a/api/repositories/service_binding_repository.go
+++ b/api/repositories/service_binding_repository.go
@@ -164,7 +164,7 @@ func (r *ServiceBindingRepo) DeleteServiceBinding(ctx context.Context, authInfo 
 
 	err = userClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: guid}, binding)
 	if err != nil {
-		return apierrors.ForbiddenAsNotFound(apierrors.FromK8sError(err, ServiceBindingResourceType))
+		return apierrors.FromK8sError(err, ServiceBindingResourceType)
 	}
 
 	err = userClient.Delete(ctx, binding)

--- a/api/repositories/service_binding_repository_test.go
+++ b/api/repositories/service_binding_repository_test.go
@@ -290,8 +290,8 @@ var _ = Describe("ServiceBindingRepo", func() {
 			ret = repo.DeleteServiceBinding(testCtx, authInfo, serviceBindingGUID)
 		})
 
-		It("returns a not-found error for users with no role in the space", func() {
-			Expect(ret).To(matchers.WrapErrorAssignableToTypeOf(apierrors.NotFoundError{}))
+		It("returns a forbidden error for users with no role in the space", func() {
+			Expect(ret).To(matchers.WrapErrorAssignableToTypeOf(apierrors.ForbiddenError{}))
 		})
 
 		When("the user is a space manager", func() {


### PR DESCRIPTION
## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Error masking is usually done in the HTTP handlers rather than in the
repositories.
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
N/A - no functional change
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@georgethebeatle
