### PR TITLE
Don't zip dora in when bumping vendir deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,4 +69,3 @@ install-vendir:
 
 vendir-update-dependencies: install-vendir
 	$(VENDIR) sync --chdir tests
-	cd tests/vendor/testApps/dora; zip -r ../../../e2e/assets/dora .


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
Git doesn't store timestamps, so the vendir'ed code will also have current timestamps on files, which means the zip timestamps will always differ from the previous. Hence the korifi-bot will try to PR a dora.zip change every time it runs.

We leave the current dora.zip for now, and this will be addressed by a work on #1146 which should generate app zips on the fly.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@gcapizzi

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
