### PR TITLE
Fix the way we log finalizer addition

### DIFF
--- a/tools/k8s/finalizer.go
+++ b/tools/k8s/finalizer.go
@@ -17,10 +17,11 @@ func AddFinalizer[T any, PT ObjectWithDeepCopy[T]](
 ) error {
 	origObj := PT(obj.DeepCopy())
 	if controllerutil.AddFinalizer(obj, finalizerName) {
-		return k8sClient.Patch(ctx, obj, client.MergeFrom(origObj))
+		if err := k8sClient.Patch(ctx, obj, client.MergeFrom(origObj)); err != nil {
+			return err
+		}
+		log.Info("added finalizer")
 	}
-
-	log.Info("Finalizer added")
 
 	return nil
 }


### PR DESCRIPTION
## Is there a related GitHub Issue?
No.

## What is this change about?
Previously we always logged a finalizer addition, even when the finalizer wasn't actually added because it was already there.

This fixes it to only log when the finalizer gets actually added.

## Does this PR introduce a breaking change?
No.

## Tag your pair, your PM, and/or team
@gcapizzi
