### PR TITLE
Allow configurable extra vals in VCAP_APPLICATION env var

### DIFF
--- a/README.helm.md
+++ b/README.helm.md
@@ -53,8 +53,9 @@ Here are all the values that can be set for the chart:
 - `contourRouter`:
   - `include` (_Boolean_): Deploy the `contour-router` component.
 - `controllers`:
+  - `extraVCAPApplicationValues`: Key-value pairs that are going to be set in the VCAP_APPLICATION env var on apps. Nested values are not supported.
   - `image` (_String_): Reference to the controllers container image.
-  - `namespaceLabels`: Key-value pairs that are going to be set as labels on the namespaces created by Korifi
+  - `namespaceLabels`: Key-value pairs that are going to be set as labels on the namespaces created by Korifi.
   - `processDefaults`:
     - `diskQuotaMB` (_Integer_): Default disk quota for the `web` process.
     - `memoryMB` (_Integer_): Default memory limit for the `web` process.

--- a/controllers/config/config.go
+++ b/controllers/config/config.go
@@ -24,7 +24,7 @@ type ControllerConfig struct {
 	BuilderName                 string            `yaml:"builderName"`
 	RunnerName                  string            `yaml:"runnerName"`
 	NamespaceLabels             map[string]string `yaml:"namespaceLabels"`
-
+	ExtraVCAPApplicationValues  map[string]any    `yaml:"extraVCAPApplicationValues"`
 	// job-task-runner
 	JobTTL string `yaml:"jobTTL"`
 

--- a/controllers/config/config_test.go
+++ b/controllers/config/config_test.go
@@ -74,6 +74,7 @@ var _ = Describe("LoadFromPath", func() {
 			BuilderName:                 "buildReconciler",
 			RunnerName:                  "statefulset-runner",
 			NamespaceLabels:             map[string]string{},
+			ExtraVCAPApplicationValues:  map[string]any{},
 			JobTTL:                      "jobTTL",
 		}))
 	})

--- a/controllers/controllers/workloads/suite_test.go
+++ b/controllers/controllers/workloads/suite_test.go
@@ -111,7 +111,7 @@ var _ = BeforeSuite(func() {
 		k8sManager.GetScheme(),
 		ctrl.Log.WithName("controllers").WithName("CFApp"),
 		env.NewVCAPServicesEnvValueBuilder(k8sManager.GetClient()),
-		env.NewVCAPApplicationEnvValueBuilder(k8sManager.GetClient()),
+		env.NewVCAPApplicationEnvValueBuilder(k8sManager.GetClient(), nil),
 	)).SetupWithManager(k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -142,7 +142,7 @@ func main() {
 			mgr.GetScheme(),
 			ctrl.Log.WithName("controllers").WithName("CFApp"),
 			env.NewVCAPServicesEnvValueBuilder(mgr.GetClient()),
-			env.NewVCAPApplicationEnvValueBuilder(mgr.GetClient()),
+			env.NewVCAPApplicationEnvValueBuilder(mgr.GetClient(), controllerConfig.ExtraVCAPApplicationValues),
 		)).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "CFApp")
 			os.Exit(1)

--- a/helm/korifi/controllers/configmap.yaml
+++ b/helm/korifi/controllers/configmap.yaml
@@ -26,6 +26,11 @@ data:
     {{- range $key, $value := .Values.controllers.namespaceLabels }}
       {{ $key }}: {{ $value }}
     {{- end }}
+    extraVCAPApplicationValues:
+    {{- $defaultDict := dict "cf_api" (printf "https://%s" .Values.api.apiServer.url) -}}
+    {{- range $key, $value := merge .Values.controllers.extraVCAPApplicationValues $defaultDict }}
+      {{ $key }}: {{ $value }}
+    {{- end }}
 {{- if .Values.kpackImageBuilder.include }}
   kpack_build_controllers_config.yaml: |
     cfRootNamespace: {{ .Values.global.rootNamespace }}

--- a/helm/korifi/values.schema.json
+++ b/helm/korifi/values.schema.json
@@ -282,7 +282,12 @@
           "type": "string"
         },
         "namespaceLabels": {
-          "description": "Key-value pairs that are going to be set as labels on the namespaces created by Korifi",
+          "description": "Key-value pairs that are going to be set as labels on the namespaces created by Korifi.",
+          "type": "object",
+          "properties": {}
+        },
+        "extraVCAPApplicationValues": {
+          "description": "Key-value pairs that are going to be set in the VCAP_APPLICATION env var on apps. Nested values are not supported.",
           "type": "object",
           "properties": {}
         }

--- a/helm/korifi/values.yaml
+++ b/helm/korifi/values.yaml
@@ -71,6 +71,7 @@ controllers:
   workloadsTLSSecret: korifi-workloads-ingress-cert
 
   namespaceLabels: {}
+  extraVCAPApplicationValues: {}
 
 kpackImageBuilder:
   include: true

--- a/tests/e2e/apps_test.go
+++ b/tests/e2e/apps_test.go
@@ -661,7 +661,6 @@ var _ = Describe("Apps", func() {
 						HaveKeyWithValue("VCAP_APPLICATION", SatisfyAll(
 							HaveKeyWithValue("application_id", appGUID),
 							HaveKeyWithValue("application_name", appName),
-							// HaveKeyWithValue("cf_api", apiServerRoot),
 							HaveKeyWithValue("name", appName),
 							HaveKeyWithValue("organization_id", commonTestOrgGUID),
 							HaveKeyWithValue("organization_name", commonTestOrgName),


### PR DESCRIPTION
## Is there a related GitHub Issue?
Issue: #2140

## What is this change about?
This is done to support `cf_api` which isn't something the controllers layer should know about.

Also populate that `cf_api` value by default in the controllers configmap in the helm templates

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Push an app. See cf_api in its VCAP_APPLICATION env var (in the running app, and via the app env endpoint)

Put other values in the controllers config (probably via helm controllers.extraVCAPApplicationValues) and see them in the VCAP_APPLICATION env.

See that you cannot override the default VCAP_APPLICATION values.

## Tag your pair, your PM, and/or team
@gcapizzi

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
