### PR TITLE
fix/adapt scripts to work on mac

### DIFF
--- a/scripts/deploy-on-kind.sh
+++ b/scripts/deploy-on-kind.sh
@@ -5,6 +5,10 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 SCRIPT_DIR="${ROOT_DIR}/scripts"
 
+# workaround for https://github.com/carvel-dev/kbld/issues/213
+# kbld fails with git error messages in languages than other english
+export LC_ALL=en_US.UTF-8
+
 function usage_text() {
   cat <<EOF
 Usage:
@@ -172,7 +176,7 @@ function deploy_korifi() {
         --namespace korifi \
         --values=scripts/assets/values.yaml \
         --set=global.debug="$doDebug" \
-        "${registry_configuration[@]}" \
+        ${registry_configuration[@]-} \
         --wait
     fi
   }

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -85,7 +85,7 @@ kubectl -n servicebinding-system rollout status deployment/servicebinding-contro
 kubectl apply -f "$VENDOR_DIR/service-binding/servicebinding-workloadresourcemappings-v"*".yaml"
 
 if ! kubectl get apiservice v1beta1.metrics.k8s.io >/dev/null 2>&1; then
-  if [[ -v INSECURE_TLS_METRICS_SERVER ]]; then
+  if [[  "${INSECURE_TLS_METRICS_SERVER}" == "true"  ]]; then
     echo "************************************************"
     echo " Installing Metrics Server Insecure TLS options"
     echo "************************************************"


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
https://github.com/cloudfoundry/korifi/issues/2108

## What is this change about?
I ran the `deploy-on-kind.sh` on my Mac and ran into a couple of issues that this PR adresses:
* kbld has a [reported bug](https://github.com/carvel-dev/kbld/issues/213) where it does not work properly on machines set to another language. Setting `LC_ALL=en_US.UTF-8` in the script fixes this.
* If `registry_configuration` is an empty array, I get a "unbound variable" so I added a default empty value. As array elements are interpreted as if in single quotes, `helm` thinks it is getting one argument too many. Removing the double quotes fixes this.
* The Mac's default bash version is unfortunately 3.2., so it does not know the `[[ -v VAR_NAME ]]` syntax. Comparing via `== "true"` should work on both newer and older machines.

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->
no
