### PR TITLE
Fix the API log level config

### DIFF
--- a/helm/korifi/api/configmap.yaml
+++ b/helm/korifi/api/configmap.yaml
@@ -28,8 +28,8 @@ data:
     {{- if .Values.api.authProxy }}
     authProxyHost: {{ .Values.api.authProxy.host | quote }}
     authProxyCACert: {{ .Values.api.authProxy.caCert | quote }}
-    logLevel: {{ .Values.api.logLevel | default "info" }}
     {{- end }}
+    logLevel: {{ .Values.api.logLevel | default "info" }}
     {{- if .Values.global.eksContainerRegistryRoleARN }}
     containerRegistryType: "ECR"
     {{- end }}


### PR DESCRIPTION
## Is there a related GitHub Issue?
#1925 

## What is this change about?
This PR fixes the API log level configuration. It was accidentally inside the check for an auth proxy value.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Deploy without configuring an auth proxy and see that the logLevel setting is present in the API ConfigMap.

## Tag your pair, your PM, and/or team
@akrishna90 