### PR TITLE
Default INSECURE_TLS_METRICS_SERVER to empty

### DIFF
--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -85,7 +85,7 @@ kubectl -n servicebinding-system rollout status deployment/servicebinding-contro
 kubectl apply -f "$VENDOR_DIR/service-binding/servicebinding-workloadresourcemappings-v"*".yaml"
 
 if ! kubectl get apiservice v1beta1.metrics.k8s.io >/dev/null 2>&1; then
-  if [[ "${INSECURE_TLS_METRICS_SERVER}" == "true" ]]; then
+  if [[ "${INSECURE_TLS_METRICS_SERVER:-}" == "true" ]]; then
     echo "************************************************"
     echo " Installing Metrics Server Insecure TLS options"
     echo "************************************************"


### PR DESCRIPTION

<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
No

## What is this change about?
Commit 7edfdb743c3ca74e7c8b14591d30539a3cea3173 broke EKS-E2E cluster creation as `install-dependencies.sh` would now fail with `INSECURE_TLS_METRICS_SERVER: unbound variable`.

This change maintains bash-3.x compatability and introduces a default empty value for the variable.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
EKS-E2E cluster creation in CI works again

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
