### PR TITLE
Fix `make manifests` in kpack-image-builder

### DIFF
--- a/kpack-image-builder/Makefile
+++ b/kpack-image-builder/Makefile
@@ -40,6 +40,7 @@ help: ## Display this help.
 ##@ Development
 
 .PHONY: manifests
+manifests: install-controller-gen
 	$(CONTROLLER_GEN) \
 		paths="./..." \
 		rbac:roleName=korifi-kpack-build-manager-role \


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
The `manifests:` line was missing

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Modify a kubebuilder role permission in kpack-image-builder, run `make manifests` and see the role yaml gets updated

## Tag your pair, your PM, and/or team
@gcapizzi
