### PR TITLE
Test that VCAP_SERVICES and VCAP_APPLICATION are valid JSON

### DIFF
--- a/tests/e2e/apps_test.go
+++ b/tests/e2e/apps_test.go
@@ -487,10 +487,9 @@ var _ = Describe("Apps", func() {
 			body := curlApp(appGUID, "/env.json")
 
 			env := map[string]string{}
-			err := json.Unmarshal(body, &env)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(env).To(HaveKeyWithValue("VCAP_SERVICES", Not(BeEmpty())))
-			Expect(env).To(HaveKeyWithValue("VCAP_APPLICATION", Not(BeEmpty())))
+			Expect(json.Unmarshal(body, &env)).To(Succeed())
+			Expect(env).To(HaveKeyWithValue("VCAP_SERVICES", BeAValidJSONObject()))
+			Expect(env).To(HaveKeyWithValue("VCAP_APPLICATION", BeAValidJSONObject()))
 		})
 
 		When("the app is re-pushed with different code", func() {


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ --> #1146 

## What is this change about?
<!-- _Please describe the change here._ --> This is a small enhancement to @kieron-dev's tests that `VCAP_SERVICES` and `VCAP_APPLICATION` are set in the app container. This also tests that they are valid JSON objects

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->
No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
