### PR TITLE
Remove nolint:unused directives

### DIFF
--- a/controllers/api/v1alpha1/cfprocess_types.go
+++ b/controllers/api/v1alpha1/cfprocess_types.go
@@ -75,10 +75,10 @@ type HealthCheckType string
 // HealthCheckData used to pass through input parameters to liveness probe
 type HealthCheckData struct {
 	// The http endpoint to use with "http" healthchecks
-	HTTPEndpoint string `json:"httpEndpoint,omitempty"` //nolint:unused
+	HTTPEndpoint string `json:"httpEndpoint,omitempty"`
 
-	InvocationTimeoutSeconds int64 `json:"invocationTimeoutSeconds"` //nolint:unused
-	TimeoutSeconds           int64 `json:"timeoutSeconds"`           //nolint:unused
+	InvocationTimeoutSeconds int64 `json:"invocationTimeoutSeconds"`
+	TimeoutSeconds           int64 `json:"timeoutSeconds"`
 }
 
 // CFProcessStatus defines the observed state of CFProcess


### PR DESCRIPTION
## Is there a related GitHub Issue?
No.

## What is this change about?
Remove nolint directives that were used to override a staticcheck regression

## Does this PR introduce a breaking change?
No. (Update to fixed version of golangci-lint v1.51.2

## Acceptance Steps
Run `make lint`

## Tag your pair, your PM, and/or team
@davewalter @gcapizzi 
