### PR TITLE
Make procfile app output configurable

### DIFF
--- a/tests/e2e/routes_test.go
+++ b/tests/e2e/routes_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
+	"os"
 
 	"code.cloudfoundry.org/korifi/tests/e2e/helpers"
 
@@ -380,7 +381,13 @@ var _ = Describe("Routes", func() {
 				Expect(result.Destinations).To(HaveLen(1))
 				Expect(result.Destinations[0].App.GUID).To(Equal(appGUID))
 
-				Expect(resp.Body()).To(ContainSubstring("hello-world"))
+				// This enables replacing the default app output via APP_BITS_PATH and APP_BITS_OUTPUT
+				expectedOutput, ok := os.LookupEnv("APP_BITS_OUTPUT")
+				if !ok {
+					expectedOutput = "hello-world"
+				}
+
+				Expect(resp.Body()).To(ContainSubstring(expectedOutput))
 			})
 
 			When("an app from a different space is added", func() {


### PR DESCRIPTION
## Is there a related GitHub Issue?
#2216 

## What is this change about?
When we restored the ability for users to provide their own app for the majority of the e2e tests, we ran into a problem where the expected output does not always match the output from the default procfile app. This PR introduces a new `APP_BITS_OUTPUT` env var to allow users to specify the expected output for the test that cares about it.

## Does this PR introduce a breaking change?
No.

## Acceptance Steps
Run the e2e tests against an environment without a procfile buildpack and see that they pass if `APP_BITS_PATH` is set to another app and `APP_BITS_OUTPUT` is set to the expected output.

## Tag your pair, your PM, and/or team
@acosta11 @Birdrock 