### PR TITLE
Allow compliant servicebindings controller to fetch cfservicebindings

### DIFF
--- a/api/repositories/app_repository_test.go
+++ b/api/repositories/app_repository_test.go
@@ -18,6 +18,7 @@ import (
 	"code.cloudfoundry.org/korifi/controllers/controllers/workloads"
 	"code.cloudfoundry.org/korifi/controllers/controllers/workloads/env"
 	"code.cloudfoundry.org/korifi/tests/matchers"
+	"code.cloudfoundry.org/korifi/tools"
 	"code.cloudfoundry.org/korifi/tools/k8s"
 
 	. "github.com/onsi/ginkgo/v2"

--- a/api/repositories/app_repository_test.go
+++ b/api/repositories/app_repository_test.go
@@ -9,8 +9,6 @@ import (
 	"sync"
 	"time"
 
-	"code.cloudfoundry.org/korifi/tools"
-
 	apierrors "code.cloudfoundry.org/korifi/api/errors"
 	. "code.cloudfoundry.org/korifi/api/repositories"
 	"code.cloudfoundry.org/korifi/api/repositories/conditions"

--- a/helm/korifi/controllers/cfservicebindings-role.yaml
+++ b/helm/korifi/controllers/cfservicebindings-role.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: korifi-controllers-cfservicebindings-role
+  labels:
+    servicebinding.io/controller: "true"
+rules:
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - cfservicebindings
+  verbs:
+  - get
+  - list
+  - watch

--- a/tests/e2e/assets/golang/go.mod
+++ b/tests/e2e/assets/golang/go.mod
@@ -1,0 +1,3 @@
+module github.com/cloudfoundry/korifi/tree/main/tests/e2e/assets/golang
+
+go 1.19

--- a/tests/e2e/assets/golang/main.go
+++ b/tests/e2e/assets/golang/main.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const ServiceBindingRootEnv = "SERVICE_BINDING_ROOT"
+
+func main() {
+	http.HandleFunc("/", helloWorldHandler)
+	http.HandleFunc("/servicebindingroot", serviceBindingRootHandler)
+	http.HandleFunc("/servicebindings", serviceBindingsHandler)
+
+	http.ListenAndServe(":"+os.Getenv("PORT"), nil)
+}
+
+func helloWorldHandler(res http.ResponseWriter, req *http.Request) {
+	fmt.Fprintln(res, "go, world!")
+}
+
+func serviceBindingRootHandler(res http.ResponseWriter, req *http.Request) {
+	serviceBindingRoot := os.Getenv(ServiceBindingRootEnv)
+	if serviceBindingRoot != "" {
+		fmt.Fprintln(res, serviceBindingRoot)
+	}
+	return
+}
+
+func serviceBindingsHandler(w http.ResponseWriter, r *http.Request) {
+	serviceBindingRoot := os.Getenv(ServiceBindingRootEnv)
+	bindings := make(map[string]interface{})
+	if serviceBindingRoot != "" {
+		var err error
+		bindings, err = getBindings(serviceBindingRoot, bindings)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+	jsonBytes, err := json.Marshal(bindings)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(jsonBytes)
+}
+
+func getBindings(dir string, bindings map[string]interface{}) (map[string]interface{}, error) {
+	files, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	for _, file := range files {
+		if file.IsDir() {
+			subdir := filepath.Join(dir, file.Name())
+			subfiles, err := os.ReadDir(subdir)
+			if err != nil {
+				return nil, err
+			}
+			secretData := make(map[string]string)
+			for _, subfile := range subfiles {
+				if !subfile.IsDir() && !strings.HasPrefix(subfile.Name(), ".") {
+
+					// Keys in the mounted Secret are symbolic links. Get the target and process it
+					target, err := os.Readlink(filepath.Join(subdir, subfile.Name()))
+					if err != nil {
+						return nil, err
+					}
+
+					targetContents, err := os.ReadFile(filepath.Join(subdir, target))
+					if err != nil {
+						return nil, err
+					}
+
+					secretData[subfile.Name()] = string(targetContents)
+				}
+			}
+			if len(secretData) > 0 {
+				bindings[file.Name()] = secretData
+			}
+		}
+	}
+	return bindings, nil
+}

--- a/tests/e2e/service_bindings_test.go
+++ b/tests/e2e/service_bindings_test.go
@@ -22,7 +22,7 @@ var _ = Describe("Service Bindings", func() {
 	BeforeEach(func() {
 		spaceGUID = createSpace(generateGUID("space1"), commonTestOrgGUID)
 		appGUID = createApp(spaceGUID, generateGUID("app"))
-		instanceGUID = createServiceInstance(spaceGUID, generateGUID("service-instance"))
+		instanceGUID = createServiceInstance(spaceGUID, generateGUID("service-instance"), nil)
 	})
 
 	AfterEach(func() {

--- a/tests/e2e/service_instances_test.go
+++ b/tests/e2e/service_instances_test.go
@@ -22,7 +22,7 @@ var _ = Describe("Service Instances", func() {
 	BeforeEach(func() {
 		spaceGUID = createSpace(generateGUID("space1"), commonTestOrgGUID)
 		existingInstanceName = generateGUID("service-instance")
-		existingInstanceGUID = createServiceInstance(spaceGUID, existingInstanceName)
+		existingInstanceGUID = createServiceInstance(spaceGUID, existingInstanceName, nil)
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION




<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->
[#2175]

## What is this change about?
<!-- _Please describe the change here._ -->
- Fixes a regression bug where compliant servicebindings controllers where not able to read cfservicebindings. This resulted in servicebindings controller failure to volume mount any `secrets` associated with `CFServiceBindings`.
- Adds a e2e case to validate that servicebindings are volume mounted.
- Reworded an `Fetch an app env` e2e case to match others.
- Formatted imports.

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->
No.

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->
See issue [#2175]

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
