### PR TITLE
Update log levels

### DIFF
--- a/api/errors/errors.go
+++ b/api/errors/errors.go
@@ -29,7 +29,7 @@ type ApiError interface {
 func LogAndReturn(logger logr.Logger, err error, msg string, keysAndValues ...interface{}) error {
 	var apiError ApiError
 	if errors.As(err, &apiError) {
-		keysAndValues = append(keysAndValues, "err", err)
+		keysAndValues = append(keysAndValues, "reason", err)
 		logger.Info(msg, keysAndValues...)
 	} else {
 		logger.Error(err, msg, keysAndValues...)

--- a/api/errors/errors_test.go
+++ b/api/errors/errors_test.go
@@ -266,7 +266,7 @@ var _ = Describe("LogAndReturn", func() {
 		Expect(json.Unmarshal(logBuf.Bytes(), &logEntry)).To(Succeed())
 	})
 
-	When("the erorr is not an ApiError", func() {
+	When("the error is not an ApiError", func() {
 		BeforeEach(func() {
 			originalErr = errors.New("not-api-error")
 		})
@@ -288,7 +288,7 @@ var _ = Describe("LogAndReturn", func() {
 			Expect(logEntry["level"]).To(Equal("info"))
 			Expect(logEntry["msg"]).To(Equal("some message"))
 			Expect(logEntry["some-key"]).To(Equal("some-value"))
-			Expect(logEntry["err"]).To(Equal("cause-err"))
+			Expect(logEntry["reason"]).To(Equal("cause-err"))
 		})
 	})
 
@@ -301,7 +301,7 @@ var _ = Describe("LogAndReturn", func() {
 			Expect(logEntry["level"]).To(Equal("info"))
 			Expect(logEntry["msg"]).To(Equal("some message"))
 			Expect(logEntry["some-key"]).To(Equal("some-value"))
-			Expect(logEntry["err"]).To(Equal("wrapping: cause-err"))
+			Expect(logEntry["reason"]).To(Equal("wrapping: cause-err"))
 		})
 	})
 })

--- a/api/handlers/package.go
+++ b/api/handlers/package.go
@@ -87,6 +87,7 @@ func (h Package) get(r *http.Request) (*routing.Response, error) {
 	return routing.NewResponse(http.StatusOK).WithBody(presenter.ForPackage(record, h.serverURL)), nil
 }
 
+//nolint:dupl
 func (h Package) list(r *http.Request) (*routing.Response, error) {
 	authInfo, _ := authorization.InfoFromContext(r.Context())
 	logger := logr.FromContextOrDiscard(r.Context()).WithName("handlers.package.list")
@@ -103,7 +104,7 @@ func (h Package) list(r *http.Request) (*routing.Response, error) {
 
 	records, err := h.packageRepo.ListPackages(r.Context(), authInfo, packageListQueryParameters.ToMessage())
 	if err != nil {
-		return nil, apierrors.LogAndReturn(logger, err, "Error fetching package with repository", "error")
+		return nil, apierrors.LogAndReturn(logger, err, "Error fetching package with repository")
 	}
 
 	if err := h.sortList(records, r.FormValue("order_by")); err != nil {

--- a/api/handlers/task.go
+++ b/api/handlers/task.go
@@ -118,7 +118,7 @@ func (h *Task) listForApp(r *http.Request) (*routing.Response, error) {
 	appGUID := routing.URLParam(r, "appGUID")
 
 	if err := r.ParseForm(); err != nil {
-		logger.Error(err, "Unable to parse request query parameters")
+		logger.Info("unable to parse request query parameters", "reason", err)
 		return nil, err
 	}
 
@@ -130,7 +130,7 @@ func (h *Task) listForApp(r *http.Request) (*routing.Response, error) {
 	taskListFilter := new(payloads.TaskList)
 	err = payloads.Decode(taskListFilter, r.Form)
 	if err != nil {
-		logger.Error(err, "Unable to decode request query parameters")
+		logger.Info("unable to decode request query parameters", "reason", err)
 		return nil, err
 	}
 

--- a/api/main.go
+++ b/api/main.go
@@ -73,7 +73,7 @@ func main() {
 
 	eventChan := make(chan string)
 	go func() {
-		ctrl.Log.Info("Starting to watch config file at "+configPath+" for logger level changes", "currentLevel", atomicLevel.Level())
+		ctrl.Log.Info("starting to watch config file at "+configPath+" for logger level changes", "currentLevel", atomicLevel.Level())
 		if err2 := tools.WatchForConfigChangeEvents(context.Background(), configPath, ctrl.Log, eventChan); err2 != nil {
 			ctrl.Log.Error(err2, "error watching logging config")
 			os.Exit(1)
@@ -382,7 +382,7 @@ func main() {
 	}
 
 	if tlsFound {
-		ctrl.Log.Info("Listening with TLS on " + portString)
+		ctrl.Log.Info("listening with TLS on " + portString)
 		certPath := filepath.Join(tlsPath, "tls.crt")
 		keyPath := filepath.Join(tlsPath, "tls.key")
 
@@ -411,7 +411,7 @@ func main() {
 			os.Exit(1)
 		}
 	} else {
-		ctrl.Log.Info("Listening without TLS on " + portString)
+		ctrl.Log.Info("listening without TLS on " + portString)
 		err := srv.ListenAndServe()
 		if err != nil {
 			ctrl.Log.Error(err, "error serving HTTP")

--- a/api/middleware/authentication.go
+++ b/api/middleware/authentication.go
@@ -45,7 +45,7 @@ func (a *authentication) middleware(next http.Handler) http.Handler {
 
 		authInfo, err := a.authInfoParser.Parse(r.Header.Get(headers.Authorization))
 		if err != nil {
-			logger.Info("failed to parse auth info", "err", err)
+			logger.Info("failed to parse auth info", "reason", err)
 			routing.PresentError(logger, w, err)
 			return
 		}

--- a/api/repositories/pod_repository.go
+++ b/api/repositories/pod_repository.go
@@ -81,7 +81,7 @@ func (r *PodRepo) GetRuntimeLogsForApp(ctx context.Context, logger logr.Logger, 
 		logReadCloser, err = k8sClient.CoreV1().Pods(message.SpaceGUID).GetLogs(pod.Name, &corev1.PodLogOptions{Timestamps: true, TailLines: &message.Limit}).Stream(ctx)
 		if err != nil {
 			// untested
-			logger.Info(fmt.Sprintf("failed to fetch logs for pod: %s", pod.Name), "err", err)
+			logger.Info(fmt.Sprintf("failed to fetch logs for pod: %s", pod.Name), "reason", err)
 			continue
 		}
 

--- a/api/routing/handler.go
+++ b/api/routing/handler.go
@@ -45,7 +45,7 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	handlerResponse, err := h(r)
 	if err != nil {
-		logger.Info("handler returned error", "error", err)
+		logger.Info("handler returned error", "reason", err)
 		PresentError(logger, w, err)
 		return
 	}

--- a/controllers/api/v1alpha1/cfapp_webhook.go
+++ b/controllers/api/v1alpha1/cfapp_webhook.go
@@ -39,7 +39,7 @@ var _ webhook.Defaulter = &CFApp{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *CFApp) Default() {
-	cfapplog.Info("Mutating CFApp webhook handler", "name", r.Name)
+	cfapplog.V(1).Info("mutating CFApp webhook handler", "name", r.Name)
 	r.SetLabels(r.defaultLabels(r.GetLabels()))
 	r.SetAnnotations(r.defaultAnnotations(r.GetAnnotations()))
 }

--- a/controllers/api/v1alpha1/cfbuild_webhook.go
+++ b/controllers/api/v1alpha1/cfbuild_webhook.go
@@ -37,7 +37,7 @@ var _ webhook.Defaulter = &CFBuild{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *CFBuild) Default() {
-	cfbuildlog.Info("Mutating Webhook for CFBuild", "name", r.Name)
+	cfbuildlog.V(1).Info("mutating Webhook for CFBuild", "name", r.Name)
 	buildLabels := r.GetLabels()
 	if buildLabels == nil {
 		buildLabels = make(map[string]string)

--- a/controllers/api/v1alpha1/cfpackage_webhook.go
+++ b/controllers/api/v1alpha1/cfpackage_webhook.go
@@ -39,7 +39,7 @@ var _ webhook.Defaulter = &CFPackage{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *CFPackage) Default() {
-	cfpackagelog.Info("Mutating CFPackage webhook handler", "name", r.Name)
+	cfpackagelog.V(1).Info("mutating CFPackage webhook handler", "name", r.Name)
 	packageLabels := r.ObjectMeta.GetLabels()
 	if packageLabels == nil {
 		packageLabels = make(map[string]string)

--- a/controllers/api/v1alpha1/cfprocess_webhook.go
+++ b/controllers/api/v1alpha1/cfprocess_webhook.go
@@ -55,7 +55,7 @@ func (d *CFProcessDefaulter) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 func (d *CFProcessDefaulter) Default(ctx context.Context, obj runtime.Object) error {
 	process := obj.(*CFProcess)
-	cfprocesslog.Info("Mutating CFProcess webhook handler", "name", process.Name)
+	cfprocesslog.V(1).Info("mutating CFProcess webhook handler", "name", process.Name)
 
 	d.defaultLabels(process)
 	d.defaultResources(process)

--- a/controllers/api/v1alpha1/cfroute_webhook.go
+++ b/controllers/api/v1alpha1/cfroute_webhook.go
@@ -39,7 +39,7 @@ var _ webhook.Defaulter = &CFRoute{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *CFRoute) Default() {
-	cfroutelog.Info("Mutating CFRoute webhook handler", "name", r.Name)
+	cfroutelog.V(1).Info("mutating CFRoute webhook handler", "name", r.Name)
 	routeLabels := r.GetLabels()
 
 	if routeLabels == nil {

--- a/controllers/controllers/networking/cfdomain_controller.go
+++ b/controllers/controllers/networking/cfdomain_controller.go
@@ -63,7 +63,7 @@ func (r *CFDomainReconciler) ReconcileResource(ctx context.Context, cfDomain *ko
 
 	err := k8s.AddFinalizer(ctx, log, r.client, cfDomain, CFDomainFinalizerName)
 	if err != nil {
-		log.Error(err, "Error adding finalizer")
+		log.Info("error adding finalizer", "reason", err)
 		return ctrl.Result{}, err
 	}
 
@@ -84,20 +84,20 @@ func (r *CFDomainReconciler) finalizeCFDomain(ctx context.Context, log logr.Logg
 
 	domainRoutes, err := r.listRoutesForDomain(ctx, cfDomain)
 	if err != nil {
-		log.Error(err, "failed to list CFRoutes")
+		log.Info("failed to list CFRoutes", "reason", err)
 		return ctrl.Result{}, err
 	}
 
 	for i := range domainRoutes {
 		err = r.client.Delete(ctx, &domainRoutes[i])
 		if err != nil {
-			log.Error(err, "failed to list CFRoutes")
+			log.Info("failed to list CFRoutes", "reason", err)
 			return ctrl.Result{}, err
 		}
 	}
 
 	if controllerutil.RemoveFinalizer(cfDomain, CFDomainFinalizerName) {
-		log.Info("finalizer removed")
+		log.V(1).Info("finalizer removed")
 	}
 
 	return ctrl.Result{}, nil

--- a/controllers/controllers/services/cfservicebinding_controller.go
+++ b/controllers/controllers/services/cfservicebinding_controller.go
@@ -76,7 +76,7 @@ func (r *CFServiceBindingReconciler) ReconcileResource(ctx context.Context, cfSe
 
 	err = controllerutil.SetOwnerReference(instance, cfServiceBinding, r.scheme)
 	if err != nil {
-		r.log.Error(err, "Error when making the service instance owner of the service binding")
+		r.log.Info("error when making the service instance owner of the service binding", "reason", err)
 		return ctrl.Result{}, err
 	}
 
@@ -98,12 +98,12 @@ func (r *CFServiceBindingReconciler) ReconcileResource(ctx context.Context, cfSe
 	cfApp := new(korifiv1alpha1.CFApp)
 	err = r.k8sClient.Get(ctx, types.NamespacedName{Name: cfServiceBinding.Spec.AppRef.Name, Namespace: cfServiceBinding.Namespace}, cfApp)
 	if err != nil {
-		r.log.Error(err, "Error when fetching CFApp")
+		r.log.Info("error when fetching CFApp", "reason", err)
 		return ctrl.Result{}, err
 	}
 
 	if cfApp.Status.VCAPServicesSecretName == "" {
-		r.log.Info("Did not find VCAPServiceSecret name on status of CFApp", "CFServiceBinding", cfServiceBinding.Name)
+		r.log.V(1).Info("did not find VCAPServiceSecret name on status of CFApp", "CFServiceBinding", cfServiceBinding.Name)
 		meta.SetStatusCondition(&cfServiceBinding.Status.Conditions, metav1.Condition{
 			Type:    VCAPServicesSecretAvailableCondition,
 			Status:  metav1.ConditionFalse,
@@ -132,7 +132,7 @@ func (r *CFServiceBindingReconciler) ReconcileResource(ctx context.Context, cfSe
 
 	_, err = controllerutil.CreateOrPatch(ctx, r.k8sClient, &actualSBServiceBinding, sbServiceBindingMutateFn(&actualSBServiceBinding, desiredSBServiceBinding))
 	if err != nil {
-		r.log.Error(err, "Error calling Create on servicebinding.io ServiceBinding")
+		r.log.Info("error calling Create on servicebinding.io ServiceBinding", "reason", err)
 		return ctrl.Result{}, err
 	}
 

--- a/controllers/controllers/workloads/cforg_controller_test.go
+++ b/controllers/controllers/workloads/cforg_controller_test.go
@@ -124,7 +124,7 @@ var _ = Describe("CFOrgReconciler Integration Tests", func() {
 					readyCondition := meta.FindStatusCondition(createdOrg.Status.Conditions, "Ready")
 					g.Expect(readyCondition).NotTo(BeNil())
 					g.Expect(readyCondition.Message).To(ContainSubstring(fmt.Sprintf(
-						"Error fetching secret %q from namespace %q",
+						"error fetching secret %q from namespace %q",
 						imageRegistrySecret.Name,
 						imageRegistrySecret.Namespace,
 					)))

--- a/controllers/controllers/workloads/cfpackage_controller.go
+++ b/controllers/controllers/workloads/cfpackage_controller.go
@@ -59,13 +59,13 @@ func (r *CFPackageReconciler) ReconcileResource(ctx context.Context, cfPackage *
 	var cfApp korifiv1alpha1.CFApp
 	err := r.k8sClient.Get(ctx, types.NamespacedName{Name: cfPackage.Spec.AppRef.Name, Namespace: cfPackage.Namespace}, &cfApp)
 	if err != nil {
-		r.log.Error(err, "Error when fetching CFApp")
+		r.log.Info("error when fetching CFApp", "reason", err)
 		return ctrl.Result{}, err
 	}
 
 	err = controllerutil.SetControllerReference(&cfApp, cfPackage, r.scheme)
 	if err != nil {
-		r.log.Error(err, "unable to set owner reference on CFPackage")
+		r.log.Info("unable to set owner reference on CFPackage", "reason", err)
 		return ctrl.Result{}, err
 	}
 

--- a/controllers/controllers/workloads/cfspace_controller_test.go
+++ b/controllers/controllers/workloads/cfspace_controller_test.go
@@ -139,7 +139,7 @@ var _ = Describe("CFSpaceReconciler Integration Tests", func() {
 					readyCondition := meta.FindStatusCondition(createdCFSpace.Status.Conditions, "Ready")
 					g.Expect(readyCondition).NotTo(BeNil())
 					g.Expect(readyCondition.Message).To(ContainSubstring(fmt.Sprintf(
-						"Error fetching secret %q from namespace %q",
+						"error fetching secret %q from namespace %q",
 						imageRegistrySecret.Name,
 						cfOrg.Name,
 					)))

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -318,7 +318,7 @@ func main() {
 			if err = statefulsetcontrollers.NewAppWorkloadReconciler(
 				mgr.GetClient(),
 				mgr.GetScheme(),
-				statefulsetcontrollers.NewAppWorkloadToStatefulsetConverter(logger, mgr.GetScheme()),
+				statefulsetcontrollers.NewAppWorkloadToStatefulsetConverter(mgr.GetScheme()),
 				statefulsetcontrollers.NewPDBUpdater(mgr.GetClient()),
 				logger,
 			).SetupWithManager(mgr); err != nil {
@@ -449,7 +449,7 @@ func main() {
 			os.Exit(1)
 		}
 	} else {
-		setupLog.Info("Skipping webhook setup because ENABLE_WEBHOOKS set to false.")
+		setupLog.Info("skipping webhook setup because ENABLE_WEBHOOKS set to false.")
 	}
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
@@ -459,7 +459,7 @@ func main() {
 
 	eventChan := make(chan string)
 	go func() {
-		setupLog.Info("Starting to watch config file at "+configPath+" for logger level changes", "currentLevel", atomicLevel.Level())
+		setupLog.Info("starting to watch config file at "+configPath+" for logger level changes", "currentLevel", atomicLevel.Level())
 		if err2 := tools.WatchForConfigChangeEvents(context.Background(), configPath, setupLog, eventChan); err2 != nil {
 			setupLog.Error(err2, "error watching logging config")
 			os.Exit(1)

--- a/controllers/webhooks/networking/cfdomain_validator.go
+++ b/controllers/webhooks/networking/cfdomain_validator.go
@@ -81,7 +81,7 @@ func (v *CFDomainValidator) ValidateCreate(ctx context.Context, obj runtime.Obje
 
 	isOverlapping, err := v.domainIsOverlapping(ctx, domain.Spec.Name)
 	if err != nil {
-		log.Error(err, "Error checking for overlapping domain")
+		log.Info("error checking for overlapping domain", "reason", err)
 		return webhooks.ValidationError{
 			Type:    webhooks.UnknownErrorType,
 			Message: webhooks.UnknownErrorMessage,

--- a/controllers/webhooks/networking/cfroute_validator.go
+++ b/controllers/webhooks/networking/cfroute_validator.go
@@ -181,7 +181,7 @@ func (v *CFRouteValidator) fetchDomain(ctx context.Context, route *korifiv1alpha
 	err := v.client.Get(ctx, types.NamespacedName{Name: route.Spec.DomainRef.Name, Namespace: route.Spec.DomainRef.Namespace}, domain)
 	if err != nil {
 		errMessage := "Error while retrieving CFDomain object"
-		logger.Error(err, errMessage)
+		logger.Info(errMessage, "reason", err)
 		return nil, webhooks.ValidationError{
 			Type:    webhooks.UnknownErrorType,
 			Message: errMessage,
@@ -206,7 +206,7 @@ func (v *CFRouteValidator) validateDestinations(ctx context.Context, route *kori
 			validationErr.Message = webhooks.UnknownErrorMessage
 		}
 
-		logger.Error(err, validationErr.Message)
+		logger.Info(validationErr.Message, "reason", err)
 		return domain, validationErr.ExportJSONError()
 	}
 	return domain, nil

--- a/controllers/webhooks/workloads/apprev_webhook.go
+++ b/controllers/webhooks/workloads/apprev_webhook.go
@@ -60,7 +60,7 @@ func (r *AppRevWebhook) Handle(ctx context.Context, req admission.Request) admis
 func bumpAppRev(currentRevValue string) string {
 	revValue, err := strconv.Atoi(currentRevValue)
 	if err != nil || revValue < 0 {
-		apprevlog.Info("setting-invalid-app-rev-to-zero", "app-rev", currentRevValue)
+		apprevlog.V(1).Info("setting-invalid-app-rev-to-zero", "app-rev", currentRevValue)
 		return korifiv1alpha1.CFAppRevisionKeyDefault
 	}
 

--- a/controllers/webhooks/workloads/cforg_validator.go
+++ b/controllers/webhooks/workloads/cforg_validator.go
@@ -61,7 +61,7 @@ func (v *CFOrgValidator) ValidateCreate(ctx context.Context, obj runtime.Object)
 
 	err := v.placementValidator.ValidateOrgCreate(*org)
 	if err != nil {
-		cfOrgLog.Error(err, err.Error())
+		cfOrgLog.Info(err.Error())
 		return err.ExportJSONError()
 	}
 

--- a/controllers/webhooks/workloads/cftask_defaulter.go
+++ b/controllers/webhooks/workloads/cftask_defaulter.go
@@ -52,7 +52,7 @@ func (d *CFTaskDefaulter) SetupWebhookWithManager(mgr ctrl.Manager) error {
 }
 
 func (d *CFTaskDefaulter) Default(ctx context.Context, obj runtime.Object) error {
-	cfTaskLog.Info("Mutating CFTask webhook handler")
+	cfTaskLog.V(1).Info("mutating CFTask webhook handler")
 
 	cfTask, ok := obj.(*korifiv1alpha1.CFTask)
 	if !ok {

--- a/controllers/webhooks/workloads/cftask_validator.go
+++ b/controllers/webhooks/workloads/cftask_validator.go
@@ -65,7 +65,7 @@ func (v *CFTaskValidator) ValidateCreate(ctx context.Context, obj runtime.Object
 		return apierrors.NewBadRequest(fmt.Sprintf("expected a CFTask but got a %T", obj))
 	}
 
-	cftasklog.Info("validate task creation", "namespace", task.Namespace, "name", task.Name)
+	cftasklog.V(1).Info("validate task creation", "namespace", task.Namespace, "name", task.Name)
 
 	if len(task.Spec.Command) == 0 {
 		return webhooks.ValidationError{
@@ -94,7 +94,7 @@ func (v *CFTaskValidator) ValidateUpdate(ctx context.Context, oldObj runtime.Obj
 		return nil
 	}
 
-	cftasklog.Info("validate task update", "namespace", newTask.Namespace, "name", newTask.Name)
+	cftasklog.V(1).Info("validate task update", "namespace", newTask.Namespace, "name", newTask.Name)
 
 	oldTask, ok := oldObj.(*v1alpha1.CFTask)
 	if !ok {

--- a/job-task-runner/controllers/status.go
+++ b/job-task-runner/controllers/status.go
@@ -25,7 +25,6 @@ func NewStatusGetter(logger logr.Logger, k8sClient client.Client) *StatusGetter 
 }
 
 func (s *StatusGetter) GetStatusConditions(ctx context.Context, job *batchv1.Job) ([]metav1.Condition, error) {
-	logger := s.logger.WithName("get status conditions").WithValues("name", job.Name, "namespace", job.Namespace)
 	conditions := []metav1.Condition{
 		{
 			Type:    korifiv1alpha1.TaskInitializedConditionType,
@@ -61,8 +60,6 @@ func (s *StatusGetter) GetStatusConditions(ctx context.Context, job *batchv1.Job
 	if job.Status.Failed > 0 && lastFailureTimestamp != nil {
 		terminationState, err := s.getFailedContainerStatus(ctx, job)
 		if err != nil {
-			logger.Error(err, "failed to get container status")
-
 			return nil, fmt.Errorf("failed to get container status: %w", err)
 		}
 

--- a/job-task-runner/controllers/taskworkload_controller.go
+++ b/job-task-runner/controllers/taskworkload_controller.go
@@ -94,8 +94,8 @@ func (r *TaskWorkloadReconciler) ReconcileResource(ctx context.Context, taskWork
 		return ctrl.Result{}, nil
 	}
 
-	if err := r.updateTaskWorkloadStatus(ctx, taskWorkload, job); err != nil {
-		logger.Error(err, "failed to update task workload status")
+	if err = r.updateTaskWorkloadStatus(ctx, taskWorkload, job); err != nil {
+		logger.Info("failed to update task workload status", "reason", err)
 		return ctrl.Result{}, err
 	}
 
@@ -118,23 +118,23 @@ func (r TaskWorkloadReconciler) getOrCreateJob(ctx context.Context, logger logr.
 		return r.createJob(ctx, logger, taskWorkload)
 	}
 
-	logger.Error(err, "getting job failed")
+	logger.Info("getting job failed", "reason", err)
 	return nil, err
 }
 
 func (r TaskWorkloadReconciler) createJob(ctx context.Context, logger logr.Logger, taskWorkload *korifiv1alpha1.TaskWorkload) (*batchv1.Job, error) {
 	job, err := r.workloadToJob(taskWorkload)
 	if err != nil {
-		logger.Error(err, "failed to convert task workload to job")
+		logger.Info("failed to convert task workload to job", "reason", err)
 		return nil, err
 	}
 
 	err = r.k8sClient.Create(ctx, job)
 	if err != nil {
 		if k8serrors.IsAlreadyExists(err) {
-			logger.Info("job for TaskWorkload already exists")
+			logger.V(1).Info("job for TaskWorkload already exists")
 		} else {
-			logger.Error(err, "failed to create job for task workload")
+			logger.Info("failed to create job for task workload", "reason", err)
 		}
 		return nil, err
 	}

--- a/kpack-image-builder/controllers/builderinfo_controller.go
+++ b/kpack-image-builder/controllers/builderinfo_controller.go
@@ -80,7 +80,7 @@ func (r *BuilderInfoReconciler) ReconcileResource(ctx context.Context, info *kor
 	clusterBuilder := new(buildv1alpha2.ClusterBuilder)
 	err := r.k8sClient.Get(ctx, types.NamespacedName{Name: r.clusterBuilderName}, clusterBuilder)
 	if err != nil {
-		r.log.Error(err, "Error when fetching ClusterBuilder")
+		r.log.Info("error when fetching ClusterBuilder", "reason", err)
 
 		info.Status.Stacks = []korifiv1alpha1.BuilderInfoStatusStack{}
 		info.Status.Buildpacks = []korifiv1alpha1.BuilderInfoStatusBuildpack{}

--- a/kpack-image-builder/controllers/imageprocessfetcher/image_process_fetcher.go
+++ b/kpack-image-builder/controllers/imageprocessfetcher/image_process_fetcher.go
@@ -34,19 +34,19 @@ type process struct {
 func (f *ImageProcessFetcher) Fetch(imageRef string, credsOption remote.Option) ([]korifiv1alpha1.ProcessType, []int32, error) {
 	ref, err := name.ParseReference(imageRef)
 	if err != nil {
-		f.Log.Info(fmt.Sprintf("Error fetching image config: %s\n", err))
+		f.Log.Info("error fetching image config", "reason", err)
 		return nil, nil, err
 	}
 
 	img, err := remote.Image(ref, credsOption)
 	if err != nil {
-		f.Log.Info(fmt.Sprintf("Error fetching image config: %s\n", err))
+		f.Log.Info("error fetching image config", "reason", err)
 		return nil, nil, err
 	}
 
 	cfgFile, err := img.ConfigFile()
 	if err != nil {
-		f.Log.Info(fmt.Sprintf("Error fetching image config: %s\n", err))
+		f.Log.Info("error fetching image config", "reason", err)
 		return nil, nil, err
 	}
 
@@ -54,7 +54,7 @@ func (f *ImageProcessFetcher) Fetch(imageRef string, credsOption remote.Option) 
 	var buildMd buildMetadata
 	err = json.Unmarshal([]byte(cfgFile.Config.Labels[buildpackBuildMetadataLabel]), &buildMd)
 	if err != nil {
-		f.Log.Info(fmt.Sprintf("Error unmarshalling image build metadata: %s\n", err))
+		f.Log.Info("error unmarshalling image build metadata", "reason", err)
 		return nil, nil, err
 	}
 
@@ -69,7 +69,7 @@ func (f *ImageProcessFetcher) Fetch(imageRef string, credsOption remote.Option) 
 
 	exposedPorts, err := extractExposedPorts(&cfgFile.Config)
 	if err != nil {
-		f.Log.Info(fmt.Sprintf("Cannot parse exposed ports from image config: %v \n", err))
+		f.Log.Info("cannot parse exposed ports from image config", "reason", err)
 		return nil, nil, err
 	}
 	return processTypes, exposedPorts, nil

--- a/statefulset-runner/api/v1/pod_webhook.go
+++ b/statefulset-runner/api/v1/pod_webhook.go
@@ -54,7 +54,7 @@ var _ webhook.CustomDefaulter = &STSPodDefaulter{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *STSPodDefaulter) Default(ctx context.Context, obj runtime.Object) error {
-	podlog.Info("default", "name", obj.DeepCopyObject().GetObjectKind())
+	podlog.V(1).Info("default", "name", obj.DeepCopyObject().GetObjectKind())
 
 	pod, ok := obj.(*corev1.Pod)
 	if !ok {
@@ -72,7 +72,7 @@ func (r *STSPodDefaulter) Default(ctx context.Context, obj runtime.Object) error
 			cfInstanceVar := corev1.EnvVar{Name: controllers.EnvCFInstanceIndex, Value: index}
 			container.Env = append(container.Env, cfInstanceVar)
 
-			podlog.Info(fmt.Sprintf("patching-instance-index env-var - %s: %s", controllers.EnvCFInstanceIndex, index))
+			podlog.V(1).Info(fmt.Sprintf("patching-instance-index env-var - %s: %s", controllers.EnvCFInstanceIndex, index))
 
 			return nil
 		}

--- a/statefulset-runner/controllers/appworkload_to_stset.go
+++ b/statefulset-runner/controllers/appworkload_to_stset.go
@@ -10,7 +10,6 @@ import (
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"code.cloudfoundry.org/korifi/tools"
-	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -19,13 +18,11 @@ import (
 )
 
 type AppWorkloadToStatefulsetConverter struct {
-	log    logr.Logger
 	scheme *runtime.Scheme
 }
 
-func NewAppWorkloadToStatefulsetConverter(log logr.Logger, scheme *runtime.Scheme) *AppWorkloadToStatefulsetConverter {
+func NewAppWorkloadToStatefulsetConverter(scheme *runtime.Scheme) *AppWorkloadToStatefulsetConverter {
 	return &AppWorkloadToStatefulsetConverter{
-		log:    log,
 		scheme: scheme,
 	}
 }
@@ -157,8 +154,7 @@ func (r *AppWorkloadToStatefulsetConverter) Convert(appWorkload *korifiv1alpha1.
 
 	err = controllerutil.SetOwnerReference(appWorkload, statefulSet, r.scheme)
 	if err != nil {
-		r.log.Error(err, "failed to set OwnerRef on StatefulSet")
-		return nil, err
+		return nil, fmt.Errorf("failed to set OwnerRef on StatefulSet :%w", err)
 	}
 
 	labels := map[string]string{

--- a/statefulset-runner/controllers/appworkload_to_stset_test.go
+++ b/statefulset-runner/controllers/appworkload_to_stset_test.go
@@ -6,6 +6,7 @@ import (
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"code.cloudfoundry.org/korifi/statefulset-runner/controllers"
 	"code.cloudfoundry.org/korifi/tools"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
@@ -13,7 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 var _ = Describe("AppWorkload to StatefulSet Converter", func() {
@@ -26,7 +26,7 @@ var _ = Describe("AppWorkload to StatefulSet Converter", func() {
 	BeforeEach(func() {
 		Expect(korifiv1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
 		appWorkload = createAppWorkload("some-namespace", "guid_1234")
-		converter = controllers.NewAppWorkloadToStatefulsetConverter(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)), scheme.Scheme)
+		converter = controllers.NewAppWorkloadToStatefulsetConverter(scheme.Scheme)
 	})
 
 	JustBeforeEach(func() {

--- a/statefulset-runner/controllers/integration/suite_test.go
+++ b/statefulset-runner/controllers/integration/suite_test.go
@@ -95,7 +95,7 @@ var _ = BeforeSuite(func() {
 	appWorkloadReconciler := NewAppWorkloadReconciler(
 		k8sManager.GetClient(),
 		k8sManager.GetScheme(),
-		NewAppWorkloadToStatefulsetConverter(logger, k8sManager.GetScheme()),
+		NewAppWorkloadToStatefulsetConverter(k8sManager.GetScheme()),
 		NewPDBUpdater(k8sManager.GetClient()),
 		logger,
 	)

--- a/tools/config_change_watcher.go
+++ b/tools/config_change_watcher.go
@@ -8,7 +8,7 @@ import (
 )
 
 func WatchForConfigChangeEvents(ctx context.Context, configFilePath string, logger logr.Logger, eventChan chan string) error {
-	logger.V(1).Info("Starting config watcher")
+	logger.V(1).Info("starting config watcher")
 
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
@@ -45,7 +45,7 @@ func WatchForConfigChangeEvents(ctx context.Context, configFilePath string, logg
 			logger.Error(err, "config watcher error")
 
 		case <-ctx.Done():
-			logger.V(1).Info("Stopping config watcher")
+			logger.V(1).Info("stopping config watcher")
 			return nil
 		}
 	}

--- a/tools/k8s/finalizer.go
+++ b/tools/k8s/finalizer.go
@@ -20,7 +20,7 @@ func AddFinalizer[T any, PT ObjectWithDeepCopy[T]](
 		if err := k8sClient.Patch(ctx, obj, client.MergeFrom(origObj)); err != nil {
 			return err
 		}
-		log.Info("added finalizer")
+		log.V(1).Info("added finalizer")
 	}
 
 	return nil

--- a/tools/k8s/reconcile.go
+++ b/tools/k8s/reconcile.go
@@ -39,7 +39,7 @@ func (r *PatchingReconciler[T, PT]) Reconcile(ctx context.Context, req ctrl.Requ
 		if apierrors.IsNotFound(err) {
 			return ctrl.Result{}, nil
 		}
-		log.Error(err, fmt.Sprintf("unable to fetch %T", obj))
+		log.Info(fmt.Sprintf("unable to fetch %T", obj), "reason", err)
 		return ctrl.Result{}, err
 	}
 
@@ -52,7 +52,7 @@ func (r *PatchingReconciler[T, PT]) Reconcile(ctx context.Context, req ctrl.Requ
 		result, delegateErr = r.objectReconciler.ReconcileResource(ctx, obj)
 	})
 	if err != nil {
-		log.Error(err, "patch object failed")
+		log.Info("patch object failed", "reason", err)
 		return ctrl.Result{}, err
 	}
 

--- a/tools/sync_log_level.go
+++ b/tools/sync_log_level.go
@@ -25,12 +25,12 @@ func SyncLogLevel(ctx context.Context, logger logr.Logger, eventChan chan string
 			}
 
 			if atomicLevel.Level() != cfgLogLevel {
-				logger.Info("Updating logging level", "originalLevel", atomicLevel.Level(), "newLevel", cfgLogLevel)
+				logger.Info("updating logging level", "originalLevel", atomicLevel.Level(), "newLevel", cfgLogLevel)
 				atomicLevel.SetLevel(cfgLogLevel)
 			}
 
 		case <-ctx.Done():
-			logger.Info("Stopping change log level function")
+			logger.Info("stopping change log level function")
 			return
 		}
 	}


### PR DESCRIPTION
## Is there a related GitHub Issue?
#1926 

## What is this change about?
Audit and update all existing logs to an appropriate level. We generally did the following to logs:
- Use error log level for platform startup issues, debug log level for resource lifecycle events and info log level for everything else.
- Attach an error to an info log entry as a "reason" if appropriate.
- Deduplicated error logging

~Note that after rebasing on main there is a new helper function that is logging at the error level. We left the helper alone for now and will confirm with the team whether there is any issue with moving that down to info by default, potentially with a sibling helper function.~
Updated the new helper function to info log level like the rest of the controller logs returning errors back to the api.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Deploy Korifi normally and see many fewer noisy logs at the default log level.

## Tag your pair, your PM, and/or team
@davewalter @matt-royal 
cc @julian-hj for thoughts