### PR TITLE
Improve "cf buildpacks" error responses

### DIFF
--- a/api/errors/errors.go
+++ b/api/errors/errors.go
@@ -298,15 +298,15 @@ func NewBlobstoreUnavailableError(cause error) BlobstoreUnavailableError {
 	}
 }
 
-type CFCreateError struct {
+type ResourceNotReadyError struct {
 	apiError
 }
 
-func NewCFCreateError(cause error) CFCreateError {
-	return CFCreateError{
+func NewResourceNotReadyError(cause error) ResourceNotReadyError {
+	return ResourceNotReadyError{
 		apiError: apiError{
 			cause:      cause,
-			title:      "CF-Create",
+			title:      "CF-ResourceNotReady",
 			detail:     cause.Error(),
 			code:       420000,
 			httpStatus: http.StatusInternalServerError,

--- a/api/repositories/org_repository.go
+++ b/api/repositories/org_repository.go
@@ -148,7 +148,8 @@ func (r *OrgRepo) createOrgCR(ctx context.Context,
 		if len(conditionNotReadyMessage) > 0 {
 			err = errors.New(conditionNotReadyMessage)
 		}
-		return nil, apierrors.NewCFCreateError(err)
+
+		return nil, apierrors.NewResourceNotReadyError(err)
 	}
 
 	return createdOrg, nil

--- a/api/repositories/space_repository.go
+++ b/api/repositories/space_repository.go
@@ -159,7 +159,8 @@ func (r *SpaceRepo) createSpaceCR(ctx context.Context,
 		if len(conditionNotReadyMessage) > 0 {
 			err = errors.New(conditionNotReadyMessage)
 		}
-		return nil, apierrors.NewCFCreateError(err)
+
+		return nil, apierrors.NewResourceNotReadyError(err)
 	}
 
 	return createdSpace, nil

--- a/kpack-image-builder/controllers/builderinfo_controller.go
+++ b/kpack-image-builder/controllers/builderinfo_controller.go
@@ -87,8 +87,8 @@ func (r *BuilderInfoReconciler) ReconcileResource(ctx context.Context, info *kor
 		meta.SetStatusCondition(&info.Status.Conditions, metav1.Condition{
 			Type:    ReadyConditionType,
 			Status:  metav1.ConditionFalse,
-			Reason:  "cluster_builder_missing",
-			Message: fmt.Sprintf("Error fetching ClusterBuilder %q: %q", r.clusterBuilderName, err),
+			Reason:  "ClusterBuilderMissing",
+			Message: fmt.Sprintf("Error fetching ClusterBuilder %q: %s", r.clusterBuilderName, err),
 		})
 		return ctrl.Result{}, err
 	}
@@ -106,11 +106,20 @@ func (r *BuilderInfoReconciler) ReconcileResource(ctx context.Context, info *kor
 			Message: fmt.Sprintf("ClusterBuilder %q is ready", r.clusterBuilderName),
 		})
 	} else {
+		var msg string
+		if clusterBuilderReadyCondition != nil {
+			msg = clusterBuilderReadyCondition.Message
+		}
+
+		if msg == "" {
+			msg = "resource not reconciled"
+		}
+
 		meta.SetStatusCondition(&info.Status.Conditions, metav1.Condition{
 			Type:    ReadyConditionType,
 			Status:  metav1.ConditionFalse,
 			Reason:  "ClusterBuilderNotReady",
-			Message: fmt.Sprintf("ClusterBuilder %q is not ready", r.clusterBuilderName),
+			Message: fmt.Sprintf("ClusterBuilder %q is not ready: %s", r.clusterBuilderName, msg),
 		})
 	}
 


### PR DESCRIPTION
## Is there a related GitHub Issue?
#2174 

## What is this change about?
This PR improves the error responses from the `/v3/buildpacks` endpoint used by the "cf buildpacks" command.

- Wrap the error returned when the BuilderInfo resource cannot be retrieved in a ResourceNotFound apierror.
- Check the status of the BuilderInfo resource, and return the message if it isn't ready.
- Include the ClusterBuilder ready condition message in the BuilderInfo condition message if it is not ready.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
See #2174 

## Tag your pair, your PM, and/or team
@clintyoshimura @tcdowney 