### PR TITLE
Remove Ginkgo from tools/tools.go

### DIFF
--- a/tools/tools.go
+++ b/tools/tools.go
@@ -5,7 +5,6 @@ package tools
 
 import (
 	_ "github.com/maxbrunsfeld/counterfeiter/v6"
-	_ "github.com/onsi/ginkgo/v2/ginkgo"
 	_ "sigs.k8s.io/controller-tools/cmd/controller-gen"
 )
 


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
No

## What is this change about?
As of [Ginkgo v2.8.2](https://github.com/onsi/ginkgo/releases/tag/v2.8.2), "Ginkgo now includes a tools.go file in the root directory of the ginkgo package. This should allow modules that simply go get github.com/onsi/ginkgo/v2 to also pull in the CLI dependencies. This obviates the need for consumers of Ginkgo to have their own tools.go file and makes it simpler to ensure that the version of the ginkgo CLI being used matches the version of the library. You can simply run go run github.com/onsi/ginkgo/v2/ginkgo to run the version of the cli associated with your package go.mod."

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Everything still works.

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
