### PR TITLE
Improve `reason` on korifi resources

### DIFF
--- a/api/repositories/app_repository.go
+++ b/api/repositories/app_repository.go
@@ -499,7 +499,7 @@ func (f *AppRepo) SetCurrentDroplet(ctx context.Context, authInfo authorization.
 		return CurrentDropletRecord{}, fmt.Errorf("failed to set app droplet: %w", apierrors.FromK8sError(err, AppResourceType))
 	}
 
-	_, err = f.appConditionAwaiter.AwaitCondition(ctx, userClient, cfApp, workloads.StatusConditionStaged)
+	_, err = f.appConditionAwaiter.AwaitCondition(ctx, userClient, cfApp, workloads.StatusConditionReady)
 	if err != nil {
 		return CurrentDropletRecord{}, fmt.Errorf("failed to await the app staged condition: %w", apierrors.FromK8sError(err, AppResourceType))
 	}
@@ -711,7 +711,7 @@ func cfAppToAppRecord(cfApp korifiv1alpha1.CFApp) AppRecord {
 		},
 		CreatedAt:             cfApp.CreationTimestamp.UTC().Format(TimestampFormat),
 		UpdatedAt:             updatedAtTime,
-		IsStaged:              meta.IsStatusConditionTrue(cfApp.Status.Conditions, workloads.StatusConditionStaged),
+		IsStaged:              meta.IsStatusConditionTrue(cfApp.Status.Conditions, workloads.StatusConditionReady),
 		envSecretName:         cfApp.Spec.EnvSecretName,
 		vcapServiceSecretName: cfApp.Status.VCAPServicesSecretName,
 		vcapAppSecretName:     cfApp.Status.VCAPApplicationSecretName,

--- a/api/repositories/app_repository_test.go
+++ b/api/repositories/app_repository_test.go
@@ -98,7 +98,7 @@ var _ = Describe("AppRepository", func() {
 			When("the app has staged condition true", func() {
 				BeforeEach(func() {
 					cfApp.Status.Conditions = []metav1.Condition{{
-						Type:               workloads.StatusConditionStaged,
+						Type:               workloads.StatusConditionReady,
 						Status:             metav1.ConditionTrue,
 						LastTransitionTime: metav1.Now(),
 						Reason:             "staged",
@@ -121,7 +121,7 @@ var _ = Describe("AppRepository", func() {
 			When("the app has staged condition false", func() {
 				BeforeEach(func() {
 					meta.SetStatusCondition(&cfApp.Status.Conditions, metav1.Condition{
-						Type:    workloads.StatusConditionStaged,
+						Type:    workloads.StatusConditionReady,
 						Status:  metav1.ConditionFalse,
 						Reason:  "appStaged",
 						Message: "",
@@ -130,7 +130,7 @@ var _ = Describe("AppRepository", func() {
 					Eventually(func(g Gomega) {
 						app := korifiv1alpha1.CFApp{}
 						g.Expect(k8sClient.Get(testCtx, client.ObjectKeyFromObject(cfApp), &app)).To(Succeed())
-						g.Expect(meta.IsStatusConditionFalse(app.Status.Conditions, workloads.StatusConditionStaged)).To(BeTrue())
+						g.Expect(meta.IsStatusConditionFalse(app.Status.Conditions, workloads.StatusConditionReady)).To(BeTrue())
 					}).Should(Succeed())
 				})
 
@@ -1131,7 +1131,7 @@ var _ = Describe("AppRepository", func() {
 					theAppCopy := theApp.DeepCopy()
 					theAppCopy.Status = korifiv1alpha1.CFAppStatus{
 						Conditions: []metav1.Condition{{
-							Type:               workloads.StatusConditionStaged,
+							Type:               workloads.StatusConditionReady,
 							Status:             metav1.ConditionTrue,
 							LastTransitionTime: metav1.Now(),
 							Reason:             "staged",
@@ -1196,7 +1196,7 @@ var _ = Describe("AppRepository", func() {
 				})
 
 				It("returns an error", func() {
-					Expect(setDropletErr).To(MatchError(ContainSubstring("did not get the Staged condition")))
+					Expect(setDropletErr).To(MatchError(ContainSubstring("did not get the Ready condition")))
 				})
 			})
 		})

--- a/api/repositories/task_repository_test.go
+++ b/api/repositories/task_repository_test.go
@@ -292,7 +292,7 @@ var _ = Describe("TaskRepository", func() {
 					meta.SetStatusCondition(&(cfTask.Status.Conditions), metav1.Condition{
 						Type:   korifiv1alpha1.TaskFailedConditionType,
 						Status: metav1.ConditionTrue,
-						Reason: "taskCanceled",
+						Reason: "TaskCanceled",
 					})
 					Expect(k8sClient.Status().Update(ctx, cfTask)).To(Succeed())
 				})

--- a/controllers/controllers/workloads/cfbuild_controller_test.go
+++ b/controllers/controllers/workloads/cfbuild_controller_test.go
@@ -196,6 +196,7 @@ var _ = Describe("CFBuildReconciler Integration Tests", func() {
 					stagingCondition := meta.FindStatusCondition(createdCFBuild.Status.Conditions, stagingConditionType)
 					g.Expect(stagingCondition).NotTo(BeNil())
 					g.Expect(stagingCondition.Status).To(Equal(metav1.ConditionTrue))
+					g.Expect(stagingCondition.Reason).To(Equal("BuildRunning"))
 
 					succeededCondition := meta.FindStatusCondition(createdCFBuild.Status.Conditions, succeededConditionType)
 					g.Expect(succeededCondition).NotTo(BeNil())
@@ -430,6 +431,7 @@ var _ = Describe("CFBuildReconciler Integration Tests", func() {
 					stagingCondition := meta.FindStatusCondition(createdCFBuild.Status.Conditions, stagingConditionType)
 					g.Expect(stagingCondition).NotTo(BeNil())
 					g.Expect(stagingCondition.Status).To(Equal(metav1.ConditionTrue))
+					g.Expect(stagingCondition.Reason).To(Equal("BuildRunning"))
 
 					succeededCondition := meta.FindStatusCondition(createdCFBuild.Status.Conditions, succeededConditionType)
 					g.Expect(succeededCondition).NotTo(BeNil())
@@ -468,7 +470,17 @@ var _ = Describe("CFBuildReconciler Integration Tests", func() {
 				createdCFBuild := new(korifiv1alpha1.CFBuild)
 				Eventually(func(g Gomega) {
 					g.Expect(k8sClient.Get(context.Background(), lookupKey, createdCFBuild)).To(Succeed())
-					g.Expect(meta.IsStatusConditionFalse(createdCFBuild.Status.Conditions, succeededConditionType)).To(BeTrue())
+
+					stagingStatusCondition := meta.FindStatusCondition(createdCFBuild.Status.Conditions, stagingConditionType)
+					g.Expect(stagingStatusCondition).NotTo(BeNil())
+					g.Expect(stagingStatusCondition.Status).To(Equal(metav1.ConditionFalse))
+					g.Expect(stagingStatusCondition.Reason).To(Equal("BuildNotRunning"))
+
+					succeededStatusCondition := meta.FindStatusCondition(createdCFBuild.Status.Conditions, succeededConditionType)
+					g.Expect(succeededStatusCondition).NotTo(BeNil())
+					g.Expect(succeededStatusCondition.Status).To(Equal(metav1.ConditionFalse))
+					g.Expect(succeededStatusCondition.Reason).To(Equal("BuildFailed"))
+
 				}).Should(Succeed())
 			})
 		})
@@ -521,9 +533,15 @@ var _ = Describe("CFBuildReconciler Integration Tests", func() {
 
 				Eventually(func(g Gomega) {
 					g.Expect(k8sClient.Get(context.Background(), lookupKey, createdCFBuild)).To(Succeed())
-					statusCondition := meta.FindStatusCondition(createdCFBuild.Status.Conditions, succeededConditionType)
-					g.Expect(statusCondition).NotTo(BeNil())
-					g.Expect(statusCondition.Status).To(Equal(metav1.ConditionTrue))
+					stagingStatusCondition := meta.FindStatusCondition(createdCFBuild.Status.Conditions, stagingConditionType)
+					g.Expect(stagingStatusCondition).NotTo(BeNil())
+					g.Expect(stagingStatusCondition.Status).To(Equal(metav1.ConditionFalse))
+					g.Expect(stagingStatusCondition.Reason).To(Equal("BuildNotRunning"))
+
+					succeededStatusCondition := meta.FindStatusCondition(createdCFBuild.Status.Conditions, succeededConditionType)
+					g.Expect(succeededStatusCondition).NotTo(BeNil())
+					g.Expect(succeededStatusCondition.Status).To(Equal(metav1.ConditionTrue))
+					g.Expect(succeededStatusCondition.Reason).To(Equal("BuildSucceeded"))
 				}).Should(Succeed())
 			})
 

--- a/controllers/controllers/workloads/cftask_controller.go
+++ b/controllers/controllers/workloads/cftask_controller.go
@@ -41,7 +41,7 @@ import (
 )
 
 const (
-	TaskCanceledReason    = "taskCanceled"
+	TaskCanceledReason    = "TaskCanceled"
 	LifecycleLauncherPath = "/cnb/lifecycle/launcher"
 )
 
@@ -168,7 +168,7 @@ func (r *CFTaskReconciler) getApp(ctx context.Context, cfTask *korifiv1alpha1.CF
 		return nil, err
 	}
 
-	if !meta.IsStatusConditionTrue(cfApp.Status.Conditions, StatusConditionStaged) {
+	if !meta.IsStatusConditionTrue(cfApp.Status.Conditions, StatusConditionReady) {
 		r.logger.Info("cfapp not staged", "app-namespace", cfApp.Namespace, "app-name", cfApp.Name)
 		r.recorder.Eventf(cfTask, "Warning", "appNotStaged", "App %s:%s is not staged", cfApp.Namespace, cfApp.Name)
 		return nil, errors.New("app not staged")
@@ -288,10 +288,9 @@ func calculateDefaultCPURequestMillicores(memoryMiB int64) int64 {
 func (r *CFTaskReconciler) initializeStatus(ctx context.Context, cfTask *korifiv1alpha1.CFTask, cfDroplet *korifiv1alpha1.CFBuild) {
 	cfTask.Status.DropletRef.Name = cfDroplet.Name
 	meta.SetStatusCondition(&cfTask.Status.Conditions, metav1.Condition{
-		Type:    korifiv1alpha1.TaskInitializedConditionType,
-		Status:  metav1.ConditionTrue,
-		Reason:  "taskInitialized",
-		Message: "taskInitialized",
+		Type:   korifiv1alpha1.TaskInitializedConditionType,
+		Status: metav1.ConditionTrue,
+		Reason: "TaskInitialized",
 	})
 }
 

--- a/controllers/controllers/workloads/cftask_controller_test.go
+++ b/controllers/controllers/workloads/cftask_controller_test.go
@@ -148,7 +148,10 @@ var _ = Describe("CFTaskReconciler Integration Tests", func() {
 			JustBeforeEach(func() {
 				Eventually(func(g Gomega) {
 					g.Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: cfSpace.Status.GUID, Name: cfTask.Name}, task)).To(Succeed())
-					g.Expect(meta.IsStatusConditionTrue(task.Status.Conditions, korifiv1alpha1.TaskInitializedConditionType)).To(BeTrue(), "task did not become initialized")
+					initializedStatusCondition := meta.FindStatusCondition(task.Status.Conditions, korifiv1alpha1.TaskInitializedConditionType)
+					g.Expect(initializedStatusCondition).NotTo(BeNil())
+					g.Expect(initializedStatusCondition.Status).To(Equal(metav1.ConditionTrue), "task did not become initialized")
+					g.Expect(initializedStatusCondition.Reason).To(Equal("TaskInitialized"))
 				}).Should(Succeed())
 			})
 
@@ -290,7 +293,10 @@ var _ = Describe("CFTaskReconciler Integration Tests", func() {
 			It("sets the canceled status condition", func() {
 				Eventually(func(g Gomega) {
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cfTask), cfTask)).To(Succeed())
-					g.Expect(meta.IsStatusConditionTrue(cfTask.Status.Conditions, korifiv1alpha1.TaskCanceledConditionType)).To(BeTrue())
+					canceledStatusCondition := meta.FindStatusCondition(cfTask.Status.Conditions, korifiv1alpha1.TaskCanceledConditionType)
+					g.Expect(canceledStatusCondition).NotTo(BeNil())
+					g.Expect(canceledStatusCondition.Status).To(Equal(metav1.ConditionTrue))
+					g.Expect(canceledStatusCondition.Reason).To(Equal("TaskCancelled"))
 				})
 			})
 		})

--- a/job-task-runner/controllers/status.go
+++ b/job-task-runner/controllers/status.go
@@ -27,10 +27,9 @@ func NewStatusGetter(logger logr.Logger, k8sClient client.Client) *StatusGetter 
 func (s *StatusGetter) GetStatusConditions(ctx context.Context, job *batchv1.Job) ([]metav1.Condition, error) {
 	conditions := []metav1.Condition{
 		{
-			Type:    korifiv1alpha1.TaskInitializedConditionType,
-			Status:  metav1.ConditionTrue,
-			Reason:  "job_created",
-			Message: "Job created",
+			Type:   korifiv1alpha1.TaskInitializedConditionType,
+			Status: metav1.ConditionTrue,
+			Reason: "JobCreated",
 		},
 	}
 
@@ -42,8 +41,7 @@ func (s *StatusGetter) GetStatusConditions(ctx context.Context, job *batchv1.Job
 		Type:               korifiv1alpha1.TaskStartedConditionType,
 		Status:             metav1.ConditionTrue,
 		LastTransitionTime: *job.Status.StartTime,
-		Reason:             "job_started",
-		Message:            "Job started",
+		Reason:             "JobStarted",
 	})
 
 	if job.Status.Succeeded > 0 && job.Status.CompletionTime != nil {
@@ -51,8 +49,7 @@ func (s *StatusGetter) GetStatusConditions(ctx context.Context, job *batchv1.Job
 			Type:               korifiv1alpha1.TaskSucceededConditionType,
 			Status:             metav1.ConditionTrue,
 			LastTransitionTime: *job.Status.CompletionTime,
-			Reason:             "job_succeeded",
-			Message:            "Job succeeded",
+			Reason:             "JobSucceeded",
 		})
 	}
 

--- a/job-task-runner/controllers/status_test.go
+++ b/job-task-runner/controllers/status_test.go
@@ -42,7 +42,10 @@ var _ = Describe("StatusGetter", func() {
 	})
 
 	It("returns an initialized condition", func() {
-		Expect(meta.IsStatusConditionTrue(conditions, korifiv1alpha1.TaskInitializedConditionType)).To(BeTrue())
+		initializedStatusCondition := meta.FindStatusCondition(conditions, korifiv1alpha1.TaskInitializedConditionType)
+		Expect(initializedStatusCondition).NotTo(BeNil())
+		Expect(initializedStatusCondition.Status).To(Equal(metav1.ConditionTrue))
+		Expect(initializedStatusCondition.Reason).To(Equal("JobCreated"))
 	})
 
 	When("the job is running", func() {
@@ -58,8 +61,11 @@ var _ = Describe("StatusGetter", func() {
 		})
 
 		It("contains a started condition with a matching timestamp", func() {
-			Expect(meta.IsStatusConditionTrue(conditions, korifiv1alpha1.TaskStartedConditionType)).To(BeTrue())
-			Expect(meta.FindStatusCondition(conditions, korifiv1alpha1.TaskStartedConditionType).LastTransitionTime).To(Equal(now))
+			startedStatusCondition := meta.FindStatusCondition(conditions, korifiv1alpha1.TaskStartedConditionType)
+			Expect(startedStatusCondition).NotTo(BeNil())
+			Expect(startedStatusCondition.Status).To(Equal(metav1.ConditionTrue))
+			Expect(startedStatusCondition.Reason).To(Equal("JobStarted"))
+			Expect(startedStatusCondition.LastTransitionTime).To(Equal(now))
 		})
 	})
 
@@ -82,8 +88,11 @@ var _ = Describe("StatusGetter", func() {
 		})
 
 		It("contains a succeeded condition", func() {
-			Expect(meta.IsStatusConditionTrue(conditions, korifiv1alpha1.TaskSucceededConditionType)).To(BeTrue())
-			Expect(meta.FindStatusCondition(conditions, korifiv1alpha1.TaskSucceededConditionType).LastTransitionTime).To(Equal(later))
+			succeededStatusCondition := meta.FindStatusCondition(conditions, korifiv1alpha1.TaskSucceededConditionType)
+			Expect(succeededStatusCondition).NotTo(BeNil())
+			Expect(succeededStatusCondition.Status).To(Equal(metav1.ConditionTrue))
+			Expect(succeededStatusCondition.Reason).To(Equal("JobSucceeded"))
+			Expect(succeededStatusCondition.LastTransitionTime).To(Equal(later))
 		})
 	})
 
@@ -164,6 +173,7 @@ var _ = Describe("StatusGetter", func() {
 			Expect(meta.IsStatusConditionTrue(conditions, korifiv1alpha1.TaskFailedConditionType)).To(BeTrue())
 			failedCondition := meta.FindStatusCondition(conditions, korifiv1alpha1.TaskFailedConditionType)
 			Expect(failedCondition.LastTransitionTime).To(Equal(later))
+			Expect(failedCondition.Reason).To(Equal("Error"))
 
 			Expect(fakeClient.ListCallCount()).To(Equal(1))
 			_, listObj, opts := fakeClient.ListArgsForCall(0)

--- a/kpack-image-builder/controllers/buildworkload_controller.go
+++ b/kpack-image-builder/controllers/buildworkload_controller.go
@@ -49,7 +49,6 @@ import (
 )
 
 const (
-	kpackReadyConditionType  = "Ready"
 	clusterBuilderKind       = "ClusterBuilder"
 	clusterBuilderAPIVersion = "kpack.io/v1alpha2"
 	BuildWorkloadLabelKey    = "korifi.cloudfoundry.org/build-workload-name"


### PR DESCRIPTION




<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->
[#2166]

## What is this change about?
Improved `reason` on korifi resources

- Removed `Running` status condition from `cfApp`. The actual place to verify that the App processes are running is to look at the CFProcess objects or the pods that they scheduled.
- Renamed `Staged` status condition on `cfApp` to `Ready`. `Ready` actually indicates that a valid droplet is assigned to the App. That droplet might have just been staged, or it might be an old droplet that was reassigned to the App. It would be more accurate to say that the App is Ready instead. An app would start as Ready false and then become Ready true when a valid droplet ref is assigned.
- Updated `cfbuild` resource to have `BuildRunning` & `BuildNotRunnning` as reasons for `Staging` condition. `BuildFailed` & `BuildSucceeded` for `Succeeded` status condition
- Updated `cftask` & `TaskWorkload` reasons to match CamelCase
- Removed redundant `Message` attribute wherever applicable.
- When the `job` created by the `taskworkload` fails, the `status.condition.reason` on the taskWorkload is derived from job's container status. We observed that it follows the convention of using CamelCase.

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->
Yes. 
- `reason` on all of `cfapp`, `cfbuild`, `cftask` & `taskWorkload` have been changed.
- `cfapp` now has a new `Ready` status condition and will no longer have `Staging` & `Running` conditions. When existing cfapps reconciles it would get the `Ready` status condition but also keep their `Staging` & `Running` conditions with the same status, reason and message. 

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->
See #2166

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->
@matt-royal 

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
