### PR TITLE
Remove the "[Chore]:" prefix of chore titles

### DIFF
--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -1,6 +1,5 @@
 name: Chore
 description: Request a chore
-title: "[Chore]: "
 labels: [chore]
 body:
   - type: textarea


### PR DESCRIPTION
The chore label already makes it clear enough that this is a chore. Clicking on the label filters by it. Looks like the name prefix is redundant.