### PR TITLE
Integrate logLevel with helm configuration

### DIFF
--- a/README.helm.md
+++ b/README.helm.md
@@ -16,6 +16,7 @@ Here are all the values that can be set for the chart:
   - `defaultAppDomainName` (_String_): Base domain name for application URLs.
   - `eksContainerRegistryRoleARN` (_String_): Amazon Resource Name (ARN) of the IAM role to use to access the ECR registry from an EKS deployed Korifi. Required if containerRegistrySecret not set.
   - `generateIngressCertificates` (_Boolean_): Use `cert-manager` to generate self-signed certificates for the API and app endpoints.
+  - `logLevel` (_String_): Sets level of logging for api and controllers components. Can be 'info' or 'debug'.
   - `rootNamespace` (_String_): Root of the Cloud Foundry namespace hierarchy.
 - `adminUserName` (_String_): Name of the admin user that will be bound to the Cloud Foundry Admin role.
 - `api`:

--- a/helm/korifi/api/configmap.yaml
+++ b/helm/korifi/api/configmap.yaml
@@ -29,7 +29,7 @@ data:
     authProxyHost: {{ .Values.api.authProxy.host | quote }}
     authProxyCACert: {{ .Values.api.authProxy.caCert | quote }}
     {{- end }}
-    logLevel: {{ .Values.api.logLevel | default "info" }}
+    logLevel: {{ .Values.global.logLevel }}
     {{- if .Values.global.eksContainerRegistryRoleARN }}
     containerRegistryType: "ECR"
     {{- end }}

--- a/helm/korifi/controllers/configmap.yaml
+++ b/helm/korifi/controllers/configmap.yaml
@@ -31,7 +31,7 @@ data:
     {{- range $key, $value := merge .Values.controllers.extraVCAPApplicationValues $defaultDict }}
       {{ $key }}: {{ $value }}
     {{- end }}
-    logLevel: {{ .Values.api.logLevel | default "info" }}
+    logLevel: {{ .Values.global.logLevel }}
 {{- if .Values.kpackImageBuilder.include }}
   kpack_build_controllers_config.yaml: |
     cfRootNamespace: {{ .Values.global.rootNamespace }}

--- a/helm/korifi/values.schema.json
+++ b/helm/korifi/values.schema.json
@@ -16,6 +16,11 @@
           "description": "Enables remote debugging with [Delve](https://github.com/go-delve/delve).",
           "type": "boolean"
         },
+        "logLevel": {
+          "description": "Sets level of logging for api and controllers components. Can be 'info' or 'debug'.",
+          "type": "string",
+          "enum": ["info", "debug"]
+        },
         "defaultAppDomainName": {
           "description": "Base domain name for application URLs.",
           "type": "string"
@@ -40,7 +45,8 @@
       "required": [
         "rootNamespace",
         "containerRepositoryPrefix",
-        "defaultAppDomainName"
+        "defaultAppDomainName",
+        "logLevel"
       ],
       "type": "object"
     },

--- a/helm/korifi/values.yaml
+++ b/helm/korifi/values.yaml
@@ -1,7 +1,8 @@
 global:
   rootNamespace: cf
   debug: false
-  defaultAppDomainName: apps.my-cf-domain.com
+  logLevel: info
+  defaultAppDomainName:
   generateIngressCertificates: false
   containerRegistrySecret: image-registry-credentials
   eksContainerRegistryRoleARN: ""

--- a/scripts/assets/values-template.yaml
+++ b/scripts/assets/values-template.yaml
@@ -4,6 +4,7 @@ global:
   defaultAppDomainName: apps-127-0-0-1.nip.io
   generateIngressCertificates: true
   containerRepositoryPrefix: localregistry-docker-registry.default.svc.cluster.local:30050/
+  logLevel: debug
 
 api:
   apiServer:


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
LogLevel was introduced into the helm configmaps without exposing it correctly in the values.yaml and values schema. This PR makes those changes, restricts the valid values to 'info' and 'debug', and updates the docs.

## Does this PR introduce a breaking change?
No
