### PR TITLE
Add the crds test suite to test CRD-based workflows

### DIFF
--- a/tests/crds/README.md
+++ b/tests/crds/README.md
@@ -1,0 +1,22 @@
+# Kubernetes CRD tests
+
+These tests run a "smoke test" of the Korifi system, driven exclusively by the kubernetes API (via our Custom Resources).
+
+## Prerequisites
+
+Before running these tests, you must be targeting a kubernetes cluster that has korifi installed. This can be done via
+the default kubeconfig or by setting the `KUBECONFIG` environment variable. Your currently selected context must be for
+a user that has the ability to get/list namespaces and to get/list/create/update/patch/delete all korifi
+Custom Resources (e.g. CFOrg, CFSpace).
+
+For local testing against a kind cluster, you can simply run the `scripts/deploy-on-kind.sh` script to bring up an
+environment and then follow the instructions below to run the tests.
+
+## Running the tests
+
+Simply run `ginkgo` from this directory or run `ginkgo ./tests/crds` from the project root. 
+
+## Configuration
+
+If your deployment uses a non-standard root namespace (default is `cf`), then you must set the `ROOT_NAMESPACE`
+environment variable when running the tests.

--- a/tests/crds/crds_suite_test.go
+++ b/tests/crds/crds_suite_test.go
@@ -1,0 +1,48 @@
+package crds_test
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+)
+
+func TestCrds(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CRDs Suite")
+}
+
+var rootNamespace string
+
+var _ = BeforeSuite(func() {
+	var ok bool
+	rootNamespace, ok = os.LookupEnv("ROOT_NAMESPACE")
+	if !ok {
+		rootNamespace = "cf"
+	}
+
+	expectCommandToSucceed(kubectl("get", "namespace/"+rootNamespace),
+		"Could not find root namespace called %q", rootNamespace)
+})
+
+func kubectl(words ...string) *exec.Cmd {
+	return exec.Command("kubectl", words...)
+}
+
+func writeToStdIn(cmd *exec.Cmd, stdinText string, sprintfArgs ...any) {
+	stdin, err := cmd.StdinPipe()
+	Expect(err).NotTo(HaveOccurred())
+	_, err = stdin.Write([]byte(fmt.Sprintf(stdinText, sprintfArgs...)))
+	Expect(err).NotTo(HaveOccurred())
+	stdin.Close()
+}
+
+func expectCommandToSucceed(cmd *exec.Cmd, optionalDescription ...any) {
+	session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+	Expect(err).NotTo(HaveOccurred())
+	Eventually(session, "10s").Should(gexec.Exit(0), optionalDescription...)
+}

--- a/tests/crds/crds_test.go
+++ b/tests/crds/crds_test.go
@@ -1,0 +1,42 @@
+package crds_test
+
+import (
+	. "code.cloudfoundry.org/korifi/controllers/controllers/workloads/testutils"
+
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("Using the k8s API directly", Ordered, func() {
+	var (
+		orgName        string
+		orgDisplayName string
+	)
+
+	BeforeAll(func() {
+		orgName = PrefixedGUID("org")
+		orgDisplayName = PrefixedGUID("Org")
+	})
+
+	AfterAll(func() {
+		expectCommandToSucceed(kubectl("delete", "--ignore-not-found=true", "-n="+rootNamespace, "cforg/"+orgName))
+	})
+
+	It("creates a CFOrg (and its namespace)", func() {
+		kubectlApply := kubectl("apply", "-f=-")
+		writeToStdIn(kubectlApply, `---
+            apiVersion: korifi.cloudfoundry.org/v1alpha1
+            kind: CFOrg
+            metadata:
+                namespace: %s
+                name: %s
+            spec:
+                displayName: %s
+        `,
+			rootNamespace, orgName, orgDisplayName,
+		)
+		expectCommandToSucceed(kubectlApply)
+
+		expectCommandToSucceed(kubectl("wait", "--for=condition=ready", "-n="+rootNamespace, "cforg/"+orgName))
+		expectCommandToSucceed(kubectl("get", "namespace/"+orgName))
+	})
+})


### PR DESCRIPTION

<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ --> #1566

## What is this change about?
<!-- _Please describe the change here._ --> This PR adds a new test suite that uses the kubernetes API to drive korifi (via kubectl). For now it only tests org creation.

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ --> No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ --> Run the new tests locally against a kind cluster and verify that they pass

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ --> @clintyoshimura @tcdowney 

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
