### PR TITLE
Set ServiceBinding .spec.name to the CFServiceBinding's displayName

### DIFF
--- a/controllers/controllers/services/cfservicebinding_controller.go
+++ b/controllers/controllers/services/cfservicebinding_controller.go
@@ -185,8 +185,14 @@ func generateDesiredServiceBinding(actualServiceBinding *servicebindingv1beta1.S
 			UID:        cfServiceBinding.UID,
 		},
 	}
+
+	bindingName := secret.Name
+	if cfServiceBinding.Spec.DisplayName != nil {
+		bindingName = *cfServiceBinding.Spec.DisplayName
+	}
+
 	desiredServiceBinding.Spec = servicebindingv1beta1.ServiceBindingSpec{
-		Name: secret.Name,
+		Name: bindingName,
 		Type: "user-provided",
 		Workload: servicebindingv1beta1.ServiceBindingWorkloadReference{
 			APIVersion: "apps/v1",

--- a/controllers/controllers/services/cfservicebinding_controller_test.go
+++ b/controllers/controllers/services/cfservicebinding_controller_test.go
@@ -184,6 +184,46 @@ var _ = Describe("CFServiceBinding", func() {
 		}).Should(Succeed())
 	})
 
+	When("the CFServiceBinding has a displayName set", func() {
+		var (
+			bindingName string
+		)
+
+		BeforeEach(func() {
+			cfServiceBindingGUID = GenerateGUID()
+			bindingName = "a-custom-binding-name"
+			cfServiceBinding = &korifiv1alpha1.CFServiceBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      cfServiceBindingGUID,
+					Namespace: namespace.Name,
+				},
+				Spec: korifiv1alpha1.CFServiceBindingSpec{
+					DisplayName: &bindingName,
+					Service: corev1.ObjectReference{
+						Kind:       "ServiceInstance",
+						Name:       cfServiceInstance.Name,
+						APIVersion: "korifi.cloudfoundry.org/v1alpha1",
+					},
+					AppRef: corev1.LocalObjectReference{
+						Name: cfAppGUID,
+					},
+				},
+			}
+		})
+
+		It("sets the displayName as the name on the servicebinding.io ServiceBinding", func() {
+			Eventually(func(g Gomega) {
+				sbServiceBinding := servicebindingv1beta1.ServiceBinding{}
+				g.Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: fmt.Sprintf("cf-binding-%s", cfServiceBindingGUID), Namespace: namespace.Name}, &sbServiceBinding)).To(Succeed())
+				g.Expect(sbServiceBinding).To(MatchFields(IgnoreExtras, Fields{
+					"Spec": MatchFields(IgnoreExtras, Fields{
+						"Name": Equal(bindingName),
+					}),
+				}))
+			}).Should(Succeed())
+		})
+	})
+
 	When("the referenced secret does not exist", func() {
 		var otherSecret *corev1.Secret
 

--- a/tests/e2e/assets/golang/main.go
+++ b/tests/e2e/assets/golang/main.go
@@ -25,9 +25,34 @@ func helloWorldHandler(res http.ResponseWriter, req *http.Request) {
 
 func serviceBindingRootHandler(res http.ResponseWriter, req *http.Request) {
 	serviceBindingRoot := os.Getenv(ServiceBindingRootEnv)
-	if serviceBindingRoot != "" {
-		fmt.Fprintln(res, serviceBindingRoot)
+	if serviceBindingRoot == "" {
+		fmt.Fprintln(res, "$SERVICE_BINDING_ROOT is empty")
+		return
 	}
+
+	fmt.Fprintln(res, serviceBindingRoot)
+	dirs, err := os.ReadDir(serviceBindingRoot)
+	if err != nil {
+		http.Error(res, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	for _, dir := range dirs {
+		dirPath := filepath.Join(serviceBindingRoot, dir.Name())
+		fmt.Fprintln(res, dirPath)
+
+		files, err := os.ReadDir(dirPath)
+		if err != nil {
+			http.Error(res, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		for _, file := range files {
+			filePath := filepath.Join(dirPath, file.Name())
+			fmt.Fprintln(res, filePath)
+		}
+	}
+
 	return
 }
 

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -649,22 +649,24 @@ func listServiceInstances(names ...string) resourceList[serviceInstanceResource]
 	return serviceInstances
 }
 
-func createServiceBinding(appGUID, instanceGUID string) string {
-	var pkg resource
+func createServiceBinding(appGUID, instanceGUID, bindingName string) string {
+	var serviceCredentialBinding resource
+
 	resp, err := adminClient.R().
 		SetBody(typedResource{
 			Type: "app",
 			resource: resource{
+				Name:          bindingName,
 				Relationships: relationships{"app": {Data: resource{GUID: appGUID}}, "service_instance": {Data: resource{GUID: instanceGUID}}},
 			},
 		}).
-		SetResult(&pkg).
+		SetResult(&serviceCredentialBinding).
 		Post("/v3/service_credential_bindings")
 
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
-	ExpectWithOffset(1, resp.StatusCode()).To(Equal(http.StatusCreated))
+	ExpectWithOffset(1, resp.StatusCode()).To(Equal(http.StatusCreated), string(resp.Body()))
 
-	return pkg.GUID
+	return serviceCredentialBinding.GUID
 }
 
 func createPackage(appGUID string) string {

--- a/tests/e2e/service_bindings_test.go
+++ b/tests/e2e/service_bindings_test.go
@@ -69,7 +69,7 @@ var _ = Describe("Service Bindings", func() {
 
 			When("the user attempts to create a duplicate service binding", func() {
 				BeforeEach(func() {
-					_ = createServiceBinding(appGUID, instanceGUID)
+					_ = createServiceBinding(appGUID, instanceGUID, "")
 				})
 
 				It("returns an error", func() {
@@ -85,7 +85,7 @@ var _ = Describe("Service Bindings", func() {
 
 		BeforeEach(func() {
 			createSpaceRole("space_developer", certUserName, spaceGUID)
-			bindingGUID = createServiceBinding(appGUID, instanceGUID)
+			bindingGUID = createServiceBinding(appGUID, instanceGUID, "")
 		})
 
 		JustBeforeEach(func() {
@@ -102,7 +102,7 @@ var _ = Describe("Service Bindings", func() {
 
 	Describe("DELETE /v3/service_credential_bindings/{guid}", func() {
 		BeforeEach(func() {
-			bindingGUID = createServiceBinding(appGUID, instanceGUID)
+			bindingGUID = createServiceBinding(appGUID, instanceGUID, "")
 		})
 
 		JustBeforeEach(func() {
@@ -144,7 +144,7 @@ var _ = Describe("Service Bindings", func() {
 		)
 
 		BeforeEach(func() {
-			bindingGUID = createServiceBinding(appGUID, instanceGUID)
+			bindingGUID = createServiceBinding(appGUID, instanceGUID, "")
 
 			queryString = ""
 			result = resourceListWithInclusion{}
@@ -213,7 +213,7 @@ var _ = Describe("Service Bindings", func() {
 		var respResource responseResource
 
 		BeforeEach(func() {
-			bindingGUID = createServiceBinding(appGUID, instanceGUID)
+			bindingGUID = createServiceBinding(appGUID, instanceGUID, "")
 			createSpaceRole("space_developer", certUserName, spaceGUID)
 		})
 


### PR DESCRIPTION
## Is there a related GitHub Issue?
Issue: https://github.com/cloudfoundry/korifi/issues/2285

## What is this change about?
Some service binding libraries (such as the Oauth2 connector in Spring Cloud Bindings) use a Service Binding's name as a configuration value. This does not always place nicely with the Service Instance GUID that Korifi currently sets for the Service Binding's name.

This change allows users to override the `.spec.name` property of a Service Binding during binding creation using the `cf bind-service --binding-name` parameter. If `--binding-name` is omitted then the ServiceBinding continues to use the Service Instance GUID as its name.

## Does this PR introduce a breaking change?
No, it should only impact new service bindings.

## Acceptance Steps
1. Push the golang test app (`tests/e2e/assets/golang`): `cf push test-app`
2. Create an UPSI: `cf cups my-upsi -p '{"secret": "credential"}'`
3. Bind the service and specify a name: `cf bind-service test-app my-upsi --binding-name my-custom-binding`
4. curl the `/servicebindings` or `/servicebindingroot` endpoint to see that the binding name is reflected in the app container

## Tag your pair, your PM, and/or team
@akrishna90 since this builds on those service binding tests you added :) 