### PR TITLE
Prevent k8s admin from creating orgs

### DIFF
--- a/api/authorization/namespace_permissions.go
+++ b/api/authorization/namespace_permissions.go
@@ -119,15 +119,15 @@ func (o *NamespacePermissions) hasRole(ctx context.Context, info Info, namespace
 	return false, nil
 }
 
-func (o *NamespacePermissions) AuthorizedCreateOrg(ctx context.Context, info Info) (bool, error) {
-	hasRole, err := o.hasRole(ctx, info, types.NamespacedName{Namespace: "cf", Name: "default-admin-binding"})
+func (o *NamespacePermissions) AuthorizedCreateOrg(ctx context.Context, info Info, namespace string) (bool, error) {
+	hasRole, err := o.hasRole(ctx, info, types.NamespacedName{Namespace: namespace, Name: "default-admin-binding"})
 	if hasRole {
 		return true, err
 	}
 	if k8serrors.IsNotFound(err) {
 		return false, nil
 	}
-	hasRole, err = o.hasRole(ctx, info, types.NamespacedName{Namespace: "cf", Name: "korifi-controllers-organization-manager"})
+	hasRole, err = o.hasRole(ctx, info, types.NamespacedName{Namespace: namespace, Name: "korifi-controllers-organization-manager"})
 	if hasRole {
 		return true, err
 	}

--- a/api/errors/errors.go
+++ b/api/errors/errors.go
@@ -314,6 +314,22 @@ func NewResourceNotReadyError(cause error) ResourceNotReadyError {
 	}
 }
 
+type MissingRoleError struct {
+	apiError
+}
+
+func NewMissingRoleError(cause error) MissingRoleError {
+	return MissingRoleError{
+		apiError: apiError{
+			cause:      cause,
+			title:      "CF-MissingRole",
+			detail:     cause.Error(),
+			code:       420000,
+			httpStatus: http.StatusForbidden,
+		},
+	}
+}
+
 func FromK8sError(err error, resourceType string) error {
 	if webhookValidationError, ok := webhooks.WebhookErrorToValidationError(err); ok {
 		return NewUnprocessableEntityError(err, webhookValidationError.GetMessage())

--- a/api/repositories/org_repository.go
+++ b/api/repositories/org_repository.go
@@ -78,7 +78,7 @@ func NewOrgRepo(
 }
 
 func (r *OrgRepo) CreateOrg(ctx context.Context, info authorization.Info, message CreateOrgMessage) (OrgRecord, error) {
-	canCreate, err := r.nsPerms.AuthorizedCreateOrg(ctx, info)
+	canCreate, err := r.nsPerms.AuthorizedCreateOrg(ctx, info, r.rootNamespace)
 	if err != nil {
 		return OrgRecord{}, err
 	}

--- a/api/repositories/org_repository.go
+++ b/api/repositories/org_repository.go
@@ -78,6 +78,14 @@ func NewOrgRepo(
 }
 
 func (r *OrgRepo) CreateOrg(ctx context.Context, info authorization.Info, message CreateOrgMessage) (OrgRecord, error) {
+	canCreate, err := r.nsPerms.AuthorizedCreateOrg(ctx, info)
+	if err != nil {
+		return OrgRecord{}, err
+	}
+	if !canCreate {
+		return OrgRecord{}, apierrors.NewMissingRoleError(errors.New("No provided roles allow creation of Orgs"))
+	}
+
 	userClient, err := r.userClientFactory.BuildClient(info)
 	if err != nil {
 		return OrgRecord{}, fmt.Errorf("failed to build user client: %w", err)

--- a/helm/korifi/api/role.yaml
+++ b/helm/korifi/api/role.yaml
@@ -47,6 +47,7 @@ rules:
     resources:
       - rolebindings
     verbs:
+      - get
       - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## Is there a related GitHub Issue?
No.

## What is this change about?
The Kubernetes admin can create orgs, but not fetch them, no do anything further. The Kubernetes admin should not be able to create orgs via the CF api.

## Does this PR introduce a breaking change?
This fixes unintended functionality. No breaking changes are included from intended functionality.

## Acceptance Steps
Create a Kind cluster and log in with the CF CLI as 'kind-kind'. Try to create an org `cf create-org my-org`. Notice that an error `No provided roles allow creation of Orgs` is returned.

## Tag your pair, your PM, and/or team
@davewalter @tcdowney 
