### PR TITLE
whoami endpoint returns full serviceaccount IDs

### DIFF
--- a/api/authorization/token_reviewer.go
+++ b/api/authorization/token_reviewer.go
@@ -55,8 +55,6 @@ func (r *TokenReviewer) WhoAmI(ctx context.Context, token string) (Identity, err
 		if !strings.HasPrefix(idName, serviceAccountNamePrefix) {
 			return Identity{}, fmt.Errorf("invalid serviceaccount name: %q", idName)
 		}
-		nameSegments := strings.Split(idName, ":")
-		idName = nameSegments[len(nameSegments)-1]
 	}
 
 	return Identity{

--- a/api/authorization/token_reviewer_test.go
+++ b/api/authorization/token_reviewer_test.go
@@ -42,10 +42,11 @@ var _ = Describe("TokenReviewer", func() {
 
 	When("the token is issued for a serviceaccount", func() {
 		BeforeEach(func() {
-			restartEnvTest(authProvider.APIServerExtraArgs("system:serviceaccount:"))
+			restartEnvTest(authProvider.APIServerExtraArgs("system:serviceaccount:cf:"))
 			token = authProvider.GenerateJWTToken(
 				"my-serviceaccount",
 				"system:serviceaccounts",
+				"system:serviceaccounts:cf",
 			)
 			tokenReviewer = authorization.NewTokenReviewer(k8sClient)
 		})
@@ -56,7 +57,7 @@ var _ = Describe("TokenReviewer", func() {
 
 		It("extracts the identity of the serviceaccount", func() {
 			Expect(id.Kind).To(Equal(rbacv1.ServiceAccountKind))
-			Expect(id.Name).To(Equal("my-serviceaccount"))
+			Expect(id.Name).To(Equal("system:serviceaccount:cf:my-serviceaccount"))
 		})
 	})
 

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -938,7 +938,7 @@ func getAppBitsFileFromPath(sharedSetup sharedSetupData) string {
 func commonTestSetup() {
 	apiServerRoot = mustHaveEnv("API_SERVER_ROOT")
 	rootNamespace = mustHaveEnv("ROOT_NAMESPACE")
-	serviceAccountName = mustHaveEnv("E2E_SERVICE_ACCOUNT")
+	serviceAccountName = fmt.Sprintf("system:serviceaccount:%s:%s", rootNamespace, mustHaveEnv("E2E_SERVICE_ACCOUNT"))
 	serviceAccountToken = mustHaveEnv("E2E_SERVICE_ACCOUNT_TOKEN")
 
 	certUserName = mustHaveEnv("E2E_USER_NAME")


### PR DESCRIPTION
## Is there a related GitHub Issue?
#2280 

## What is this change about?
The `/whoami` endpoint returns the full ID from Service Account tokens.

## Does this PR introduce a breaking change?
No.

## Acceptance Steps
1. Create a Service Account (and Secret for k8s v1.24+)
2. Extract kubeconfig for SA.
3. Run `cf target` and verify that it is of the form `system:serviceaccount:<namespace>:<name>` (e.g. `system:serviceaccount:cf:my-serviceaccount`)

## Tag your pair, your PM, and/or team
@akrishna90 
