### PR TITLE
Allow setting roles for service accounts

### DIFF
--- a/api/handlers/role_test.go
+++ b/api/handlers/role_test.go
@@ -314,9 +314,9 @@ var _ = Describe("Role", func() {
 				createRoleRequestBody = `{
 					"type": "organization_manager",
 					"relationships": {
-						"kubernetesServiceAccount": {
+						"User": {
 							"data": {
-								"guid": "my-user"
+								"guid": "system:serviceaccount:cf:my-user"
 							}
 						},
 						"organization": {
@@ -335,11 +335,12 @@ var _ = Describe("Role", func() {
 				Expect(roleRecord.Type).To(Equal("organization_manager"))
 				Expect(roleRecord.Org).To(Equal("my-org"))
 				Expect(roleRecord.User).To(Equal("my-user"))
+				Expect(roleRecord.ServiceAccountNamespace).To(Equal("cf"))
 				Expect(roleRecord.Kind).To(Equal(rbacv1.ServiceAccountKind))
 			})
 		})
 
-		When("the role does not contain a user or service account", func() {
+		When("the role does not contain a user", func() {
 			BeforeEach(func() {
 				createRoleRequestBody = `{
 					"type": "organization_manager",
@@ -357,8 +358,7 @@ var _ = Describe("Role", func() {
 				Expect(rr).To(HaveHTTPStatus(http.StatusUnprocessableEntity))
 				Expect(rr).To(HaveHTTPHeaderWithValue("Content-Type", "application/json"))
 				Expect(rr).To(HaveHTTPBody(SatisfyAll(
-					ContainSubstring("Field validation for 'User' failed on the 'required_without' tag"),
-					ContainSubstring("Field validation for 'KubernetesServiceAccount' failed on the 'required_without' tag"),
+					ContainSubstring("User is a required field"),
 				)))
 			})
 		})

--- a/api/payloads/role_test.go
+++ b/api/payloads/role_test.go
@@ -1,0 +1,89 @@
+package payloads_test
+
+import (
+	"bytes"
+	"encoding/json"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"net/http"
+
+	"code.cloudfoundry.org/korifi/api/payloads"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+)
+
+var _ = Describe("RoleCreate", func() {
+	var (
+		createPayload payloads.RoleCreate
+		roleCreate    *payloads.RoleCreate
+		validatorErr  error
+	)
+
+	BeforeEach(func() {
+		roleCreate = new(payloads.RoleCreate)
+		createPayload = payloads.RoleCreate{
+			Type: "space_manager",
+			Relationships: payloads.RoleRelationships{
+				User: &payloads.UserRelationship{
+					Data: payloads.UserRelationshipData{
+						Username: "cf-service-account",
+					},
+				},
+				Space: &payloads.Relationship{
+					Data: &payloads.RelationshipData{
+						GUID: "cf-space-guid",
+					},
+				},
+			},
+		}
+	})
+
+	JustBeforeEach(func() {
+		body, err := json.Marshal(createPayload)
+		Expect(err).NotTo(HaveOccurred())
+
+		req, err := http.NewRequest("", "", bytes.NewReader(body))
+		Expect(err).NotTo(HaveOccurred())
+
+		validatorErr = validator.DecodeAndValidateJSONPayload(req, roleCreate)
+	})
+
+	It("succeeds", func() {
+		Expect(validatorErr).NotTo(HaveOccurred())
+		Expect(roleCreate).To(PointTo(Equal(createPayload)))
+	})
+
+	Context("ToMessage()", func() {
+		It("converts to repo message correctly", func() {
+			msg := roleCreate.ToMessage()
+			Expect(msg.Type).To(Equal("space_manager"))
+			Expect(msg.Space).To(Equal("cf-space-guid"))
+			Expect(msg.User).To(Equal("cf-service-account"))
+			Expect(msg.Kind).To(Equal(rbacv1.UserKind))
+		})
+	})
+
+	When("the service account name is provided", func() {
+		BeforeEach(func() {
+			createPayload.Relationships.User.Data.Username = "system:serviceaccount:cf-space-guid:cf-service-account"
+		})
+
+		It("succeeds", func() {
+			Expect(validatorErr).NotTo(HaveOccurred())
+			Expect(roleCreate).To(PointTo(Equal(createPayload)))
+		})
+
+		Context("ToMessage()", func() {
+			It("converts to repo message correctly", func() {
+				msg := roleCreate.ToMessage()
+				Expect(msg.Type).To(Equal("space_manager"))
+				Expect(msg.Space).To(Equal("cf-space-guid"))
+				Expect(msg.User).To(Equal("cf-service-account"))
+				Expect(msg.Kind).To(Equal(rbacv1.ServiceAccountKind))
+				Expect(msg.ServiceAccountNamespace).To(Equal("cf-space-guid"))
+			})
+		})
+
+	})
+})

--- a/helm/korifi/controllers/cf_roles/cf_org_manager.yaml
+++ b/helm/korifi/controllers/cf_roles/cf_org_manager.yaml
@@ -12,16 +12,23 @@ rules:
   - get
   - list
   - watch
-
 - apiGroups:
-    - korifi.cloudfoundry.org
+  - korifi.cloudfoundry.org
   resources:
-    - builderinfos
+  - cfspaces
   verbs:
-    - get
-    - list
-    - watch
-
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - builderinfos
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:


### PR DESCRIPTION

## Is there a related GitHub Issue?
[#2279]

## What is this change about?
Allow setting roles for service accounts
- usernames of the form `system:serviceaccount:<namespace>:<name>` will be considered as service account type
- updated POST `/v3/roles` endpoint to create `Rolebindings` with subject as `Kind:ServiceAcccount` if username matches the above pattern
- updated GET `/v3/role`s endpoint to return user as `system:serviceaccount:<namespace>:<name>` if users are service accounts.

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->
No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->
See issue #2279 

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->
@Birdrock 

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
