### PR TITLE
Improve app manifest api validation

### DIFF
--- a/api/payloads/manifest.go
+++ b/api/payloads/manifest.go
@@ -1,64 +1,70 @@
 package payloads
 
 import (
+	"errors"
+	"regexp"
+
 	"code.cloudfoundry.org/korifi/api/repositories"
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"code.cloudfoundry.org/korifi/tools"
+	"github.com/jellydator/validation"
 
 	"code.cloudfoundry.org/bytefmt"
 )
 
 type Manifest struct {
 	Version      int                   `yaml:"version"`
-	Applications []ManifestApplication `yaml:"applications" validate:"dive"`
+	Applications []ManifestApplication `json:"applications" yaml:"applications"`
 }
 
 type ManifestApplication struct {
-	Name         string            `yaml:"name" validate:"required"`
+	Name         string            `json:"name" yaml:"name"`
 	Env          map[string]string `yaml:"env"`
-	DefaultRoute bool              `yaml:"default-route"`
+	DefaultRoute bool              `json:"default-route" yaml:"default-route"`
 	RandomRoute  bool              `yaml:"random-route"`
 	NoRoute      bool              `yaml:"no-route"`
 	Command      *string           `yaml:"command"`
-	Instances    *int              `yaml:"instances" validate:"omitempty,gte=0"`
-	Memory       *string           `yaml:"memory" validate:"amountWithUnit,positiveAmountWithUnit"`
-	DiskQuota    *string           `yaml:"disk_quota" validate:"amountWithUnit,positiveAmountWithUnit"`
+	Instances    *int              `json:"instances" yaml:"instances"`
+	Memory       *string           `json:"memory" yaml:"memory"`
+	DiskQuota    *string           `json:"disk_quota" yaml:"disk_quota"`
 	// AltDiskQuota supports `disk-quota` with a hyphen for backwards compatibility.
 	// Do not set both DiskQuota and AltDiskQuota.
 	//
 	// Deprecated: Use DiskQuota instead
-	AltDiskQuota                 *string                      `yaml:"disk-quota" validate:"amountWithUnit,positiveAmountWithUnit"`
+	AltDiskQuota                 *string                      `json:"disk-quota" yaml:"disk-quota"`
 	HealthCheckHTTPEndpoint      *string                      `yaml:"health-check-http-endpoint"`
-	HealthCheckInvocationTimeout *int64                       `yaml:"health-check-invocation-timeout" validate:"omitempty,gte=1"`
-	HealthCheckType              *string                      `yaml:"health-check-type" validate:"omitempty,oneof=none process port http"`
-	Timeout                      *int64                       `yaml:"timeout" validate:"omitempty,gte=1"`
-	Processes                    []ManifestApplicationProcess `yaml:"processes" validate:"dive"`
-	Routes                       []ManifestRoute              `yaml:"routes" validate:"dive"`
+	HealthCheckInvocationTimeout *int64                       `json:"health-check-invocation-timeout" yaml:"health-check-invocation-timeout"`
+	HealthCheckType              *string                      `json:"health-check-type" yaml:"health-check-type"`
+	Timeout                      *int64                       `json:"timeout" yaml:"timeout"`
+	Processes                    []ManifestApplicationProcess `json:"processes" yaml:"processes"`
+	Routes                       []ManifestRoute              `json:"routes" yaml:"routes"`
 	Buildpacks                   []string                     `yaml:"buildpacks"`
 	// Deprecated: Use Buildpacks instead
 	Buildpack string        `yaml:"buildpack"`
 	Metadata  MetadataPatch `yaml:"metadata"`
 }
 
+// TODO: Why is kebab-case used everywhere anyway and we have a deprecated field that claims to use
+// it for backwards compatibility?
 type ManifestApplicationProcess struct {
-	Type      string  `yaml:"type" validate:"required"`
+	Type      string  `json:"type" yaml:"type"`
 	Command   *string `yaml:"command"`
-	DiskQuota *string `yaml:"disk_quota" validate:"amountWithUnit,positiveAmountWithUnit"`
+	DiskQuota *string `json:"disk_quota" yaml:"disk_quota"`
 	// AltDiskQuota supports `disk-quota` with a hyphen for backwards compatibility.
 	// Do not set both DiskQuota and AltDiskQuota.
 	//
 	// Deprecated: Use DiskQuota instead
-	AltDiskQuota                 *string `yaml:"disk-quota" validate:"amountWithUnit,positiveAmountWithUnit"`
+	AltDiskQuota                 *string `json:"disk-quota" yaml:"disk-quota"`
 	HealthCheckHTTPEndpoint      *string `yaml:"health-check-http-endpoint"`
-	HealthCheckInvocationTimeout *int64  `yaml:"health-check-invocation-timeout" validate:"omitempty,gte=1"`
-	HealthCheckType              *string `yaml:"health-check-type" validate:"omitempty,oneof=none process port http"`
-	Instances                    *int    `yaml:"instances" validate:"omitempty,gte=0"`
-	Memory                       *string `yaml:"memory" validate:"amountWithUnit,positiveAmountWithUnit"`
-	Timeout                      *int64  `yaml:"timeout" validate:"omitempty,gte=1"`
+	HealthCheckInvocationTimeout *int64  `json:"health-check-invocation-timeout" yaml:"health-check-invocation-timeout"`
+	HealthCheckType              *string `json:"health-check-type" yaml:"health-check-type"`
+	Instances                    *int    `json:"instances" yaml:"instances"`
+	Memory                       *string `json:"memory" yaml:"memory"`
+	Timeout                      *int64  `json:"timeout" yaml:"timeout"`
 }
 
 type ManifestRoute struct {
-	Route *string `yaml:"route" validate:"route"`
+	Route *string `json:"route" yaml:"route"`
 }
 
 func (a ManifestApplication) ToAppCreateMessage(spaceGUID string) repositories.CreateAppMessage {
@@ -176,4 +182,70 @@ func (p ManifestApplicationProcess) ToProcessPatchMessage(processGUID, spaceGUID
 		message.MemoryMB = &int64MMB
 	}
 	return message
+}
+
+func (m Manifest) Validate() error {
+	return validation.ValidateStruct(&m,
+		validation.Field(&m.Applications))
+}
+
+func (a ManifestApplication) Validate() error {
+	return validation.ValidateStruct(&a,
+		validation.Field(&a.Name, validation.Required),
+		validation.Field(&a.DefaultRoute, validation.When(a.RandomRoute, validation.Nil.Error("and random-route may not be used together"))),
+		validation.Field(&a.DiskQuota, validation.By(validateAmountWithUnit), validation.When(a.AltDiskQuota != nil, validation.Nil.Error("and disk-quota may not be used together"))),
+		validation.Field(&a.AltDiskQuota, validation.By(validateAmountWithUnit)),
+		validation.Field(&a.Instances, validation.Min(0)),
+		validation.Field(&a.HealthCheckInvocationTimeout, validation.Min(1), validation.NilOrNotEmpty.Error("must be no less than 1")),
+		validation.Field(&a.HealthCheckType, validation.In("none", "process", "port", "http")),
+		validation.Field(&a.Memory, validation.By(validateAmountWithUnit)),
+		validation.Field(&a.Timeout, validation.Min(1), validation.NilOrNotEmpty.Error("must be no less than 1")),
+		validation.Field(&a.Processes),
+		validation.Field(&a.Routes),
+	)
+}
+
+func (p ManifestApplicationProcess) Validate() error {
+	return validation.ValidateStruct(&p,
+		validation.Field(&p.Type, validation.Required),
+		validation.Field(&p.DiskQuota, validation.By(validateAmountWithUnit), validation.When(p.AltDiskQuota != nil, validation.Nil.Error("and disk-quota may not be used together"))),
+		validation.Field(&p.AltDiskQuota, validation.By(validateAmountWithUnit)),
+		validation.Field(&p.HealthCheckInvocationTimeout, validation.Min(1), validation.NilOrNotEmpty.Error("must be no less than 1")),
+		validation.Field(&p.HealthCheckType, validation.In("none", "process", "port", "http")),
+		validation.Field(&p.Instances, validation.Min(0)),
+		validation.Field(&p.Memory, validation.By(validateAmountWithUnit)),
+		validation.Field(&p.Timeout, validation.Min(1), validation.NilOrNotEmpty.Error("must be no less than 1")),
+	)
+}
+
+func (m ManifestRoute) Validate() error {
+	routeRegex := regexp.MustCompile(
+		`^(?:https?://|tcp://)?(?:(?:[\w-]+\.)|(?:[*]\.))+\w+(?:\:\d+)?(?:/.*)*(?:\.\w+)?$`,
+	)
+	return validation.ValidateStruct(&m,
+		validation.Field(&m.Route, validation.Match(routeRegex).Error("is not a valid route")))
+}
+
+var unitAmount = regexp.MustCompile(`^\d+(?:B|K|KB|M|MB|G|GB|T|TB)$`)
+
+func validateAmountWithUnit(value any) error {
+	v, isNil := validation.Indirect(value)
+	if isNil {
+		return nil
+	}
+
+	if !unitAmount.MatchString(v.(string)) {
+		return errors.New("must use a supported unit (B, K, KB, M, MB, G, GB, T, or TB)")
+	}
+
+	mbs, err := bytefmt.ToMegabytes(v.(string))
+	if err != nil {
+		return err
+	}
+
+	if mbs <= 0 {
+		return errors.New("must be greater than 0MB")
+	}
+
+	return nil
 }

--- a/api/payloads/manifest_test.go
+++ b/api/payloads/manifest_test.go
@@ -4,66 +4,409 @@ import (
 	. "code.cloudfoundry.org/korifi/api/payloads"
 	"code.cloudfoundry.org/korifi/api/repositories"
 	"code.cloudfoundry.org/korifi/tools"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 )
 
-var _ = Describe("ManifestApplicationProcess", func() {
+var _ = Describe("Manifest payload", func() {
 	const spaceGUID = "the-space-guid"
 
-	Describe("ToProcessCreateMessage", func() {
-		const appGUID = "the-app-guid"
-		var processInfo ManifestApplicationProcess
-
-		When("all fields are specified", func() {
+	Describe("Manifest", func() {
+		Describe("Validate", func() {
+			var (
+				testSpaceManifest Manifest
+				validateErr       error
+			)
 			BeforeEach(func() {
-				processInfo = ManifestApplicationProcess{
-					Type:                         "web",
-					Command:                      tools.PtrTo("start-web.sh"),
-					DiskQuota:                    tools.PtrTo("512M"),
-					HealthCheckHTTPEndpoint:      tools.PtrTo("/stuff"),
-					HealthCheckInvocationTimeout: tools.PtrTo(int64(90)),
-					HealthCheckType:              tools.PtrTo("http"),
-					Instances:                    tools.PtrTo(3),
-					Memory:                       tools.PtrTo("1G"),
-					Timeout:                      tools.PtrTo(int64(60)),
+				testSpaceManifest = Manifest{Applications: []ManifestApplication{{
+					Name:         "test-app",
+					DefaultRoute: true,
+					Memory:       nil,
+					DiskQuota:    nil,
+					Metadata:     MetadataPatch{},
+				}},
+				}
+			})
+			JustBeforeEach(func() {
+				validateErr = testSpaceManifest.Validate()
+			})
+
+			It("validates the struct", func() {
+				Expect(validateErr).NotTo(HaveOccurred())
+			})
+
+			When("Name is empty", func() {
+				BeforeEach(func() {
+					testSpaceManifest.Applications[0].Memory = tools.PtrTo("badmemory")
+				})
+
+				It("returns a validation error", func() {
+					Expect(validateErr).To(MatchError("applications: (0: (memory: must use a supported unit (B, K, KB, M, MB, G, GB, T, or TB).).)."))
+				})
+			})
+		})
+	})
+
+	Describe("ManifestApplication", func() {
+		var (
+			testManifest ManifestApplication
+			validateErr  error
+		)
+
+		Describe("Validate", func() {
+			BeforeEach(func() {
+				testManifest = ManifestApplication{
+					Name:         "test-app",
+					DefaultRoute: true,
 				}
 			})
 
-			It("returns a CreateProcessMessage with those values", func() {
-				message := processInfo.ToProcessCreateMessage(appGUID, spaceGUID)
+			JustBeforeEach(func() {
+				validateErr = testManifest.Validate()
+			})
 
-				Expect(message).To(Equal(repositories.CreateProcessMessage{
-					AppGUID:     appGUID,
-					SpaceGUID:   spaceGUID,
-					Type:        "web",
-					Command:     "start-web.sh",
-					DiskQuotaMB: 512,
-					HealthCheck: repositories.HealthCheck{
-						Type: "http",
-						Data: repositories.HealthCheckData{
-							HTTPEndpoint:             "/stuff",
-							TimeoutSeconds:           60,
-							InvocationTimeoutSeconds: 90,
+			It("validates the struct", func() {
+				Expect(validateErr).NotTo(HaveOccurred())
+			})
+
+			When("Name is empty", func() {
+				BeforeEach(func() {
+					testManifest.Name = ""
+				})
+				It("returns a validation error", func() {
+					Expect(validateErr).To(MatchError("name: cannot be blank."))
+				})
+			})
+
+			When("Instances is negative", func() {
+				BeforeEach(func() {
+					testManifest.Instances = tools.PtrTo(-1)
+				})
+				It("returns a validation error", func() {
+					Expect(validateErr).To(MatchError("instances: must be no less than 0."))
+				})
+			})
+
+			When("the disk quota doesn't supply a unit", func() {
+				BeforeEach(func() {
+					testManifest.DiskQuota = tools.PtrTo("1024")
+				})
+
+				It("returns a validation error", func() {
+					Expect(validateErr).To(MatchError("disk_quota: must use a supported unit (B, K, KB, M, MB, G, GB, T, or TB)."))
+				})
+			})
+
+			When("the disk quota is not positive", func() {
+				BeforeEach(func() {
+					testManifest.DiskQuota = tools.PtrTo("0MB")
+				})
+
+				It("returns a validation error", func() {
+					Expect(validateErr).To(MatchError("disk_quota: must be greater than 0MB."))
+				})
+			})
+
+			When("the alt disk quota doesn't supply a unit", func() {
+				BeforeEach(func() {
+					testManifest.AltDiskQuota = tools.PtrTo("1024")
+				})
+
+				It("returns a validation error", func() {
+					Expect(validateErr).To(MatchError("disk-quota: must use a supported unit (B, K, KB, M, MB, G, GB, T, or TB)."))
+				})
+			})
+
+			When("the alt disk quota is not positive", func() {
+				BeforeEach(func() {
+					testManifest.AltDiskQuota = tools.PtrTo("0MB")
+				})
+
+				It("returns a validation error", func() {
+					Expect(validateErr).To(MatchError("disk-quota: must be greater than 0MB."))
+				})
+			})
+
+			When("HealthCheckInvocationTimeout is not positive", func() {
+				BeforeEach(func() {
+					testManifest.HealthCheckInvocationTimeout = tools.PtrTo(int64(0))
+				})
+				It("returns a validation error", func() {
+					Expect(validateErr).To(MatchError("health-check-invocation-timeout: must be no less than 1."))
+				})
+			})
+
+			When("HealthCheckType is invalid", func() {
+				BeforeEach(func() {
+					testManifest.HealthCheckType = tools.PtrTo("FakeHealthcheckType")
+				})
+				It("returns a validation error", func() {
+					Expect(validateErr).To(MatchError("health-check-type: must be a valid value."))
+				})
+			})
+
+			When("Timeout is not positive", func() {
+				BeforeEach(func() {
+					testManifest.Timeout = tools.PtrTo(int64(0))
+				})
+				It("returns a validation error", func() {
+					Expect(validateErr).To(MatchError("timeout: must be no less than 1."))
+				})
+			})
+
+			When("Memory units not valid", func() {
+				BeforeEach(func() {
+					testManifest.Memory = tools.PtrTo("5CUPS")
+				})
+				It("returns a validation error", func() {
+					Expect(validateErr).To(MatchError("memory: must use a supported unit (B, K, KB, M, MB, G, GB, T, or TB)."))
+				})
+			})
+
+			When("the memory is not positive", func() {
+				BeforeEach(func() {
+					testManifest.Memory = tools.PtrTo("0MB")
+				})
+
+				It("returns a validation error", func() {
+					Expect(validateErr).To(MatchError("memory: must be greater than 0MB."))
+				})
+			})
+		})
+	})
+
+	Describe("ManifestApplicationProcess", func() {
+		Describe("Validate", func() {
+			var (
+				testManifestProcess ManifestApplicationProcess
+				validateErr         error
+			)
+
+			BeforeEach(func() {
+				testManifestProcess = ManifestApplicationProcess{
+					Type: "some-type",
+				}
+			})
+
+			JustBeforeEach(func() {
+				validateErr = testManifestProcess.Validate()
+			})
+
+			It("Validates the struct", func() {
+				Expect(validateErr).NotTo(HaveOccurred())
+			})
+
+			When("the type is empty", func() {
+				BeforeEach(func() {
+					testManifestProcess.Type = ""
+				})
+
+				It("returns a validation error", func() {
+					Expect(validateErr).To(MatchError("type: cannot be blank."))
+				})
+			})
+
+			When("the disk quota doesn't supply a unit", func() {
+				BeforeEach(func() {
+					testManifestProcess.DiskQuota = tools.PtrTo("1024")
+				})
+
+				It("returns a validation error", func() {
+					Expect(validateErr).To(MatchError("disk_quota: must use a supported unit (B, K, KB, M, MB, G, GB, T, or TB)."))
+				})
+			})
+
+			When("the disk quota is not positive", func() {
+				BeforeEach(func() {
+					testManifestProcess.DiskQuota = tools.PtrTo("0MB")
+				})
+
+				It("returns a validation error", func() {
+					Expect(validateErr).To(MatchError("disk_quota: must be greater than 0MB."))
+				})
+			})
+
+			When("the alt disk quota doesn't supply a unit", func() {
+				BeforeEach(func() {
+					testManifestProcess.AltDiskQuota = tools.PtrTo("1024")
+				})
+
+				It("returns a validation error", func() {
+					Expect(validateErr).To(MatchError("disk-quota: must use a supported unit (B, K, KB, M, MB, G, GB, T, or TB)."))
+				})
+			})
+
+			When("the alt disk quota is not positive", func() {
+				BeforeEach(func() {
+					testManifestProcess.AltDiskQuota = tools.PtrTo("0MB")
+				})
+
+				It("returns a validation error", func() {
+					Expect(validateErr).To(MatchError("disk-quota: must be greater than 0MB."))
+				})
+			})
+
+			When("HealthCheckInvocationTimeout is not positive", func() {
+				BeforeEach(func() {
+					testManifestProcess.HealthCheckInvocationTimeout = tools.PtrTo(int64(0))
+				})
+				It("returns a validation error", func() {
+					Expect(validateErr).To(MatchError("health-check-invocation-timeout: must be no less than 1."))
+				})
+			})
+
+			When("HealthCheckType is invalid", func() {
+				BeforeEach(func() {
+					testManifestProcess.HealthCheckType = tools.PtrTo("FakeHealthcheckType")
+				})
+				It("returns a validation error", func() {
+					Expect(validateErr).To(MatchError("health-check-type: must be a valid value."))
+				})
+			})
+
+			When("Instances is negative", func() {
+				BeforeEach(func() {
+					testManifestProcess.Instances = tools.PtrTo(-1)
+				})
+				It("returns a validation error", func() {
+					Expect(validateErr).To(MatchError("instances: must be no less than 0."))
+				})
+			})
+
+			When("the memory doesn't supply a unit", func() {
+				BeforeEach(func() {
+					testManifestProcess.Memory = tools.PtrTo("1024")
+				})
+
+				It("returns a validation error", func() {
+					Expect(validateErr).To(MatchError("memory: must use a supported unit (B, K, KB, M, MB, G, GB, T, or TB)."))
+				})
+			})
+
+			When("the memory is not positive", func() {
+				BeforeEach(func() {
+					testManifestProcess.Memory = tools.PtrTo("0MB")
+				})
+
+				It("returns a validation error", func() {
+					Expect(validateErr).To(MatchError("memory: must be greater than 0MB."))
+				})
+			})
+
+			When("Timeout is not positive", func() {
+				BeforeEach(func() {
+					testManifestProcess.Timeout = tools.PtrTo(int64(0))
+				})
+
+				It("returns a validation error", func() {
+					Expect(validateErr).To(MatchError("timeout: must be no less than 1."))
+				})
+			})
+		})
+
+		Describe("ToProcessCreateMessage", func() {
+			const appGUID = "the-app-guid"
+			var processInfo ManifestApplicationProcess
+
+			When("all fields are specified", func() {
+				BeforeEach(func() {
+					processInfo = ManifestApplicationProcess{
+						Type:                         "web",
+						Command:                      tools.PtrTo("start-web.sh"),
+						DiskQuota:                    tools.PtrTo("512M"),
+						HealthCheckHTTPEndpoint:      tools.PtrTo("/stuff"),
+						HealthCheckInvocationTimeout: tools.PtrTo(int64(90)),
+						HealthCheckType:              tools.PtrTo("http"),
+						Instances:                    tools.PtrTo(3),
+						Memory:                       tools.PtrTo("1G"),
+						Timeout:                      tools.PtrTo(int64(60)),
+					}
+				})
+
+				It("returns a CreateProcessMessage with those values", func() {
+					message := processInfo.ToProcessCreateMessage(appGUID, spaceGUID)
+
+					Expect(message).To(Equal(repositories.CreateProcessMessage{
+						AppGUID:     appGUID,
+						SpaceGUID:   spaceGUID,
+						Type:        "web",
+						Command:     "start-web.sh",
+						DiskQuotaMB: 512,
+						HealthCheck: repositories.HealthCheck{
+							Type: "http",
+							Data: repositories.HealthCheckData{
+								HTTPEndpoint:             "/stuff",
+								TimeoutSeconds:           60,
+								InvocationTimeoutSeconds: 90,
+							},
 						},
-					},
-					DesiredInstances: tools.PtrTo(3),
-					MemoryMB:         1024,
-				}))
+						DesiredInstances: tools.PtrTo(3),
+						MemoryMB:         1024,
+					}))
+				})
+
+				Describe("HealthCheckType", func() {
+					When("HealthCheckType is 'none' (legacy alias for 'process')", func() {
+						const noneHealthCheckType = "none"
+
+						It("converts the type to 'process'", func() {
+							processInfo.HealthCheckType = tools.PtrTo(noneHealthCheckType)
+
+							message := processInfo.ToProcessCreateMessage(appGUID, spaceGUID)
+
+							Expect(message.HealthCheck.Type).To(Equal("process"))
+						})
+					})
+
+					When("HealthCheckType is specified as some other valid type", func() {
+						It("passes the type through to the message", func() {
+							processInfo.HealthCheckType = tools.PtrTo("port")
+
+							message := processInfo.ToProcessCreateMessage(appGUID, spaceGUID)
+
+							Expect(message.HealthCheck.Type).To(Equal("port"))
+						})
+					})
+				})
+			})
+
+			When("only type is specified", func() {
+				BeforeEach(func() {
+					processInfo = ManifestApplicationProcess{}
+					processInfo.Type = "bob"
+				})
+
+				It("returns a CreateProcessMessage with only type, appGUID and spaceGUID set", func() {
+					message := processInfo.ToProcessCreateMessage(appGUID, spaceGUID)
+
+					Expect(message).To(Equal(repositories.CreateProcessMessage{
+						Type:      "bob",
+						AppGUID:   appGUID,
+						SpaceGUID: spaceGUID,
+					}))
+				})
+			})
+		})
+
+		Describe("ToProcessPatchMessage", func() {
+			const processGUID = "the-process-guid"
+			var processInfo ManifestApplicationProcess
+
+			BeforeEach(func() {
+				processInfo = ManifestApplicationProcess{Type: "web"}
 			})
 
 			Describe("HealthCheckType", func() {
-				When("HealthCheckType is 'none' (legacy alias for 'process')", func() {
+				When("HealthCheckType is specified as 'none' (legacy alias for 'process')", func() {
 					const noneHealthCheckType = "none"
 
 					It("converts the type to 'process'", func() {
 						processInfo.HealthCheckType = tools.PtrTo(noneHealthCheckType)
 
-						message := processInfo.ToProcessCreateMessage(appGUID, spaceGUID)
+						message := processInfo.ToProcessPatchMessage(processGUID, spaceGUID)
 
-						Expect(message.HealthCheck.Type).To(Equal("process"))
+						Expect(message.HealthCheckType).To(Equal(tools.PtrTo("process")))
 					})
 				})
 
@@ -71,129 +414,105 @@ var _ = Describe("ManifestApplicationProcess", func() {
 					It("passes the type through to the message", func() {
 						processInfo.HealthCheckType = tools.PtrTo("port")
 
-						message := processInfo.ToProcessCreateMessage(appGUID, spaceGUID)
+						message := processInfo.ToProcessPatchMessage(processGUID, spaceGUID)
 
-						Expect(message.HealthCheck.Type).To(Equal("port"))
+						Expect(message.HealthCheckType).To(Equal(tools.PtrTo("port")))
+					})
+				})
+
+				When("HealthCheckType is unspecified", func() {
+					It("returns a message with HealthCheckType unset", func() {
+						Expect(
+							processInfo.ToProcessPatchMessage(processGUID, spaceGUID).HealthCheckType,
+						).To(BeNil())
 					})
 				})
 			})
-		})
 
-		When("only type is specified", func() {
-			BeforeEach(func() {
-				processInfo = ManifestApplicationProcess{}
-				processInfo.Type = "bob"
-			})
-
-			It("returns a CreateProcessMessage with only type, appGUID and spaceGUID set", func() {
-				message := processInfo.ToProcessCreateMessage(appGUID, spaceGUID)
-
-				Expect(message).To(Equal(repositories.CreateProcessMessage{
-					Type:      "bob",
-					AppGUID:   appGUID,
-					SpaceGUID: spaceGUID,
-				}))
-			})
-		})
-	})
-
-	Describe("ToProcessPatchMessage", func() {
-		const processGUID = "the-process-guid"
-		var processInfo ManifestApplicationProcess
-
-		BeforeEach(func() {
-			processInfo = ManifestApplicationProcess{Type: "web"}
-		})
-
-		Describe("HealthCheckType", func() {
-			When("HealthCheckType is specified as 'none' (legacy alias for 'process')", func() {
-				const noneHealthCheckType = "none"
-
-				It("converts the type to 'process'", func() {
-					processInfo.HealthCheckType = tools.PtrTo(noneHealthCheckType)
-
-					message := processInfo.ToProcessPatchMessage(processGUID, spaceGUID)
-
-					Expect(message.HealthCheckType).To(Equal(tools.PtrTo("process")))
+			When("DiskQuota is specified", func() {
+				BeforeEach(func() {
+					processInfo.DiskQuota = tools.PtrTo("1G")
 				})
-			})
 
-			When("HealthCheckType is specified as some other valid type", func() {
-				It("passes the type through to the message", func() {
-					processInfo.HealthCheckType = tools.PtrTo("port")
-
-					message := processInfo.ToProcessPatchMessage(processGUID, spaceGUID)
-
-					Expect(message.HealthCheckType).To(Equal(tools.PtrTo("port")))
-				})
-			})
-
-			When("HealthCheckType is unspecified", func() {
-				It("returns a message with HealthCheckType unset", func() {
+				It("returns a message with DiskQuotaMB set to the parsed value", func() {
 					Expect(
-						processInfo.ToProcessPatchMessage(processGUID, spaceGUID).HealthCheckType,
+						processInfo.ToProcessPatchMessage(processGUID, spaceGUID).DiskQuotaMB,
+					).To(PointTo(BeEquivalentTo(1024)))
+				})
+			})
+
+			When("DiskQuota is unspecified", func() {
+				It("returns a message with DiskQuotaMB unset", func() {
+					Expect(
+						processInfo.ToProcessPatchMessage(processGUID, spaceGUID).DiskQuotaMB,
+					).To(BeNil())
+				})
+			})
+
+			When("Memory is specified", func() {
+				BeforeEach(func() {
+					processInfo.Memory = tools.PtrTo("1G")
+				})
+
+				It("returns a message with MemoryMB set to the parsed value", func() {
+					Expect(
+						processInfo.ToProcessPatchMessage(processGUID, spaceGUID).MemoryMB,
+					).To(PointTo(BeEquivalentTo(1024)))
+				})
+			})
+
+			When("Memory is unspecified", func() {
+				It("returns a message with MemoryMB unset", func() {
+					Expect(
+						processInfo.ToProcessPatchMessage(processGUID, spaceGUID).MemoryMB,
+					).To(BeNil())
+				})
+			})
+
+			When("Instances is specified", func() {
+				BeforeEach(func() {
+					processInfo.Instances = tools.PtrTo(3)
+				})
+
+				It("returns a message with DesiredInstances set to the parsed value", func() {
+					Expect(
+						processInfo.ToProcessPatchMessage(processGUID, spaceGUID).DesiredInstances,
+					).To(PointTo(BeEquivalentTo(3)))
+				})
+			})
+
+			When("Instances is unspecified", func() {
+				It("returns a message with DesiredInstances unset", func() {
+					Expect(
+						processInfo.ToProcessPatchMessage(processGUID, spaceGUID).DesiredInstances,
 					).To(BeNil())
 				})
 			})
 		})
+	})
 
-		When("DiskQuota is specified", func() {
+	Describe("ManifestRoute", func() {
+		var (
+			validateErr       error
+			testManifestRoute ManifestRoute
+		)
+		BeforeEach(func() {
+			testManifestRoute = ManifestRoute{}
+		})
+		JustBeforeEach(func() {
+			validateErr = testManifestRoute.Validate()
+		})
+		It("validates the struct", func() {
+			Expect(validateErr).NotTo(HaveOccurred())
+		})
+
+		When("the route is not valid", func() {
 			BeforeEach(func() {
-				processInfo.DiskQuota = tools.PtrTo("1G")
+				testManifestRoute.Route = tools.PtrTo("httpp://invalidprotocol.net")
 			})
 
-			It("returns a message with DiskQuotaMB set to the parsed value", func() {
-				Expect(
-					processInfo.ToProcessPatchMessage(processGUID, spaceGUID).DiskQuotaMB,
-				).To(PointTo(BeEquivalentTo(1024)))
-			})
-		})
-
-		When("DiskQuota is unspecified", func() {
-			It("returns a message with DiskQuotaMB unset", func() {
-				Expect(
-					processInfo.ToProcessPatchMessage(processGUID, spaceGUID).DiskQuotaMB,
-				).To(BeNil())
-			})
-		})
-
-		When("Memory is specified", func() {
-			BeforeEach(func() {
-				processInfo.Memory = tools.PtrTo("1G")
-			})
-
-			It("returns a message with MemoryMB set to the parsed value", func() {
-				Expect(
-					processInfo.ToProcessPatchMessage(processGUID, spaceGUID).MemoryMB,
-				).To(PointTo(BeEquivalentTo(1024)))
-			})
-		})
-
-		When("Memory is unspecified", func() {
-			It("returns a message with MemoryMB unset", func() {
-				Expect(
-					processInfo.ToProcessPatchMessage(processGUID, spaceGUID).MemoryMB,
-				).To(BeNil())
-			})
-		})
-
-		When("Instances is specified", func() {
-			BeforeEach(func() {
-				processInfo.Instances = tools.PtrTo(3)
-			})
-
-			It("returns a message with DesiredInstances set to the parsed value", func() {
-				Expect(
-					processInfo.ToProcessPatchMessage(processGUID, spaceGUID).DesiredInstances,
-				).To(PointTo(BeEquivalentTo(3)))
-			})
-		})
-
-		When("Instances is unspecified", func() {
-			It("returns a message with DesiredInstances unset", func() {
-				Expect(
-					processInfo.ToProcessPatchMessage(processGUID, spaceGUID).DesiredInstances,
-				).To(BeNil())
+			It("returns a validation error", func() {
+				Expect(validateErr).To(MatchError("route: is not a valid route."))
 			})
 		})
 	})

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/google/go-containerregistry v0.14.0
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-multierror v1.1.1
+	github.com/jellydator/validation v1.0.0
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.6.1
 	github.com/mileusna/useragent v1.2.1
 	github.com/onsi/ginkgo/v2 v2.9.1

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,8 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apex/log v1.9.0 h1:FHtw/xuaM8AgmvDDTI9fiwoAL25Sq2cxojnZICUU8l0=
 github.com/apoydence/eachers v0.0.0-20181020210610-23942921fe77/go.mod h1:bXvGk6IkT1Agy7qzJ+DjIw/SJ1AaB3AvAuMDVV+Vkoo=
+github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d h1:Byv0BzEl3/e6D5CLfI0j/7hiIEtvGVFPCZ7Ei2oq8iQ=
+github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/aws/aws-sdk-go-v2 v1.17.3/go.mod h1:uzbQtefpm44goOPmdKyAlXSNcwlRgF3ePWVW6EtJvvw=
 github.com/aws/aws-sdk-go-v2 v1.17.4/go.mod h1:uzbQtefpm44goOPmdKyAlXSNcwlRgF3ePWVW6EtJvvw=
 github.com/aws/aws-sdk-go-v2 v1.17.6 h1:Y773UK7OBqhzi5VDXMi1zVGsoj+CVHs2eaC2bDsLwi0=
@@ -299,6 +301,8 @@ github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLf
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
+github.com/jellydator/validation v1.0.0 h1:B+KBCWSxXlPO8xoqKRqrVyVAE0W+8wUHJIp4S7bNG84=
+github.com/jellydator/validation v1.0.0/go.mod h1:AaCjfkQ4Ykdcb+YCwqCtaI3wDsf2UAGhJ06lJs0VgOw=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=


### PR DESCRIPTION
## Is there a related GitHub Issue?
#2123 

## What is this change about?
See issue

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Deploy korifi normally, hand-craft malformed app manifest file, and cf push with the manifest flag to trigger the error. Otherwise, see modified tests for specific field level errors to trigger.

## Tag your pair, your PM, and/or team
@davewalter 
.
Note that we included a small change to the error message serialization from the related explore issue. Array fields no longer have a `.` before them, instead only having enclosing brackets `[]`.
