### PR TITLE
Use status conditions on CFPackage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,10 +51,10 @@ test: lint
 	make test-e2e
 
 
-test-tools: install-ginkgo
+test-tools:
 	./scripts/run-tests.sh tools
 
-test-e2e: install-ginkgo
+test-e2e:
 	./scripts/run-tests.sh tests/e2e
 
 GOFUMPT = $(shell go env GOPATH)/bin/gofumpt
@@ -64,9 +64,6 @@ install-gofumpt:
 SHFMT = $(shell go env GOPATH)/bin/shfmt
 install-shfmt:
 	go install mvdan.cc/sh/v3/cmd/shfmt@latest
-
-install-ginkgo:
-	go install github.com/onsi/ginkgo/v2/ginkgo
 
 VENDIR = $(shell go env GOPATH)/bin/vendir
 install-vendir:

--- a/api/main.go
+++ b/api/main.go
@@ -167,6 +167,7 @@ func main() {
 		nsPermissions,
 		toolsregistry.NewRepositoryCreator(cfg.ContainerRegistryType),
 		cfg.ContainerRepositoryPrefix,
+		createTimeout,
 	)
 	serviceInstanceRepo := repositories.NewServiceInstanceRepo(
 		namespaceRetriever,

--- a/api/repositories/package_repository.go
+++ b/api/repositories/package_repository.go
@@ -3,15 +3,19 @@ package repositories
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"code.cloudfoundry.org/korifi/api/authorization"
 	apierrors "code.cloudfoundry.org/korifi/api/errors"
+	"code.cloudfoundry.org/korifi/api/repositories/conditions"
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
+	"code.cloudfoundry.org/korifi/controllers/controllers/workloads"
 	"code.cloudfoundry.org/korifi/tools/k8s"
 
 	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -32,6 +36,7 @@ type PackageRepo struct {
 	namespacePermissions *authorization.NamespacePermissions
 	repositoryCreator    RepositoryCreator
 	repositoryPrefix     string
+	awaiter              *conditions.Awaiter[*korifiv1alpha1.CFPackage, korifiv1alpha1.CFPackageList, *korifiv1alpha1.CFPackageList]
 }
 
 func NewPackageRepo(
@@ -40,6 +45,7 @@ func NewPackageRepo(
 	authPerms *authorization.NamespacePermissions,
 	repositoryCreator RepositoryCreator,
 	repositoryPrefix string,
+	createTimeout time.Duration,
 ) *PackageRepo {
 	return &PackageRepo{
 		userClientFactory:    userClientFactory,
@@ -47,6 +53,7 @@ func NewPackageRepo(
 		namespacePermissions: authPerms,
 		repositoryCreator:    repositoryCreator,
 		repositoryPrefix:     repositoryPrefix,
+		awaiter:              conditions.NewConditionAwaiter[*korifiv1alpha1.CFPackage, korifiv1alpha1.CFPackageList](createTimeout),
 	}
 }
 
@@ -76,9 +83,9 @@ type CreatePackageMessage struct {
 	Metadata  Metadata
 }
 
-func (message CreatePackageMessage) toCFPackage() korifiv1alpha1.CFPackage {
+func (message CreatePackageMessage) toCFPackage() *korifiv1alpha1.CFPackage {
 	guid := uuid.NewString()
-	pkg := korifiv1alpha1.CFPackage{
+	pkg := &korifiv1alpha1.CFPackage{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       kind,
 			APIVersion: korifiv1alpha1.GroupVersion.Identifier(),
@@ -119,7 +126,7 @@ func (r *PackageRepo) CreatePackage(ctx context.Context, authInfo authorization.
 	}
 
 	cfPackage := message.toCFPackage()
-	err = userClient.Create(ctx, &cfPackage)
+	err = userClient.Create(ctx, cfPackage)
 	if err != nil {
 		return PackageRecord{}, apierrors.FromK8sError(err, PackageResourceType)
 	}
@@ -127,6 +134,11 @@ func (r *PackageRepo) CreatePackage(ctx context.Context, authInfo authorization.
 	err = r.repositoryCreator.CreateRepository(ctx, r.repositoryRef(message.AppGUID))
 	if err != nil {
 		return PackageRecord{}, fmt.Errorf("failed to create package repository: %w", err)
+	}
+
+	cfPackage, err = r.awaiter.AwaitCondition(ctx, userClient, cfPackage, workloads.InitializedConditionType)
+	if err != nil {
+		return PackageRecord{}, fmt.Errorf("failed waiting for Initialized condition: %w", err)
 	}
 
 	return r.cfPackageToPackageRecord(cfPackage), nil
@@ -157,7 +169,7 @@ func (r *PackageRepo) UpdatePackage(ctx context.Context, authInfo authorization.
 		return PackageRecord{}, fmt.Errorf("failed to patch package metadata: %w", apierrors.FromK8sError(err, PackageResourceType))
 	}
 
-	return r.cfPackageToPackageRecord(*cfPackage), nil
+	return r.cfPackageToPackageRecord(cfPackage), nil
 }
 
 func (r *PackageRepo) GetPackage(ctx context.Context, authInfo authorization.Info, guid string) (PackageRecord, error) {
@@ -171,8 +183,8 @@ func (r *PackageRepo) GetPackage(ctx context.Context, authInfo authorization.Inf
 		return PackageRecord{}, fmt.Errorf("failed to build user k8s client: %w", err)
 	}
 
-	cfPackage := korifiv1alpha1.CFPackage{}
-	if err := userClient.Get(ctx, client.ObjectKey{Namespace: ns, Name: guid}, &cfPackage); err != nil {
+	cfPackage := new(korifiv1alpha1.CFPackage)
+	if err := userClient.Get(ctx, client.ObjectKey{Namespace: ns, Name: guid}, cfPackage); err != nil {
 		return PackageRecord{}, fmt.Errorf("failed to get package %q: %w", guid, apierrors.FromK8sError(err, PackageResourceType))
 	}
 
@@ -264,14 +276,19 @@ func (r *PackageRepo) UpdatePackageSource(ctx context.Context, authInfo authoriz
 		return PackageRecord{}, fmt.Errorf("failed to update package source: %w", apierrors.FromK8sError(err, PackageResourceType))
 	}
 
-	record := r.cfPackageToPackageRecord(*cfPackage)
+	cfPackage, err = r.awaiter.AwaitCondition(ctx, userClient, cfPackage, workloads.StatusConditionReady)
+	if err != nil {
+		return PackageRecord{}, fmt.Errorf("failed awaiting Ready status condition: %w", err)
+	}
+
+	record := r.cfPackageToPackageRecord(cfPackage)
 	return record, nil
 }
 
-func (r *PackageRepo) cfPackageToPackageRecord(cfPackage korifiv1alpha1.CFPackage) PackageRecord {
+func (r *PackageRepo) cfPackageToPackageRecord(cfPackage *korifiv1alpha1.CFPackage) PackageRecord {
 	updatedAtTime, _ := getTimeLastUpdatedTimestamp(&cfPackage.ObjectMeta)
 	state := PackageStateAwaitingUpload
-	if cfPackage.Spec.Source.Registry.Image != "" {
+	if meta.IsStatusConditionTrue(cfPackage.Status.Conditions, workloads.StatusConditionReady) {
 		state = PackageStateReady
 	}
 	return PackageRecord{
@@ -293,7 +310,7 @@ func (r *PackageRepo) convertToPackageRecords(packages []korifiv1alpha1.CFPackag
 	packageRecords := make([]PackageRecord, 0, len(packages))
 
 	for _, currentPackage := range packages {
-		packageRecords = append(packageRecords, r.cfPackageToPackageRecord(currentPackage))
+		packageRecords = append(packageRecords, r.cfPackageToPackageRecord(&currentPackage))
 	}
 	return packageRecords
 }

--- a/api/repositories/package_repository_test.go
+++ b/api/repositories/package_repository_test.go
@@ -10,26 +10,32 @@ import (
 	"code.cloudfoundry.org/korifi/api/repositories"
 	"code.cloudfoundry.org/korifi/api/repositories/fake"
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
+	"code.cloudfoundry.org/korifi/controllers/controllers/workloads"
 	"code.cloudfoundry.org/korifi/tests/matchers"
 	"code.cloudfoundry.org/korifi/tools"
+	"code.cloudfoundry.org/korifi/tools/image"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
 )
 
 var _ = Describe("PackageRepository", func() {
-	const appGUID = "the-app-guid"
-
 	var (
 		repoCreator *fake.RepositoryCreator
 		packageRepo *repositories.PackageRepo
 		org         *korifiv1alpha1.CFOrg
 		space       *korifiv1alpha1.CFSpace
+		app         *korifiv1alpha1.CFApp
+		mgrCancel   context.CancelFunc
 	)
 
 	BeforeEach(func() {
@@ -40,9 +46,41 @@ var _ = Describe("PackageRepository", func() {
 			nsPerms,
 			repoCreator,
 			"container.registry/foo/my/prefix-",
+			time.Second*4,
 		)
 		org = createOrgWithCleanup(ctx, prefixedGUID("org"))
 		space = createSpaceWithCleanup(ctx, org.Name, prefixedGUID("space"))
+		app = createApp(space.Name)
+
+		k8sManager, err := ctrl.NewManager(k8sConfig, ctrl.Options{
+			Scheme:             scheme.Scheme,
+			MetricsBindAddress: "0",
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		k8sInterface, err := kubernetes.NewForConfig(k8sConfig)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = (workloads.NewCFPackageReconciler(
+			k8sManager.GetClient(),
+			image.NewClient(k8sInterface),
+			k8sManager.GetScheme(),
+			"package-repo-secret-name",
+			ctrl.Log.WithName("controllers").WithName("CFPackage"),
+		)).SetupWithManager(k8sManager)
+		Expect(err).NotTo(HaveOccurred())
+
+		var mgrCtx context.Context
+		mgrCtx, mgrCancel = context.WithCancel(ctx)
+		go func() {
+			defer GinkgoRecover()
+			err = k8sManager.Start(mgrCtx)
+			Expect(err).NotTo(HaveOccurred())
+		}()
+	})
+
+	AfterEach(func() {
+		mgrCancel()
 	})
 
 	Describe("CreatePackage", func() {
@@ -55,7 +93,7 @@ var _ = Describe("PackageRepository", func() {
 		BeforeEach(func() {
 			packageCreate = repositories.CreatePackageMessage{
 				Type:      "bits",
-				AppGUID:   appGUID,
+				AppGUID:   app.Name,
 				SpaceGUID: space.Name,
 				Metadata: repositories.Metadata{
 					Labels: map[string]string{
@@ -87,11 +125,11 @@ var _ = Describe("PackageRepository", func() {
 				packageGUID := createdPackage.GUID
 				Expect(packageGUID).NotTo(BeEmpty())
 				Expect(createdPackage.Type).To(Equal("bits"))
-				Expect(createdPackage.AppGUID).To(Equal(appGUID))
+				Expect(createdPackage.AppGUID).To(Equal(app.Name))
 				Expect(createdPackage.State).To(Equal("AWAITING_UPLOAD"))
 				Expect(createdPackage.Labels).To(HaveKeyWithValue("bob", "foo"))
 				Expect(createdPackage.Annotations).To(HaveKeyWithValue("jim", "bar"))
-				Expect(createdPackage.ImageRef).To(Equal(fmt.Sprintf("container.registry/foo/my/prefix-%s-packages", appGUID)))
+				Expect(createdPackage.ImageRef).To(Equal(fmt.Sprintf("container.registry/foo/my/prefix-%s-packages", app.Name)))
 
 				createdAt, err := time.Parse(time.RFC3339, createdPackage.CreatedAt)
 				Expect(err).NotTo(HaveOccurred())
@@ -108,16 +146,18 @@ var _ = Describe("PackageRepository", func() {
 				Expect(createdCFPackage.Name).To(Equal(packageGUID))
 				Expect(createdCFPackage.Namespace).To(Equal(space.Name))
 				Expect(createdCFPackage.Spec.Type).To(Equal(korifiv1alpha1.PackageType("bits")))
-				Expect(createdCFPackage.Spec.AppRef.Name).To(Equal(appGUID))
+				Expect(createdCFPackage.Spec.AppRef.Name).To(Equal(app.Name))
 
 				Expect(createdCFPackage.Labels).To(HaveKeyWithValue("bob", "foo"))
 				Expect(createdCFPackage.Annotations).To(HaveKeyWithValue("jim", "bar"))
+
+				Expect(meta.IsStatusConditionTrue(createdCFPackage.Status.Conditions, "Initialized")).To(BeTrue())
 			})
 
 			It("creates a package repository", func() {
 				Expect(repoCreator.CreateRepositoryCallCount()).To(Equal(1))
 				_, repoName := repoCreator.CreateRepositoryArgsForCall(0)
-				Expect(repoName).To(Equal("container.registry/foo/my/prefix-" + appGUID + "-packages"))
+				Expect(repoName).To(Equal("container.registry/foo/my/prefix-" + app.Name + "-packages"))
 			})
 
 			When("repo creation errors", func() {
@@ -141,7 +181,7 @@ var _ = Describe("PackageRepository", func() {
 
 		BeforeEach(func() {
 			packageGUID = generateGUID()
-			createPackageCR(ctx, k8sClient, packageGUID, appGUID, space.Name, "")
+			createPackageCR(ctx, k8sClient, packageGUID, app.Name, space.Name, "")
 		})
 
 		JustBeforeEach(func() {
@@ -157,11 +197,11 @@ var _ = Describe("PackageRepository", func() {
 				Expect(getErr).NotTo(HaveOccurred())
 				Expect(packageRecord.GUID).To(Equal(packageGUID))
 				Expect(packageRecord.Type).To(Equal("bits"))
-				Expect(packageRecord.AppGUID).To(Equal(appGUID))
+				Expect(packageRecord.AppGUID).To(Equal(app.Name))
 				Expect(packageRecord.State).To(Equal("AWAITING_UPLOAD"))
 				Expect(packageRecord.Labels).To(HaveKeyWithValue("foo", "the-original-value"))
 				Expect(packageRecord.Annotations).To(HaveKeyWithValue("bar", "the-original-value"))
-				Expect(packageRecord.ImageRef).To(Equal(fmt.Sprintf("container.registry/foo/my/prefix-%s-packages", appGUID)))
+				Expect(packageRecord.ImageRef).To(Equal(fmt.Sprintf("container.registry/foo/my/prefix-%s-packages", app.Name)))
 
 				createdAt, err := time.Parse(time.RFC3339, packageRecord.CreatedAt)
 				Expect(err).NotTo(HaveOccurred())
@@ -177,10 +217,10 @@ var _ = Describe("PackageRepository", func() {
 					Expect(packageRecord.State).To(Equal("AWAITING_UPLOAD"))
 				})
 
-				When("an source image is set", func() {
+				When("the package is ready", func() {
 					BeforeEach(func() {
 						packageGUID = generateGUID()
-						createPackageCR(ctx, k8sClient, packageGUID, appGUID, space.Name, "some-org/some-repo")
+						createPackageCR(ctx, k8sClient, packageGUID, app.Name, space.Name, "some-org/some-repo")
 					})
 
 					It("equals READY", func() {
@@ -199,7 +239,7 @@ var _ = Describe("PackageRepository", func() {
 		When("duplicate Packages exist across namespaces with the same GUID", func() {
 			BeforeEach(func() {
 				anotherSpace := createSpaceWithCleanup(ctx, org.Name, prefixedGUID("space"))
-				createPackageCR(ctx, k8sClient, packageGUID, appGUID, anotherSpace.Name, "")
+				createPackageCR(ctx, k8sClient, packageGUID, app.Name, anotherSpace.Name, "")
 			})
 
 			It("returns an error", func() {
@@ -219,11 +259,8 @@ var _ = Describe("PackageRepository", func() {
 	})
 
 	Describe("ListPackages", func() {
-		const (
-			appGUID2 = "the-app-guid-2"
-		)
-
 		var (
+			app2        *korifiv1alpha1.CFApp
 			space2      *korifiv1alpha1.CFSpace
 			packageList []repositories.PackageRecord
 			listMessage repositories.ListPackagesMessage
@@ -231,6 +268,7 @@ var _ = Describe("PackageRepository", func() {
 
 		BeforeEach(func() {
 			space2 = createSpaceWithCleanup(ctx, org.Name, prefixedGUID("space2"))
+			app2 = createApp(space2.Name)
 			listMessage = repositories.ListPackagesMessage{}
 		})
 
@@ -248,14 +286,14 @@ var _ = Describe("PackageRepository", func() {
 
 			BeforeEach(func() {
 				package1GUID = generateGUID()
-				createPackageCR(ctx, k8sClient, package1GUID, appGUID, space.Name, "")
+				createPackageCR(ctx, k8sClient, package1GUID, app.Name, space.Name, "")
 
 				package2GUID = generateGUID()
-				createPackageCR(ctx, k8sClient, package2GUID, appGUID2, space2.Name, "my-image-url")
+				createPackageCR(ctx, k8sClient, package2GUID, app2.Name, space2.Name, "my-image-url")
 
 				noPermissionsSpace = createSpaceWithCleanup(ctx, org.Name, prefixedGUID("no-permissions-space"))
 				noPermissionsPackageGUID = prefixedGUID("no-permissions-package")
-				createPackageCR(ctx, k8sClient, noPermissionsPackageGUID, appGUID2, noPermissionsSpace.Name, "")
+				createPackageCR(ctx, k8sClient, noPermissionsPackageGUID, app2.Name, noPermissionsSpace.Name, "")
 			})
 
 			When("the user is allowed to list packages in some namespaces", func() {
@@ -268,11 +306,11 @@ var _ = Describe("PackageRepository", func() {
 					Expect(packageList).To(ContainElements(
 						MatchFields(IgnoreExtras, Fields{
 							"GUID":    Equal(package1GUID),
-							"AppGUID": Equal(appGUID),
+							"AppGUID": Equal(app.Name),
 						}),
 						MatchFields(IgnoreExtras, Fields{
 							"GUID":    Equal(package2GUID),
-							"AppGUID": Equal(appGUID2),
+							"AppGUID": Equal(app2.Name),
 						}),
 					))
 					Expect(packageList).ToNot(ContainElement(
@@ -284,14 +322,14 @@ var _ = Describe("PackageRepository", func() {
 
 				When("app_guids filter is provided", func() {
 					BeforeEach(func() {
-						listMessage = repositories.ListPackagesMessage{AppGUIDs: []string{appGUID}}
+						listMessage = repositories.ListPackagesMessage{AppGUIDs: []string{app.Name}}
 					})
 
 					It("fetches all PackageRecords for that app", func() {
 						for _, packageRecord := range packageList {
 							Expect(packageRecord).To(
 								MatchFields(IgnoreExtras, Fields{
-									"AppGUID": Equal(appGUID),
+									"AppGUID": Equal(app.Name),
 								}),
 							)
 						}
@@ -340,12 +378,12 @@ var _ = Describe("PackageRepository", func() {
 							Expect(packageList).To(ContainElements(
 								MatchFields(IgnoreExtras, Fields{
 									"GUID":    Equal(package1GUID),
-									"AppGUID": Equal(appGUID),
+									"AppGUID": Equal(app.Name),
 									"State":   Equal("AWAITING_UPLOAD"),
 								}),
 								MatchFields(IgnoreExtras, Fields{
 									"GUID":    Equal(package2GUID),
-									"AppGUID": Equal(appGUID2),
+									"AppGUID": Equal(app2.Name),
 									"State":   Equal("READY"),
 								}),
 							))
@@ -376,6 +414,7 @@ var _ = Describe("PackageRepository", func() {
 	Describe("UpdatePackageSource", func() {
 		var (
 			existingCFPackage     *korifiv1alpha1.CFPackage
+			updatedCFPackage      *korifiv1alpha1.CFPackage
 			returnedPackageRecord repositories.PackageRecord
 			updateMessage         repositories.UpdatePackageSourceMessage
 			updateErr             error
@@ -398,7 +437,7 @@ var _ = Describe("PackageRepository", func() {
 				},
 				Spec: korifiv1alpha1.CFPackageSpec{
 					Type:   "bits",
-					AppRef: corev1.LocalObjectReference{Name: appGUID},
+					AppRef: corev1.LocalObjectReference{Name: app.Name},
 				},
 			}
 
@@ -414,23 +453,18 @@ var _ = Describe("PackageRepository", func() {
 			Expect(k8sClient.Create(ctx, existingCFPackage)).To(Succeed())
 
 			returnedPackageRecord, updateErr = packageRepo.UpdatePackageSource(ctx, authInfo, updateMessage)
+			updatedCFPackage = &korifiv1alpha1.CFPackage{}
+			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(existingCFPackage), updatedCFPackage)).To(Succeed())
 		})
 
 		When("the user is authorized", func() {
-			var updatedCFPackage *korifiv1alpha1.CFPackage
-
 			BeforeEach(func() {
 				createRoleBinding(ctx, userName, spaceDeveloperRole.Name, space.Name)
 			})
 
-			JustBeforeEach(func() {
+			It("updates the CFPackage and returns an updated record", func() {
 				Expect(updateErr).NotTo(HaveOccurred())
 
-				updatedCFPackage = &korifiv1alpha1.CFPackage{}
-				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(existingCFPackage), updatedCFPackage)).To(Succeed())
-			})
-
-			It("returns an updated record", func() {
 				Expect(returnedPackageRecord.GUID).To(Equal(existingCFPackage.Name))
 				Expect(returnedPackageRecord.Type).To(Equal(string(existingCFPackage.Spec.Type)))
 				Expect(returnedPackageRecord.AppGUID).To(Equal(existingCFPackage.Spec.AppRef.Name))
@@ -444,9 +478,7 @@ var _ = Describe("PackageRepository", func() {
 				updatedAt, err := time.Parse(time.RFC3339, returnedPackageRecord.CreatedAt)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(updatedAt).To(BeTemporally("~", time.Now(), timeCheckThreshold*time.Second))
-			})
 
-			It("updates only the Registry field of the existing CFPackage", func() {
 				Expect(updatedCFPackage.Name).To(Equal(existingCFPackage.Name))
 				Expect(updatedCFPackage.Namespace).To(Equal(existingCFPackage.Namespace))
 				Expect(updatedCFPackage.Spec.Type).To(Equal(existingCFPackage.Spec.Type))
@@ -509,7 +541,7 @@ var _ = Describe("PackageRepository", func() {
 					},
 				},
 			}
-			cfPackage = createPackageCR(ctx, k8sClient, packageGUID, appGUID, space.Name, "")
+			cfPackage = createPackageCR(ctx, k8sClient, packageGUID, app.Name, space.Name, "")
 		})
 
 		JustBeforeEach(func() {

--- a/api/repositories/repositories_suite_test.go
+++ b/api/repositories/repositories_suite_test.go
@@ -77,7 +77,6 @@ var _ = BeforeSuite(func() {
 	var err error
 	k8sConfig, err = testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())
-	Expect(k8sConfig).NotTo(BeNil())
 
 	err = korifiv1alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())

--- a/controllers/api/v1alpha1/cfpackage_types.go
+++ b/controllers/api/v1alpha1/cfpackage_types.go
@@ -72,3 +72,7 @@ type CFPackageList struct {
 func init() {
 	SchemeBuilder.Register(&CFPackage{}, &CFPackageList{})
 }
+
+func (p CFPackage) StatusConditions() []metav1.Condition {
+	return p.Status.Conditions
+}

--- a/controllers/controllers/workloads/cfpackage_controller_test.go
+++ b/controllers/controllers/workloads/cfpackage_controller_test.go
@@ -5,12 +5,14 @@ import (
 	"errors"
 
 	"code.cloudfoundry.org/korifi/tools"
+	"code.cloudfoundry.org/korifi/tools/k8s"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
+	"code.cloudfoundry.org/korifi/controllers/controllers/workloads"
 	. "code.cloudfoundry.org/korifi/controllers/controllers/workloads/testutils"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -39,18 +41,23 @@ var _ = Describe("CFPackageReconciler Integration Tests", func() {
 	When("a new CFPackage resource is created", func() {
 		BeforeEach(func() {
 			cfPackage = BuildCFPackageCRObject(cfPackageGUID, cfSpace.Status.GUID, cfAppGUID, "ref")
+			cfPackage.Spec.Source = korifiv1alpha1.PackageSource{}
 			Expect(k8sClient.Create(context.Background(), cfPackage)).To(Succeed())
 		})
 
-		It("eventually reconciles to set the owner reference on the CFPackage", func() {
-			Eventually(func() []metav1.OwnerReference {
-				var createdCFPackage korifiv1alpha1.CFPackage
-				err := k8sClient.Get(context.Background(), types.NamespacedName{Name: cfPackageGUID, Namespace: cfSpace.Status.GUID}, &createdCFPackage)
-				if err != nil {
-					return nil
-				}
-				return createdCFPackage.GetOwnerReferences()
-			}).Should(ConsistOf(metav1.OwnerReference{
+		It("initializes it", func() {
+			var createdCFPackage korifiv1alpha1.CFPackage
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(cfPackage), &createdCFPackage)).To(Succeed())
+				g.Expect(meta.IsStatusConditionTrue(createdCFPackage.Status.Conditions, workloads.InitializedConditionType)).To(BeTrue())
+			}).Should(Succeed())
+
+			Expect(meta.FindStatusCondition(createdCFPackage.Status.Conditions, workloads.InitializedConditionType).ObservedGeneration).To(Equal(createdCFPackage.Generation))
+
+			Expect(meta.IsStatusConditionFalse(createdCFPackage.Status.Conditions, workloads.StatusConditionReady)).To(BeTrue())
+			Expect(meta.FindStatusCondition(createdCFPackage.Status.Conditions, workloads.StatusConditionReady).ObservedGeneration).To(Equal(createdCFPackage.Generation))
+
+			Expect(createdCFPackage.GetOwnerReferences()).To(ConsistOf(metav1.OwnerReference{
 				APIVersion:         korifiv1alpha1.GroupVersion.Identifier(),
 				Kind:               "CFApp",
 				Name:               cfApp.Name,
@@ -58,6 +65,30 @@ var _ = Describe("CFPackageReconciler Integration Tests", func() {
 				Controller:         tools.PtrTo(true),
 				BlockOwnerDeletion: tools.PtrTo(true),
 			}))
+		})
+
+		When("the package is updated with its source image", func() {
+			var createdCFPackage korifiv1alpha1.CFPackage
+
+			BeforeEach(func() {
+				Eventually(func(g Gomega) {
+					g.Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(cfPackage), &createdCFPackage)).To(Succeed())
+					g.Expect(meta.IsStatusConditionTrue(createdCFPackage.Status.Conditions, workloads.InitializedConditionType)).To(BeTrue())
+				}).Should(Succeed())
+			})
+
+			JustBeforeEach(func() {
+				Expect(k8s.PatchResource(ctx, k8sClient, &createdCFPackage, func() {
+					createdCFPackage.Spec.Source.Registry.Image = "hello"
+				})).To(Succeed())
+			})
+
+			It("sets the ready condition to true", func() {
+				Eventually(func(g Gomega) {
+					g.Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(cfPackage), &createdCFPackage)).To(Succeed())
+					g.Expect(meta.IsStatusConditionTrue(createdCFPackage.Status.Conditions, workloads.StatusConditionReady)).To(BeTrue())
+				}).Should(Succeed())
+			})
 		})
 	})
 
@@ -76,10 +107,9 @@ var _ = Describe("CFPackageReconciler Integration Tests", func() {
 		JustBeforeEach(func() {
 			Expect(k8sClient.Create(context.Background(), cfPackage)).To(Succeed())
 
-			// wait for package to have reconciled at least once
 			Eventually(func(g Gomega) {
 				g.Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(cfPackage), cfPackage)).To(Succeed())
-				g.Expect(cfPackage.Finalizers).ToNot(BeEmpty())
+				g.Expect(meta.IsStatusConditionTrue(cfPackage.Status.Conditions, workloads.InitializedConditionType)).To(BeTrue())
 			}).Should(Succeed())
 
 			Expect(k8sClient.Delete(context.Background(), cfPackage)).To(Succeed())

--- a/helm/korifi/controllers/cf_roles/cf_admin.yaml
+++ b/helm/korifi/controllers/cf_roles/cf_admin.yaml
@@ -89,6 +89,7 @@ rules:
   - list
   - create
   - patch
+  - watch
 
 - apiGroups:
   - korifi.cloudfoundry.org

--- a/helm/korifi/controllers/cf_roles/cf_space_developer.yaml
+++ b/helm/korifi/controllers/cf_roles/cf_space_developer.yaml
@@ -65,6 +65,7 @@ rules:
   - list
   - create
   - patch
+  - watch
 
 - apiGroups:
   - korifi.cloudfoundry.org

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -73,4 +73,4 @@ if [[ -z "${NO_RACE:-}" ]]; then
   extra_args+=("--race")
 fi
 
-ginkgo -p --randomize-all --randomize-suites "${extra_args[@]}" $@
+go run github.com/onsi/ginkgo/v2/ginkgo -p --randomize-all --randomize-suites "${extra_args[@]}" $@


### PR DESCRIPTION
## Is there a related GitHub Issue?
This is a prelude to #2232

## What is this change about?
This add status conditions to CFPackages.

Set initialized condition to true when:
- resource has finalizer set, and
- resource has app owner ref set.

Set ready condition to true when:
- resource has source package image set

Wait for the initialized condition in the CFPackage repo when creating a CFPackage.

Wait for the ready condition in the CFPackage repo when updating a CFPackage source image.

This will be used in the story above, where we need to expire old packages in controllers on the edge where the source image is first set.

This also improves the flake we've seen where CFPackage is not deleted in the e2e test which checks deleting an app deletes its related objects (due to a race where the package was not reconciled to set the app ownership before the app was deleted). We suspect CFBuild might cause a problem next.
## Does this PR introduce a breaking change?
No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
