### PR TITLE
Cleanup all images after image/client tests on real registries

### DIFF
--- a/tools/image/client_test.go
+++ b/tools/image/client_test.go
@@ -317,6 +317,10 @@ var _ = Describe("Client", func() {
 				Expect(err).NotTo(HaveOccurred())
 			})
 
+			AfterEach(func() {
+				_ = imgClient.Delete(ctx, creds, imgRef, "jim", "bob")
+			})
+
 			JustBeforeEach(func() {
 				testErr = imgClient.Delete(ctx, creds, imgRef, tagsToDelete...)
 			})
@@ -342,9 +346,16 @@ var _ = Describe("Client", func() {
 			})
 
 			When("another digest exists in the repo with another tag", func() {
+				var otherImg string
+
 				BeforeEach(func() {
-					_, err := imgClient.Push(ctx, creds, pushRef, otherZipFile, "alice")
+					var err error
+					otherImg, err = imgClient.Push(ctx, creds, pushRef, otherZipFile, "alice")
 					Expect(err).NotTo(HaveOccurred())
+				})
+
+				AfterEach(func() {
+					Expect(imgClient.Delete(ctx, creds, otherImg, "alice")).To(Succeed())
 				})
 
 				It("still deletes the image when all _its_ tags are removed", func() {

--- a/tools/image/image_suite_test.go
+++ b/tools/image/image_suite_test.go
@@ -31,14 +31,7 @@ import (
 )
 
 func TestImage(t *testing.T) {
-	registries = []registry{
-		// {
-		// 	Username:   "user",
-		// 	Password:   "password",
-		// 	Server:     authRegistryServer.URL,
-		// 	PathPrefix: strings.Replace(authRegistryServer.URL, "http://", "", 1),
-		// },
-	}
+	registries = []registry{}
 	registriesEnv, ok := os.LookupEnv("REGISTRY_DETAILS")
 	if ok {
 		err := yaml.Unmarshal([]byte(registriesEnv), &registries)


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
Best effort to delete all images created during testing on real registries.

Note that repositories _are_ leaked, but being empty, we assume that is not a problem.

## Does this PR introduce a breaking change?
No

## Acceptance Steps


## Tag your pair, your PM, and/or team
@kieron-dev
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
