### PR TITLE
Return valid CF 404 errors

### DIFF
--- a/api/errors/errors.go
+++ b/api/errors/errors.go
@@ -146,6 +146,21 @@ func NewNotFoundError(cause error, resourceType string) NotFoundError {
 	}
 }
 
+type EndpointNotFoundError struct {
+	apiError
+}
+
+func NewEndpointNotFoundError() EndpointNotFoundError {
+	return EndpointNotFoundError{
+		apiError{
+			title:      "CF-NotFound",
+			detail:     "Unknown request",
+			code:       10000,
+			httpStatus: http.StatusNotFound,
+		},
+	}
+}
+
 type InvalidAuthError struct {
 	apiError
 }

--- a/api/handlers/errors.go
+++ b/api/handlers/errors.go
@@ -1,0 +1,12 @@
+package handlers
+
+import (
+	"net/http"
+
+	"code.cloudfoundry.org/korifi/api/errors"
+	"code.cloudfoundry.org/korifi/api/routing"
+)
+
+func NotFound(r *http.Request) (*routing.Response, error) {
+	return nil, errors.NewEndpointNotFoundError()
+}

--- a/api/main.go
+++ b/api/main.go
@@ -368,6 +368,9 @@ func main() {
 		routerBuilder.LoadRoutes(handler)
 	}
 
+	routerBuilder.SetNotFoundHandler(handlers.NotFound)
+	routerBuilder.SetMethodNotAllowedHandler(handlers.NotFound)
+
 	portString := fmt.Sprintf(":%v", cfg.InternalPort)
 	tlsPath, tlsFound := os.LookupEnv("TLSCONFIG")
 

--- a/api/routing/handler_test.go
+++ b/api/routing/handler_test.go
@@ -48,15 +48,15 @@ var _ = Describe("Handler", func() {
 
 	When("the response body is not nil", func() {
 		BeforeEach(func() {
-			response = response.WithBody("some-response-content")
+			response = response.WithBody(map[string]string{"hello": "world"})
 		})
 
 		It("sets the application/json content type in the response", func() {
 			Expect(rr).To(HaveHTTPHeaderWithValue(headers.ContentType, "application/json"))
 		})
 
-		It("sets the body into the response", func() {
-			Expect(rr).To(HaveHTTPBody(ContainSubstring("some-response-content")))
+		It("encodes the body into JSON", func() {
+			Expect(rr).To(HaveHTTPBody(MatchJSON(`{"hello":"world"}`)))
 		})
 	})
 

--- a/tests/e2e/errors_test.go
+++ b/tests/e2e/errors_test.go
@@ -1,0 +1,68 @@
+package e2e_test
+
+import (
+	"crypto/tls"
+	"net/http"
+
+	"github.com/go-resty/resty/v2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("404 errors", func() {
+	var (
+		client   *resty.Client
+		httpResp *resty.Response
+		method   string
+		url      string
+	)
+
+	BeforeEach(func() {
+		method = ""
+		url = ""
+		client = resty.New().
+			SetBaseURL(apiServerRoot).
+			SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true})
+	})
+
+	JustBeforeEach(func() {
+		var err error
+		httpResp, err = client.R().Execute(method, url)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	When("an endpoint does not exist", func() {
+		BeforeEach(func() {
+			method = "GET"
+			url = "/does-not-exist"
+		})
+
+		It("returns a valid CF 404 error", func() {
+			Expect404(httpResp)
+		})
+	})
+
+	When("a method is not supported", func() {
+		BeforeEach(func() {
+			method = "POST"
+			url = "/v3"
+		})
+
+		It("returns a valid CF 404 error", func() {
+			Expect404(httpResp)
+		})
+	})
+})
+
+func Expect404(httpResp *resty.Response) {
+	Expect(httpResp).To(HaveRestyStatusCode(http.StatusNotFound))
+	Expect(httpResp).To(HaveRestyBody(MatchJSON(`{
+		"errors": [
+			{
+				"code": 10000,
+				"detail": "Unknown request",
+				"title": "CF-NotFound"
+			}
+		]
+	}`)))
+}


### PR DESCRIPTION
## Is there a related GitHub Issue?

#2292

## What is this change about?

This adds support for custom 404 and 405 handlers to our `routing` package. It then uses it to return well-formed CF errors.

## Does this PR introduce a breaking change?
The format of 404 and 405 errors will now be compatible with CF.

## Tag your pair, your PM, and/or team
@kieron-dev
