### PR TITLE
Set current creation date on kpack build images

### DIFF
--- a/kpack-image-builder/controllers/buildworkload_controller.go
+++ b/kpack-image-builder/controllers/buildworkload_controller.go
@@ -231,8 +231,9 @@ func (r *BuildWorkloadReconciler) createKpackImageAndUpdateStatus(ctx context.Co
 				},
 			},
 			Build: &buildv1alpha2.ImageBuild{
-				Services: buildWorkload.Spec.Services,
-				Env:      buildWorkload.Spec.Env,
+				Services:     buildWorkload.Spec.Services,
+				Env:          buildWorkload.Spec.Env,
+				CreationTime: "now",
 			},
 		},
 	}


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
No

## What is this change about?
We are seeing flakes in google artifact registry where sometimes droplet
pushes fail due to 'config blob not found'.

This _might_ be due to us pushing and deleting the identical image very
heavily in the e2e tests.

This experimental change enables setting the current time as the build
creation date on the image, which will lead to slightly different images
each build. At the moment it seems to be stopping the flake.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
e2e greener

## Tag your pair, your PM, and/or team
@kieron-dev

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
