### PR TITLE
Add GET apps/packages handler

### DIFF
--- a/api/handlers/app.go
+++ b/api/handlers/app.go
@@ -557,6 +557,11 @@ func (h *App) getPackages(r *http.Request) (*routing.Response, error) {
 	logger := logr.FromContextOrDiscard(r.Context()).WithName("handlers.app.get-packages")
 	appGUID := routing.URLParam(r, "guid")
 
+	_, err := h.appRepo.GetApp(r.Context(), authInfo, appGUID)
+	if err != nil {
+		return nil, apierrors.LogAndReturn(logger, apierrors.ForbiddenAsNotFound(err), "Failed to fetch app from Kubernetes", "AppGUID", appGUID)
+	}
+
 	fetchPackagesForAppMessage := repositories.ListPackagesMessage{
 		AppGUIDs: []string{appGUID},
 		States:   []string{},

--- a/api/handlers/app.go
+++ b/api/handlers/app.go
@@ -572,7 +572,7 @@ func (h *App) getPackages(r *http.Request) (*routing.Response, error) {
 		return nil, apierrors.LogAndReturn(logger, err, "Failed to fetch app Package(s) from Kubernetes")
 	}
 
-	return routing.NewResponse(http.StatusOK).WithBody(presenter.ForPackageList(packageList, h.serverURL, *r.URL)), nil
+	return routing.NewResponse(http.StatusOK).WithBody(presenter.ForList(presenter.ForPackage, packageList, h.serverURL, *r.URL)), nil
 }
 
 //nolint:dupl

--- a/api/handlers/app_test.go
+++ b/api/handlers/app_test.go
@@ -37,6 +37,7 @@ var _ = Describe("App", func() {
 		routeRepo   *fake.CFRouteRepository
 		domainRepo  *fake.CFDomainRepository
 		spaceRepo   *fake.SpaceRepository
+		packageRepo *fake.CFPackageRepository
 		req         *http.Request
 
 		appRecord repositories.AppRecord
@@ -49,6 +50,7 @@ var _ = Describe("App", func() {
 		routeRepo = new(fake.CFRouteRepository)
 		domainRepo = new(fake.CFDomainRepository)
 		spaceRepo = new(fake.SpaceRepository)
+		packageRepo = new(fake.CFPackageRepository)
 		decoderValidator, err := NewDefaultDecoderValidator()
 		Expect(err).NotTo(HaveOccurred())
 
@@ -60,6 +62,7 @@ var _ = Describe("App", func() {
 			routeRepo,
 			domainRepo,
 			spaceRepo,
+			packageRepo,
 			decoderValidator,
 		)
 

--- a/api/main.go
+++ b/api/main.go
@@ -259,6 +259,7 @@ func main() {
 			routeRepo,
 			domainRepo,
 			spaceRepo,
+			packageRepo,
 			decoderValidator,
 		),
 		handlers.NewRoute(

--- a/tests/e2e/apps_test.go
+++ b/tests/e2e/apps_test.go
@@ -290,6 +290,32 @@ var _ = Describe("Apps", func() {
 		})
 	})
 
+	Describe("List app packages", func() {
+		var (
+			result  resourceList[typedResource]
+			pkgGUID string
+		)
+
+		BeforeEach(func() {
+			createSpaceRole("space_developer", certUserName, space1GUID)
+			appGUID = createApp(space1GUID, generateGUID("app"))
+			pkgGUID = createPackage(appGUID)
+			uploadTestApp(pkgGUID, procfileAppBitsFile())
+		})
+
+		JustBeforeEach(func() {
+			var err error
+			resp, err = certClient.R().SetResult(&result).Get("/v3/apps/" + appGUID + "/packages")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("successfully lists the packages", func() {
+			Expect(resp).To(HaveRestyStatusCode(http.StatusOK))
+			Expect(result.Resources).To(HaveLen(1))
+			Expect(result.Resources[0].Type).To(Equal("bits"))
+		})
+	})
+
 	Describe("List app routes", func() {
 		var result resourceList[resource]
 

--- a/tests/e2e/apps_test.go
+++ b/tests/e2e/apps_test.go
@@ -300,7 +300,7 @@ var _ = Describe("Apps", func() {
 			createSpaceRole("space_developer", certUserName, space1GUID)
 			appGUID = createApp(space1GUID, generateGUID("app"))
 			pkgGUID = createPackage(appGUID)
-			uploadTestApp(pkgGUID, procfileAppBitsFile())
+			uploadTestApp(pkgGUID, procfileAppBitsFile)
 		})
 
 		JustBeforeEach(func() {


### PR DESCRIPTION
## Is there a related GitHub Issue?
Fixes https://github.com/cloudfoundry/korifi/issues/2333

## What is this change about?
Add GET apps/packages handler

## Does this PR introduce a breaking change?
No

## Acceptance Steps
GIVEN I have pushed an app
WHEN I perform the following request
```
curl "https://api.example.org/v3/apps/[guid]/packages"
```
THEN I get a 200 OK response with a list of packages

