### PR TITLE
Improve handler tests

### DIFF
--- a/api/handlers/app.go
+++ b/api/handlers/app.go
@@ -157,7 +157,7 @@ func (h *App) list(r *http.Request) (*routing.Response, error) { //nolint:dupl
 		return nil, apierrors.LogAndReturn(logger, err, "unable to parse order by request")
 	}
 
-	return routing.NewResponse(http.StatusOK).WithBody(presenter.ForAppList(appList, h.serverURL, *r.URL)), nil
+	return routing.NewResponse(http.StatusOK).WithBody(presenter.ForList(presenter.ForApp, appList, h.serverURL, *r.URL)), nil
 }
 
 func (h *App) sortList(appList []repositories.AppRecord, order string) error {
@@ -361,7 +361,7 @@ func (h *App) getRoutes(r *http.Request) (*routing.Response, error) {
 		return nil, apierrors.LogAndReturn(logger, err, "Failed to fetch route or domains from Kubernetes")
 	}
 
-	return routing.NewResponse(http.StatusOK).WithBody(presenter.ForRouteList(routes, h.serverURL, *r.URL)), nil
+	return routing.NewResponse(http.StatusOK).WithBody(presenter.ForList(presenter.ForRoute, routes, h.serverURL, *r.URL)), nil
 }
 
 func (h *App) scaleProcess(r *http.Request) (*routing.Response, error) {

--- a/api/handlers/app_test.go
+++ b/api/handlers/app_test.go
@@ -13,6 +13,7 @@ import (
 	. "code.cloudfoundry.org/korifi/api/handlers"
 	"code.cloudfoundry.org/korifi/api/handlers/fake"
 	"code.cloudfoundry.org/korifi/api/repositories"
+	. "code.cloudfoundry.org/korifi/tests/matchers"
 	"code.cloudfoundry.org/korifi/tools"
 
 	"github.com/go-http-utils/headers"
@@ -109,79 +110,9 @@ var _ = Describe("App", func() {
 			contentTypeHeader := rr.Header().Get("Content-Type")
 			Expect(contentTypeHeader).To(Equal(jsonHeader), "Matching Content-Type header:")
 
-			Expect(rr.Body.String()).To(MatchJSON(fmt.Sprintf(`{
-                    "guid": "%[2]s",
-                    "created_at": "",
-                    "updated_at": "",
-                    "name": "test-app",
-                    "state": "STOPPED",
-                    "lifecycle": {
-                      "type": "buildpack",
-                      "data": {
-                        "buildpacks": [],
-                        "stack": ""
-                      }
-                    },
-                    "relationships": {
-                      "space": {
-                        "data": {
-                          "guid": "%[3]s"
-                        }
-                      }
-                    },
-                    "metadata": {
-                      "labels": {
-                        "label-key": "label-value"
-                      },
-                      "annotations": {
-						"korifi.cloudfoundry.org/app-rev": "0",
-                        "annotation-key": "annotation-value"
-                      }
-                    },
-                    "links": {
-                      "self": {
-                        "href": "https://api.example.org/v3/apps/%[2]s"
-                      },
-                      "environment_variables": {
-                        "href": "https://api.example.org/v3/apps/%[2]s/environment_variables"
-                      },
-                      "space": {
-                        "href": "https://api.example.org/v3/spaces/%[3]s"
-                      },
-                      "processes": {
-                        "href": "https://api.example.org/v3/apps/%[2]s/processes"
-                      },
-                      "packages": {
-                        "href": "https://api.example.org/v3/apps/%[2]s/packages"
-                      },
-                      "current_droplet": {
-                        "href": "https://api.example.org/v3/apps/%[2]s/droplets/current"
-                      },
-                      "droplets": {
-                        "href": "https://api.example.org/v3/apps/%[2]s/droplets"
-                      },
-                      "tasks": {
-                        "href": "https://api.example.org/v3/apps/%[2]s/tasks"
-                      },
-                      "start": {
-                        "href": "https://api.example.org/v3/apps/%[2]s/actions/start",
-                        "method": "POST"
-                      },
-                      "stop": {
-                        "href": "https://api.example.org/v3/apps/%[2]s/actions/stop",
-                        "method": "POST"
-                      },
-                      "revisions": {
-                        "href": "https://api.example.org/v3/apps/%[2]s/revisions"
-                      },
-                      "deployed_revisions": {
-                        "href": "https://api.example.org/v3/apps/%[2]s/revisions/deployed"
-                      },
-                      "features": {
-                        "href": "https://api.example.org/v3/apps/%[2]s/features"
-                      }
-                    }
-                }`, defaultServerURL, appGUID, spaceGUID)), "Response body matches response:")
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.guid", "test-app-guid"))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.state", "STOPPED"))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.links.self.href", HavePrefix("https://api.example.org")))
 		})
 
 		When("the app is not accessible", func() {
@@ -238,79 +169,9 @@ var _ = Describe("App", func() {
 			contentTypeHeader := rr.Header().Get("Content-Type")
 			Expect(contentTypeHeader).To(Equal(jsonHeader))
 
-			Expect(rr.Body.String()).To(MatchJSON(fmt.Sprintf(`{
-                    "guid": "%[2]s",
-                    "created_at": "",
-                    "updated_at": "",
-                    "name": "test-app",
-                    "state": "STOPPED",
-                    "lifecycle": {
-                      "type": "buildpack",
-                      "data": {
-                        "buildpacks": [],
-                        "stack": ""
-                      }
-                    },
-                    "relationships": {
-                      "space": {
-                        "data": {
-                          "guid": "%[3]s"
-                        }
-                      }
-                    },
-                    "metadata": {
-                      "labels": {
-                        "label-key": "label-value"
-                      },
-                      "annotations": {
-						"korifi.cloudfoundry.org/app-rev": "0",
-                        "annotation-key": "annotation-value"
-                      }
-                    },
-                    "links": {
-                      "self": {
-                        "href": "https://api.example.org/v3/apps/%[2]s"
-                      },
-                      "environment_variables": {
-                        "href": "https://api.example.org/v3/apps/%[2]s/environment_variables"
-                      },
-                      "space": {
-                        "href": "https://api.example.org/v3/spaces/%[3]s"
-                      },
-                      "processes": {
-                        "href": "https://api.example.org/v3/apps/%[2]s/processes"
-                      },
-                      "packages": {
-                        "href": "https://api.example.org/v3/apps/%[2]s/packages"
-                      },
-                      "current_droplet": {
-                        "href": "https://api.example.org/v3/apps/%[2]s/droplets/current"
-                      },
-                      "droplets": {
-                        "href": "https://api.example.org/v3/apps/%[2]s/droplets"
-                      },
-                      "tasks": {
-                        "href": "https://api.example.org/v3/apps/%[2]s/tasks"
-                      },
-                      "start": {
-                        "href": "https://api.example.org/v3/apps/%[2]s/actions/start",
-                        "method": "POST"
-                      },
-                      "stop": {
-                        "href": "https://api.example.org/v3/apps/%[2]s/actions/stop",
-                        "method": "POST"
-                      },
-                      "revisions": {
-                        "href": "https://api.example.org/v3/apps/%[2]s/revisions"
-                      },
-                      "deployed_revisions": {
-                        "href": "https://api.example.org/v3/apps/%[2]s/revisions/deployed"
-                      },
-                      "features": {
-                        "href": "https://api.example.org/v3/apps/%[2]s/features"
-                      }
-                    }
-                }`, defaultServerURL, appGUID, spaceGUID)), "Response body matches response:")
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.guid", appGUID))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.state", "STOPPED"))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.links.self.href", HavePrefix("https://api.example.org")))
 		})
 
 		It("creates the `web` process", func() {
@@ -529,163 +390,12 @@ var _ = Describe("App", func() {
 			Expect(contentTypeHeader).Should(Equal(jsonHeader), "Matching Content-Type header:")
 		})
 
-		It("returns the Pagination Data and App Resources in the response", func() {
-			Expect(rr.Body.String()).Should(MatchJSON(fmt.Sprintf(`{
-				"pagination": {
-				  "total_results": 2,
-				  "total_pages": 1,
-				  "first": {
-					"href": "%[1]s/v3/apps"
-				  },
-				  "last": {
-					"href": "%[1]s/v3/apps"
-				  },
-				  "next": null,
-				  "previous": null
-				},
-				"resources": [
-					{
-						"guid": "first-test-app-guid",
-						"created_at": "",
-						"updated_at": "",
-						"name": "first-test-app",
-						"state": "STOPPED",
-						"lifecycle": {
-						  "type": "buildpack",
-						  "data": {
-							"buildpacks": [],
-							"stack": ""
-						  }
-						},
-						"relationships": {
-						  "space": {
-							"data": {
-							  "guid": "test-space-guid"
-							}
-						  }
-						},
-						"metadata": {
-						  "labels": {},
-						  "annotations": {
-						    "korifi.cloudfoundry.org/app-rev": "0"
-						  }
-						},
-						"links": {
-						  "self": {
-							"href": "%[1]s/v3/apps/first-test-app-guid"
-						  },
-						  "environment_variables": {
-							"href": "%[1]s/v3/apps/first-test-app-guid/environment_variables"
-						  },
-						  "space": {
-							"href": "%[1]s/v3/spaces/test-space-guid"
-						  },
-						  "processes": {
-							"href": "%[1]s/v3/apps/first-test-app-guid/processes"
-						  },
-						  "packages": {
-							"href": "%[1]s/v3/apps/first-test-app-guid/packages"
-						  },
-						  "current_droplet": {
-							"href": "%[1]s/v3/apps/first-test-app-guid/droplets/current"
-						  },
-						  "droplets": {
-							"href": "%[1]s/v3/apps/first-test-app-guid/droplets"
-						  },
-						  "tasks": {
-							"href": "%[1]s/v3/apps/first-test-app-guid/tasks"
-						  },
-						  "start": {
-							"href": "%[1]s/v3/apps/first-test-app-guid/actions/start",
-							"method": "POST"
-						  },
-						  "stop": {
-							"href": "%[1]s/v3/apps/first-test-app-guid/actions/stop",
-							"method": "POST"
-						  },
-						  "revisions": {
-							"href": "%[1]s/v3/apps/first-test-app-guid/revisions"
-						  },
-						  "deployed_revisions": {
-							"href": "%[1]s/v3/apps/first-test-app-guid/revisions/deployed"
-						  },
-						  "features": {
-							"href": "%[1]s/v3/apps/first-test-app-guid/features"
-						  }
-						}
-					},
-					{
-						"guid": "second-test-app-guid",
-						"created_at": "",
-						"updated_at": "",
-						"name": "second-test-app",
-						"state": "STOPPED",
-						"lifecycle": {
-						  "type": "buildpack",
-						  "data": {
-							"buildpacks": [],
-							"stack": ""
-						  }
-						},
-						"relationships": {
-						  "space": {
-							"data": {
-							  "guid": "test-space-guid"
-							}
-						  }
-						},
-						"metadata": {
-						  "labels": {},
-						  "annotations": {
-						    "korifi.cloudfoundry.org/app-rev": "0"
-						  }
-						},
-						"links": {
-						  "self": {
-							"href": "%[1]s/v3/apps/second-test-app-guid"
-						  },
-						  "environment_variables": {
-							"href": "%[1]s/v3/apps/second-test-app-guid/environment_variables"
-						  },
-						  "space": {
-							"href": "%[1]s/v3/spaces/test-space-guid"
-						  },
-						  "processes": {
-							"href": "%[1]s/v3/apps/second-test-app-guid/processes"
-						  },
-						  "packages": {
-							"href": "%[1]s/v3/apps/second-test-app-guid/packages"
-						  },
-						  "current_droplet": {
-							"href": "%[1]s/v3/apps/second-test-app-guid/droplets/current"
-						  },
-						  "droplets": {
-							"href": "%[1]s/v3/apps/second-test-app-guid/droplets"
-						  },
-						  "tasks": {
-							"href": "%[1]s/v3/apps/second-test-app-guid/tasks"
-						  },
-						  "start": {
-							"href": "%[1]s/v3/apps/second-test-app-guid/actions/start",
-							"method": "POST"
-						  },
-						  "stop": {
-							"href": "%[1]s/v3/apps/second-test-app-guid/actions/stop",
-							"method": "POST"
-						  },
-						  "revisions": {
-							"href": "%[1]s/v3/apps/second-test-app-guid/revisions"
-						  },
-						  "deployed_revisions": {
-							"href": "%[1]s/v3/apps/second-test-app-guid/revisions/deployed"
-						  },
-						  "features": {
-							"href": "%[1]s/v3/apps/second-test-app-guid/features"
-						  }
-						}
-					}
-				]
-			}`, defaultServerURL)), "Response body matches response:")
+		It("returns App Resources in the response", func() {
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.pagination.first.href", "https://api.example.org/v3/apps"))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.resources", HaveLen(2)))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.resources[0].guid", "first-test-app-guid"))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.resources[0].state", Equal("STOPPED")))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.resources[1].guid", "second-test-app-guid"))
 		})
 
 		It("invokes the repository with the provided auth info", func() {
@@ -708,18 +418,11 @@ var _ = Describe("App", func() {
 			})
 
 			It("correctly sets query parameters in response pagination links", func() {
-				Expect(rr.Body.String()).To(ContainSubstring("https://api.example.org/v3/apps?names=app1,app2&space_guids=space1,space2"))
+				Expect(rr.Body.Bytes()).To(MatchJSONPath("$.pagination.first.href", "https://api.example.org/v3/apps?names=app1,app2&space_guids=space1,space2"))
 			})
 		})
 
 		Describe("Order results", func() {
-			type res struct {
-				GUID string `json:"guid"`
-			}
-			type resList struct {
-				Resources []res `json:"resources"`
-			}
-
 			BeforeEach(func() {
 				appRepo.ListAppsReturns([]repositories.AppRecord{
 					{
@@ -753,18 +456,11 @@ var _ = Describe("App", func() {
 				}, nil)
 			})
 
-			DescribeTable("ordering results", func(orderBy string, expectedOrder ...string) {
+			DescribeTable("ordering results", func(orderBy string, expectedOrder ...any) {
 				req = createHttpRequest("GET", "/v3/apps?order_by="+orderBy, nil)
 				rr = httptest.NewRecorder()
 				routerBuilder.Build().ServeHTTP(rr, req)
-				var respList resList
-				err := json.Unmarshal(rr.Body.Bytes(), &respList)
-				Expect(err).NotTo(HaveOccurred())
-				expectedList := make([]res, len(expectedOrder))
-				for i := range expectedOrder {
-					expectedList[i] = res{GUID: expectedOrder[i]}
-				}
-				Expect(respList.Resources).To(Equal(expectedList))
+				Expect(rr.Body.Bytes()).To(MatchJSONPath("$.resources[*].guid", expectedOrder))
 			},
 				Entry("created_at ASC", "created_at", "3", "4", "2", "1"),
 				Entry("created_at DESC", "-created_at", "1", "2", "4", "3"),
@@ -801,22 +497,9 @@ var _ = Describe("App", func() {
 				Expect(contentTypeHeader).Should(Equal(jsonHeader), "Matching Content-Type header:")
 			})
 
-			It("returns a CF API formatted Error response", func() {
-				Expect(rr.Body.String()).Should(MatchJSON(fmt.Sprintf(`{
-				"pagination": {
-				  "total_results": 0,
-				  "total_pages": 1,
-				  "first": {
-					"href": "%[1]s/v3/apps"
-				  },
-				  "last": {
-					"href": "%[1]s/v3/apps"
-				  },
-				  "next": null,
-				  "previous": null
-				},
-				"resources": []
-			}`, defaultServerURL)), "Response body matches response:")
+			It("returns an empty response", func() {
+				Expect(rr.Body.Bytes()).To(MatchJSONPath("$.pagination.total_results", BeEquivalentTo(0)))
+				Expect(rr.Body.Bytes()).To(MatchJSONPath("$.resources", BeEmpty()))
 			})
 		})
 
@@ -843,6 +526,7 @@ var _ = Describe("App", func() {
 
 	Describe("PATCH /v3/apps/:guid", func() {
 		BeforeEach(func() {
+			appRecord.GUID = "patched-app-guid"
 			appRepo.PatchAppMetadataReturns(appRecord, nil)
 			req = createHttpRequest("PATCH", "/v3/apps/"+appGUID, strings.NewReader(`{
 				  "metadata": {
@@ -876,80 +560,9 @@ var _ = Describe("App", func() {
 		It("returns the App in the response", func() {
 			contentTypeHeader := rr.Header().Get("Content-Type")
 			Expect(contentTypeHeader).To(Equal(jsonHeader), "Matching Content-Type header:")
-
-			Expect(rr.Body.String()).To(MatchJSON(fmt.Sprintf(`{
-                    "guid": "%[2]s",
-                    "created_at": "",
-                    "updated_at": "",
-                    "name": "test-app",
-                    "state": "STOPPED",
-                    "lifecycle": {
-                      "type": "buildpack",
-                      "data": {
-                        "buildpacks": [],
-                        "stack": ""
-                      }
-                    },
-                    "relationships": {
-                      "space": {
-                        "data": {
-                          "guid": "%[3]s"
-                        }
-                      }
-                    },
-                    "metadata": {
-                      "labels": {
-                        "label-key": "label-value"
-                      },
-                      "annotations": {
-						"korifi.cloudfoundry.org/app-rev": "0",
-                        "annotation-key": "annotation-value"
-                      }
-                    },
-                    "links": {
-                      "self": {
-                        "href": "https://api.example.org/v3/apps/%[2]s"
-                      },
-                      "environment_variables": {
-                        "href": "https://api.example.org/v3/apps/%[2]s/environment_variables"
-                      },
-                      "space": {
-                        "href": "https://api.example.org/v3/spaces/%[3]s"
-                      },
-                      "processes": {
-                        "href": "https://api.example.org/v3/apps/%[2]s/processes"
-                      },
-                      "packages": {
-                        "href": "https://api.example.org/v3/apps/%[2]s/packages"
-                      },
-                      "current_droplet": {
-                        "href": "https://api.example.org/v3/apps/%[2]s/droplets/current"
-                      },
-                      "droplets": {
-                        "href": "https://api.example.org/v3/apps/%[2]s/droplets"
-                      },
-                      "tasks": {
-                        "href": "https://api.example.org/v3/apps/%[2]s/tasks"
-                      },
-                      "start": {
-                        "href": "https://api.example.org/v3/apps/%[2]s/actions/start",
-                        "method": "POST"
-                      },
-                      "stop": {
-                        "href": "https://api.example.org/v3/apps/%[2]s/actions/stop",
-                        "method": "POST"
-                      },
-                      "revisions": {
-                        "href": "https://api.example.org/v3/apps/%[2]s/revisions"
-                      },
-                      "deployed_revisions": {
-                        "href": "https://api.example.org/v3/apps/%[2]s/revisions/deployed"
-                      },
-                      "features": {
-                        "href": "https://api.example.org/v3/apps/%[2]s/features"
-                      }
-                    }
-                }`, defaultServerURL, appGUID, spaceGUID)), "Response body matches response:")
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.guid", "patched-app-guid"))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.state", "STOPPED"))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.links.self.href", HavePrefix("https://api.example.org")))
 		})
 
 		When("the user doesn't have permission to get the App", func() {
@@ -1097,20 +710,8 @@ var _ = Describe("App", func() {
 		It("responds with JSON", func() {
 			contentTypeHeader := rr.Header().Get("Content-Type")
 			Expect(contentTypeHeader).To(Equal(jsonHeader), "Matching Content-Type header:")
-
-			Expect(rr.Body.String()).To(MatchJSON(`{
-                	"data": {
-                		"guid": "` + dropletGUID + `"
-                	},
-                	"links": {
-                		"self": {
-                			"href": "https://api.example.org/v3/apps/` + appGUID + `/relationships/current_droplet"
-                		},
-                		"related": {
-                			"href": "https://api.example.org/v3/apps/` + appGUID + `/droplets/current"
-                		}
-                	}
-                }`))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.data.guid", dropletGUID))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.links.self.href", HavePrefix("https://api.example.org")))
 		})
 
 		It("fetches the right App", func() {
@@ -1245,79 +846,9 @@ var _ = Describe("App", func() {
 			contentTypeHeader := rr.Header().Get("Content-Type")
 			Expect(contentTypeHeader).To(Equal(jsonHeader), "Matching Content-Type header:")
 
-			Expect(rr.Body.String()).To(MatchJSON(fmt.Sprintf(`{
-                    "guid": "%[2]s",
-                    "created_at": "",
-                    "updated_at": "",
-                    "name": "%[4]s",
-                    "state": "STARTED",
-                    "lifecycle": {
-                      "type": "buildpack",
-                      "data": {
-                        "buildpacks": [],
-                        "stack": ""
-                      }
-                    },
-                    "relationships": {
-                      "space": {
-                        "data": {
-                          "guid": "%[3]s"
-                        }
-                      }
-                    },
-                    "metadata": {
-                      "labels": {
-					    "label-key": "label-value"
-					  },
-                      "annotations": {
-					    "annotation-key": "annotation-value",
-					    "korifi.cloudfoundry.org/app-rev": "0"
-					  }
-                    },
-                    "links": {
-                      "self": {
-                        "href": "https://api.example.org/v3/apps/%[2]s"
-                      },
-                      "environment_variables": {
-                        "href": "https://api.example.org/v3/apps/%[2]s/environment_variables"
-                      },
-                      "space": {
-                        "href": "https://api.example.org/v3/spaces/%[3]s"
-                      },
-                      "processes": {
-                        "href": "https://api.example.org/v3/apps/%[2]s/processes"
-                      },
-                      "packages": {
-                        "href": "https://api.example.org/v3/apps/%[2]s/packages"
-                      },
-                      "current_droplet": {
-                        "href": "https://api.example.org/v3/apps/%[2]s/droplets/current"
-                      },
-                      "droplets": {
-                        "href": "https://api.example.org/v3/apps/%[2]s/droplets"
-                      },
-                      "tasks": {
-                        "href": "https://api.example.org/v3/apps/%[2]s/tasks"
-                      },
-                      "start": {
-                        "href": "https://api.example.org/v3/apps/%[2]s/actions/start",
-                        "method": "POST"
-                      },
-                      "stop": {
-                        "href": "https://api.example.org/v3/apps/%[2]s/actions/stop",
-                        "method": "POST"
-                      },
-                      "revisions": {
-                        "href": "https://api.example.org/v3/apps/%[2]s/revisions"
-                      },
-                      "deployed_revisions": {
-                        "href": "https://api.example.org/v3/apps/%[2]s/revisions/deployed"
-                      },
-                      "features": {
-                        "href": "https://api.example.org/v3/apps/%[2]s/features"
-                      }
-                    }
-                }`, defaultServerURL, appGUID, spaceGUID, appName)), "Response body matches response:")
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.guid", appGUID))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.state", "STARTED"))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.links.self.href", HavePrefix("https://api.example.org")))
 		})
 
 		When("getting the app is forbidden", func() {
@@ -1380,79 +911,9 @@ var _ = Describe("App", func() {
 			contentTypeHeader := rr.Header().Get("Content-Type")
 			Expect(contentTypeHeader).To(Equal(jsonHeader), "Matching Content-Type header:")
 
-			Expect(rr.Body.String()).To(MatchJSON(fmt.Sprintf(`{
-					"guid": "%[2]s",
-					"created_at": "",
-					"updated_at": "",
-					"name": "%[4]s",
-					"state": "STOPPED",
-					"lifecycle": {
-						"type": "buildpack",
-						"data": {
-							"buildpacks": [],
-							"stack": ""
-						}
-					},
-					"relationships": {
-						"space": {
-							"data": {
-								"guid": "%[3]s"
-							}
-						}
-					},
-					"metadata": {
-						"labels": {
-						  "label-key": "label-value"
-						},
-						"annotations": {
-					      "annotation-key": "annotation-value",
-						  "korifi.cloudfoundry.org/app-rev": "0"
-						}
-					},
-					"links": {
-						"self": {
-							"href": "https://api.example.org/v3/apps/%[2]s"
-						},
-						"environment_variables": {
-							"href": "https://api.example.org/v3/apps/%[2]s/environment_variables"
-						},
-						"space": {
-							"href": "https://api.example.org/v3/spaces/%[3]s"
-						},
-						"processes": {
-							"href": "https://api.example.org/v3/apps/%[2]s/processes"
-						},
-						"packages": {
-							"href": "https://api.example.org/v3/apps/%[2]s/packages"
-						},
-						"current_droplet": {
-							"href": "https://api.example.org/v3/apps/%[2]s/droplets/current"
-						},
-						"droplets": {
-							"href": "https://api.example.org/v3/apps/%[2]s/droplets"
-						},
-						"tasks": {
-							"href": "https://api.example.org/v3/apps/%[2]s/tasks"
-						},
-						"start": {
-							"href": "https://api.example.org/v3/apps/%[2]s/actions/start",
-							"method": "POST"
-						},
-						"stop": {
-							"href": "https://api.example.org/v3/apps/%[2]s/actions/stop",
-							"method": "POST"
-						},
-						"revisions": {
-							"href": "https://api.example.org/v3/apps/%[2]s/revisions"
-						},
-						"deployed_revisions": {
-							"href": "https://api.example.org/v3/apps/%[2]s/revisions/deployed"
-						},
-						"features": {
-							"href": "https://api.example.org/v3/apps/%[2]s/features"
-						}
-					}
-				}`, defaultServerURL, appGUID, spaceGUID, appName)), "Response body matches response:")
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.guid", appGUID))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.state", "STOPPED"))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.links.self.href", HavePrefix("https://api.example.org")))
 		})
 
 		When("fetching the app is forbidden", func() {
@@ -1536,113 +997,12 @@ var _ = Describe("App", func() {
 			contentTypeHeader := rr.Header().Get("Content-Type")
 			Expect(contentTypeHeader).To(Equal(jsonHeader), "Matching Content-Type header:")
 
-			Expect(rr.Body.String()).Should(MatchJSON(fmt.Sprintf(`{
-						"pagination": {
-						  "total_results": 2,
-						  "total_pages": 1,
-						  "first": {
-							"href": "%[1]s/v3/apps/%[2]s/processes"
-						  },
-						  "last": {
-							"href": "%[1]s/v3/apps/%[2]s/processes"
-						  },
-						  "next": null,
-						  "previous": null
-						},
-						"resources": [
-							{
-								"guid": "%[4]s",
-								"type": "web",
-								"command": "[PRIVATE DATA HIDDEN IN LISTS]",
-								"instances": 5,
-								"memory_in_mb": 256,
-								"disk_in_mb": 1024,
-								"health_check": {
-									"type": "port",
-									"data": {
-										"timeout": null,
-										"invocation_timeout": null
-									}
-								},
-								"relationships": {
-									"app": {
-										"data": {
-											"guid": "%[2]s"
-										}
-									}
-								},
-								"metadata": {
-									"labels": {},
-									"annotations": {}
-								},
-								"created_at": "2016-03-23T18:48:22Z",
-								"updated_at": "2016-03-23T18:48:42Z",
-								"links": {
-									"self": {
-										"href": "%[1]s/v3/processes/%[4]s"
-									},
-									"scale": {
-										"href": "%[1]s/v3/processes/%[4]s/actions/scale",
-										"method": "POST"
-									},
-									"app": {
-										"href": "%[1]s/v3/apps/%[2]s"
-									},
-									"space": {
-										"href": "%[1]s/v3/spaces/%[3]s"
-									},
-									"stats": {
-										"href": "%[1]s/v3/processes/%[4]s/stats"
-									}
-								}
-							},
-							{
-								"guid": "%[5]s",
-								"type": "worker",
-								"command": "[PRIVATE DATA HIDDEN IN LISTS]",
-								"instances": 1,
-								"memory_in_mb": 256,
-								"disk_in_mb": 1024,
-								"health_check": {
-									"type": "process",
-									"data": {
-										"timeout": null
-									}
-								},
-								"relationships": {
-									"app": {
-										"data": {
-											"guid": "%[2]s"
-										}
-									}
-								},
-								"metadata": {
-									"labels": {},
-									"annotations": {}
-								},
-								"created_at": "2016-03-23T18:48:22Z",
-								"updated_at": "2016-03-23T18:48:42Z",
-								"links": {
-									"self": {
-										"href": "%[1]s/v3/processes/%[5]s"
-									},
-									"scale": {
-										"href": "%[1]s/v3/processes/%[5]s/actions/scale",
-										"method": "POST"
-									},
-									"app": {
-										"href": "%[1]s/v3/apps/%[2]s"
-									},
-									"space": {
-										"href": "%[1]s/v3/spaces/%[3]s"
-									},
-									"stats": {
-										"href": "%[1]s/v3/processes/%[5]s/stats"
-									}
-								}
-							}
-						]
-					}`, defaultServerURL, appGUID, spaceGUID, process1Record.GUID, process2Record.GUID)), "Response body matches response:")
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.pagination.first.href", "https://api.example.org/v3/apps/"+appGUID+"/processes"))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.resources", HaveLen(2)))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.resources[0].guid", "process-1-guid"))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.resources[0].command", "[PRIVATE DATA HIDDEN IN LISTS]"))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.resources[1].guid", "process-2-guid"))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.resources[1].command", "[PRIVATE DATA HIDDEN IN LISTS]"))
 		})
 
 		When("the app cannot be accessed", func() {
@@ -1714,52 +1074,9 @@ var _ = Describe("App", func() {
 			contentTypeHeader := rr.Header().Get("Content-Type")
 			Expect(contentTypeHeader).To(Equal(jsonHeader), "Matching Content-Type header:")
 
-			Expect(rr.Body.String()).To(MatchJSON(`{
-					"guid": "process-1-guid",
-					"created_at": "1906-04-18T13:12:00Z",
-					"updated_at": "1906-04-18T13:12:01Z",
-					"type": "web",
-					"command": "bundle exec rackup config.ru -p $PORT -o 0.0.0.0",
-					"instances": 1,
-					"memory_in_mb": 256,
-					"disk_in_mb": 1024,
-					"health_check": {
-					   "type": "port",
-					   "data": {
-						  "timeout": null,
-						  "invocation_timeout": null
-					   }
-					},
-					"relationships": {
-					   "app": {
-						  "data": {
-							 "guid": "` + appGUID + `"
-						  }
-					   }
-					},
-					"metadata": {
-					   "labels": {},
-					   "annotations": {}
-					},
-					"links": {
-					   "self": {
-						  "href": "https://api.example.org/v3/processes/process-1-guid"
-					   },
-					   "scale": {
-						  "href": "https://api.example.org/v3/processes/process-1-guid/actions/scale",
-						  "method": "POST"
-					   },
-					   "app": {
-						  "href": "https://api.example.org/v3/apps/` + appGUID + `"
-					   },
-					   "space": {
-						  "href": "https://api.example.org/v3/spaces/` + spaceGUID + `"
-					   },
-					   "stats": {
-						  "href": "https://api.example.org/v3/processes/process-1-guid/stats"
-					   }
-					}
-				 }`))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.guid", "process-1-guid"))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.command", "bundle exec rackup config.ru -p $PORT -o 0.0.0.0"))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.links.self.href", HavePrefix("https://api.example.org")))
 		})
 
 		When("the user lacks access in the app namespace", func() {
@@ -1870,52 +1187,10 @@ var _ = Describe("App", func() {
 			contentTypeHeader := rr.Header().Get("Content-Type")
 			Expect(contentTypeHeader).To(Equal(jsonHeader), "Matching Content-Type header:")
 
-			Expect(rr.Body.String()).To(MatchJSON(`{
-						"guid": "process-1-guid",
-						"created_at": "1906-04-18T13:12:00Z",
-						"updated_at": "1906-04-18T13:12:01Z",
-						"type": "web",
-						"command": "bundle exec rackup config.ru -p $PORT -o 0.0.0.0",
-						"instances": 5,
-						"memory_in_mb": 256,
-						"disk_in_mb": 1024,
-						"health_check": {
-						   "type": "port",
-						   "data": {
-							  "timeout": null,
-							  "invocation_timeout": null
-						   }
-						},
-						"relationships": {
-						   "app": {
-							  "data": {
-								 "guid": "` + appGUID + `"
-							  }
-						   }
-						},
-						"metadata": {
-						   "labels": {},
-						   "annotations": {}
-						},
-						"links": {
-						   "self": {
-							  "href": "https://api.example.org/v3/processes/process-1-guid"
-						   },
-						   "scale": {
-							  "href": "https://api.example.org/v3/processes/process-1-guid/actions/scale",
-							  "method": "POST"
-						   },
-						   "app": {
-							  "href": "https://api.example.org/v3/apps/` + appGUID + `"
-						   },
-						   "space": {
-							  "href": "https://api.example.org/v3/spaces/` + spaceGUID + `"
-						   },
-						   "stats": {
-							  "href": "https://api.example.org/v3/processes/process-1-guid/stats"
-						   }
-						}
-				 }`))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.guid", "process-1-guid"))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.command", "bundle exec rackup config.ru -p $PORT -o 0.0.0.0"))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.instances", BeEquivalentTo(5)))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.links.self.href", HavePrefix("https://api.example.org")))
 		})
 
 		When("the request JSON is invalid", func() {
@@ -2061,64 +1336,12 @@ var _ = Describe("App", func() {
 			Expect(contentTypeHeader).To(Equal(jsonHeader), "Matching Content-Type header:")
 		})
 
-		It("returns the Pagination Data and App Resources in the response", func() {
-			Expect(rr.Body.String()).To(MatchJSON(`{
-						"pagination": {
-							"total_results": 1,
-							"total_pages": 1,
-							"first": {
-								"href": "https://api.example.org/v3/apps/test-app-guid/routes"
-							},
-							"last": {
-								"href": "https://api.example.org/v3/apps/test-app-guid/routes"
-							},
-							"next": null,
-							"previous": null
-						},
-						"resources": [
-							{
-								"guid": "test-route-guid",
-								"port": null,
-								"path": "/some_path",
-								"protocol": "http",
-								"host": "test-route-host",
-								"url": "test-route-host.example.org/some_path",
-								"created_at": "2019-05-10T17:17:48Z",
-								"updated_at": "2019-05-10T17:17:48Z",
-								"destinations": [],
-								"relationships": {
-									"space": {
-										"data": {
-											"guid": "test-space-guid"
-										}
-									},
-									"domain": {
-										"data": {
-											"guid": "test-domain-guid"
-										}
-									}
-								},
-								"metadata": {
-									"labels": {},
-									"annotations": {}
-								},
-								"links": {
-									"self":{
-										"href": "https://api.example.org/v3/routes/test-route-guid"
-									},
-									"space":{
-										"href": "https://api.example.org/v3/spaces/test-space-guid"
-									},
-									"domain":{
-										"href": "https://api.example.org/v3/domains/test-domain-guid"
-									},
-									"destinations":{
-										"href": "https://api.example.org/v3/routes/test-route-guid/destinations"
-									}
-								}
-							}
-						]
-					}`))
+		It("returns the list of routes", func() {
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.pagination.total_results", BeEquivalentTo(1)))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.pagination.first.href", "https://api.example.org/v3/apps/"+appGUID+"/routes"))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.resources", HaveLen(1)))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.resources[0].guid", "test-route-guid"))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.resources[0].url", "test-route-host.example.org/some_path"))
 		})
 
 		When("the app cannot be accessed", func() {
@@ -2195,57 +1418,9 @@ var _ = Describe("App", func() {
 		It("responds with the current droplet encoded as JSON", func() {
 			contentTypeHeader := rr.Header().Get("Content-Type")
 			Expect(contentTypeHeader).To(Equal(jsonHeader), "Matching Content-Type header:")
-
-			Expect(rr.Body.String()).To(MatchJSON(`{
-					  "guid": "` + dropletGUID + `",
-					  "state": "STAGED",
-					  "error": null,
-					  "lifecycle": {
-						"type": "buildpack",
-						"data": {
-							"buildpacks": [],
-							"stack": ""
-						}
-					},
-					  "execution_metadata": "",
-					  "process_types": {
-						"rake": "bundle exec rake",
-						"web": "bundle exec rackup config.ru -p $PORT"
-					  },
-					  "checksum": null,
-					  "buildpacks": [],
-					  "stack": "cflinuxfs3",
-					  "image": null,
-					  "created_at": "2019-05-10T17:17:48Z",
-					  "updated_at": "2019-05-10T17:17:48Z",
-					  "relationships": {
-						"app": {
-						  "data": {
-							"guid": "` + appGUID + `"
-						  }
-						}
-					  },
-					  "links": {
-						"self": {
-						  "href": "` + defaultServerURI("/v3/droplets/", dropletGUID) + `"
-						},
-						"package": {
-						  "href": "` + defaultServerURI("/v3/packages/", "test-package-guid") + `"
-						},
-						"app": {
-						  "href": "` + defaultServerURI("/v3/apps/", appGUID) + `"
-						},
-						"assign_current_droplet": {
-						  "href": "` + defaultServerURI("/v3/apps/", appGUID, "/relationships/current_droplet") + `",
-						  "method": "PATCH"
-						  },
-						"download": null
-					  },
-					  "metadata": {
-						"labels": {},
-						"annotations": {}
-					  }
-					}`))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.guid", dropletGUID))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.state", "STAGED"))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.links.self.href", HavePrefix("https://api.example.org")))
 		})
 
 		It("fetches the correct app", func() {
@@ -2378,79 +1553,9 @@ var _ = Describe("App", func() {
 			contentTypeHeader := rr.Header().Get("Content-Type")
 			Expect(contentTypeHeader).To(Equal(jsonHeader), "Matching Content-Type header:")
 
-			Expect(rr.Body.String()).To(MatchJSON(`{
-                    "guid": "test-app-guid",
-                    "created_at": "",
-                    "updated_at": "",
-                    "name": "test-app",
-                    "state": "STARTED",
-                    "lifecycle": {
-                      "type": "buildpack",
-                      "data": {
-                        "buildpacks": [],
-                        "stack": ""
-                      }
-                    },
-                    "relationships": {
-                      "space": {
-                        "data": {
-                          "guid": "test-space-guid"
-                        }
-                      }
-                    },
-                    "metadata": {
-                      "labels": {
-                        "label-key": "label-value"
-                      },
-                      "annotations": {
-						"korifi.cloudfoundry.org/app-rev": "0",
-                        "annotation-key": "annotation-value"
-                      }
-                    },
-                    "links": {
-                      "self": {
-                        "href": "https://api.example.org/v3/apps/test-app-guid"
-                      },
-                      "environment_variables": {
-                        "href": "https://api.example.org/v3/apps/test-app-guid/environment_variables"
-                      },
-                      "space": {
-                        "href": "https://api.example.org/v3/spaces/test-space-guid"
-                      },
-                      "processes": {
-                        "href": "https://api.example.org/v3/apps/test-app-guid/processes"
-                      },
-                      "packages": {
-                        "href": "https://api.example.org/v3/apps/test-app-guid/packages"
-                      },
-                      "current_droplet": {
-                        "href": "https://api.example.org/v3/apps/test-app-guid/droplets/current"
-                      },
-                      "droplets": {
-                        "href": "https://api.example.org/v3/apps/test-app-guid/droplets"
-                      },
-                      "tasks": {
-                        "href": "https://api.example.org/v3/apps/test-app-guid/tasks"
-                      },
-                      "start": {
-                        "href": "https://api.example.org/v3/apps/test-app-guid/actions/start",
-                        "method": "POST"
-                      },
-                      "stop": {
-                        "href": "https://api.example.org/v3/apps/test-app-guid/actions/stop",
-                        "method": "POST"
-                      },
-                      "revisions": {
-                        "href": "https://api.example.org/v3/apps/test-app-guid/revisions"
-                      },
-                      "deployed_revisions": {
-                        "href": "https://api.example.org/v3/apps/test-app-guid/revisions/deployed"
-                      },
-                      "features": {
-                        "href": "https://api.example.org/v3/apps/test-app-guid/features"
-                      }
-                    }
-                }`))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.guid", "test-app-guid"))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.state", "STARTED"))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.links.self.href", HavePrefix("https://api.example.org")))
 		})
 
 		When("no permissions to get the app", func() {
@@ -2592,11 +1697,7 @@ var _ = Describe("App", func() {
 	Describe("GET /v3/apps/:guid/env", func() {
 		BeforeEach(func() {
 			appRepo.GetAppEnvReturns(repositories.AppEnvRecord{
-				AppGUID:              appGUID,
-				SpaceGUID:            spaceGUID,
 				EnvironmentVariables: map[string]string{"VAR": "VAL"},
-				SystemEnv:            map[string]interface{}{},
-				AppEnv:               map[string]interface{}{},
 			}, nil)
 
 			req = createHttpRequest("GET", "/v3/apps/"+appGUID+"/env", nil)
@@ -2616,13 +1717,7 @@ var _ = Describe("App", func() {
 			contentTypeHeader := rr.Header().Get("Content-Type")
 			Expect(contentTypeHeader).To(Equal(jsonHeader), "Matching Content-Type header:")
 
-			Expect(rr.Body.String()).To(MatchJSON(`{
-                  "staging_env_json": {},
-                  "running_env_json": {},
-                  "environment_variables": { "VAR": "VAL" },
-                  "system_env_json": {},
-                  "application_env_json": {}
-                }`))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.environment_variables.VAR", "VAL"))
 		})
 
 		When("there is an error fetching the app env", func() {
@@ -2657,21 +1752,9 @@ var _ = Describe("App", func() {
 		It("responds with JSON", func() {
 			contentTypeHeader := rr.Header().Get("Content-Type")
 			Expect(contentTypeHeader).To(Equal(jsonHeader), "Matching Content-Type header:")
-
-			Expect(rr.Body.String()).To(MatchJSON(fmt.Sprintf(`{
-					"var": {
-						"KEY0": "VAL0",
-						"KEY2": "VAL2"
-					},
-					"links": {
-						"self": {
-							"href": "%[1]s/v3/apps/%[2]s/environment_variables"
-						},
-						"app": {
-							"href": "%[1]s/v3/apps/%[2]s"
-						}
-					}
-				}`, defaultServerURL, appGUID)))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.var.KEY0", "VAL0"))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.var.KEY2", "VAL2"))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.links.self.href", HavePrefix("https://api.example.org")))
 		})
 
 		It("fetches the right app", func() {
@@ -2696,7 +1779,7 @@ var _ = Describe("App", func() {
 				tableTestRecorder := httptest.NewRecorder()
 				req = createHttpRequest("PATCH", "/v3/apps/"+appGUID+"/environment_variables", strings.NewReader(requestBody))
 				routerBuilder.Build().ServeHTTP(tableTestRecorder, req)
-				Expect(tableTestRecorder.Code).To(Equal(status))
+				Expect(tableTestRecorder).To(HaveHTTPStatus(status))
 			},
 			Entry("contains a null value", `{ "var": { "key": null } }`, http.StatusOK),
 			Entry("contains an int value", `{ "var": { "key": 9999 } }`, http.StatusOK),

--- a/api/handlers/buildpack.go
+++ b/api/handlers/buildpack.go
@@ -63,7 +63,7 @@ func (h *Buildpack) list(r *http.Request) (*routing.Response, error) {
 		return nil, apierrors.LogAndReturn(logger, err, "unable to parse order by request")
 	}
 
-	return routing.NewResponse(http.StatusOK).WithBody(presenter.ForBuildpackList(buildpacks, h.serverURL, *r.URL)), nil
+	return routing.NewResponse(http.StatusOK).WithBody(presenter.ForList(presenter.ForBuildpack, buildpacks, h.serverURL, *r.URL)), nil
 }
 
 // nolint:dupl

--- a/api/handlers/domain.go
+++ b/api/handlers/domain.go
@@ -129,7 +129,7 @@ func (h *Domain) list(r *http.Request) (*routing.Response, error) { //nolint:dup
 		return nil, apierrors.LogAndReturn(logger, err, "Failed to fetch domain(s) from Kubernetes")
 	}
 
-	return routing.NewResponse(http.StatusOK).WithBody(presenter.ForDomainList(domainList, h.serverURL, *r.URL)), nil
+	return routing.NewResponse(http.StatusOK).WithBody(presenter.ForList(presenter.ForDomain, domainList, h.serverURL, *r.URL)), nil
 }
 
 func (h *Domain) delete(r *http.Request) (*routing.Response, error) {

--- a/api/handlers/org.go
+++ b/api/handlers/org.go
@@ -122,7 +122,7 @@ func (h *Org) list(r *http.Request) (*routing.Response, error) {
 		return nil, apierrors.LogAndReturn(logger, err, "failed to fetch orgs")
 	}
 
-	resp := routing.NewResponse(http.StatusOK).WithBody(presenter.ForOrgList(orgs, h.apiBaseURL, *r.URL))
+	resp := routing.NewResponse(http.StatusOK).WithBody(presenter.ForList(presenter.ForOrg, orgs, h.apiBaseURL, *r.URL))
 	notAfter, certParsed := decodePEMNotAfter(authInfo.CertData)
 
 	if !isExpirationValid(notAfter, h.userCertificateExpirationWarningDuration, certParsed) {
@@ -157,7 +157,7 @@ func (h *Org) listDomains(r *http.Request) (*routing.Response, error) {
 		return nil, apierrors.LogAndReturn(logger, err, "Failed to fetch domain(s) from Kubernetes")
 	}
 
-	return routing.NewResponse(http.StatusOK).WithBody(presenter.ForDomainList(domainList, h.apiBaseURL, *r.URL)), nil
+	return routing.NewResponse(http.StatusOK).WithBody(presenter.ForList(presenter.ForDomain, domainList, h.apiBaseURL, *r.URL)), nil
 }
 
 func (h *Org) UnauthenticatedRoutes() []routing.Route {

--- a/api/handlers/package.go
+++ b/api/handlers/package.go
@@ -111,7 +111,7 @@ func (h Package) list(r *http.Request) (*routing.Response, error) {
 		return nil, apierrors.LogAndReturn(logger, err, "bad order by value")
 	}
 
-	return routing.NewResponse(http.StatusOK).WithBody(presenter.ForPackageList(records, h.serverURL, *r.URL)), nil
+	return routing.NewResponse(http.StatusOK).WithBody(presenter.ForList(presenter.ForPackage, records, h.serverURL, *r.URL)), nil
 }
 
 func (h Package) sortList(records []repositories.PackageRecord, order string) error {
@@ -251,7 +251,7 @@ func (h Package) listDroplets(r *http.Request) (*routing.Response, error) {
 		return nil, apierrors.LogAndReturn(logger, err, "Error fetching droplet list with repository")
 	}
 
-	return routing.NewResponse(http.StatusOK).WithBody(presenter.ForDropletList(dropletList, h.serverURL, *r.URL)), nil
+	return routing.NewResponse(http.StatusOK).WithBody(presenter.ForList(presenter.ForDroplet, dropletList, h.serverURL, *r.URL)), nil
 }
 
 func (h *Package) UnauthenticatedRoutes() []routing.Route {

--- a/api/handlers/role.go
+++ b/api/handlers/role.go
@@ -77,7 +77,7 @@ func (h *Role) create(r *http.Request) (*routing.Response, error) {
 		return nil, apierrors.LogAndReturn(logger, err, "Failed to create role", "Role Type", role.Type, "Space", role.Space, "User", role.User)
 	}
 
-	return routing.NewResponse(http.StatusCreated).WithBody(presenter.ForCreateRole(record, h.apiBaseURL)), nil
+	return routing.NewResponse(http.StatusCreated).WithBody(presenter.ForRole(record, h.apiBaseURL)), nil
 }
 
 func (h *Role) list(r *http.Request) (*routing.Response, error) {
@@ -105,7 +105,7 @@ func (h *Role) list(r *http.Request) (*routing.Response, error) {
 		return nil, apierrors.LogAndReturn(logger, err, "unable to parse order by request")
 	}
 
-	return routing.NewResponse(http.StatusOK).WithBody(presenter.ForRoleList(filteredRoles, h.apiBaseURL, *r.URL)), nil
+	return routing.NewResponse(http.StatusOK).WithBody(presenter.ForList(presenter.ForRole, filteredRoles, h.apiBaseURL, *r.URL)), nil
 }
 
 func filterRoles(roleListFilter *payloads.RoleListFilter, roles []repositories.RoleRecord) []repositories.RoleRecord {

--- a/api/handlers/route.go
+++ b/api/handlers/route.go
@@ -95,7 +95,7 @@ func (h *Route) list(r *http.Request) (*routing.Response, error) {
 		return nil, apierrors.LogAndReturn(logger, err, "Failed to fetch routes from Kubernetes")
 	}
 
-	return routing.NewResponse(http.StatusOK).WithBody(presenter.ForRouteList(routes, h.serverURL, *r.URL)), nil
+	return routing.NewResponse(http.StatusOK).WithBody(presenter.ForList(presenter.ForRoute, routes, h.serverURL, *r.URL)), nil
 }
 
 func (h *Route) listDestinations(r *http.Request) (*routing.Response, error) {

--- a/api/handlers/service_instance.go
+++ b/api/handlers/service_instance.go
@@ -138,7 +138,7 @@ func (h *ServiceInstance) list(r *http.Request) (*routing.Response, error) {
 		return nil, apierrors.LogAndReturn(logger, err, "bad order by value")
 	}
 
-	return routing.NewResponse(http.StatusOK).WithBody(presenter.ForServiceInstanceList(serviceInstanceList, h.serverURL, *r.URL)), nil
+	return routing.NewResponse(http.StatusOK).WithBody(presenter.ForList(presenter.ForServiceInstance, serviceInstanceList, h.serverURL, *r.URL)), nil
 }
 
 // nolint:dupl

--- a/api/handlers/space.go
+++ b/api/handlers/space.go
@@ -83,7 +83,7 @@ func (h *Space) list(r *http.Request) (*routing.Response, error) {
 		return nil, apierrors.LogAndReturn(logger, err, "Failed to fetch spaces")
 	}
 
-	spaceList := presenter.ForSpaceList(spaces, h.apiBaseURL, *r.URL)
+	spaceList := presenter.ForList(presenter.ForSpace, spaces, h.apiBaseURL, *r.URL)
 	return routing.NewResponse(http.StatusOK).WithBody(spaceList), nil
 }
 

--- a/api/handlers/task.go
+++ b/api/handlers/task.go
@@ -76,7 +76,7 @@ func (h *Task) list(r *http.Request) (*routing.Response, error) {
 		return nil, apierrors.LogAndReturn(logger, err, "failed to list tasks")
 	}
 
-	return routing.NewResponse(http.StatusOK).WithBody(presenter.ForTaskList(tasks, h.serverURL, *r.URL)), nil
+	return routing.NewResponse(http.StatusOK).WithBody(presenter.ForList(presenter.ForTask, tasks, h.serverURL, *r.URL)), nil
 }
 
 func (h *Task) create(r *http.Request) (*routing.Response, error) {
@@ -141,7 +141,7 @@ func (h *Task) listForApp(r *http.Request) (*routing.Response, error) {
 		return nil, apierrors.LogAndReturn(logger, err, "failed to list tasks")
 	}
 
-	return routing.NewResponse(http.StatusOK).WithBody(presenter.ForTaskList(tasks, h.serverURL, *r.URL)), nil
+	return routing.NewResponse(http.StatusOK).WithBody(presenter.ForList(presenter.ForTask, tasks, h.serverURL, *r.URL)), nil
 }
 
 func (h *Task) cancel(r *http.Request) (*routing.Response, error) {

--- a/api/handlers/user.go
+++ b/api/handlers/user.go
@@ -25,13 +25,11 @@ func NewUser(apiBaseURL url.URL) User {
 
 func (h User) list(req *http.Request) (*routing.Response, error) {
 	usernames := req.URL.Query().Get("usernames")
-	users := []interface{}{}
+	users := []string{}
 	if len(usernames) > 0 {
-		for _, username := range strings.Split(usernames, ",") {
-			users = append(users, presenter.ForUser(username))
-		}
+		users = strings.Split(usernames, ",")
 	}
-	return routing.NewResponse(http.StatusOK).WithBody(presenter.ForList(users, h.apiBaseURL, *req.URL)), nil
+	return routing.NewResponse(http.StatusOK).WithBody(presenter.ForList(presenter.ForUser, users, h.apiBaseURL, *req.URL)), nil
 }
 
 func (h User) UnauthenticatedRoutes() []routing.Route {

--- a/api/presenter/app.go
+++ b/api/presenter/app.go
@@ -110,15 +110,6 @@ func ForApp(responseApp repositories.AppRecord, baseURL url.URL) AppResponse {
 	}
 }
 
-func ForAppList(appRecordList []repositories.AppRecord, baseURL, requestURL url.URL) ListResponse {
-	appResponses := make([]interface{}, 0, len(appRecordList))
-	for _, app := range appRecordList {
-		appResponses = append(appResponses, ForApp(app, baseURL))
-	}
-
-	return ForList(appResponses, baseURL, requestURL)
-}
-
 type CurrentDropletResponse struct {
 	Relationship `json:",inline"`
 	Links        CurrentDropletLinks `json:"links"`

--- a/api/presenter/app.go
+++ b/api/presenter/app.go
@@ -56,7 +56,7 @@ func ForApp(responseApp repositories.AppRecord, baseURL url.URL) AppResponse {
 		Lifecycle: Lifecycle{
 			Type: responseApp.Lifecycle.Type,
 			Data: LifecycleData{
-				Buildpacks: responseApp.Lifecycle.Data.Buildpacks,
+				Buildpacks: emptySliceIfNil(responseApp.Lifecycle.Data.Buildpacks),
 				Stack:      responseApp.Lifecycle.Data.Stack,
 			},
 		},
@@ -175,7 +175,15 @@ func ForAppEnv(envVarRecord repositories.AppEnvRecord) AppEnvResponse {
 		EnvironmentVariables: envVarRecord.EnvironmentVariables,
 		StagingEnvJSON:       map[string]string{},
 		RunningEnvJSON:       map[string]string{},
-		SystemEnvJSON:        envVarRecord.SystemEnv,
-		ApplicationEnvJSON:   envVarRecord.AppEnv,
+		SystemEnvJSON:        emptyMapToAnyIfEmpty(envVarRecord.SystemEnv),
+		ApplicationEnvJSON:   emptyMapToAnyIfEmpty(envVarRecord.AppEnv),
 	}
+}
+
+func emptyMapToAnyIfEmpty(m map[string]any) map[string]any {
+	if m == nil {
+		return map[string]any{}
+	}
+
+	return m
 }

--- a/api/presenter/app_test.go
+++ b/api/presenter/app_test.go
@@ -1,0 +1,287 @@
+package presenter_test
+
+import (
+	"encoding/json"
+	"net/url"
+
+	"code.cloudfoundry.org/korifi/api/presenter"
+	"code.cloudfoundry.org/korifi/api/repositories"
+	. "code.cloudfoundry.org/korifi/tests/matchers"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("App", func() {
+	var (
+		baseURL *url.URL
+		output  []byte
+	)
+
+	BeforeEach(func() {
+		var err error
+		baseURL, err = url.Parse("https://api.example.org")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	Describe("App Response", func() {
+		var record repositories.AppRecord
+
+		BeforeEach(func() {
+			record = repositories.AppRecord{
+				Name:        "test-app",
+				GUID:        "app-guid",
+				SpaceGUID:   "space-guid",
+				Labels:      map[string]string{"label-key": "label-value"},
+				Annotations: map[string]string{"annotation-key": "annotation-value"},
+				State:       "STOPPED",
+				Lifecycle: repositories.Lifecycle{
+					Type: "buildpack",
+					Data: repositories.LifecycleData{
+						Buildpacks: []string{"foo", "bar"},
+						Stack:      "cflinuxfs2",
+					},
+				},
+				CreatedAt: "2023-03-28T15:00:00Z",
+				UpdatedAt: "2023-03-28T15:00:01Z",
+				IsStaged:  false,
+			}
+		})
+
+		JustBeforeEach(func() {
+			response := presenter.ForApp(record, *baseURL)
+			var err error
+			output, err = json.Marshal(response)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("produces expected app json", func() {
+			Expect(output).To(MatchJSON(`{
+			"guid": "app-guid",
+			"created_at": "2023-03-28T15:00:00Z",
+			"updated_at": "2023-03-28T15:00:01Z",
+			"name": "test-app",
+			"state": "STOPPED",
+			"lifecycle": {
+				"type": "buildpack",
+				"data": {
+					"buildpacks": ["foo", "bar"],
+					"stack": "cflinuxfs2"
+				}
+			},
+			"relationships": {
+				"space": {
+					"data": {
+						"guid": "space-guid"
+					}
+				}
+			},
+			"metadata": {
+				"labels": {
+					"label-key": "label-value"
+				},
+				"annotations": {
+					"annotation-key": "annotation-value"
+				}
+			},
+			"links": {
+				"self": {
+					"href": "https://api.example.org/v3/apps/app-guid"
+				},
+				"environment_variables": {
+					"href": "https://api.example.org/v3/apps/app-guid/environment_variables"
+				},
+				"space": {
+					"href": "https://api.example.org/v3/spaces/space-guid"
+				},
+				"processes": {
+					"href": "https://api.example.org/v3/apps/app-guid/processes"
+				},
+				"packages": {
+					"href": "https://api.example.org/v3/apps/app-guid/packages"
+				},
+				"current_droplet": {
+					"href": "https://api.example.org/v3/apps/app-guid/droplets/current"
+				},
+				"droplets": {
+					"href": "https://api.example.org/v3/apps/app-guid/droplets"
+				},
+				"tasks": {
+					"href": "https://api.example.org/v3/apps/app-guid/tasks"
+				},
+				"start": {
+					"href": "https://api.example.org/v3/apps/app-guid/actions/start",
+					"method": "POST"
+				},
+				"stop": {
+					"href": "https://api.example.org/v3/apps/app-guid/actions/stop",
+					"method": "POST"
+				},
+				"revisions": {
+					"href": "https://api.example.org/v3/apps/app-guid/revisions"
+				},
+				"deployed_revisions": {
+					"href": "https://api.example.org/v3/apps/app-guid/revisions/deployed"
+				},
+				"features": {
+					"href": "https://api.example.org/v3/apps/app-guid/features"
+				}
+			}
+		} `))
+		})
+
+		When("buildpacks is not set", func() {
+			BeforeEach(func() {
+				record.Lifecycle.Data.Buildpacks = nil
+			})
+
+			It("renders an empty list", func() {
+				Expect(string(output)).To(ContainSubstring(`"buildpacks":[]`))
+			})
+		})
+	})
+
+	Describe("Droplet Response", func() {
+		var record repositories.CurrentDropletRecord
+
+		BeforeEach(func() {
+			record = repositories.CurrentDropletRecord{
+				AppGUID:     "app-guid",
+				DropletGUID: "droplet-guid",
+			}
+		})
+
+		JustBeforeEach(func() {
+			response := presenter.ForCurrentDroplet(record, *baseURL)
+			var err error
+			output, err = json.Marshal(response)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("returns the expected JSON", func() {
+			Expect(output).To(MatchJSON(`{
+				"data": {
+					"guid": "droplet-guid"
+				},
+				"links": {
+					"self": {
+						"href": "https://api.example.org/v3/apps/app-guid/relationships/current_droplet"
+					},
+					"related": {
+						"href": "https://api.example.org/v3/apps/app-guid/droplets/current"
+					}
+				}
+			}`))
+		})
+	})
+
+	Describe("App Env", func() {
+		var record repositories.AppEnvRecord
+
+		BeforeEach(func() {
+			record = repositories.AppEnvRecord{
+				EnvironmentVariables: map[string]string{"VAR": "VAL"},
+				SystemEnv: map[string]any{
+					"VCAP_SERVICES": map[string]any{
+						"mysql": map[string]any{
+							"plan": "xlarge",
+						},
+					},
+				},
+				AppEnv: map[string]any{
+					"VCAP_APPLICATION": map[string]any{
+						"application_name": "my-app",
+					},
+				},
+			}
+		})
+
+		JustBeforeEach(func() {
+			response := presenter.ForAppEnv(record)
+			var err error
+			output, err = json.Marshal(response)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("returns the expected output", func() {
+			Expect(output).To(MatchJSON(`{
+				"staging_env_json": {},
+				"running_env_json": {},
+				"environment_variables": {
+					"VAR": "VAL"
+				},
+				"system_env_json": {
+					"VCAP_SERVICES": {
+						"mysql": {
+							"plan": "xlarge"
+						}
+					}
+				},
+				"application_env_json": {
+					"VCAP_APPLICATION": {
+						"application_name": "my-app"
+					}
+				}
+			}`))
+		})
+
+		When("system env is nil", func() {
+			BeforeEach(func() {
+				record.SystemEnv = nil
+			})
+
+			It("returns an empty list", func() {
+				Expect(output).To(MatchJSONPath("$.system_env_json", Not(BeNil())))
+			})
+		})
+
+		When("app env is nil", func() {
+			BeforeEach(func() {
+				record.AppEnv = nil
+			})
+
+			It("returns an empty list", func() {
+				Expect(output).To(MatchJSONPath("$.application_env_json", Not(BeNil())))
+			})
+		})
+	})
+
+	Describe("App Env Vars", func() {
+		var record repositories.AppEnvVarsRecord
+
+		BeforeEach(func() {
+			record = repositories.AppEnvVarsRecord{
+				Name:      "my-app-env",
+				AppGUID:   "app-guid",
+				SpaceGUID: "space-guid",
+				EnvironmentVariables: map[string]string{
+					"KEY0": "VAL0",
+					"KEY2": "VAL2",
+				},
+			}
+		})
+
+		JustBeforeEach(func() {
+			response := presenter.ForAppEnvVars(record, *baseURL)
+			var err error
+			output, err = json.Marshal(response)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("returns the expected output", func() {
+			Expect(output).To(MatchJSON(`{
+				"var": {
+					"KEY0": "VAL0",
+					"KEY2": "VAL2"
+				},
+				"links": {
+					"self": {
+						"href": "https://api.example.org/v3/apps/app-guid/environment_variables"
+					},
+					"app": {
+						"href": "https://api.example.org/v3/apps/app-guid"
+					}
+				}
+			}`))
+		})
+	})
+})

--- a/api/presenter/buildpack.go
+++ b/api/presenter/buildpack.go
@@ -40,12 +40,3 @@ func ForBuildpack(buildpackRecord repositories.BuildpackRecord, baseURL url.URL)
 
 	return toReturn
 }
-
-func ForBuildpackList(buildpackRecordList []repositories.BuildpackRecord, baseURL, requestURL url.URL) ListResponse {
-	buildpackResponses := make([]interface{}, 0, len(buildpackRecordList))
-	for _, buildpack := range buildpackRecordList {
-		buildpackResponses = append(buildpackResponses, ForBuildpack(buildpack, baseURL))
-	}
-
-	return ForList(buildpackResponses, baseURL, requestURL)
-}

--- a/api/presenter/domain.go
+++ b/api/presenter/domain.go
@@ -83,12 +83,3 @@ func ForDomain(responseDomain repositories.DomainRecord, baseURL url.URL) Domain
 		},
 	}
 }
-
-func ForDomainList(domainListRecords []repositories.DomainRecord, baseURL, requestURL url.URL) ListResponse {
-	domainResponses := make([]interface{}, 0, len(domainListRecords))
-	for _, domain := range domainListRecords {
-		domainResponses = append(domainResponses, ForDomain(domain, baseURL))
-	}
-
-	return ForList(domainResponses, baseURL, requestURL)
-}

--- a/api/presenter/droplet.go
+++ b/api/presenter/droplet.go
@@ -45,7 +45,7 @@ func ForDroplet(dropletRecord repositories.DropletRecord, baseURL url.URL) Dropl
 		Lifecycle: Lifecycle{
 			Type: dropletRecord.Lifecycle.Type,
 			Data: LifecycleData{
-				Buildpacks: dropletRecord.Lifecycle.Data.Buildpacks,
+				Buildpacks: emptySliceIfNil(dropletRecord.Lifecycle.Data.Buildpacks),
 				Stack:      dropletRecord.Lifecycle.Data.Stack,
 			},
 		},

--- a/api/presenter/droplet.go
+++ b/api/presenter/droplet.go
@@ -86,13 +86,3 @@ func ForDroplet(dropletRecord repositories.DropletRecord, baseURL url.URL) Dropl
 	}
 	return toReturn
 }
-
-func ForDropletList(dropletRecordList []repositories.DropletRecord, baseURL, requestURL url.URL) ListResponse {
-	dropletResponses := make([]interface{}, 0, len(dropletRecordList))
-	for _, droplet := range dropletRecordList {
-		dropletResponses = append(dropletResponses, ForDroplet(droplet, baseURL))
-	}
-	// https://v3-apidocs.cloudfoundry.org/version/3.100.0/index.html#list-droplets-for-a-package
-	// https://api.example.org/v3/packages/7b34f1cf-7e73-428a-bb5a-8a17a8058396/droplets
-	return ForList(dropletResponses, baseURL, requestURL)
-}

--- a/api/presenter/droplet_test.go
+++ b/api/presenter/droplet_test.go
@@ -1,0 +1,101 @@
+package presenter_test
+
+import (
+	"encoding/json"
+	"net/url"
+
+	"code.cloudfoundry.org/korifi/api/presenter"
+	"code.cloudfoundry.org/korifi/api/repositories"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Droplet", func() {
+	var (
+		baseURL *url.URL
+		output  []byte
+		record  repositories.DropletRecord
+	)
+
+	BeforeEach(func() {
+		var err error
+		baseURL, err = url.Parse("https://api.example.org")
+		Expect(err).NotTo(HaveOccurred())
+		record = repositories.DropletRecord{
+			GUID:      "the-droplet-guid",
+			State:     "STAGED",
+			CreatedAt: "2019-05-10T17:17:48Z",
+			UpdatedAt: "2019-05-10T17:17:48Z",
+			Lifecycle: repositories.Lifecycle{
+				Type: "buildpack",
+			},
+			Stack: "cflinuxfs3",
+			ProcessTypes: map[string]string{
+				"rake": "bundle exec rake",
+				"web":  "bundle exec rackup config.ru -p $PORT",
+			},
+			AppGUID:     "the-app-guid",
+			PackageGUID: "the-package-guid",
+		}
+	})
+
+	JustBeforeEach(func() {
+		response := presenter.ForDroplet(record, *baseURL)
+		var err error
+		output, err = json.Marshal(response)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("produces expected droplet json", func() {
+		Expect(output).To(MatchJSON(`{
+			"guid": "the-droplet-guid",
+			"state": "STAGED",
+			"error": null,
+			"lifecycle": {
+				"type": "buildpack",
+				"data": {
+					"buildpacks": [],
+					"stack": ""
+				}
+			},
+			"execution_metadata": "",
+			"process_types": {
+				"rake": "bundle exec rake",
+				"web": "bundle exec rackup config.ru -p $PORT"
+			},
+			"checksum": null,
+			"buildpacks": [],
+			"stack": "cflinuxfs3",
+			"image": null,
+			"created_at": "2019-05-10T17:17:48Z",
+			"updated_at": "2019-05-10T17:17:48Z",
+			"relationships": {
+				"app": {
+					"data": {
+						"guid": "the-app-guid"
+					}
+				}
+			},
+			"links": {
+				"self": {
+					"href": "https://api.example.org/v3/droplets/the-droplet-guid"
+				},
+				"package": {
+					"href": "https://api.example.org/v3/packages/the-package-guid"
+				},
+				"app": {
+					"href": "https://api.example.org/v3/apps/the-app-guid"
+				},
+				"assign_current_droplet": {
+					"href": "https://api.example.org/v3/apps/the-app-guid/relationships/current_droplet",
+					"method": "PATCH"
+				},
+				"download": null
+			},
+			"metadata": {
+				"labels": {},
+				"annotations": {}
+			}
+		}`))
+	})
+})

--- a/api/presenter/org.go
+++ b/api/presenter/org.go
@@ -30,15 +30,6 @@ type OrgLinks struct {
 	Quota         *Link `json:"quota,omitempty"`
 }
 
-func ForOrgList(orgs []repositories.OrgRecord, apiBaseURL, requestURL url.URL) ListResponse {
-	orgResponses := make([]interface{}, 0, len(orgs))
-	for _, org := range orgs {
-		orgResponses = append(orgResponses, ForOrg(org, apiBaseURL))
-	}
-
-	return ForList(orgResponses, apiBaseURL, requestURL)
-}
-
 func ForOrg(org repositories.OrgRecord, apiBaseURL url.URL) OrgResponse {
 	return OrgResponse{
 		Name:      org.Name,

--- a/api/presenter/package.go
+++ b/api/presenter/package.go
@@ -73,12 +73,3 @@ func ForPackage(record repositories.PackageRecord, baseURL url.URL) PackageRespo
 		},
 	}
 }
-
-func ForPackageList(packageRecordList []repositories.PackageRecord, baseURL, requestURL url.URL) ListResponse {
-	packageResponses := make([]interface{}, 0, len(packageRecordList))
-	for _, currentPackage := range packageRecordList {
-		packageResponses = append(packageResponses, ForPackage(currentPackage, baseURL))
-	}
-
-	return ForList(packageResponses, baseURL, requestURL)
-}

--- a/api/presenter/presenter_suite_test.go
+++ b/api/presenter/presenter_suite_test.go
@@ -1,0 +1,13 @@
+package presenter_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestPresenter(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Presenter Suite")
+}

--- a/api/presenter/process.go
+++ b/api/presenter/process.go
@@ -144,13 +144,10 @@ func ForProcess(responseProcess repositories.ProcessRecord, baseURL url.URL) Pro
 	}
 }
 
-func ForProcessList(processRecordList []repositories.ProcessRecord, baseURL, requestURL url.URL) ListResponse {
-	processResponses := make([]interface{}, 0, len(processRecordList))
-	for _, process := range processRecordList {
+func ForProcessList(processRecordList []repositories.ProcessRecord, baseURL, requestURL url.URL) ListResponse[ProcessResponse] {
+	return ForList(func(process repositories.ProcessRecord, baseURL url.URL) ProcessResponse {
 		processResponse := ForProcess(process, baseURL)
 		processResponse.Command = "[PRIVATE DATA HIDDEN IN LISTS]"
-		processResponses = append(processResponses, processResponse)
-	}
-
-	return ForList(processResponses, baseURL, requestURL)
+		return processResponse
+	}, processRecordList, baseURL, requestURL)
 }

--- a/api/presenter/process_test.go
+++ b/api/presenter/process_test.go
@@ -1,0 +1,113 @@
+package presenter_test
+
+import (
+	"encoding/json"
+	"net/url"
+
+	"code.cloudfoundry.org/korifi/api/presenter"
+	"code.cloudfoundry.org/korifi/api/repositories"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Process", func() {
+	var (
+		baseURL *url.URL
+		output  []byte
+	)
+
+	BeforeEach(func() {
+		var err error
+		baseURL, err = url.Parse("https://api.example.org")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	Describe("Process Response", func() {
+		var record repositories.ProcessRecord
+
+		BeforeEach(func() {
+			record = repositories.ProcessRecord{
+				GUID:             "process-guid",
+				SpaceGUID:        "space-guid",
+				AppGUID:          "app-guid",
+				Type:             "web",
+				Command:          "rackup",
+				DesiredInstances: 5,
+				MemoryMB:         256,
+				DiskQuotaMB:      1024,
+				Ports:            []int32{8080},
+				HealthCheck: repositories.HealthCheck{
+					Type: "port",
+				},
+				Labels: map[string]string{
+					"label-key": "label-val",
+				},
+				Annotations: map[string]string{
+					"annotation-key": "annotation-val",
+				},
+				CreatedAt: "2016-03-23T18:48:22Z",
+				UpdatedAt: "2016-03-23T18:48:42Z",
+			}
+		})
+
+		JustBeforeEach(func() {
+			response := presenter.ForProcess(record, *baseURL)
+			var err error
+			output, err = json.Marshal(response)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("returns the expected JSON", func() {
+			Expect(output).Should(MatchJSON(`{
+				"guid": "process-guid",
+				"type": "web",
+				"command": "rackup",
+				"instances": 5,
+				"memory_in_mb": 256,
+				"disk_in_mb": 1024,
+				"health_check": {
+					"type": "port",
+					"data": {
+						"timeout": null,
+						"invocation_timeout": null
+					}
+				},
+				"relationships": {
+					"app": {
+						"data": {
+							"guid": "app-guid"
+						}
+					}
+				},
+				"metadata": {
+					"labels": {
+						"label-key": "label-val"
+					},
+					"annotations": {
+						"annotation-key": "annotation-val"
+					}
+				},
+				"created_at": "2016-03-23T18:48:22Z",
+				"updated_at": "2016-03-23T18:48:42Z",
+				"links": {
+					"self": {
+						"href": "https://api.example.org/v3/processes/process-guid"
+					},
+					"scale": {
+						"href": "https://api.example.org/v3/processes/process-guid/actions/scale",
+						"method": "POST"
+					},
+					"app": {
+						"href": "https://api.example.org/v3/apps/app-guid"
+					},
+					"space": {
+						"href": "https://api.example.org/v3/spaces/space-guid"
+					},
+					"stats": {
+						"href": "https://api.example.org/v3/processes/process-guid/stats"
+					}
+				}
+			}`))
+		})
+	})
+})

--- a/api/presenter/role.go
+++ b/api/presenter/role.go
@@ -27,20 +27,7 @@ type RoleLinks struct {
 	Organization *Link `json:"organization,omitempty"`
 }
 
-func ForCreateRole(role repositories.RoleRecord, apiBaseURL url.URL) RoleResponse {
-	return toRoleResponse(role, apiBaseURL)
-}
-
-func ForRoleList(roles []repositories.RoleRecord, apiBaseURL, requestURL url.URL) ListResponse {
-	items := make([]any, len(roles))
-	for i := range items {
-		items[i] = toRoleResponse(roles[i], apiBaseURL)
-	}
-
-	return ForList(items, apiBaseURL, requestURL)
-}
-
-func toRoleResponse(role repositories.RoleRecord, apiBaseURL url.URL) RoleResponse {
+func ForRole(role repositories.RoleRecord, apiBaseURL url.URL) RoleResponse {
 	resp := RoleResponse{
 		GUID:      role.GUID,
 		CreatedAt: role.CreatedAt,

--- a/api/presenter/route.go
+++ b/api/presenter/route.go
@@ -108,15 +108,6 @@ func ForRoute(route repositories.RouteRecord, baseURL url.URL) RouteResponse {
 	}
 }
 
-func ForRouteList(routeRecordList []repositories.RouteRecord, baseURL, requestURL url.URL) ListResponse {
-	routeResponses := make([]interface{}, 0, len(routeRecordList))
-	for _, routeRecord := range routeRecordList {
-		routeResponses = append(routeResponses, ForRoute(routeRecord, baseURL))
-	}
-
-	return ForList(routeResponses, baseURL, requestURL)
-}
-
 func forDestination(destination repositories.DestinationRecord) routeDestination {
 	return routeDestination{
 		GUID: destination.GUID,

--- a/api/presenter/route_test.go
+++ b/api/presenter/route_test.go
@@ -1,0 +1,98 @@
+package presenter_test
+
+import (
+	"encoding/json"
+	"net/url"
+
+	"code.cloudfoundry.org/korifi/api/presenter"
+	"code.cloudfoundry.org/korifi/api/repositories"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Route", func() {
+	var (
+		baseURL *url.URL
+		output  []byte
+	)
+
+	BeforeEach(func() {
+		var err error
+		baseURL, err = url.Parse("https://api.example.org")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	Describe("Route Response", func() {
+		var record repositories.RouteRecord
+
+		BeforeEach(func() {
+			record = repositories.RouteRecord{
+				GUID:      "test-route-guid",
+				SpaceGUID: "test-space-guid",
+				Domain: repositories.DomainRecord{
+					GUID: "test-domain-guid",
+					Name: "example.org",
+				},
+				Host:         "test-route-host",
+				Path:         "/some_path",
+				Protocol:     "http",
+				Destinations: nil,
+				Labels:       nil,
+				Annotations:  nil,
+				CreatedAt:    "2019-05-10T17:17:48Z",
+				UpdatedAt:    "2019-05-10T17:17:48Z",
+			}
+		})
+
+		JustBeforeEach(func() {
+			response := presenter.ForRoute(record, *baseURL)
+			var err error
+			output, err = json.Marshal(response)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("returns the expected JSON", func() {
+			Expect(output).Should(MatchJSON(`{
+				"guid": "test-route-guid",
+				"port": null,
+				"path": "/some_path",
+				"protocol": "http",
+				"host": "test-route-host",
+				"url": "test-route-host.example.org/some_path",
+				"created_at": "2019-05-10T17:17:48Z",
+				"updated_at": "2019-05-10T17:17:48Z",
+				"destinations": [],
+				"relationships": {
+					"space": {
+						"data": {
+							"guid": "test-space-guid"
+						}
+					},
+					"domain": {
+						"data": {
+							"guid": "test-domain-guid"
+						}
+					}
+				},
+				"metadata": {
+					"labels": {},
+					"annotations": {}
+				},
+				"links": {
+					"self":{
+						"href": "https://api.example.org/v3/routes/test-route-guid"
+					},
+					"space":{
+						"href": "https://api.example.org/v3/spaces/test-space-guid"
+					},
+					"domain":{
+						"href": "https://api.example.org/v3/domains/test-domain-guid"
+					},
+					"destinations":{
+						"href": "https://api.example.org/v3/routes/test-route-guid/destinations"
+					}
+				}
+			}`))
+		})
+	})
+})

--- a/api/presenter/service_binding.go
+++ b/api/presenter/service_binding.go
@@ -76,13 +76,8 @@ func ForServiceBinding(record repositories.ServiceBindingRecord, baseURL url.URL
 	}
 }
 
-func ForServiceBindingList(serviceBindingRecord []repositories.ServiceBindingRecord, appRecords []repositories.AppRecord, baseURL, requestURL url.URL) ListResponse {
-	serviceBindingResponses := make([]interface{}, 0, len(serviceBindingRecord))
-	for _, serviceBinding := range serviceBindingRecord {
-		serviceBindingResponses = append(serviceBindingResponses, ForServiceBinding(serviceBinding, baseURL))
-	}
-
-	ret := ForList(serviceBindingResponses, baseURL, requestURL)
+func ForServiceBindingList(serviceBindingRecords []repositories.ServiceBindingRecord, appRecords []repositories.AppRecord, baseURL, requestURL url.URL) ListResponse[ServiceBindingResponse] {
+	ret := ForList(ForServiceBinding, serviceBindingRecords, baseURL, requestURL)
 	if len(appRecords) > 0 {
 		appData := IncludedData{}
 		for _, appRecord := range appRecords {

--- a/api/presenter/service_instance.go
+++ b/api/presenter/service_instance.go
@@ -93,12 +93,3 @@ func ForServiceInstance(serviceInstanceRecord repositories.ServiceInstanceRecord
 		},
 	}
 }
-
-func ForServiceInstanceList(serviceInstanceRecord []repositories.ServiceInstanceRecord, baseURL, requestURL url.URL) ListResponse {
-	serviceInstanceResponses := make([]interface{}, 0, len(serviceInstanceRecord))
-	for _, serviceInstance := range serviceInstanceRecord {
-		serviceInstanceResponses = append(serviceInstanceResponses, ForServiceInstance(serviceInstance, baseURL))
-	}
-
-	return ForList(serviceInstanceResponses, baseURL, requestURL)
-}

--- a/api/presenter/service_route_binding.go
+++ b/api/presenter/service_route_binding.go
@@ -4,6 +4,6 @@ import "net/url"
 
 type ServiceRouteBinding struct{}
 
-func ForServiceRouteBindingsList(baseURL, requestURL url.URL) ListResponse {
-	return ForList([]interface{}{}, baseURL, requestURL)
+func ForServiceRouteBindingsList(baseURL, requestURL url.URL) ListResponse[any] {
+	return ForList(func(a any, _ url.URL) any { return a }, []any{}, baseURL, requestURL)
 }

--- a/api/presenter/shared_test.go
+++ b/api/presenter/shared_test.go
@@ -1,0 +1,109 @@
+package presenter_test
+
+import (
+	"encoding/json"
+	"net/url"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"code.cloudfoundry.org/korifi/api/presenter"
+)
+
+type (
+	record struct {
+		N int
+	}
+
+	presentedRecord struct {
+		M int    `json:"m"`
+		U string `json:"u"`
+	}
+)
+
+func forRecord(r record, u url.URL) presentedRecord {
+	return presentedRecord{
+		M: r.N,
+		U: u.String(),
+	}
+}
+
+var _ = Describe("Shared", func() {
+	Describe("ForList", func() {
+		var (
+			records    []record
+			baseURL    *url.URL
+			requestURL *url.URL
+			output     []byte
+		)
+
+		BeforeEach(func() {
+			var err error
+			baseURL, err = url.Parse("https://api.example.org")
+			Expect(err).NotTo(HaveOccurred())
+
+			requestURL, err = url.Parse("https://api.example.org/v3/records?foo=bar")
+			Expect(err).NotTo(HaveOccurred())
+
+			records = []record{{N: 42}, {N: 43}}
+		})
+
+		JustBeforeEach(func() {
+			response := presenter.ForList(forRecord, records, *baseURL, *requestURL)
+			var err error
+			output, err = json.Marshal(response)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("returns the expected json", func() {
+			Expect(output).To(MatchJSON(`{
+				"pagination": {
+					"total_results": 2,
+					"total_pages": 1,
+					"first": {
+						"href": "https://api.example.org/v3/records?foo=bar"
+					},
+					"last": {
+						"href": "https://api.example.org/v3/records?foo=bar"
+					},
+					"next": null,
+					"previous": null
+				},
+				"resources": [
+					{
+						"m": 42,
+						"u": "https://api.example.org"
+					},
+					{
+						"m": 43,
+						"u": "https://api.example.org"
+					}
+				]
+			}`))
+		})
+
+		When("records are empty", func() {
+			BeforeEach(func() {
+				records = nil
+			})
+
+			It("returns an empty response", func() {
+				Expect(output).To(MatchJSON(`{
+					"pagination": {
+						"total_results": 0,
+						"total_pages": 1,
+						"first": {
+							"href": "https://api.example.org/v3/records?foo=bar"
+						},
+						"last": {
+							"href": "https://api.example.org/v3/records?foo=bar"
+						},
+						"next": null,
+						"previous": null
+					},
+					"resources": []
+				}`))
+			})
+		})
+	})
+})

--- a/api/presenter/space.go
+++ b/api/presenter/space.go
@@ -27,15 +27,6 @@ type SpaceLinks struct {
 	Organization *Link `json:"organization"`
 }
 
-func ForSpaceList(spaces []repositories.SpaceRecord, apiBaseURL, requestURL url.URL) ListResponse {
-	spaceResponses := make([]interface{}, 0, len(spaces))
-	for _, space := range spaces {
-		spaceResponses = append(spaceResponses, ForSpace(space, apiBaseURL))
-	}
-
-	return ForList(spaceResponses, apiBaseURL, requestURL)
-}
-
 func ForSpace(space repositories.SpaceRecord, apiBaseURL url.URL) SpaceResponse {
 	return SpaceResponse{
 		Name:      space.Name,

--- a/api/presenter/task.go
+++ b/api/presenter/task.go
@@ -87,12 +87,3 @@ func ForTask(responseTask repositories.TaskRecord, baseURL url.URL) TaskResponse
 		},
 	}
 }
-
-func ForTaskList(tasks []repositories.TaskRecord, baseURL, requestURL url.URL) ListResponse {
-	taskResponses := make([]interface{}, len(tasks))
-	for i, task := range tasks {
-		taskResponses[i] = ForTask(task, baseURL)
-	}
-
-	return ForList(taskResponses, baseURL, requestURL)
-}

--- a/api/presenter/user.go
+++ b/api/presenter/user.go
@@ -1,5 +1,7 @@
 package presenter
 
+import "net/url"
+
 const usersBase = "/v3/users"
 
 type UserResponse struct {
@@ -7,6 +9,6 @@ type UserResponse struct {
 	GUID string `json:"guid"`
 }
 
-func ForUser(name string) UserResponse {
+func ForUser(name string, _ url.URL) UserResponse {
 	return UserResponse{Name: name, GUID: name}
 }

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	code.cloudfoundry.org/bytefmt v0.0.0-20211005130812-5bb3c17173e5
 	code.cloudfoundry.org/go-loggregator/v8 v8.0.5
 	github.com/Masterminds/semver v1.5.0
+	github.com/PaesslerAG/jsonpath v0.1.1
 	github.com/SermoDigital/jose v0.9.2-0.20161205224733-f6df55f235c2
 	github.com/aws/aws-sdk-go-v2/config v1.18.19
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.18.7
@@ -47,6 +48,7 @@ require (
 )
 
 require (
+	github.com/PaesslerAG/gval v1.0.0 // indirect
 	github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c // indirect
 	github.com/docker/go-metrics v0.0.1 // indirect
 	github.com/docker/libtrust v0.0.0-20150114040149-fa567046d9b1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,11 @@ github.com/Masterminds/semver/v3 v3.2.0 h1:3MEsd0SM6jqZojhjLWWeBY+Kcjy9i6MQAeY7Y
 github.com/Masterminds/semver/v3 v3.2.0/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/Microsoft/go-winio v0.6.0 h1:slsWYD/zyx7lCXoZVlvQrj0hPTM1HI4+v1sIda2yDvg=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/PaesslerAG/gval v1.0.0 h1:GEKnRwkWDdf9dOmKcNrar9EA1bz1z9DqPIO1+iLzhd8=
+github.com/PaesslerAG/gval v1.0.0/go.mod h1:y/nm5yEyTeX6av0OfKJNp9rBNj2XrGhAf5+v24IBN1I=
+github.com/PaesslerAG/jsonpath v0.1.0/go.mod h1:4BzmtoM/PI8fPO4aQGIusjGxGir2BzcV0grWtFzq1Y8=
+github.com/PaesslerAG/jsonpath v0.1.1 h1:c1/AToHQMVsduPAa4Vh6xp2U0evy4t8SWp8imEsylIk=
+github.com/PaesslerAG/jsonpath v0.1.1/go.mod h1:lVboNxFGal/VwW6d9JzIy56bUsYAP6tH/x80vjnCseY=
 github.com/ProtonMail/go-crypto v0.0.0-20221026131551-cf6655e29de4 h1:ra2OtmuW0AE5csawV4YXMNGNQQXvLRps3z2Z59OPO+I=
 github.com/SermoDigital/jose v0.9.2-0.20161205224733-f6df55f235c2 h1:koK7z0nSsRiRiBWwa+E714Puh+DO+ZRdIyAXiXzL+lg=
 github.com/SermoDigital/jose v0.9.2-0.20161205224733-f6df55f235c2/go.mod h1:ARgCUhI1MHQH+ONky/PAtmVHQrP5JlGY0F3poXOp/fA=

--- a/tests/crds/crds_test.go
+++ b/tests/crds/crds_test.go
@@ -154,7 +154,6 @@ var _ = Describe("Using the k8s API directly", Ordered, func() {
 		Eventually(kubectl("wait", "--for=delete", "rolebinding/cf-admin-test-cli-role-binding", "-n", orgGUID, "--timeout=60s"), "60s").Should(Exit(0))
 
 		Eventually(kubectl("wait", "--for=delete", "rolebinding/cf-admin-test-cli-role-binding", "-n", spaceGUID, "--timeout=60s"), "60s").Should(Exit(0))
-
 	})
 
 	It("can delete the org", func() {
@@ -168,6 +167,5 @@ var _ = Describe("Using the k8s API directly", Ordered, func() {
 		Eventually(kubectl("wait", "--for=delete", "namespace/"+orgGUID, "--timeout=60s"), "60s").Should(Exit(0))
 
 		Eventually(kubectl("wait", "--for=delete", "namespace/"+spaceGUID, "--timeout=60s"), "60s").Should(Exit(0))
-
 	})
 })

--- a/tests/matchers/jsonpath.go
+++ b/tests/matchers/jsonpath.go
@@ -1,0 +1,70 @@
+package matchers
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+)
+
+type JSONPathMatcher struct {
+	path          string
+	expected      types.GomegaMatcher
+	jsonPathValue any
+	respObj       any
+}
+
+func MatchJSONPath(path string, expected any) *JSONPathMatcher {
+	matcher := &JSONPathMatcher{path: path}
+
+	if gm, ok := expected.(types.GomegaMatcher); ok {
+		matcher.expected = gm
+	} else {
+		matcher.expected = gomega.Equal(expected)
+	}
+
+	return matcher
+}
+
+func (m *JSONPathMatcher) Match(actual interface{}) (bool, error) {
+	bs, ok := actual.([]byte)
+	if !ok {
+		return false, fmt.Errorf("found %T, expected []byte", actual)
+	}
+
+	resp := any(nil)
+	err := json.Unmarshal(bs, &resp)
+	if err != nil {
+		return false, err
+	}
+	m.respObj = resp
+
+	v, err := jsonpath.Get(m.path, resp)
+	if err != nil {
+		return false, err
+	}
+
+	m.jsonPathValue = v
+
+	return m.expected.Match(v)
+}
+
+func (m JSONPathMatcher) FailureMessage(actual interface{}) string {
+	return fmt.Sprintf(
+		"Expected\n\t%s in %#v\nto match: %s",
+		m.path,
+		m.respObj,
+		m.expected.FailureMessage(m.jsonPathValue),
+	)
+}
+
+func (m JSONPathMatcher) NegatedFailureMessage(actual interface{}) string {
+	return fmt.Sprintf(
+		"Expected\n\t%s in %#v\nnot to match: %s",
+		m.path,
+		m.respObj,
+		m.expected.NegatedFailureMessage(m.jsonPathValue),
+	)
+}


### PR DESCRIPTION
## Is there a related GitHub Issue?
#2255

## What is this change about?
- Make ForList generic and delete repeated code
- Remove verbose JSON from handlers app test

This is the first PR. Here we deal with the app test only.

The idea is that the full API output JSON should be fully tested in the presenters package. This means we no longer have to include the entire JSON in the handlers tests, which can make the tests long and hard to navigate.

In the handlers test we check sufficient fields of the output JSON to be confident that the correct ForXXX presenter function has been invoked to produce the output.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
API/Handlers tests continue to be green

## Tag your pair, your PM, and/or team
@gcapizzi
