### PR TITLE
Improve handlers build test

### DIFF
--- a/api/handlers/build_test.go
+++ b/api/handlers/build_test.go
@@ -3,7 +3,6 @@ package handlers_test
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"strings"
 
@@ -12,6 +11,7 @@ import (
 	"code.cloudfoundry.org/korifi/api/handlers/fake"
 	"code.cloudfoundry.org/korifi/api/payloads"
 	"code.cloudfoundry.org/korifi/api/repositories"
+	. "code.cloudfoundry.org/korifi/tests/matchers"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -89,46 +89,9 @@ var _ = Describe("Build", func() {
 				})
 
 				It("returns the Build in the response", func() {
-					Expect(rr.Body.String()).To(MatchJSON(`{
-					"guid": "`+buildGUID+`",
-					"created_at": "`+createdAt+`",
-					"updated_at": "`+updatedAt+`",
-					"created_by": {},
-					"state": "STAGING",
-					"staging_memory_in_mb": `+fmt.Sprint(stagingMem)+`,
-					"staging_disk_in_mb": `+fmt.Sprint(stagingDisk)+`,
-					"error": null,
-					"lifecycle": {
-						"type": "buildpack",
-						"data": {
-							"buildpacks": [],
-							"stack": ""
-						}
-					},
-					"package": {
-						"guid": "`+packageGUID+`"
-					},
-					"droplet": null,
-					"relationships": {
-						"app": {
-							"data": {
-								"guid": "`+appGUID+`"
-							}
-						}
-					},
-					"metadata": {
-						"labels": {},
-						"annotations": {}
-					},
-					"links": {
-						"self": {
-							"href": "`+defaultServerURI("/v3/builds/", buildGUID)+`"
-						},
-						"app": {
-							"href": "`+defaultServerURI("/v3/apps/", appGUID)+`"
-						}
-					}
-				}`), "Response body matches response:")
+					Expect(rr.Body.Bytes()).To(MatchJSONPath("$.guid", "test-build-guid"))
+					Expect(rr.Body.Bytes()).To(MatchJSONPath("$.state", "STAGING"))
+					Expect(rr.Body.Bytes()).To(MatchJSONPath("$.links.self.href", HavePrefix("https://api.example.org")))
 				})
 			})
 
@@ -164,51 +127,10 @@ var _ = Describe("Build", func() {
 				})
 
 				It("returns the Build in the response", func() {
-					Expect(rr.Body.String()).To(MatchJSON(`{
-					"guid": "`+buildGUID+`",
-					"created_at": "`+createdAt+`",
-					"updated_at": "`+updatedAt+`",
-					"created_by": {},
-					"state": "STAGED",
-					"staging_memory_in_mb": `+fmt.Sprint(stagingMem)+`,
-					"staging_disk_in_mb": `+fmt.Sprint(stagingDisk)+`,
-					"error": null,
-					"lifecycle": {
-						"type": "buildpack",
-						"data": {
-							"buildpacks": [],
-							"stack": ""
-						}
-					},
-					"package": {
-						"guid": "`+packageGUID+`"
-					},
-					"droplet": {
-						"guid": "`+buildGUID+`"
-					},
-					"relationships": {
-						"app": {
-							"data": {
-								"guid": "`+appGUID+`"
-							}
-						}
-					},
-					"metadata": {
-						"labels": {},
-						"annotations": {}
-					},
-					"links": {
-						"self": {
-							"href": "`+defaultServerURI("/v3/builds/", buildGUID)+`"
-						},
-						"app": {
-							"href": "`+defaultServerURI("/v3/apps/", appGUID)+`"
-						},
-						"droplet": {
-							"href": "`+defaultServerURI("/v3/droplets/", buildGUID)+`"
-						}
-					}
-				}`), "Response body matches response:")
+					Expect(rr.Body.Bytes()).To(MatchJSONPath("$.guid", "test-build-guid"))
+					Expect(rr.Body.Bytes()).To(MatchJSONPath("$.state", "STAGED"))
+					Expect(rr.Body.Bytes()).To(MatchJSONPath("$.droplet.guid", "test-build-guid"))
+					Expect(rr.Body.Bytes()).To(MatchJSONPath("$.links.self.href", HavePrefix("https://api.example.org")))
 				})
 			})
 
@@ -248,46 +170,9 @@ var _ = Describe("Build", func() {
 				})
 
 				It("returns the Build in the response", func() {
-					Expect(rr.Body.String()).To(MatchJSON(`{
-					"guid": "`+buildGUID+`",
-					"created_at": "`+createdAt+`",
-					"updated_at": "`+updatedAt+`",
-					"created_by": {},
-					"state": "FAILED",
-					"staging_memory_in_mb": `+fmt.Sprint(stagingMem)+`,
-					"staging_disk_in_mb": `+fmt.Sprint(stagingDisk)+`,
-					"error": "`+stagingErrorMsg+`",
-					"lifecycle": {
-						"type": "buildpack",
-						"data": {
-							"buildpacks": [],
-							"stack": ""
-						}
-					},
-					"package": {
-						"guid": "`+packageGUID+`"
-					},
-					"droplet": null,
-					"relationships": {
-						"app": {
-							"data": {
-								"guid": "`+appGUID+`"
-							}
-						}
-					},
-					"metadata": {
-						"labels": {},
-						"annotations": {}
-					},
-					"links": {
-						"self": {
-							"href": "`+defaultServerURI("/v3/builds/", buildGUID)+`"
-						},
-						"app": {
-							"href": "`+defaultServerURI("/v3/apps/", appGUID)+`"
-						}
-					}
-				}`), "Make sure there is no droplet and error is surfaced from record")
+					Expect(rr.Body.Bytes()).To(MatchJSONPath("$.guid", "test-build-guid"))
+					Expect(rr.Body.Bytes()).To(MatchJSONPath("$.state", "FAILED"))
+					Expect(rr.Body.Bytes()).To(MatchJSONPath("$.links.self.href", HavePrefix("https://api.example.org")))
 				})
 			})
 		})
@@ -439,46 +324,9 @@ var _ = Describe("Build", func() {
 			})
 
 			It("returns the Build in the response", func() {
-				Expect(rr.Body.String()).To(MatchJSON(`{
-					"guid": "`+buildGUID+`",
-					"created_at": "`+createdAt+`",
-					"updated_at": "`+updatedAt+`",
-					"created_by": {},
-					"state": "STAGING",
-					"staging_memory_in_mb": `+fmt.Sprint(expectedStagingMem)+`,
-					"staging_disk_in_mb": `+fmt.Sprint(expectedStagingDisk)+`,
-					"error": null,
-					"lifecycle": {
-						"type": "`+expectedLifecycleType+`",
-						"data": {
-							"buildpacks": ["`+expectedLifecycleBuildpacks[0]+`", "`+expectedLifecycleBuildpacks[1]+`"],
-							"stack": "`+expectedLifecycleStack+`"
-						}
-					},
-					"package": {
-						"guid": "`+packageGUID+`"
-					},
-					"droplet": null,
-					"relationships": {
-						"app": {
-							"data": {
-								"guid": "`+appGUID+`"
-							}
-						}
-					},
-					"metadata": {
-						"labels": {},
-						"annotations": {}
-					},
-					"links": {
-						"self": {
-							"href": "`+defaultServerURI("/v3/builds/", buildGUID)+`"
-						},
-						"app": {
-							"href": "`+defaultServerURI("/v3/apps/", appGUID)+`"
-						}
-					}
-				}`), "Response body matches response:")
+				Expect(rr.Body.Bytes()).To(MatchJSONPath("$.guid", "test-build-guid"))
+				Expect(rr.Body.Bytes()).To(MatchJSONPath("$.state", "STAGING"))
+				Expect(rr.Body.Bytes()).To(MatchJSONPath("$.links.self.href", HavePrefix("https://api.example.org")))
 			})
 
 			It("looks up the app by the correct GUID", func() {

--- a/api/presenter/build.go
+++ b/api/presenter/build.go
@@ -56,8 +56,8 @@ func ForBuild(buildRecord repositories.BuildRecord, baseURL url.URL) BuildRespon
 			},
 		},
 		Metadata: Metadata{
-			Labels:      map[string]string{},
-			Annotations: map[string]string{},
+			Labels:      emptyMapIfNil(buildRecord.Labels),
+			Annotations: emptyMapIfNil(buildRecord.Annotations),
 		},
 		Links: map[string]Link{
 			"self": {

--- a/api/presenter/build_test.go
+++ b/api/presenter/build_test.go
@@ -1,0 +1,146 @@
+package presenter_test
+
+import (
+	"encoding/json"
+	"net/url"
+
+	"code.cloudfoundry.org/korifi/api/presenter"
+	"code.cloudfoundry.org/korifi/api/repositories"
+	. "code.cloudfoundry.org/korifi/tests/matchers"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Build", func() {
+	var (
+		baseURL *url.URL
+		output  []byte
+		record  repositories.BuildRecord
+	)
+
+	BeforeEach(func() {
+		var err error
+		baseURL, err = url.Parse("https://api.example.org")
+		Expect(err).NotTo(HaveOccurred())
+		record = repositories.BuildRecord{
+			GUID:            "build-guid",
+			State:           "STAGING",
+			CreatedAt:       "2023-03-29T15:42:12Z",
+			UpdatedAt:       "2023-03-29T15:42:13Z",
+			StagingMemoryMB: 128,
+			StagingDiskMB:   512,
+			Lifecycle: repositories.Lifecycle{
+				Type: "buildpack",
+				Data: repositories.LifecycleData{
+					Buildpacks: []string{"foo"},
+					Stack:      "fdsa",
+				},
+			},
+			PackageGUID: "package-guid",
+			AppGUID:     "app-guid",
+			Labels: map[string]string{
+				"label-key": "label-val",
+			},
+			Annotations: map[string]string{
+				"annotation-key": "annotation-val",
+			},
+		}
+	})
+
+	JustBeforeEach(func() {
+		response := presenter.ForBuild(record, *baseURL)
+		var err error
+		output, err = json.Marshal(response)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("produces expected build json", func() {
+		Expect(output).To(MatchJSON(`{
+			"guid": "build-guid",
+			"created_at": "2023-03-29T15:42:12Z",
+			"updated_at": "2023-03-29T15:42:13Z",
+			"created_by": {},
+			"state": "STAGING",
+			"staging_memory_in_mb": 128,
+			"staging_disk_in_mb": 512,
+			"error": null,
+			"lifecycle": {
+				"type": "buildpack",
+				"data": {
+					"buildpacks": [
+						"foo"
+					],
+					"stack": "fdsa"
+				}
+			},
+			"package": {
+				"guid": "package-guid"
+			},
+			"droplet": null,
+			"relationships": {
+				"app": {
+					"data": {
+						"guid": "app-guid"
+					}
+				}
+			},
+			"metadata": {
+				"labels": {
+					"label-key": "label-val"
+				},
+				"annotations": {
+					"annotation-key": "annotation-val"
+				}
+			},
+			"links": {
+				"self": {
+					"href": "https://api.example.org/v3/builds/build-guid"
+				},
+				"app": {
+					"href": "https://api.example.org/v3/apps/app-guid"
+				}
+			}
+		}`))
+	})
+
+	When("labels is nil", func() {
+		BeforeEach(func() {
+			record.Labels = nil
+		})
+
+		It("returns an empty slice of labels", func() {
+			Expect(output).To(MatchJSONPath("$.metadata.labels", Not(BeNil())))
+		})
+	})
+
+	When("annotations is nil", func() {
+		BeforeEach(func() {
+			record.Annotations = nil
+		})
+
+		It("returns an empty slice of annotations", func() {
+			Expect(output).To(MatchJSONPath("$.metadata.annotations", Not(BeNil())))
+		})
+	})
+
+	When("droplet is set", func() {
+		BeforeEach(func() {
+			record.DropletGUID = "droplet-guid"
+		})
+
+		It("includes droplet and link/droplet", func() {
+			Expect(output).To(MatchJSONPath("$.droplet.guid", "droplet-guid"))
+			Expect(output).To(MatchJSONPath("$.links.droplet.href", HaveSuffix("droplet-guid")))
+		})
+	})
+
+	When("staging error is set", func() {
+		BeforeEach(func() {
+			record.StagingErrorMsg = "oops"
+		})
+
+		It("includes the error message", func() {
+			Expect(output).To(MatchJSONPath("$.error", "oops"))
+		})
+	})
+})


### PR DESCRIPTION
## Is there a related GitHub Issue?
#2255

## What is this change about?
Remove JSON from the handlers build test. Use selective MatchJSONPath instead, and move full JSON testing to the presenters package

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Handlers tests remain green

## Tag your pair, your PM, and/or team
@gcapizzi

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
