### PR TITLE
Move buildpack handler test json to presenter test

### DIFF
--- a/api/presenter/buildpack_test.go
+++ b/api/presenter/buildpack_test.go
@@ -1,0 +1,59 @@
+package presenter_test
+
+import (
+	"encoding/json"
+	"net/url"
+
+	"code.cloudfoundry.org/korifi/api/presenter"
+	"code.cloudfoundry.org/korifi/api/repositories"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Buildpacks", func() {
+	var (
+		baseURL *url.URL
+		output  []byte
+		record  repositories.BuildpackRecord
+	)
+
+	BeforeEach(func() {
+		var err error
+		baseURL, err = url.Parse("https://api.example.org")
+		Expect(err).NotTo(HaveOccurred())
+		record = repositories.BuildpackRecord{
+			Name:      "paketo-foopacks/bar",
+			Position:  1,
+			Stack:     "waffle-house",
+			Version:   "1.0.0",
+			CreatedAt: "2016-03-18T23:26:46Z",
+			UpdatedAt: "2016-10-17T20:00:42Z",
+		}
+	})
+
+	JustBeforeEach(func() {
+		response := presenter.ForBuildpack(record, *baseURL)
+		var err error
+		output, err = json.Marshal(response)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("produces expected build json", func() {
+		Expect(output).To(MatchJSON(`{
+			"guid": "",
+			"created_at": "2016-03-18T23:26:46Z",
+			"updated_at": "2016-10-17T20:00:42Z",
+			"name": "paketo-foopacks/bar",
+			"filename": "paketo-foopacks/bar@1.0.0",
+			"stack": "waffle-house",
+			"position": 1,
+			"enabled": true,
+			"locked": false,
+			"metadata": {
+				"labels": {},
+				"annotations": {}
+			},
+			"links": {}
+		}`))
+	})
+})


### PR DESCRIPTION
## Is there a related GitHub Issue?
Issue: #2255

## What is this change about?
Simply handlers tests by moving json comparisons to the presenter package. Here we update the buildpack handler test.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@gcapizzi

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
