### PR TITLE
Remove literal JSON from handlers/domain test

### DIFF
--- a/api/handlers/domain_test.go
+++ b/api/handlers/domain_test.go
@@ -2,7 +2,6 @@ package handlers_test
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 	"strings"
 
@@ -11,6 +10,7 @@ import (
 	"code.cloudfoundry.org/korifi/api/handlers/fake"
 	"code.cloudfoundry.org/korifi/api/payloads"
 	"code.cloudfoundry.org/korifi/api/repositories"
+	. "code.cloudfoundry.org/korifi/tests/matchers"
 	"code.cloudfoundry.org/korifi/tools"
 
 	"github.com/go-http-utils/headers"
@@ -99,44 +99,9 @@ var _ = Describe("Domain", func() {
 		})
 
 		It("returns the correct JSON", func() {
-			Expect(rr.Body.String()).To(MatchJSON(`
-			{
-				"name": "my.domain",
-				"guid": "domain-guid",
-				"internal": false,
-				"router_group": null,
-				"supported_protocols": [
-					"http"
-				],
-				"created_at": "created-on",
-				"updated_at": "updated-on",
-				"metadata": {
-					"labels": {
-						"foo": "bar"
-					},
-					"annotations": {
-						"bar": "baz"
-					}
-				},
-				"relationships": {
-					"organization": {
-						"data": null
-					},
-					"shared_organizations": {
-						"data": []
-					}
-				},
-				"links": {
-					"self": {
-						"href": "https://api.example.org/v3/domains/domain-guid"
-					},
-					"route_reservations": {
-						"href": "https://api.example.org/v3/domains/domain-guid/route_reservations"
-					},
-					"router_group": null
-				}
-			}
-			`))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.guid", "domain-guid"))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.supported_protocols", ConsistOf("http")))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.links.self.href", "https://api.example.org/v3/domains/domain-guid"))
 		})
 
 		When("decoding the payload fails", func() {
@@ -193,44 +158,9 @@ var _ = Describe("Domain", func() {
 		})
 
 		It("returns the correct JSON", func() {
-			Expect(rr.Body.String()).To(MatchJSON(`
-			{
-				"name": "my.domain",
-				"guid": "domain-guid",
-				"internal": false,
-				"router_group": null,
-				"supported_protocols": [
-					"http"
-				],
-				"created_at": "created-on",
-				"updated_at": "updated-on",
-				"metadata": {
-					"labels": {
-						"foo": "bar"
-					},
-					"annotations": {
-						"bar": "baz"
-					}
-				},
-				"relationships": {
-					"organization": {
-						"data": null
-					},
-					"shared_organizations": {
-						"data": []
-					}
-				},
-				"links": {
-					"self": {
-						"href": "https://api.example.org/v3/domains/domain-guid"
-					},
-					"route_reservations": {
-						"href": "https://api.example.org/v3/domains/domain-guid/route_reservations"
-					},
-					"router_group": null
-				}
-			}
-			`))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.guid", "domain-guid"))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.supported_protocols", ConsistOf("http")))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.links.self.href", "https://api.example.org/v3/domains/domain-guid"))
 		})
 
 		When("the domain repo returns an error", func() {
@@ -297,44 +227,9 @@ var _ = Describe("Domain", func() {
 		})
 
 		It("returns the correct JSON", func() {
-			Expect(rr.Body.String()).To(MatchJSON(`
-			{
-				"name": "my.domain",
-				"guid": "domain-guid",
-				"internal": false,
-				"router_group": null,
-				"supported_protocols": [
-					"http"
-				],
-				"created_at": "created-on",
-				"updated_at": "updated-on",
-				"metadata": {
-					"labels": {
-						"foo": "bar"
-					},
-					"annotations": {
-						"bar": "baz"
-					}
-				},
-				"relationships": {
-					"organization": {
-						"data": null
-					},
-					"shared_organizations": {
-						"data": []
-					}
-				},
-				"links": {
-					"self": {
-						"href": "https://api.example.org/v3/domains/domain-guid"
-					},
-					"route_reservations": {
-						"href": "https://api.example.org/v3/domains/domain-guid/route_reservations"
-					},
-					"router_group": null
-				}
-			}
-			`))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.guid", "domain-guid"))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.supported_protocols", ConsistOf("http")))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.links.self.href", "https://api.example.org/v3/domains/domain-guid"))
 		})
 
 		It("invokes the domain repo correctly", func() {
@@ -407,52 +302,11 @@ var _ = Describe("Domain", func() {
 		})
 
 		It("returns the Pagination Data and Domain Resources in the response", func() {
-			Expect(rr.Body.String()).To(MatchJSON(fmt.Sprintf(`{
-				"pagination": {
-					"total_results": 1,
-					"total_pages": 1,
-					"first": {
-						"href": "%[1]s/v3/domains"
-					},
-					"last": {
-						"href": "%[1]s/v3/domains"
-					},
-					"next": null,
-					"previous": null
-				},
-				"resources": [
-					 {
-					  "guid": "%[2]s",
-					  "created_at": "%[3]s",
-					  "updated_at": "%[4]s",
-					  "name": "%[5]s",
-					  "internal": false,
-					  "router_group": null,
-					  "supported_protocols": ["http"],
-					  "metadata": {
-						"labels": {},
-						"annotations": {}
-					  },
-					  "relationships": {
-						"organization": {
-						  "data": null
-						},
-						"shared_organizations": {
-						  "data": []
-						}
-					  },
-					  "links": {
-						"self": {
-						  "href": "%[1]s/v3/domains/%[2]s"
-						},
-						"route_reservations": {
-						  "href": "%[1]s/v3/domains/%[2]s/route_reservations"
-						},
-						"router_group": null
-					  }
-					}
-				]
-				}`, defaultServerURL, domainRecord.GUID, domainRecord.CreatedAt, domainRecord.UpdatedAt, domainRecord.Name, domainRecord.Name)), "Response body matches response:")
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.pagination.total_results", BeEquivalentTo(1)))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.pagination.first.href", "https://api.example.org/v3/domains"))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.resources", HaveLen(1)))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.resources[0].guid", "test-domain-guid"))
+			Expect(rr.Body.Bytes()).To(MatchJSONPath("$.resources[0].supported_protocols", ConsistOf("http")))
 		})
 
 		When("no domain exists", func() {
@@ -470,24 +324,8 @@ var _ = Describe("Domain", func() {
 			})
 
 			It("returns an empty list in the response", func() {
-				expectedBody := fmt.Sprintf(`{
-					"pagination": {
-						"total_results": 0,
-						"total_pages": 1,
-						"first": {
-							"href": "%[1]s/v3/domains"
-						},
-						"last": {
-							"href": "%[1]s/v3/domains"
-						},
-						"next": null,
-						"previous": null
-					},
-					"resources": [
-					]
-				}`, defaultServerURL)
-
-				Expect(rr.Body.String()).To(MatchJSON(expectedBody), "Response body matches response:")
+				Expect(rr.Body.Bytes()).To(MatchJSONPath("$.pagination.total_results", BeZero()))
+				Expect(rr.Body.Bytes()).To(MatchJSONPath("$.resources", BeEmpty()))
 			})
 		})
 

--- a/api/presenter/buildpack_test.go
+++ b/api/presenter/buildpack_test.go
@@ -1,0 +1,59 @@
+package presenter_test
+
+import (
+	"encoding/json"
+	"net/url"
+
+	"code.cloudfoundry.org/korifi/api/presenter"
+	"code.cloudfoundry.org/korifi/api/repositories"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Buildpacks", func() {
+	var (
+		baseURL *url.URL
+		output  []byte
+		record  repositories.BuildpackRecord
+	)
+
+	BeforeEach(func() {
+		var err error
+		baseURL, err = url.Parse("https://api.example.org")
+		Expect(err).NotTo(HaveOccurred())
+		record = repositories.BuildpackRecord{
+			Name:      "paketo-foopacks/bar",
+			Position:  1,
+			Stack:     "waffle-house",
+			Version:   "1.0.0",
+			CreatedAt: "2016-03-18T23:26:46Z",
+			UpdatedAt: "2016-10-17T20:00:42Z",
+		}
+	})
+
+	JustBeforeEach(func() {
+		response := presenter.ForBuildpack(record, *baseURL)
+		var err error
+		output, err = json.Marshal(response)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("produces expected build json", func() {
+		Expect(output).To(MatchJSON(`{
+			"guid": "",
+			"created_at": "2016-03-18T23:26:46Z",
+			"updated_at": "2016-10-17T20:00:42Z",
+			"name": "paketo-foopacks/bar",
+			"filename": "paketo-foopacks/bar@1.0.0",
+			"stack": "waffle-house",
+			"position": 1,
+			"enabled": true,
+			"locked": false,
+			"metadata": {
+				"labels": {},
+				"annotations": {}
+			},
+			"links": {}
+		}`))
+	})
+})

--- a/api/presenter/domain.go
+++ b/api/presenter/domain.go
@@ -44,13 +44,6 @@ type SharedOrganizations struct {
 }
 
 func ForDomain(responseDomain repositories.DomainRecord, baseURL url.URL) DomainResponse {
-	if responseDomain.Labels == nil {
-		responseDomain.Labels = map[string]string{}
-	}
-	if responseDomain.Annotations == nil {
-		responseDomain.Annotations = map[string]string{}
-	}
-
 	return DomainResponse{
 		Name:               responseDomain.Name,
 		GUID:               responseDomain.GUID,
@@ -61,8 +54,8 @@ func ForDomain(responseDomain repositories.DomainRecord, baseURL url.URL) Domain
 		UpdatedAt:          responseDomain.UpdatedAt,
 
 		Metadata: Metadata{
-			Labels:      responseDomain.Labels,
-			Annotations: responseDomain.Annotations,
+			Labels:      emptyMapIfNil(responseDomain.Labels),
+			Annotations: emptyMapIfNil(responseDomain.Annotations),
 		},
 		Relationships: DomainRelationships{
 			Organization: Organization{

--- a/api/presenter/domain_test.go
+++ b/api/presenter/domain_test.go
@@ -1,0 +1,102 @@
+package presenter_test
+
+import (
+	"encoding/json"
+	"net/url"
+
+	"code.cloudfoundry.org/korifi/api/presenter"
+	"code.cloudfoundry.org/korifi/api/repositories"
+	. "code.cloudfoundry.org/korifi/tests/matchers"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Domains", func() {
+	var (
+		baseURL *url.URL
+		output  []byte
+		record  repositories.DomainRecord
+	)
+
+	BeforeEach(func() {
+		var err error
+		baseURL, err = url.Parse("https://api.example.org")
+		Expect(err).NotTo(HaveOccurred())
+		record = repositories.DomainRecord{
+			Name:        "my.domain",
+			GUID:        "domain-guid",
+			Labels:      map[string]string{"foo": "bar"},
+			Annotations: map[string]string{"bar": "baz"},
+			Namespace:   "my-ns",
+			CreatedAt:   "created-on",
+			UpdatedAt:   "updated-on",
+		}
+	})
+
+	JustBeforeEach(func() {
+		response := presenter.ForDomain(record, *baseURL)
+		var err error
+		output, err = json.Marshal(response)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("produces expected build json", func() {
+		Expect(output).To(MatchJSON(`{
+			"name": "my.domain",
+			"guid": "domain-guid",
+			"internal": false,
+			"router_group": null,
+			"supported_protocols": [
+				"http"
+			],
+			"created_at": "created-on",
+			"updated_at": "updated-on",
+			"metadata": {
+				"labels": {
+					"foo": "bar"
+				},
+				"annotations": {
+					"bar": "baz"
+				}
+			},
+			"relationships": {
+				"organization": {
+					"data": null
+				},
+				"shared_organizations": {
+					"data": []
+				}
+			},
+			"links": {
+				"self": {
+					"href": "https://api.example.org/v3/domains/domain-guid"
+				},
+				"route_reservations": {
+					"href": "https://api.example.org/v3/domains/domain-guid/route_reservations"
+				},
+				"router_group": null
+			}
+		}`))
+	})
+
+	When("labels is nil", func() {
+		BeforeEach(func() {
+			record.Labels = nil
+		})
+
+		It("returns an empty slice of labels", func() {
+			Expect(output).To(MatchJSONPath("$.metadata.labels", Not(BeNil())))
+		})
+	})
+
+	When("annotations is nil", func() {
+		BeforeEach(func() {
+			record.Annotations = nil
+		})
+
+		It("returns an empty slice of annotations", func() {
+			Expect(output).To(MatchJSONPath("$.metadata.annotations", Not(BeNil())))
+		})
+	})
+})


### PR DESCRIPTION
## Is there a related GitHub Issue?
#2255

## What is this change about?
Move literal JSON testing from handlers to presenter package. In this case, do it for the domain handler test.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@gcapizzi

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
