### PR TITLE
Move json from handlers/job_test to presenters

### DIFF
--- a/api/handlers/job.go
+++ b/api/handlers/job.go
@@ -57,7 +57,7 @@ func (h *Job) get(r *http.Request) (*routing.Response, error) {
 	case syncSpacePrefix:
 		jobResponse = presenter.ForManifestApplyJob(jobGUID, resourceGUID, h.serverURL)
 	case appDeletePrefix, orgDeletePrefix, spaceDeletePrefix, routeDeletePrefix, domainDeletePrefix, roleDeletePrefix:
-		jobResponse = presenter.ForDeleteJob(jobGUID, jobType, h.serverURL)
+		jobResponse = presenter.ForJob(jobGUID, jobType, h.serverURL)
 	default:
 		return nil, apierrors.LogAndReturn(
 			logger,

--- a/api/presenter/job.go
+++ b/api/presenter/job.go
@@ -34,26 +34,14 @@ type JobLinks struct {
 }
 
 func ForManifestApplyJob(jobGUID string, spaceGUID string, baseURL url.URL) JobResponse {
-	return JobResponse{
-		GUID:      jobGUID,
-		Errors:    nil,
-		Warnings:  nil,
-		Operation: SpaceApplyManifestOperation,
-		State:     "COMPLETE",
-		CreatedAt: "",
-		UpdatedAt: "",
-		Links: JobLinks{
-			Self: Link{
-				HRef: buildURL(baseURL).appendPath("/v3/jobs", jobGUID).build(),
-			},
-			Space: &Link{
-				HRef: buildURL(baseURL).appendPath("/v3/spaces", spaceGUID).build(),
-			},
-		},
+	response := ForJob(jobGUID, SpaceApplyManifestOperation, baseURL)
+	response.Links.Space = &Link{
+		HRef: buildURL(baseURL).appendPath("/v3/spaces", spaceGUID).build(),
 	}
+	return response
 }
 
-func ForDeleteJob(jobGUID string, operation string, baseURL url.URL) JobResponse {
+func ForJob(jobGUID string, operation string, baseURL url.URL) JobResponse {
 	return JobResponse{
 		GUID:      jobGUID,
 		Errors:    nil,
@@ -70,7 +58,7 @@ func ForDeleteJob(jobGUID string, operation string, baseURL url.URL) JobResponse
 	}
 }
 
-func JobURLForRedirects(resourceName string, operation string, baseURL url.URL) string {
-	jobGUID := fmt.Sprintf("%s%s%s", operation, JobGUIDDelimiter, resourceName)
+func JobURLForRedirects(resourceGUID string, operation string, baseURL url.URL) string {
+	jobGUID := fmt.Sprintf("%s%s%s", operation, JobGUIDDelimiter, resourceGUID)
 	return buildURL(baseURL).appendPath("/v3/jobs", jobGUID).build()
 }

--- a/api/presenter/job_test.go
+++ b/api/presenter/job_test.go
@@ -1,0 +1,81 @@
+package presenter_test
+
+import (
+	"encoding/json"
+	"net/url"
+
+	"code.cloudfoundry.org/korifi/api/presenter"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("", func() {
+	var (
+		baseURL *url.URL
+		output  []byte
+	)
+
+	BeforeEach(func() {
+		var err error
+		baseURL, err = url.Parse("https://api.example.org")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	Describe("ForManifestApplyJob", func() {
+		JustBeforeEach(func() {
+			response := presenter.ForManifestApplyJob("the-job-guid", "the-space-guid", *baseURL)
+			var err error
+			output, err = json.Marshal(response)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("renders the job", func() {
+			Expect(output).To(MatchJSON(`{
+				"created_at": "",
+				"errors": null,
+				"guid": "the-job-guid",
+				"links": {
+					"self": {
+						"href": "https://api.example.org/v3/jobs/the-job-guid"
+					},
+					"space": {
+						"href": "https://api.example.org/v3/spaces/the-space-guid"
+					}
+				},
+				"operation": "space.apply_manifest",
+				"state": "COMPLETE",
+				"updated_at": "",
+				"warnings": null
+			}`))
+		})
+	})
+
+	Describe("ForDeleteJob", func() {
+		JustBeforeEach(func() {
+			response := presenter.ForJob("the-job-guid", "the.operation", *baseURL)
+			var err error
+			output, err = json.Marshal(response)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("renders the job", func() {
+			Expect(output).To(MatchJSON(`{
+				"created_at": "",
+				"errors": null,
+				"guid": "the-job-guid",
+				"links": {
+					"self": {
+						"href": "https://api.example.org/v3/jobs/the-job-guid"
+					}
+				},
+				"operation": "the.operation",
+				"state": "COMPLETE",
+				"updated_at": "",
+				"warnings": null
+			}`))
+		})
+	})
+
+	Describe("JobURLForRedirects", func() {
+	})
+})


### PR DESCRIPTION
## Is there a related GitHub Issue?
Issue: #2255

## What is this change about?
Move full JSON matching from handlers tests to presenters tests. This PR addresses job_test.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@gcapizzi

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
