### PR TITLE
Patch instead of Update in case obj modified in background

### DIFF
--- a/controllers/controllers/workloads/cftask_controller_test.go
+++ b/controllers/controllers/workloads/cftask_controller_test.go
@@ -174,9 +174,10 @@ var _ = Describe("CFTaskReconciler Integration Tests", func() {
 
 		JustBeforeEach(func() {
 			Expect(k8sClient.Create(ctx, cfTask)).To(Succeed())
+			orig := cfTask.DeepCopy()
 			cfTask.Status.MemoryMB = 123
 			cfTask.Status.DiskQuotaMB = 432
-			Expect(k8sClient.Status().Update(ctx, cfTask)).To(Succeed())
+			Expect(k8sClient.Status().Patch(ctx, cfTask, client.MergeFrom(orig))).To(Succeed())
 
 			Eventually(func(g Gomega) {
 				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: cfSpace.Status.GUID, Name: cfTask.Name}, &task)).To(Succeed())


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
The CFTask might be modified by the controller between the creation and update. So let's use patch instead of update to avoid update failing

## Does this PR introduce a breaking change?
No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@gcapizzi

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
