### PR TITLE
Remove JSON from log-cache handlers test to presenter package

### DIFF
--- a/api/handlers/log_cache_test.go
+++ b/api/handlers/log_cache_test.go
@@ -1,16 +1,15 @@
 package handlers_test
 
 import (
-	"encoding/base64"
 	"errors"
-	"fmt"
 	"net/http"
-	"time"
 
 	apierrors "code.cloudfoundry.org/korifi/api/errors"
 	. "code.cloudfoundry.org/korifi/api/handlers"
 	"code.cloudfoundry.org/korifi/api/handlers/fake"
+	"code.cloudfoundry.org/korifi/api/payloads"
 	"code.cloudfoundry.org/korifi/api/repositories"
+	. "code.cloudfoundry.org/korifi/tests/matchers"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -47,135 +46,67 @@ var _ = Describe("LogCache", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("returns status 200 OK", func() {
-			Expect(rr.Code).To(Equal(http.StatusOK))
-		})
-
-		It("returns Content-Type as JSON in header", func() {
-			contentTypeHeader := rr.Header().Get("Content-Type")
-			Expect(contentTypeHeader).To(Equal(jsonHeader))
-		})
-
-		It("matches the expected response body format", func() {
-			expectedBody := `{"version":"2.11.4+cf-k8s","vm_uptime":"0"}`
-			Expect(rr.Body).To(MatchJSON(expectedBody))
+		It("returns the expected info", func() {
+			Expect(rr).To(HaveHTTPStatus(http.StatusOK))
+			Expect(rr).To(HaveHTTPHeaderWithValue("Content-Type", "application/json"))
+			Expect(rr).To(HaveHTTPBody(MatchJSON(`{"version":"2.11.4+cf-k8s","vm_uptime":"0"}`)))
 		})
 	})
 
 	Describe("the GET /api/v1/read/<app-guid> endpoint", func() {
-		const (
-			testAppGUID = "unused-app-guid"
-		)
-
-		var buildLogs, appLogs []repositories.LogRecord
-
 		BeforeEach(func() {
 			var err error
-			req, err = http.NewRequestWithContext(ctx, "GET", "/api/v1/read/"+testAppGUID, nil)
+			req, err = http.NewRequestWithContext(ctx, "GET", "/api/v1/read/the-app-guid", nil)
 			Expect(err).NotTo(HaveOccurred())
 
-			buildLogs = []repositories.LogRecord{
+			appLogsReader.ReadReturns([]repositories.LogRecord{
 				{
-					Message:   "BuildMessage1",
-					Timestamp: time.Now().UnixNano(),
-					Tags: map[string]string{
-						"source_type": "STG",
-					},
+					Message: "message-1",
 				},
 				{
-					Message:   "BuildMessage2",
-					Timestamp: time.Now().UnixNano(),
-					Tags: map[string]string{
-						"source_type": "STG",
-					},
+					Message: "message-2",
 				},
-			}
-
-			time.Sleep(5 * time.Millisecond)
-
-			appLogs = []repositories.LogRecord{
-				{
-					Message:   "AppMessage1",
-					Timestamp: time.Now().UnixNano(),
-				},
-				{
-					Message:   "AppMessage2",
-					Timestamp: time.Now().UnixNano(),
-				},
-			}
-			appLogsReader.ReadReturns(append(buildLogs, appLogs...), nil)
+			}, nil)
 		})
 
-		It("returns status 200 OK", func() {
-			Expect(rr.Code).To(Equal(http.StatusOK))
-		})
+		It("lists the log envelopes", func() {
+			Expect(appLogsReader.ReadCallCount()).To(Equal(1))
+			_, _, actualAuthInfo, appGUID, payload := appLogsReader.ReadArgsForCall(0)
+			Expect(actualAuthInfo).To(Equal(authInfo))
+			Expect(appGUID).To(Equal("the-app-guid"))
+			Expect(payload).To(BeZero())
 
-		It("returns Content-Type as JSON in header", func() {
-			contentTypeHeader := rr.Header().Get("Content-Type")
-			Expect(contentTypeHeader).To(Equal(jsonHeader))
-		})
-
-		It("returns a list of log envelopes", func() {
-			expectedBody := fmt.Sprintf(`{
-				"envelopes": {
-					"batch": [
-						{
-							"timestamp": %[1]d,
-							"log": {
-								"payload": "%[2]s",
-								"type": 0
-							},
-							"tags": {
-								"source_type": "STG"
-							}
-						},
-						{
-							"timestamp": %[3]d,
-							"log": {
-								"payload": "%[4]s",
-								"type": 0
-							},
-							"tags": {
-								"source_type": "STG"
-							}
-						},
-						{
-							"timestamp": %[5]d,
-							"log": {
-								"payload": "%[6]s",
-								"type": 0
-							}
-						},
-						{
-							"timestamp": %[7]d,
-							"log": {
-								"payload": "%[8]s",
-								"type": 0
-							}
-						}
-					]
-				}
-			}`, buildLogs[0].Timestamp, base64.URLEncoding.EncodeToString([]byte(buildLogs[0].Message)), buildLogs[1].Timestamp, base64.URLEncoding.EncodeToString([]byte(buildLogs[1].Message)),
-				appLogs[0].Timestamp, base64.URLEncoding.EncodeToString([]byte(appLogs[0].Message)), appLogs[1].Timestamp, base64.URLEncoding.EncodeToString([]byte(appLogs[1].Message)))
-			Expect(rr.Body).To(MatchJSON(expectedBody))
+			Expect(rr).To(HaveHTTPStatus(http.StatusOK))
+			Expect(rr).To(HaveHTTPHeaderWithValue("Content-Type", "application/json"))
+			Expect(rr).To(HaveHTTPBody(SatisfyAll(
+				MatchJSONPath("$.envelopes.batch[0].log.payload", "bWVzc2FnZS0x"),
+				MatchJSONPath("$.envelopes.batch[1].log.payload", "bWVzc2FnZS0y"),
+			)))
 		})
 
 		When("query parameters are specified", func() {
 			BeforeEach(func() {
 				var err error
-				req, err = http.NewRequestWithContext(ctx, "GET", "/api/v1/read/"+testAppGUID+"?descending=true&envelope_types=LOG&envelope_types=TIMER&limit=1000&start_time=-6795364578871345152", nil)
+				req, err = http.NewRequestWithContext(ctx, "GET", "/api/v1/read/the-app-guid?descending=true&envelope_types=LOG&envelope_types=TIMER&limit=1000&start_time=-6795364578871345152", nil)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
-			It("returns status 200 OK", func() {
-				Expect(rr.Code).Should(Equal(http.StatusOK))
+			It("filters the log records accordingly", func() {
+				Expect(appLogsReader.ReadCallCount()).To(Equal(1))
+				_, _, _, _, payload := appLogsReader.ReadArgsForCall(0)
+				Expect(payload).To(Equal(payloads.LogRead{
+					StartTime:     -6795364578871345152,
+					EnvelopeTypes: []string{"LOG", "TIMER"},
+					Limit:         1000,
+					Descending:    true,
+				}))
 			})
 		})
 
 		When("an invalid envelope type is provided", func() {
 			BeforeEach(func() {
 				var err error
-				req, err = http.NewRequestWithContext(ctx, "GET", "/api/v1/read/"+testAppGUID+"?envelope_types=BAD", nil)
+				req, err = http.NewRequestWithContext(ctx, "GET", "/api/v1/read/the-app-guid?envelope_types=BAD", nil)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -188,7 +119,7 @@ var _ = Describe("LogCache", func() {
 			BeforeEach(func() {
 				var err error
 				// Commas are literally interpreted instead of automatically placed as a list
-				req, err = http.NewRequestWithContext(ctx, "GET", "/api/v1/read/"+testAppGUID+"?envelope_types=LOG,TIMER", nil)
+				req, err = http.NewRequestWithContext(ctx, "GET", "/api/v1/read/the-app-guid?envelope_types=LOG,TIMER", nil)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -200,7 +131,7 @@ var _ = Describe("LogCache", func() {
 		When("invalid query parameters are provided", func() {
 			BeforeEach(func() {
 				var err error
-				req, err = http.NewRequestWithContext(ctx, "GET", "/api/v1/read/"+testAppGUID+"?foo=bar", nil)
+				req, err = http.NewRequestWithContext(ctx, "GET", "/api/v1/read/the-app-guid?foo=bar", nil)
 				Expect(err).NotTo(HaveOccurred())
 			})
 

--- a/api/presenter/log_test.go
+++ b/api/presenter/log_test.go
@@ -1,0 +1,67 @@
+package presenter_test
+
+import (
+	"encoding/json"
+
+	"code.cloudfoundry.org/korifi/api/presenter"
+	"code.cloudfoundry.org/korifi/api/repositories"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("LogCache", func() {
+	var (
+		output  []byte
+		records []repositories.LogRecord
+	)
+
+	BeforeEach(func() {
+		records = []repositories.LogRecord{
+			{
+				Message:   "message-1",
+				Timestamp: 123,
+				Tags: map[string]string{
+					"foo": "bar",
+				},
+			},
+			{
+				Message:   "message-2",
+				Timestamp: 456,
+			},
+		}
+	})
+
+	JustBeforeEach(func() {
+		response := presenter.ForLogs(records)
+		var err error
+		output, err = json.Marshal(response)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("produces expected logs json", func() {
+		Expect(output).To(MatchJSON(`{
+			"envelopes": {
+				"batch": [
+					{
+						"timestamp": 123,
+						"log": {
+							"payload": "bWVzc2FnZS0x",
+							"type": 0
+						},
+						"tags": {
+							"foo": "bar"
+						}
+					},
+					{
+						"timestamp": 456,
+						"log": {
+							"payload": "bWVzc2FnZS0y",
+							"type": 0
+						}
+					}
+				]
+			}
+		}`))
+	})
+})


### PR DESCRIPTION
## Is there a related GitHub Issue?
#2255

## What is this change about?
Move full JSON testing from handlers to presenter package. This PR address the log-cache test.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@gcapizzi

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
