### PR TITLE
Sort env var lists

### DIFF
--- a/controllers/controllers/workloads/cfprocess_controller.go
+++ b/controllers/controllers/workloads/cfprocess_controller.go
@@ -319,12 +319,18 @@ func (r *CFProcessReconciler) getPort(ctx context.Context, cfProcess *korifiv1al
 func generateEnvVars(port int, commonEnv []corev1.EnvVar) []corev1.EnvVar {
 	var result []corev1.EnvVar
 	result = append(result, commonEnv...)
+
 	portString := strconv.Itoa(port)
 	result = append(result,
 		corev1.EnvVar{Name: "VCAP_APP_HOST", Value: "0.0.0.0"},
 		corev1.EnvVar{Name: "VCAP_APP_PORT", Value: portString},
 		corev1.EnvVar{Name: "PORT", Value: portString},
 	)
+
+	// Sort env vars to guarantee idempotency
+	sort.SliceStable(result, func(i, j int) bool {
+		return result[i].Name < result[j].Name
+	})
 
 	return result
 }

--- a/statefulset-runner/controllers/appworkload_to_stset.go
+++ b/statefulset-runner/controllers/appworkload_to_stset.go
@@ -41,6 +41,7 @@ func getStatefulSetName(appWorkload *korifiv1alpha1.AppWorkload) (string, error)
 
 func (r *AppWorkloadToStatefulsetConverter) Convert(appWorkload *korifiv1alpha1.AppWorkload) (*appsv1.StatefulSet, error) {
 	envs := appWorkload.Spec.Env
+
 	fieldEnvs := []corev1.EnvVar{
 		{
 			Name: EnvPodName,
@@ -77,6 +78,11 @@ func (r *AppWorkloadToStatefulsetConverter) Convert(appWorkload *korifiv1alpha1.
 	}
 
 	envs = append(envs, fieldEnvs...)
+
+	// Sort env vars to guarantee idempotency
+	sort.SliceStable(envs, func(i, j int) bool {
+		return envs[i].Name < envs[j].Name
+	})
 
 	ports := []corev1.ContainerPort{}
 


### PR DESCRIPTION
Follow up to issue with pod affinity ordering as env vars are also a list sensitive to ordering changes.

## Is there a related GitHub Issue?
#2133 

## What is this change about?
Make AppWorkload and CFProcess reconciliation idempotent up to ordering of the env var lists.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Trigger re-reconciliation of the AppWorkload  with some frequency (by restarting the controller for instance) and see that the resource is not actually being updated. Check:
* the generation number remains consistent on the AppWorkload and its Statefulset
* the underlying Pods are not being deleted and recreated

## Tag your pair, your PM, and/or team
paired w/ @tcdowney 

## Notes
Note that we would also like to refactor the CFProcessController testing to more consistently detect ordering issues. And in general, we would like to have some sort of idempotency testing in place for the most important controllers. This will be a follow up effort.
