### PR TITLE
Avoid hanging org/space finalizers

### DIFF
--- a/controllers/controllers/workloads/cforg_controller.go
+++ b/controllers/controllers/workloads/cforg_controller.go
@@ -24,6 +24,7 @@ import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -191,7 +192,7 @@ func (r *CFOrgReconciler) finalize(ctx context.Context, log logr.Logger, org cli
 	}
 
 	err := r.client.Delete(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: org.GetName()}})
-	if err != nil {
+	if err != nil && !k8serrors.IsNotFound(err) {
 		log.Info("failed to delete namespace", "reason", err)
 		return ctrl.Result{}, err
 	}

--- a/controllers/controllers/workloads/cfspace_controller.go
+++ b/controllers/controllers/workloads/cfspace_controller.go
@@ -29,6 +29,7 @@ import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8s_labels "k8s.io/apimachinery/pkg/labels"
@@ -344,7 +345,7 @@ func (r *CFSpaceReconciler) finalize(ctx context.Context, log logr.Logger, space
 
 	log.V(1).Info("deleting namespace while finalizing CFSpace")
 	err := r.client.Delete(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: space.GetName()}})
-	if err != nil {
+	if err != nil && !k8serrors.IsNotFound(err) {
 		log.Info("failed to delete namespace", "reason", err)
 		return ctrl.Result{}, err
 	}

--- a/controllers/controllers/workloads/cfspace_controller_test.go
+++ b/controllers/controllers/workloads/cfspace_controller_test.go
@@ -12,7 +12,6 @@ import (
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -115,7 +114,7 @@ var _ = Describe("CFSpaceReconciler Integration Tests", func() {
 			BeforeEach(func() {
 				Expect(k8sClient.Delete(ctx, imageRegistrySecret)).To(Succeed())
 
-				var orgSecret v1.Secret
+				var orgSecret corev1.Secret
 				Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: cfOrg.Name, Name: imageRegistrySecret.Name}, &orgSecret)).To(Succeed())
 				Expect(k8sClient.Delete(ctx, &orgSecret)).To(Succeed())
 			})
@@ -124,7 +123,7 @@ var _ = Describe("CFSpaceReconciler Integration Tests", func() {
 				imageRegistrySecret = createSecret(ctx, k8sClient, packageRegistrySecretName, cfRootNamespace)
 
 				Eventually(func(g Gomega) {
-					var createdSecret v1.Secret
+					var createdSecret corev1.Secret
 					g.Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: cfOrg.Name, Name: imageRegistrySecret.Name}, &createdSecret)).To(Succeed())
 				}).Should(Succeed())
 			})


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
When finalizing an org or space, the associated namespace is deleted,
and the finalizer is removed from the list. If the subsequent patch of
the metadata fails, we have a situation where the finalization will be
retried, but the namespace has already been deleted.

This commit ignores the now acceptable NotFound error so that
finalization can complete successfully.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Our clusters in CI are less frequently borked

## Tag your pair, your PM, and/or team
@gcapizzi

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
