### PR TITLE
Include service account namespace in RoleBinding name

### DIFF
--- a/api/repositories/role_repository.go
+++ b/api/repositories/role_repository.go
@@ -187,8 +187,13 @@ func (r *RoleRepo) validateOrgRequirements(ctx context.Context, role CreateRoleM
 	return nil
 }
 
-func calculateRoleBindingName(roleType, roleUser string) string {
-	plain := []byte(roleType + "::" + roleUser)
+func calculateRoleBindingName(roleType, roleServiceAccountNamespace, roleUser string) string {
+	roleBindingName := roleType + "::"
+	if roleServiceAccountNamespace != "" {
+		roleBindingName = roleBindingName + roleServiceAccountNamespace + "/"
+	}
+	roleBindingName = roleBindingName + roleUser
+	plain := []byte(roleBindingName)
 	sum := sha256.Sum256(plain)
 
 	return fmt.Sprintf("%s-%x", roleBindingNamePrefix, sum)
@@ -198,7 +203,7 @@ func createRoleBinding(namespace, roleType, roleKind, roleUser, roleServiceAccou
 	return rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
-			Name:      calculateRoleBindingName(roleType, roleUser),
+			Name:      calculateRoleBindingName(roleType, roleServiceAccountNamespace, roleUser),
 			Labels: map[string]string{
 				RoleGuidLabel: roleGUID,
 			},

--- a/statefulset-runner/controllers/appworkload_to_stset_test.go
+++ b/statefulset-runner/controllers/appworkload_to_stset_test.go
@@ -279,7 +279,6 @@ var _ = Describe("AppWorkload to StatefulSet Converter", func() {
 				{Name: "c-third", Value: "third"},
 			}))
 		})
-
 	})
 
 	It("should produce a stable statefulset regardless of labels iteration order", func() {


### PR DESCRIPTION
## Is there a related GitHub Issue?
#2385

## What is this change about?
Include the service account namespace in the RoleBinding name so there is not conflicts between service accounts with the same name, but in different namespaces

## Does this PR introduce a breaking change?
no

## Acceptance Steps
See issue

## Tag your pair, your PM, and/or team
@matt-royal 
