### PR TITLE
Introduce standard filtering for repository resources

### DIFF
--- a/api/repositories/shared.go
+++ b/api/repositories/shared.go
@@ -87,3 +87,33 @@ func matchesFilter(field string, filter []string) bool {
 
 	return false
 }
+
+type Set[T comparable] map[T]struct{}
+
+func (s Set[T]) Includes(element T) bool {
+	_, ok := s[element]
+	return ok
+}
+
+func NewSet[T comparable](elements ...T) Set[T] {
+	set := Set[T]{}
+	for _, e := range elements {
+		set[e] = struct{}{}
+	}
+	return set
+}
+
+func Filter[T any](resources []T, predicate ...func(T) bool) []T {
+	var res []T
+outer:
+	for _, r := range resources {
+		for _, p := range predicate {
+			if !p(r) {
+				continue outer
+			}
+		}
+		res = append(res, r)
+	}
+
+	return res
+}


### PR DESCRIPTION
## Is there a related GitHub Issue?
#2422

## What is this change about?
Here we implement name, guid and space guid filtering for the app repository. Note that space guid filtering should be done at the top of the namespace loop for efficiency.

The new structure uses a generic Filter method which takes a list of filtering predicates. It also provides a NewSet(fromList) helper for quick lookups.

## Does this PR introduce a breaking change?
No

## Acceptance Steps


## Tag your pair, your PM, and/or team
@gcapizzi

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
