### PR TITLE
Remove JSON literals from the Service Route Binding handler test

### DIFF
--- a/api/handlers/service_route_binding_test.go
+++ b/api/handlers/service_route_binding_test.go
@@ -1,10 +1,10 @@
 package handlers_test
 
 import (
-	"fmt"
 	"net/http"
 
 	"code.cloudfoundry.org/korifi/api/handlers"
+	. "code.cloudfoundry.org/korifi/tests/matchers"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -23,30 +23,13 @@ var _ = Describe("ServiceRouteBinding", func() {
 			routerBuilder.Build().ServeHTTP(rr, req)
 		})
 
-		It("returns status 200 OK", func() {
+		It("returns an empty list", func() {
 			Expect(rr).To(HaveHTTPStatus(http.StatusOK))
-		})
-
-		It("returns Content-Type as JSON in header", func() {
 			Expect(rr).To(HaveHTTPHeaderWithValue("Content-Type", "application/json"))
-		})
-
-		It("matches the expected response body format", func() {
-			Expect(rr.Body.String()).To(MatchJSON(fmt.Sprintf(`{
-				"pagination": {
-				  "total_results": 0,
-				  "total_pages": 1,
-				  "first": {
-					"href": "%[1]s/v3/service_route_bindings"
-				  },
-				  "last": {
-					"href": "%[1]s/v3/service_route_bindings"
-				  },
-				  "next": null,
-				  "previous": null
-				},
-				"resources": []
-			}`, defaultServerURL)))
+			Expect(rr).To(HaveHTTPBody(SatisfyAll(
+				MatchJSONPath("$.pagination.total_results", BeZero()),
+				MatchJSONPath("$.pagination.first.href", "https://api.example.org/v3/service_route_bindings"),
+			)))
 		})
 	})
 })


### PR DESCRIPTION
## Is there a related GitHub Issue?
#2255

## What is this change about?
This replaces the usage of `MatchJSON` with JSON literals with `MatchJSONPath` in the Service Route Binding handler test.

## Does this PR introduce a breaking change?
No.

## Tag your pair, your PM, and/or team
@gcapizzi
