### PR TITLE
Tidy up handlers space-manifest tests

### DIFF
--- a/api/handlers/space_manifest_test.go
+++ b/api/handlers/space_manifest_test.go
@@ -19,11 +19,16 @@ var _ = Describe("SpaceManifest", func() {
 	var (
 		manifestApplier *fake.ManifestApplier
 		spaceRepo       *fake.CFSpaceRepository
-		req             *http.Request
-		requestBody     *strings.Reader
+		requestMethod   string
+		requestPath     string
+		requestBody     string
 	)
 
 	BeforeEach(func() {
+		requestMethod = "POST"
+		requestPath = ""
+		requestBody = ""
+
 		manifestApplier = new(fake.ManifestApplier)
 		spaceRepo = new(fake.CFSpaceRepository)
 
@@ -39,19 +44,17 @@ var _ = Describe("SpaceManifest", func() {
 		routerBuilder.LoadRoutes(apiHandler)
 	})
 
+	JustBeforeEach(func() {
+		req, err := http.NewRequestWithContext(ctx, requestMethod, requestPath, strings.NewReader(requestBody))
+		Expect(err).NotTo(HaveOccurred())
+		req.Header.Add("Content-type", "application/x-yaml")
+		routerBuilder.Build().ServeHTTP(rr, req)
+	})
+
 	Describe("POST /v3/spaces/{spaceGUID}/actions/apply_manifest", func() {
-		JustBeforeEach(func() {
-			var err error
-			req, err = http.NewRequestWithContext(ctx, "POST", "/v3/spaces/"+spaceGUID+"/actions/apply_manifest", requestBody)
-			Expect(err).NotTo(HaveOccurred())
-			req.Header.Add("Content-type", "application/x-yaml")
-
-			routerBuilder.Build().ServeHTTP(rr, req)
-		})
-
-		When("the manifest is valid", func() {
-			BeforeEach(func() {
-				requestBody = strings.NewReader(`---
+		BeforeEach(func() {
+			requestPath = "/v3/spaces/test-space-guid/actions/apply_manifest"
+			requestBody = `---
                 version: 1
                 applications:
                 - name: app1
@@ -67,49 +70,39 @@ var _ = Describe("SpaceManifest", func() {
                     health-check-type: http
                     instances: 1
                     memory: 256M
-                    timeout: 10
-                `)
-			})
+                    timeout: 10`
+		})
 
-			It("returns 202 with a Location header", func() {
-				Expect(rr).To(HaveHTTPStatus(http.StatusAccepted))
+		It("applies the manifest", func() {
+			Expect(rr).To(HaveHTTPStatus(http.StatusAccepted))
+			Expect(rr).To(HaveHTTPHeaderWithValue("Location", ContainSubstring("space.apply_manifest~"+spaceGUID)))
 
-				Expect(rr).To(HaveHTTPHeaderWithValue("Location", ContainSubstring("space.apply_manifest~"+spaceGUID)))
-			})
+			Expect(manifestApplier.ApplyCallCount()).To(Equal(1))
+			_, actualAuthInfo, _, payload := manifestApplier.ApplyArgsForCall(0)
+			Expect(actualAuthInfo).To(Equal(authInfo))
 
-			It("calls applyManifestAction and passes it the authInfo from the context", func() {
-				Expect(manifestApplier.ApplyCallCount()).To(Equal(1))
-				_, actualAuthInfo, _, _ := manifestApplier.ApplyArgsForCall(0)
-				Expect(actualAuthInfo).To(Equal(authInfo))
-			})
+			Expect(payload.Applications).To(HaveLen(1))
+			Expect(payload.Applications[0].Name).To(Equal("app1"))
+			Expect(payload.Applications[0].DefaultRoute).To(BeTrue())
+			Expect(payload.Applications[0].Memory).To(PointTo(Equal("128M")))
+			Expect(payload.Applications[0].DiskQuota).To(PointTo(Equal("256M")))
 
-			It("passes the parsed manifest to the action", func() {
-				Expect(manifestApplier.ApplyCallCount()).To(Equal(1))
-				_, _, _, payload := manifestApplier.ApplyArgsForCall(0)
-
-				Expect(payload.Applications).To(HaveLen(1))
-				Expect(payload.Applications[0].Name).To(Equal("app1"))
-				Expect(payload.Applications[0].DefaultRoute).To(BeTrue())
-				Expect(payload.Applications[0].Memory).To(PointTo(Equal("128M")))
-				Expect(payload.Applications[0].DiskQuota).To(PointTo(Equal("256M")))
-
-				Expect(payload.Applications[0].Processes).To(HaveLen(1))
-				Expect(payload.Applications[0].Processes[0].Type).To(Equal("web"))
-				Expect(payload.Applications[0].Processes[0].Command).NotTo(BeNil())
-				Expect(payload.Applications[0].Processes[0].Command).To(PointTo(Equal("start-web.sh")))
-				Expect(payload.Applications[0].Processes[0].DiskQuota).To(PointTo(Equal("512M")))
-				Expect(payload.Applications[0].Processes[0].HealthCheckHTTPEndpoint).To(PointTo(Equal("/healthcheck")))
-				Expect(payload.Applications[0].Processes[0].HealthCheckInvocationTimeout).To(PointTo(Equal(int64(5))))
-				Expect(payload.Applications[0].Processes[0].HealthCheckType).To(PointTo(Equal("http")))
-				Expect(payload.Applications[0].Processes[0].Instances).To(PointTo(Equal(1)))
-				Expect(payload.Applications[0].Processes[0].Memory).To(PointTo(Equal("256M")))
-				Expect(payload.Applications[0].Processes[0].Timeout).To(PointTo(Equal(int64(10))))
-			})
+			Expect(payload.Applications[0].Processes).To(HaveLen(1))
+			Expect(payload.Applications[0].Processes[0].Type).To(Equal("web"))
+			Expect(payload.Applications[0].Processes[0].Command).NotTo(BeNil())
+			Expect(payload.Applications[0].Processes[0].Command).To(PointTo(Equal("start-web.sh")))
+			Expect(payload.Applications[0].Processes[0].DiskQuota).To(PointTo(Equal("512M")))
+			Expect(payload.Applications[0].Processes[0].HealthCheckHTTPEndpoint).To(PointTo(Equal("/healthcheck")))
+			Expect(payload.Applications[0].Processes[0].HealthCheckInvocationTimeout).To(PointTo(Equal(int64(5))))
+			Expect(payload.Applications[0].Processes[0].HealthCheckType).To(PointTo(Equal("http")))
+			Expect(payload.Applications[0].Processes[0].Instances).To(PointTo(Equal(1)))
+			Expect(payload.Applications[0].Processes[0].Memory).To(PointTo(Equal("256M")))
+			Expect(payload.Applications[0].Processes[0].Timeout).To(PointTo(Equal(int64(10))))
 		})
 
 		When("the manifest is invalid", func() {
 			BeforeEach(func() {
-				requestBody = strings.NewReader(`---
+				requestBody = `---
                 version: 1
                 applications:
                 - name: app1
@@ -127,8 +120,7 @@ var _ = Describe("SpaceManifest", func() {
                     memory: 256M
                     timeout: 1
                   routes:
-                  - route: "ssh://1.2.3.4"
-                `)
+                  - route: "ssh://1.2.3.4"`
 			})
 
 			It("response with an unprocessable entity error listing all the errors", func() {
@@ -138,7 +130,7 @@ var _ = Describe("SpaceManifest", func() {
 
 		When("the manifest contains unsupported fields", func() {
 			BeforeEach(func() {
-				requestBody = strings.NewReader(`---
+				requestBody = `---
                 version: 1
                 applications:
                 - name: app1
@@ -146,8 +138,7 @@ var _ = Describe("SpaceManifest", func() {
                     annotations:
                       contact: "bob@example.com jane@example.com"
                     labels:
-                      sensitive: true
-                `)
+                      sensitive: true`
 			})
 
 			It("calls applyManifestAction and passes it the authInfo from the context", func() {
@@ -156,95 +147,28 @@ var _ = Describe("SpaceManifest", func() {
 				Expect(actualAuthInfo).To(Equal(authInfo))
 			})
 		})
-
-		When("random-route and default-route flags are both set", func() {
-			BeforeEach(func() {
-				requestBody = strings.NewReader(`---
-                version: 1
-                applications:
-                - name: app1
-                  default-route: true
-                  random-route: true
-                `)
-			})
-
-			It("response with an unprocessable entity error", func() {
-				expectUnprocessableEntityError("applications[0].default-route and random-route may not be used together")
-			})
-		})
-
-		When("app disk-quota and app disk_quota are both set", func() {
-			BeforeEach(func() {
-				requestBody = strings.NewReader(`---
-                version: 1
-                applications:
-                - name: app1
-                  disk-quota: 128M
-                  disk_quota: 128M
-                `)
-			})
-
-			It("response with an unprocessable entity error", func() {
-				expectUnprocessableEntityError("applications[0].disk_quota and disk-quota may not be used together")
-			})
-		})
-
-		When("process disk-quota and process disk_quota are both set", func() {
-			BeforeEach(func() {
-				requestBody = strings.NewReader(`---
-                version: 1
-                applications:
-                - name: app1
-                  processes:
-                  - type: foo
-                    disk-quota: 128M
-                    disk_quota: 128M
-                `)
-			})
-
-			It("response with an unprocessable entity error", func() {
-				expectUnprocessableEntityError("applications[0].processes[0].disk_quota and disk-quota may not be used together")
-			})
-		})
 	})
 
 	Describe("POST /v3/spaces/{spaceGUID}/manifest_diff", func() {
-		JustBeforeEach(func() {
-			routerBuilder.Build().ServeHTTP(rr, req)
+		BeforeEach(func() {
+			requestPath = "/v3/spaces/test-space-guid/manifest_diff"
+			requestBody = `---
+			version: 1
+			applications:
+				- name: app1`
 		})
 
-		When("the space exists", func() {
-			BeforeEach(func() {
-				var err error
-				req, err = http.NewRequestWithContext(ctx, "POST", "/v3/spaces/"+spaceGUID+"/manifest_diff", strings.NewReader(`---
-					version: 1
-					applications:
-					  - name: app1
-				`))
-				Expect(err).NotTo(HaveOccurred())
-				req.Header.Add("Content-type", "application/x-yaml")
-			})
-
-			It("returns 202 with an empty diff", func() {
-				Expect(rr).To(HaveHTTPStatus(http.StatusAccepted))
-				Expect(rr).To(HaveHTTPHeaderWithValue("Content-Type", "application/json"))
-				Expect(rr).To(HaveHTTPBody(MatchJSON(`{
-                	"diff": []
-            	}`)))
-			})
+		It("returns 202 with an empty diff", func() {
+			Expect(rr).To(HaveHTTPStatus(http.StatusAccepted))
+			Expect(rr).To(HaveHTTPHeaderWithValue("Content-Type", "application/json"))
+			Expect(rr).To(HaveHTTPBody(MatchJSON(`{
+				"diff": []
+			}`)))
 		})
 
 		When("getting the space errors", func() {
 			BeforeEach(func() {
 				spaceRepo.GetSpaceReturns(repositories.SpaceRecord{}, errors.New("foo"))
-				var err error
-				req, err = http.NewRequestWithContext(ctx, "POST", "/v3/spaces/fake-space-guid/manifest_diff", strings.NewReader(`---
-					version: 1
-					applications:
-					- name: app1
-				`))
-				Expect(err).NotTo(HaveOccurred())
-				req.Header.Add("Content-type", "application/x-yaml")
 			})
 
 			It("returns an error", func() {
@@ -255,14 +179,6 @@ var _ = Describe("SpaceManifest", func() {
 		When("getting the space is forbidden", func() {
 			BeforeEach(func() {
 				spaceRepo.GetSpaceReturns(repositories.SpaceRecord{}, apierrors.NewForbiddenError(errors.New("foo"), repositories.SpaceResourceType))
-				var err error
-				req, err = http.NewRequestWithContext(ctx, "POST", "/v3/spaces/fake-space-guid/manifest_diff", strings.NewReader(`---
-					version: 1
-					applications:
-					- name: app1
-				`))
-				Expect(err).NotTo(HaveOccurred())
-				req.Header.Add("Content-type", "application/x-yaml")
 			})
 
 			It("returns an error", func() {

--- a/api/payloads/manifest_test.go
+++ b/api/payloads/manifest_test.go
@@ -18,6 +18,7 @@ var _ = Describe("Manifest payload", func() {
 				testSpaceManifest Manifest
 				validateErr       error
 			)
+
 			BeforeEach(func() {
 				testSpaceManifest = Manifest{
 					Applications: []ManifestApplication{{
@@ -29,6 +30,7 @@ var _ = Describe("Manifest payload", func() {
 					}},
 				}
 			})
+
 			JustBeforeEach(func() {
 				validateErr = testSpaceManifest.Validate()
 			})
@@ -129,6 +131,17 @@ var _ = Describe("Manifest payload", func() {
 				})
 			})
 
+			When("app disk-quota and app disk_quota are both set", func() {
+				BeforeEach(func() {
+					testManifest.DiskQuota = tools.PtrTo("128M")
+					testManifest.AltDiskQuota = tools.PtrTo("128M")
+				})
+
+				It("response with an unprocessable entity error", func() {
+					Expect(validateErr).To(MatchError("disk_quota: and disk-quota may not be used together."))
+				})
+			})
+
 			When("HealthCheckInvocationTimeout is not positive", func() {
 				BeforeEach(func() {
 					testManifest.HealthCheckInvocationTimeout = tools.PtrTo(int64(0))
@@ -172,6 +185,17 @@ var _ = Describe("Manifest payload", func() {
 
 				It("returns a validation error", func() {
 					Expect(validateErr).To(MatchError("memory: must be greater than 0MB."))
+				})
+			})
+
+			When("random-route and default-route flags are both set", func() {
+				BeforeEach(func() {
+					testManifest.DefaultRoute = true
+					testManifest.RandomRoute = true
+				})
+
+				It("response with an unprocessable entity error", func() {
+					Expect(validateErr).To(MatchError("default-route: and random-route may not be used together."))
 				})
 			})
 		})
@@ -245,6 +269,17 @@ var _ = Describe("Manifest payload", func() {
 
 				It("returns a validation error", func() {
 					Expect(validateErr).To(MatchError("disk-quota: must be greater than 0MB."))
+				})
+			})
+
+			When("app disk-quota and app disk_quota are both set", func() {
+				BeforeEach(func() {
+					testManifestProcess.DiskQuota = tools.PtrTo("128M")
+					testManifestProcess.AltDiskQuota = tools.PtrTo("128M")
+				})
+
+				It("response with an unprocessable entity error", func() {
+					Expect(validateErr).To(MatchError("disk_quota: and disk-quota may not be used together."))
 				})
 			})
 


### PR DESCRIPTION
## Is there a related GitHub Issue?
#2255

## What is this change about?
- Use standard request manipulation in a single JustBeforeEach
- Move payload tests to the payload package


## Does this PR introduce a breaking change?
No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@gcapizzi
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
