### PR TITLE
Remove full JSON matching from handlers/task_test

### DIFF
--- a/api/handlers/task_test.go
+++ b/api/handlers/task_test.go
@@ -1,23 +1,21 @@
 package handlers_test
 
 import (
-	"context"
 	"errors"
-	"fmt"
+	"io"
 	"net/http"
 	"strings"
-	"time"
 
 	"code.cloudfoundry.org/korifi/api/payloads"
 	"code.cloudfoundry.org/korifi/tools"
 
 	. "github.com/onsi/gomega/gstruct"
 
-	"code.cloudfoundry.org/korifi/api/authorization"
 	apierrors "code.cloudfoundry.org/korifi/api/errors"
 	"code.cloudfoundry.org/korifi/api/handlers"
 	"code.cloudfoundry.org/korifi/api/handlers/fake"
 	"code.cloudfoundry.org/korifi/api/repositories"
+	. "code.cloudfoundry.org/korifi/tests/matchers"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -25,15 +23,19 @@ import (
 
 var _ = Describe("Task", func() {
 	var (
-		req                  *http.Request
+		requestMethod        string
+		requestPath          string
 		appRepo              *fake.CFAppRepository
 		taskRepo             *fake.CFTaskRepository
-		requestJSONValidator handlers.RequestJSONValidator
+		requestJSONValidator *fake.RequestJSONValidator
+		payload              any
 	)
 
 	BeforeEach(func() {
+		requestMethod = http.MethodGet
+		requestPath = "/v3/tasks"
+
 		appRepo = new(fake.CFAppRepository)
-		taskRepo = new(fake.CFTaskRepository)
 
 		appRepo.GetAppReturns(repositories.AppRecord{
 			GUID:      "the-app-guid",
@@ -41,26 +43,37 @@ var _ = Describe("Task", func() {
 			IsStaged:  true,
 		}, nil)
 
-		var err error
-		requestJSONValidator, err = handlers.NewDefaultDecoderValidator()
-		Expect(err).NotTo(HaveOccurred())
+		taskRepo = new(fake.CFTaskRepository)
+		taskRepo.GetTaskReturns(repositories.TaskRecord{
+			GUID:      "the-task-guid",
+			SpaceGUID: "the-space-guid",
+		}, nil)
+
+		requestJSONValidator = new(fake.RequestJSONValidator)
+		requestJSONValidator.DecodeAndValidateJSONPayloadStub = func(_ *http.Request, i interface{}) error {
+			switch t := i.(type) {
+			case *payloads.TaskCreate:
+				*t = *(payload.(*payloads.TaskCreate))
+			case *payloads.TaskUpdate:
+				*t = *(payload.(*payloads.TaskUpdate))
+			}
+
+			return nil
+		}
+
+		apiHandler := handlers.NewTask(*serverURL, appRepo, taskRepo, requestJSONValidator)
+		routerBuilder.LoadRoutes(apiHandler)
 	})
 
 	JustBeforeEach(func() {
-		apiHandler := handlers.NewTask(*serverURL, appRepo, taskRepo, requestJSONValidator)
-		routerBuilder.LoadRoutes(apiHandler)
-
+		req, err := http.NewRequestWithContext(ctx, requestMethod, requestPath, strings.NewReader(`{"input": "json"}`))
+		Expect(err).NotTo(HaveOccurred())
 		routerBuilder.Build().ServeHTTP(rr, req)
 	})
 
 	Describe("POST /v3/apps/:app-guid/tasks", func() {
-		var fakeRequestJSONValidator *fake.RequestJSONValidator
-
 		BeforeEach(func() {
-			fakeRequestJSONValidator = new(fake.RequestJSONValidator)
-			requestJSONValidator = fakeRequestJSONValidator
-
-			body := &payloads.TaskCreate{
+			payload = &payloads.TaskCreate{
 				Command: "echo hello",
 				Metadata: payloads.Metadata{
 					Labels:      map[string]string{"env": "production"},
@@ -68,37 +81,21 @@ var _ = Describe("Task", func() {
 				},
 			}
 
-			fakeRequestJSONValidator.DecodeAndValidateJSONPayloadStub = func(_ *http.Request, i interface{}) error {
-				b, ok := i.(*payloads.TaskCreate)
-				Expect(ok).To(BeTrue())
-				*b = *body
-				return nil
-			}
-			var err error
-			req, err = http.NewRequestWithContext(ctx, "POST", "/v3/apps/the-app-guid/tasks", strings.NewReader(`ignored by test`))
-			Expect(err).NotTo(HaveOccurred())
+			requestMethod = http.MethodPost
+			requestPath = "/v3/apps/the-app-guid/tasks"
 
 			taskRepo.CreateTaskReturns(repositories.TaskRecord{
-				Name:              "the-task-name",
-				GUID:              "the-task-guid",
-				Command:           "echo hello",
-				AppGUID:           "the-app-guid",
-				DropletGUID:       "the-droplet-guid",
-				SequenceID:        123456,
-				CreationTimestamp: time.Date(2022, 6, 14, 13, 22, 34, 0, time.UTC),
-				MemoryMB:          256,
-				DiskMB:            128,
-				State:             "task-created",
-				Labels:            map[string]string{"env": "production"},
-				Annotations:       map[string]string{"hello": "there"},
+				GUID: "the-task-guid",
 			}, nil)
 		})
 
-		It("returns a 201 Created response", func() {
-			Expect(rr).To(HaveHTTPStatus(http.StatusCreated))
-		})
-
 		It("creates a task", func() {
+			Expect(requestJSONValidator.DecodeAndValidateJSONPayloadCallCount()).To(Equal(1))
+			req, _ := requestJSONValidator.DecodeAndValidateJSONPayloadArgsForCall(0)
+			body, err := io.ReadAll(req.Body)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(body).To(MatchJSON(`{"input": "json"}`))
+
 			Expect(taskRepo.CreateTaskCallCount()).To(Equal(1))
 
 			_, actualAuthInfo, createTaskMessage := taskRepo.CreateTaskArgsForCall(0)
@@ -108,50 +105,12 @@ var _ = Describe("Task", func() {
 			Expect(createTaskMessage.SpaceGUID).To(Equal("the-space-guid"))
 			Expect(createTaskMessage.Labels).To(Equal(map[string]string{"env": "production"}))
 			Expect(createTaskMessage.Annotations).To(Equal(map[string]string{"hello": "there"}))
-		})
 
-		It("returns the created task", func() {
-			Expect(rr.Body).To(MatchJSON(`{
-              "name": "the-task-name",
-              "guid": "the-task-guid",
-              "command": "echo hello",
-              "sequence_id": 123456,
-              "created_at": "2022-06-14T13:22:34Z",
-              "updated_at": "2022-06-14T13:22:34Z",
-              "memory_in_mb": 256,
-              "disk_in_mb": 128,
-              "droplet_guid": "the-droplet-guid",
-              "state": "task-created",
-              "metadata": {
-                "labels": {"env": "production"},
-                "annotations": {"hello": "there"}
-              },
-              "relationships": {
-                "app": {
-                  "data": {
-                    "guid": "the-app-guid"
-                  }
-                }
-              },
-              "result": {
-                "failure_reason": null
-              },
-              "links": {
-                "self": {
-                  "href": "https://api.example.org/v3/tasks/the-task-guid"
-                },
-                "app": {
-                  "href": "https://api.example.org/v3/apps/the-app-guid"
-                },
-                "droplet": {
-                  "href": "https://api.example.org/v3/droplets/the-droplet-guid"
-                },
-                "cancel": {
-                  "href": "https://api.example.org/v3/tasks/the-task-guid/actions/cancel",
-                  "method": "POST"
-                }
-              }
-            }`))
+			Expect(rr).To(HaveHTTPStatus(http.StatusCreated))
+			Expect(rr).To(HaveHTTPBody(SatisfyAll(
+				MatchJSONPath("$.guid", "the-task-guid"),
+				MatchJSONPath("$.links.self.href", "https://api.example.org/v3/tasks/the-task-guid"),
+			)))
 		})
 
 		When("the app does not exist", func() {
@@ -219,156 +178,30 @@ var _ = Describe("Task", func() {
 		})
 	})
 
-	Describe("GET /v3/tasks", func() {
-		var (
-			expectedBody string
-			reqPath      string
-		)
-
+	Describe("listing tasks", func() {
 		BeforeEach(func() {
 			taskRepo.ListTasksReturns([]repositories.TaskRecord{
-				{
-					Name:              "task-1",
-					GUID:              "guid-1",
-					SequenceID:        3,
-					State:             "SUCCEEDED",
-					MemoryMB:          1024,
-					DiskMB:            1024,
-					DropletGUID:       "droplet-1",
-					CreationTimestamp: time.Date(2016, time.May, 4, 17, 0, 41, 0, time.UTC),
-					AppGUID:           "app1",
-				}, {
-					Name:              "task-2",
-					GUID:              "guid-2",
-					SequenceID:        33,
-					State:             "FAILED",
-					MemoryMB:          1024,
-					DiskMB:            1024,
-					DropletGUID:       "droplet-2",
-					CreationTimestamp: time.Date(2016, time.May, 4, 17, 0, 41, 0, time.UTC),
-					AppGUID:           "app2",
-				},
+				{GUID: "guid-1"},
+				{GUID: "guid-2"},
 			}, nil)
 		})
 
-		JustBeforeEach(func() {
-			expectedBody = fmt.Sprintf(`
-                {
-                  "pagination": {
-                    "total_results": 2,
-                    "total_pages": 1,
-                    "first": {
-                      "href": "%[1]s%[2]s"
-                    },
-                    "last": {
-                      "href": "%[1]s%[2]s"
-                    },
-                    "next": null,
-                    "previous": null
-                  },
-                  "resources": [
-                    {
-                      "guid": "guid-1",
-                      "sequence_id": 3,
-                      "name": "task-1",
-                      "state": "SUCCEEDED",
-                      "memory_in_mb": 1024,
-                      "disk_in_mb": 1024,
-                      "result": {
-                        "failure_reason": null
-                      },
-                      "droplet_guid": "droplet-1",
-                      "created_at": "2016-05-04T17:00:41Z",
-                      "updated_at": "2016-05-04T17:00:41Z",
-                      "metadata": {
-                        "labels": {},
-                        "annotations": {}
-                      },
-                      "relationships": {
-                        "app": {
-                          "data": {
-                            "guid": "app1"
-                          }
-                        }
-                      },
-                      "links": {
-                        "self": {
-                          "href": "%[1]s/v3/tasks/guid-1"
-                        },
-                        "app": {
-                          "href": "%[1]s/v3/apps/app1"
-                        },
-                        "cancel": {
-                          "href": "%[1]s/v3/tasks/guid-1/actions/cancel",
-                          "method": "POST"
-                        },
-                        "droplet": {
-                          "href": "%[1]s/v3/droplets/droplet-1"
-                        }
-                      }
-                    },
-                    {
-                      "guid": "guid-2",
-                      "sequence_id": 33,
-                      "name": "task-2",
-                      "state": "FAILED",
-                      "memory_in_mb": 1024,
-                      "disk_in_mb": 1024,
-                      "result": {
-                        "failure_reason": null
-                      },
-                      "droplet_guid": "droplet-2",
-                      "created_at": "2016-05-04T17:00:41Z",
-                      "updated_at": "2016-05-04T17:00:41Z",
-                      "metadata": {
-                        "labels": {},
-                        "annotations": {}
-                      },
-                      "relationships": {
-                        "app": {
-                          "data": {
-                            "guid": "app2"
-                          }
-                        }
-                      },
-                      "links": {
-                        "self": {
-                          "href": "%[1]s/v3/tasks/guid-2"
-                        },
-                        "app": {
-                          "href": "%[1]s/v3/apps/app2"
-                        },
-                        "cancel": {
-                          "href": "%[1]s/v3/tasks/guid-2/actions/cancel",
-                          "method": "POST"
-                        },
-                        "droplet": {
-                          "href": "%[1]s/v3/droplets/droplet-2"
-                        }
-                      }
-                    }
-                  ]
-                }
-            `, defaultServerURL, reqPath)
-		})
-
 		Describe("GET /v3/tasks", func() {
-			BeforeEach(func() {
-				var err error
-				req, err = http.NewRequestWithContext(ctx, "GET", "/v3/tasks", nil)
-				Expect(err).NotTo(HaveOccurred())
-				reqPath = "/v3/tasks"
-			})
-
-			It("returns the tasks", func() {
-				Expect(rr).To(HaveHTTPStatus(http.StatusOK))
-				Expect(rr).To(HaveHTTPBody(MatchJSON(expectedBody)))
-			})
-
-			It("provides an empty list task message to the repository", func() {
+			It("lists the tasks", func() {
 				Expect(taskRepo.ListTasksCallCount()).To(Equal(1))
-				_, _, listMsg := taskRepo.ListTasksArgsForCall(0)
+				_, info, listMsg := taskRepo.ListTasksArgsForCall(0)
+				Expect(info).To(Equal(authInfo))
 				Expect(listMsg).To(Equal(repositories.ListTaskMessage{}))
+
+				Expect(rr).To(HaveHTTPStatus(http.StatusOK))
+				Expect(rr).To(HaveHTTPHeaderWithValue("Content-Type", "application/json"))
+				Expect(rr).To(HaveHTTPBody(SatisfyAll(
+					MatchJSONPath("$.pagination.first.href", "https://api.example.org/v3/tasks"),
+					MatchJSONPath("$.resources", HaveLen(2)),
+					MatchJSONPath("$.resources[0].guid", "guid-1"),
+					MatchJSONPath("$.resources[0].links.self.href", "https://api.example.org/v3/tasks/guid-1"),
+					MatchJSONPath("$.resources[1].guid", "guid-2"),
+				)))
 			})
 
 			When("listing tasks fails", func() {
@@ -384,21 +217,25 @@ var _ = Describe("Task", func() {
 
 		Describe("GET /v3/apps/{app-guid}/tasks", func() {
 			BeforeEach(func() {
-				var err error
-				req, err = http.NewRequestWithContext(ctx, "GET", "/v3/apps/the-app-guid/tasks", nil)
-				Expect(err).NotTo(HaveOccurred())
-				reqPath = "/v3/apps/the-app-guid/tasks"
+				requestPath = "/v3/apps/the-app-guid/tasks"
 			})
 
-			It("returns the tasks", func() {
-				Expect(rr).To(HaveHTTPStatus(http.StatusOK))
-				Expect(rr).To(HaveHTTPBody(MatchJSON(expectedBody)))
-			})
-
-			It("provides a list task message with the app guid to the repository", func() {
+			It("lists the tasks", func() {
 				Expect(taskRepo.ListTasksCallCount()).To(Equal(1))
-				_, _, listMsg := taskRepo.ListTasksArgsForCall(0)
+				_, info, listMsg := taskRepo.ListTasksArgsForCall(0)
+				Expect(info).To(Equal(authInfo))
 				Expect(listMsg.AppGUIDs).To(ConsistOf("the-app-guid"))
+				Expect(listMsg.SequenceIDs).To(BeEmpty())
+
+				Expect(rr).To(HaveHTTPStatus(http.StatusOK))
+				Expect(rr).To(HaveHTTPHeaderWithValue("Content-Type", "application/json"))
+				Expect(rr).To(HaveHTTPBody(SatisfyAll(
+					MatchJSONPath("$.pagination.first.href", "https://api.example.org/v3/apps/the-app-guid/tasks"),
+					MatchJSONPath("$.resources", HaveLen(2)),
+					MatchJSONPath("$.resources[0].guid", "guid-1"),
+					MatchJSONPath("$.resources[0].links.self.href", "https://api.example.org/v3/tasks/guid-1"),
+					MatchJSONPath("$.resources[1].guid", "guid-2"),
+				)))
 			})
 
 			When("the app does not exist", func() {
@@ -433,9 +270,7 @@ var _ = Describe("Task", func() {
 
 			When("filtering tasks by sequence ID", func() {
 				BeforeEach(func() {
-					var err error
-					req, err = http.NewRequestWithContext(ctx, "GET", "/v3/apps/the-app-guid/tasks?sequence_ids=1,2", nil)
-					Expect(err).NotTo(HaveOccurred())
+					requestPath = "/v3/apps/the-app-guid/tasks?sequence_ids=1,2"
 				})
 
 				It("provides a list task message with the sequence ids to the repository", func() {
@@ -446,9 +281,7 @@ var _ = Describe("Task", func() {
 
 				When("the sequence_ids parameter cannot be parsed to ints", func() {
 					BeforeEach(func() {
-						var err error
-						req, err = http.NewRequestWithContext(ctx, "GET", "/v3/apps/the-app-guid/tasks?sequence_ids=asdf", nil)
-						Expect(err).NotTo(HaveOccurred())
+						requestPath = "/v3/apps/the-app-guid/tasks?sequence_ids=asdf"
 					})
 
 					It("returns a bad request error", func() {
@@ -459,9 +292,7 @@ var _ = Describe("Task", func() {
 
 			When("the query string contains unsupported keys", func() {
 				BeforeEach(func() {
-					var err error
-					req, err = http.NewRequestWithContext(ctx, "GET", "/v3/apps/the-app-guid/tasks?whatever=1", nil)
-					Expect(err).NotTo(HaveOccurred())
+					requestPath = "/v3/apps/the-app-guid/tasks?whatever=1"
 				})
 
 				It("returns an unknown key error", func() {
@@ -482,90 +313,34 @@ var _ = Describe("Task", func() {
 	})
 
 	Describe("GET /v3/tasks/:task-guid", func() {
-		var taskRecord repositories.TaskRecord
-
 		BeforeEach(func() {
-			taskRecord = repositories.TaskRecord{
-				Name:              "task-name",
-				GUID:              "task-guid",
-				Command:           "echo hello",
-				AppGUID:           "app-guid",
-				DropletGUID:       "droplet-guid",
-				SequenceID:        314,
-				CreationTimestamp: time.Date(2022, 6, 21, 11, 11, 55, 0, time.UTC),
-				MemoryMB:          123,
-				DiskMB:            234,
-				State:             "stateful",
-			}
-
-			taskRepo.GetTaskStub = func(context.Context, authorization.Info, string) (repositories.TaskRecord, error) {
-				return taskRecord, nil
-			}
-
-			var err error
-			req, err = http.NewRequestWithContext(ctx, "GET", "/v3/tasks/task-guid", nil)
-			Expect(err).NotTo(HaveOccurred())
+			requestPath += "/the-task-guid"
 		})
 
 		It("gets the correct task", func() {
 			Expect(taskRepo.GetTaskCallCount()).To(Equal(1))
 			_, actualAuthInfo, taskGUID := taskRepo.GetTaskArgsForCall(0)
 			Expect(actualAuthInfo).To(Equal(authInfo))
-			Expect(taskGUID).To(Equal("task-guid"))
+			Expect(taskGUID).To(Equal("the-task-guid"))
 		})
 
 		It("returns the task", func() {
 			Expect(rr).To(HaveHTTPStatus(http.StatusOK))
-			Expect(rr.Body).To(MatchJSON(`{
-              "name": "task-name",
-              "guid": "task-guid",
-              "command": "echo hello",
-              "sequence_id": 314,
-              "created_at": "2022-06-21T11:11:55Z",
-              "updated_at": "2022-06-21T11:11:55Z",
-              "memory_in_mb": 123,
-              "disk_in_mb": 234,
-              "droplet_guid": "droplet-guid",
-              "state": "stateful",
-              "metadata": {
-                "labels": {},
-                "annotations": {}
-              },
-              "relationships": {
-                "app": {
-                  "data": {
-                    "guid": "app-guid"
-                  }
-                }
-              },
-              "result": {
-                "failure_reason": null
-              },
-              "links": {
-                "self": {
-                  "href": "https://api.example.org/v3/tasks/task-guid"
-                },
-                "app": {
-                  "href": "https://api.example.org/v3/apps/app-guid"
-                },
-                "droplet": {
-                  "href": "https://api.example.org/v3/droplets/droplet-guid"
-                },
-                "cancel": {
-                  "href": "https://api.example.org/v3/tasks/task-guid/actions/cancel",
-                  "method": "POST"
-                }
-              }
-            }`))
+			Expect(rr).To(HaveHTTPBody(SatisfyAll(
+				MatchJSONPath("$.guid", "the-task-guid"),
+				MatchJSONPath("$.links.self.href", "https://api.example.org/v3/tasks/the-task-guid"),
+			)))
 		})
 
-		When("there FailureReason is set", func() {
+		When("the FailureReason is set", func() {
 			BeforeEach(func() {
-				taskRecord.FailureReason = "bar"
+				taskRepo.GetTaskReturns(repositories.TaskRecord{
+					FailureReason: "bar",
+				}, nil)
 			})
 
 			It("propagates to the response body", func() {
-				Expect(rr.Body.String()).To(ContainSubstring(`"failure_reason":"bar"`))
+				Expect(rr).To(HaveHTTPBody(MatchJSONPath("$.result.failure_reason", "bar")))
 			})
 		})
 
@@ -593,28 +368,30 @@ var _ = Describe("Task", func() {
 	Describe("POST /v3/tasks/:taskGUID/actions/cancel", func() {
 		BeforeEach(func() {
 			taskRepo.CancelTaskReturns(repositories.TaskRecord{
-				Name:              "task-name",
-				GUID:              "task-guid",
-				Command:           "echo hello",
-				AppGUID:           "app-guid",
-				DropletGUID:       "droplet-guid",
-				SequenceID:        314,
-				CreationTimestamp: time.Date(2022, 6, 21, 11, 11, 55, 0, time.UTC),
-				MemoryMB:          123,
-				DiskMB:            234,
-				State:             "stateful",
+				GUID: "the-task-guid",
 			}, nil)
 
-			var err error
-			req, err = http.NewRequestWithContext(ctx, "POST", "/v3/tasks/task-guid/actions/cancel", nil)
-			Expect(err).NotTo(HaveOccurred())
+			requestMethod = http.MethodPost
+			requestPath += "/the-task-guid/actions/cancel"
 		})
 
-		It("gets the task", func() {
+		It("cancels the task", func() {
 			Expect(taskRepo.GetTaskCallCount()).To(Equal(1))
 			_, actualAuthInfo, taskGUID := taskRepo.GetTaskArgsForCall(0)
 			Expect(actualAuthInfo).To(Equal(authInfo))
-			Expect(taskGUID).To(Equal("task-guid"))
+			Expect(taskGUID).To(Equal("the-task-guid"))
+
+			Expect(taskRepo.CancelTaskCallCount()).To(Equal(1))
+			_, actualAuthInfo, taskGUID = taskRepo.CancelTaskArgsForCall(0)
+			Expect(actualAuthInfo).To(Equal(authInfo))
+			Expect(taskGUID).To(Equal("the-task-guid"))
+
+			Expect(rr).To(HaveHTTPStatus(http.StatusAccepted))
+			Expect(rr).To(HaveHTTPHeaderWithValue("Content-Type", "application/json"))
+			Expect(rr).To(HaveHTTPBody(SatisfyAll(
+				MatchJSONPath("$.guid", "the-task-guid"),
+				MatchJSONPath("$.links.self.href", "https://api.example.org/v3/tasks/the-task-guid"),
+			)))
 		})
 
 		When("getting the task fails with forbidden error", func() {
@@ -635,58 +412,6 @@ var _ = Describe("Task", func() {
 			It("returns an Internal Server Error", func() {
 				expectUnknownError()
 			})
-		})
-
-		It("cancels the task", func() {
-			Expect(taskRepo.CancelTaskCallCount()).To(Equal(1))
-			_, actualAuthInfo, taskGUID := taskRepo.CancelTaskArgsForCall(0)
-			Expect(actualAuthInfo).To(Equal(authInfo))
-			Expect(taskGUID).To(Equal("task-guid"))
-		})
-
-		It("returns the cancelled task", func() {
-			Expect(rr).To(HaveHTTPStatus(http.StatusAccepted))
-			Expect(rr.Body).To(MatchJSON(`{
-              "name": "task-name",
-              "guid": "task-guid",
-              "command": "echo hello",
-              "sequence_id": 314,
-              "created_at": "2022-06-21T11:11:55Z",
-              "updated_at": "2022-06-21T11:11:55Z",
-              "memory_in_mb": 123,
-              "disk_in_mb": 234,
-              "droplet_guid": "droplet-guid",
-              "state": "stateful",
-              "metadata": {
-                "labels": {},
-                "annotations": {}
-              },
-              "relationships": {
-                "app": {
-                  "data": {
-                    "guid": "app-guid"
-                  }
-                }
-              },
-              "result": {
-                "failure_reason": null
-              },
-              "links": {
-                "self": {
-                  "href": "https://api.example.org/v3/tasks/task-guid"
-                },
-                "app": {
-                  "href": "https://api.example.org/v3/apps/app-guid"
-                },
-                "droplet": {
-                  "href": "https://api.example.org/v3/droplets/droplet-guid"
-                },
-                "cancel": {
-                  "href": "https://api.example.org/v3/tasks/task-guid/actions/cancel",
-                  "method": "POST"
-                }
-              }
-            }`))
 		})
 
 		When("cancelling the task fails", func() {
@@ -713,44 +438,36 @@ var _ = Describe("Task", func() {
 	Describe("PUT /v3/tasks/:taskGUID/cancel", func() {
 		BeforeEach(func() {
 			taskRepo.CancelTaskReturns(repositories.TaskRecord{
-				Name:              "task-name",
-				GUID:              "task-guid",
-				Command:           "echo hello",
-				AppGUID:           "app-guid",
-				DropletGUID:       "droplet-guid",
-				SequenceID:        314,
-				CreationTimestamp: time.Date(2022, 6, 21, 11, 11, 55, 0, time.UTC),
-				MemoryMB:          123,
-				DiskMB:            234,
-				State:             "stateful",
+				GUID: "the-task-guid",
 			}, nil)
 
-			var err error
-			req, err = http.NewRequestWithContext(ctx, "PUT", "/v3/tasks/task-guid/cancel", nil)
-			Expect(err).NotTo(HaveOccurred())
+			requestMethod = http.MethodPut
+			requestPath += "/the-task-guid/cancel"
 		})
 
 		It("cancels the task", func() {
-			Expect(taskRepo.CancelTaskCallCount()).To(Equal(1))
-			_, actualAuthInfo, taskGUID := taskRepo.CancelTaskArgsForCall(0)
+			Expect(taskRepo.GetTaskCallCount()).To(Equal(1))
+			_, actualAuthInfo, taskGUID := taskRepo.GetTaskArgsForCall(0)
 			Expect(actualAuthInfo).To(Equal(authInfo))
-			Expect(taskGUID).To(Equal("task-guid"))
+			Expect(taskGUID).To(Equal("the-task-guid"))
+
+			Expect(taskRepo.CancelTaskCallCount()).To(Equal(1))
+			_, actualAuthInfo, taskGUID = taskRepo.CancelTaskArgsForCall(0)
+			Expect(actualAuthInfo).To(Equal(authInfo))
+			Expect(taskGUID).To(Equal("the-task-guid"))
+
+			Expect(rr).To(HaveHTTPStatus(http.StatusAccepted))
+			Expect(rr).To(HaveHTTPHeaderWithValue("Content-Type", "application/json"))
+			Expect(rr).To(HaveHTTPBody(SatisfyAll(
+				MatchJSONPath("$.guid", "the-task-guid"),
+				MatchJSONPath("$.links.self.href", "https://api.example.org/v3/tasks/the-task-guid"),
+			)))
 		})
 	})
 
 	Describe("PATCH /v3/tasks/:guid", func() {
-		var (
-			taskGUID                 string
-			taskRecord               repositories.TaskRecord
-			dropletGUID              string
-			fakeRequestJSONValidator *fake.RequestJSONValidator
-		)
-
 		BeforeEach(func() {
-			fakeRequestJSONValidator = new(fake.RequestJSONValidator)
-			requestJSONValidator = fakeRequestJSONValidator
-
-			body := &payloads.TaskUpdate{
+			payload = &payloads.TaskUpdate{
 				Metadata: payloads.MetadataPatch{
 					Labels: map[string]*string{
 						"env":                           tools.PtrTo("production"),
@@ -763,110 +480,38 @@ var _ = Describe("Task", func() {
 				},
 			}
 
-			fakeRequestJSONValidator.DecodeAndValidateJSONPayloadStub = func(_ *http.Request, i interface{}) error {
-				b, ok := i.(*payloads.TaskUpdate)
-				Expect(ok).To(BeTrue())
-				*b = *body
-				return nil
-			}
+			taskRepo.PatchTaskMetadataReturns(repositories.TaskRecord{GUID: "the-task-guid"}, nil)
 
-			taskGUID = generateGUID("task")
-			dropletGUID = generateGUID("droplet")
-			taskRecord = repositories.TaskRecord{
-				Name:              "my-task",
-				GUID:              taskGUID,
-				SpaceGUID:         spaceGUID,
-				Command:           "do-the-thing",
-				AppGUID:           appGUID,
-				DropletGUID:       dropletGUID,
-				SequenceID:        0,
-				CreationTimestamp: time.Time{},
-				MemoryMB:          42,
-				DiskMB:            42,
-				State:             "RUNNING",
-				FailureReason:     "",
-			}
-			taskRepo.GetTaskReturns(taskRecord, nil)
-
-			updatedTaskRecord := taskRecord
-			updatedTaskRecord.Labels = map[string]string{
-				"env":                           "production",
-				"foo.example.com/my-identifier": "aruba",
-			}
-			updatedTaskRecord.Annotations = map[string]string{
-				"hello":                       "there",
-				"foo.example.com/lorem-ipsum": "Lorem ipsum.",
-			}
-			taskRepo.PatchTaskMetadataReturns(updatedTaskRecord, nil)
-
-			req = createHttpRequest("PATCH", "/v3/tasks/"+taskGUID, strings.NewReader(`ignored in test`))
+			requestMethod = http.MethodPatch
+			requestPath += "/the-task-guid"
 		})
 
 		It("returns status 200 OK", func() {
-			Expect(rr).To(HaveHTTPStatus(http.StatusOK))
 		})
 
 		It("patches the task with the new labels and annotations", func() {
+			Expect(requestJSONValidator.DecodeAndValidateJSONPayloadCallCount()).To(Equal(1))
+			req, _ := requestJSONValidator.DecodeAndValidateJSONPayloadArgsForCall(0)
+			body, err := io.ReadAll(req.Body)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(body).To(MatchJSON(`{"input": "json"}`))
+
 			Expect(taskRepo.PatchTaskMetadataCallCount()).To(Equal(1))
 			_, _, msg := taskRepo.PatchTaskMetadataArgsForCall(0)
-			Expect(msg.TaskGUID).To(Equal(taskGUID))
-			Expect(msg.SpaceGUID).To(Equal(spaceGUID))
+			Expect(msg.TaskGUID).To(Equal("the-task-guid"))
+			Expect(msg.SpaceGUID).To(Equal("the-space-guid"))
 			Expect(msg.Annotations).To(HaveKeyWithValue("hello", PointTo(Equal("there"))))
 			Expect(msg.Annotations).To(HaveKeyWithValue("foo.example.com/lorem-ipsum", PointTo(Equal("Lorem ipsum."))))
 			Expect(msg.Labels).To(HaveKeyWithValue("env", PointTo(Equal("production"))))
 			Expect(msg.Labels).To(HaveKeyWithValue("foo.example.com/my-identifier", PointTo(Equal("aruba"))))
-		})
 
-		It("returns the task in the response", func() {
+			Expect(rr).To(HaveHTTPStatus(http.StatusOK))
 			Expect(rr).To(HaveHTTPHeaderWithValue("Content-Type", "application/json"))
 
-			Expect(rr.Body.String()).To(MatchJSON(fmt.Sprintf(`{
-              "name": "my-task",
-              "guid": "%[2]s",
-              "command": "do-the-thing",
-              "droplet_guid": "%[4]s",
-              "metadata": {
-                "labels": {
-                  "env": "production",
-                  "foo.example.com/my-identifier": "aruba"
-                },
-                "annotations": {
-                  "hello": "there",
-                  "foo.example.com/lorem-ipsum": "Lorem ipsum."
-                }
-              },
-              "relationships": {
-                "app": {
-                  "data": {
-                    "guid": "%[3]s"
-                  }
-                }
-              },
-              "links": {
-                "self": {
-                  "href": "%[1]s/v3/tasks/%[2]s"
-                },
-                "app": {
-                  "href": "%[1]s/v3/apps/%[3]s"
-                },
-                "droplet": {
-                  "href": "%[1]s/v3/droplets/%[4]s"
-                },
-                "cancel": {
-                  "href": "%[1]s/v3/tasks/%[2]s/actions/cancel",
-                  "method": "POST"
-                }
-              },
-              "sequence_id": 0,
-              "created_at": "0001-01-01T00:00:00Z",
-              "updated_at": "0001-01-01T00:00:00Z",
-              "memory_in_mb": 42,
-              "disk_in_mb": 42,
-              "state": "RUNNING",
-              "result": {
-                "failure_reason": null
-              }
-            }`, defaultServerURL, taskGUID, appGUID, dropletGUID)), "Response body matches response:")
+			Expect(rr).To(HaveHTTPBody(SatisfyAll(
+				MatchJSONPath("$.guid", "the-task-guid"),
+				MatchJSONPath("$.links.self.href", "https://api.example.org/v3/tasks/the-task-guid"),
+			)))
 		})
 
 		When("the user doesn't have permission to get the task", func() {
@@ -874,11 +519,8 @@ var _ = Describe("Task", func() {
 				taskRepo.GetTaskReturns(repositories.TaskRecord{}, apierrors.NewForbiddenError(nil, repositories.TaskResourceType))
 			})
 
-			It("returns a not found error", func() {
+			It("returns a not found error and doesn't call patch", func() {
 				expectNotFoundError("Task")
-			})
-
-			It("does not call patch", func() {
 				Expect(taskRepo.PatchTaskMetadataCallCount()).To(Equal(0))
 			})
 		})
@@ -888,11 +530,8 @@ var _ = Describe("Task", func() {
 				taskRepo.GetTaskReturns(repositories.TaskRecord{}, errors.New("boom"))
 			})
 
-			It("returns an error", func() {
+			It("returns an error and doesn't call patch", func() {
 				expectUnknownError()
-			})
-
-			It("does not call patch", func() {
 				Expect(taskRepo.PatchTaskMetadataCallCount()).To(Equal(0))
 			})
 		})

--- a/api/presenter/task.go
+++ b/api/presenter/task.go
@@ -3,7 +3,6 @@ package presenter
 import (
 	"net/http"
 	"net/url"
-	"time"
 
 	"code.cloudfoundry.org/korifi/api/repositories"
 )
@@ -53,8 +52,8 @@ func ForTask(responseTask repositories.TaskRecord, baseURL url.URL) TaskResponse
 		Command:     responseTask.Command,
 		SequenceID:  responseTask.SequenceID,
 		DropletGUID: responseTask.DropletGUID,
-		CreatedAt:   responseTask.CreationTimestamp.UTC().Format(time.RFC3339),
-		UpdatedAt:   responseTask.CreationTimestamp.UTC().Format(time.RFC3339),
+		CreatedAt:   responseTask.CreatedAt,
+		UpdatedAt:   responseTask.UpdatedAt,
 		MemoryMB:    responseTask.MemoryMB,
 		DiskMB:      responseTask.DiskMB,
 		State:       responseTask.State,

--- a/api/presenter/task_test.go
+++ b/api/presenter/task_test.go
@@ -1,0 +1,115 @@
+package presenter_test
+
+import (
+	"encoding/json"
+	"net/url"
+
+	"code.cloudfoundry.org/korifi/api/presenter"
+	"code.cloudfoundry.org/korifi/api/repositories"
+	. "code.cloudfoundry.org/korifi/tests/matchers"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Task", func() {
+	var (
+		baseURL *url.URL
+		output  []byte
+		record  repositories.TaskRecord
+	)
+
+	BeforeEach(func() {
+		var err error
+		baseURL, err = url.Parse("https://api.example.org")
+		Expect(err).NotTo(HaveOccurred())
+		record = repositories.TaskRecord{
+			Name:          "task-name",
+			GUID:          "task-guid",
+			SpaceGUID:     "space-guid",
+			Command:       "sleep 10000",
+			AppGUID:       "app-guid",
+			DropletGUID:   "droplet-guid",
+			Labels:        map[string]string{"l": "l1"},
+			Annotations:   map[string]string{"a": "a1"},
+			SequenceID:    4,
+			CreatedAt:     "then",
+			UpdatedAt:     "now",
+			MemoryMB:      100,
+			DiskMB:        200,
+			State:         "ok",
+			FailureReason: "nope",
+		}
+	})
+
+	JustBeforeEach(func() {
+		response := presenter.ForTask(record, *baseURL)
+		var err error
+		output, err = json.Marshal(response)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("produces expected task json", func() {
+		Expect(output).To(MatchJSON(`{
+			"name": "task-name",
+			"guid": "task-guid",
+			"command": "sleep 10000",
+			"sequence_id": 4,
+			"created_at": "then",
+			"updated_at": "now",
+			"memory_in_mb": 100,
+			"disk_in_mb": 200,
+			"droplet_guid": "droplet-guid",
+			"state": "ok",
+			"metadata": {
+				"labels": {"l": "l1"},
+				"annotations": {"a": "a1"}
+			},
+			"relationships": {
+				"app": {
+					"data": {
+						"guid": "app-guid"
+					}
+				}
+			},
+			"result": {
+				"failure_reason": "nope"
+			},
+			"links": {
+				"self": {
+					"href": "https://api.example.org/v3/tasks/task-guid"
+				},
+				"app": {
+					"href": "https://api.example.org/v3/apps/app-guid"
+				},
+				"droplet": {
+					"href": "https://api.example.org/v3/droplets/droplet-guid"
+				},
+				"cancel": {
+					"href": "https://api.example.org/v3/tasks/task-guid/actions/cancel",
+					"method": "POST"
+				}
+			}
+		}`))
+	})
+
+	When("labels is nil", func() {
+		BeforeEach(func() {
+			record.Labels = nil
+		})
+
+		It("returns an empty slice of labels", func() {
+			Expect(output).To(MatchJSONPath("$.metadata.labels", Not(BeNil())))
+		})
+	})
+
+	When("annotations is nil", func() {
+		BeforeEach(func() {
+			record.Annotations = nil
+		})
+
+		It("returns an empty slice of annotations", func() {
+			Expect(output).To(MatchJSONPath("$.metadata.annotations", Not(BeNil())))
+		})
+	})
+})

--- a/api/repositories/task_repository.go
+++ b/api/repositories/task_repository.go
@@ -3,7 +3,6 @@ package repositories
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"code.cloudfoundry.org/korifi/api/authorization"
 	apierrors "code.cloudfoundry.org/korifi/api/errors"
@@ -30,20 +29,21 @@ const (
 )
 
 type TaskRecord struct {
-	Name              string
-	GUID              string
-	SpaceGUID         string
-	Command           string
-	AppGUID           string
-	DropletGUID       string
-	Labels            map[string]string
-	Annotations       map[string]string
-	SequenceID        int64
-	CreationTimestamp time.Time
-	MemoryMB          int64
-	DiskMB            int64
-	State             string
-	FailureReason     string
+	Name          string
+	GUID          string
+	SpaceGUID     string
+	Command       string
+	AppGUID       string
+	DropletGUID   string
+	Labels        map[string]string
+	Annotations   map[string]string
+	SequenceID    int64
+	CreatedAt     string
+	UpdatedAt     string
+	MemoryMB      int64
+	DiskMB        int64
+	State         string
+	FailureReason string
 }
 
 type CreateTaskMessage struct {
@@ -286,20 +286,22 @@ func filterBySequenceIDs(tasks []korifiv1alpha1.CFTask, sequenceIDs []int64) []k
 }
 
 func taskToRecord(task *korifiv1alpha1.CFTask) TaskRecord {
+	updatedAtTime, _ := getTimeLastUpdatedTimestamp(&task.ObjectMeta)
 	taskRecord := TaskRecord{
-		Name:              task.Name,
-		GUID:              task.Name,
-		SpaceGUID:         task.Namespace,
-		Command:           task.Spec.Command,
-		AppGUID:           task.Spec.AppRef.Name,
-		SequenceID:        task.Status.SequenceID,
-		CreationTimestamp: task.CreationTimestamp.Time,
-		MemoryMB:          task.Status.MemoryMB,
-		DiskMB:            task.Status.DiskQuotaMB,
-		DropletGUID:       task.Status.DropletRef.Name,
-		State:             toRecordState(task),
-		Labels:            task.Labels,
-		Annotations:       task.Annotations,
+		Name:        task.Name,
+		GUID:        task.Name,
+		SpaceGUID:   task.Namespace,
+		Command:     task.Spec.Command,
+		AppGUID:     task.Spec.AppRef.Name,
+		SequenceID:  task.Status.SequenceID,
+		CreatedAt:   formatTimestamp(task.CreationTimestamp),
+		UpdatedAt:   updatedAtTime,
+		MemoryMB:    task.Status.MemoryMB,
+		DiskMB:      task.Status.DiskQuotaMB,
+		DropletGUID: task.Status.DropletRef.Name,
+		State:       toRecordState(task),
+		Labels:      task.Labels,
+		Annotations: task.Annotations,
 	}
 
 	failedCond := meta.FindStatusCondition(task.Status.Conditions, korifiv1alpha1.TaskFailedConditionType)

--- a/api/repositories/task_repository_test.go
+++ b/api/repositories/task_repository_test.go
@@ -152,7 +152,15 @@ var _ = Describe("TaskRepository", func() {
 				Expect(taskRecord.Command).To(Equal("echo 'hello world'"))
 				Expect(taskRecord.AppGUID).To(Equal(cfApp.Name))
 				Expect(taskRecord.SequenceID).NotTo(BeZero())
-				Expect(taskRecord.CreationTimestamp).To(BeTemporally("~", time.Now(), 5*time.Second))
+
+				recordCreatedTime, err := time.Parse(repositories.TimestampFormat, taskRecord.CreatedAt)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(recordCreatedTime).To(BeTemporally("~", time.Now(), 5*time.Second))
+
+				recordUpdatedTime, err := time.Parse(repositories.TimestampFormat, taskRecord.UpdatedAt)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(recordUpdatedTime).To(BeTemporally("~", time.Now(), 5*time.Second))
+
 				Expect(taskRecord.MemoryMB).To(BeEquivalentTo(256))
 				Expect(taskRecord.DiskMB).To(BeEquivalentTo(128))
 				Expect(taskRecord.DropletGUID).To(Equal(cfApp.Spec.CurrentDropletRef.Name))
@@ -244,7 +252,15 @@ var _ = Describe("TaskRepository", func() {
 					Expect(taskRecord.Command).To(Equal("echo hello"))
 					Expect(taskRecord.AppGUID).To(Equal(cfApp.Name))
 					Expect(taskRecord.SequenceID).To(BeEquivalentTo(6))
-					Expect(taskRecord.CreationTimestamp).To(BeTemporally("~", time.Now(), 5*time.Second))
+
+					recordCreatedTime, err := time.Parse(repositories.TimestampFormat, taskRecord.CreatedAt)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(recordCreatedTime).To(BeTemporally("~", time.Now(), 5*time.Second))
+
+					recordUpdatedTime, err := time.Parse(repositories.TimestampFormat, taskRecord.UpdatedAt)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(recordUpdatedTime).To(BeTemporally("~", time.Now(), 5*time.Second))
+
 					Expect(taskRecord.MemoryMB).To(BeEquivalentTo(256))
 					Expect(taskRecord.DiskMB).To(BeEquivalentTo(128))
 					Expect(taskRecord.DropletGUID).To(Equal(cfApp.Spec.CurrentDropletRef.Name))
@@ -539,7 +555,15 @@ var _ = Describe("TaskRepository", func() {
 				Expect(taskRecord.Command).To(Equal("echo hello"))
 				Expect(taskRecord.AppGUID).To(Equal(cfApp.Name))
 				Expect(taskRecord.SequenceID).To(BeEquivalentTo(6))
-				Expect(taskRecord.CreationTimestamp).To(BeTemporally("~", time.Now(), 5*time.Second))
+
+				recordCreatedTime, err := time.Parse(repositories.TimestampFormat, taskRecord.CreatedAt)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(recordCreatedTime).To(BeTemporally("~", time.Now(), 5*time.Second))
+
+				recordUpdatedTime, err := time.Parse(repositories.TimestampFormat, taskRecord.UpdatedAt)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(recordUpdatedTime).To(BeTemporally("~", time.Now(), 5*time.Second))
+
 				Expect(taskRecord.MemoryMB).To(BeEquivalentTo(256))
 				Expect(taskRecord.DiskMB).To(BeEquivalentTo(128))
 				Expect(taskRecord.DropletGUID).To(Equal(cfApp.Spec.CurrentDropletRef.Name))


### PR DESCRIPTION
## Is there a related GitHub Issue?
#2255

## What is this change about?
- Replace CreationTimestamp with CreatedAt & UpdatedAt in TaskRecord
- Move full JSON matching from handlers/task_test to presenter package

## Does this PR introduce a breaking change?
No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@gcapizzi

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
