### PR TITLE
Move full JSON matching from handlers to presenter tests for user

### DIFF
--- a/api/handlers/user_test.go
+++ b/api/handlers/user_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"code.cloudfoundry.org/korifi/api/handlers"
+	. "code.cloudfoundry.org/korifi/tests/matchers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -28,21 +29,10 @@ var _ = Describe("User", func() {
 			It("returns an empty list", func() {
 				Expect(rr).To(HaveHTTPStatus(http.StatusOK))
 				Expect(rr).To(HaveHTTPHeaderWithValue("Content-Type", "application/json"))
-				Expect(rr).To(HaveHTTPBody(MatchJSON(`{
-					"pagination": {
-						"total_results": 0,
-						"total_pages": 1,
-						"first": {
-							"href": "https://api.example.org/v3/users"
-						},
-						"last": {
-							"href": "https://api.example.org/v3/users"
-						},
-						"next": null,
-						"previous": null
-					},
-					"resources": []
-				}`)))
+				Expect(rr).To(HaveHTTPBody(SatisfyAll(
+					MatchJSONPath("$.pagination.total_results", BeZero()),
+					MatchJSONPath("$.pagination.first.href", "https://api.example.org/v3/users"),
+				)))
 			})
 		})
 
@@ -54,30 +44,12 @@ var _ = Describe("User", func() {
 			It("returns a list of users matching the usernames", func() {
 				Expect(rr).To(HaveHTTPStatus(http.StatusOK))
 				Expect(rr).To(HaveHTTPHeaderWithValue("Content-Type", "application/json"))
-				Expect(rr).To(HaveHTTPBody(MatchJSON(`{
-					"pagination": {
-						"total_results": 2,
-						"total_pages": 1,
-						"first": {
-							"href": "https://api.example.org/v3/users?usernames=foo,bar"
-						},
-						"last": {
-							"href": "https://api.example.org/v3/users?usernames=foo,bar"
-						},
-						"next": null,
-						"previous": null
-					},
-					"resources": [
-						{
-							"username": "foo",
-							"guid": "foo"
-						},
-						{
-							"username": "bar",
-							"guid": "bar"
-						}
-					]
-				}`)))
+				Expect(rr).To(HaveHTTPBody(SatisfyAll(
+					MatchJSONPath("$.pagination.total_results", BeEquivalentTo(2)),
+					MatchJSONPath("$.pagination.first.href", "https://api.example.org/v3/users?usernames=foo,bar"),
+					MatchJSONPath("$.resources[0].username", "foo"),
+					MatchJSONPath("$.resources[1].username", "bar"),
+				)))
 			})
 		})
 	})

--- a/api/presenter/user_test.go
+++ b/api/presenter/user_test.go
@@ -1,0 +1,40 @@
+package presenter_test
+
+import (
+	"encoding/json"
+	"net/url"
+
+	"code.cloudfoundry.org/korifi/api/presenter"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("User", func() {
+	var (
+		baseURL *url.URL
+		output  []byte
+		name    string
+	)
+
+	BeforeEach(func() {
+		var err error
+		baseURL, err = url.Parse("https://api.example.org")
+		Expect(err).NotTo(HaveOccurred())
+		name = "bob"
+	})
+
+	JustBeforeEach(func() {
+		response := presenter.ForUser(name, *baseURL)
+		var err error
+		output, err = json.Marshal(response)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("produces expected user json", func() {
+		Expect(output).To(MatchJSON(`{
+			"guid": "bob",
+			"username": "bob"
+		}`))
+	})
+})


### PR DESCRIPTION
## Is there a related GitHub Issue?
#2255

## What is this change about?
Move full JSON testing from handlers to presenter package for the user handler.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@gcapizzi

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
