### PR TITLE
Remove full JSON matching from whoami handlers test to presenter package

### DIFF
--- a/api/presenter/identity_test.go
+++ b/api/presenter/identity_test.go
@@ -1,0 +1,39 @@
+package presenter_test
+
+import (
+	"encoding/json"
+
+	"code.cloudfoundry.org/korifi/api/authorization"
+	"code.cloudfoundry.org/korifi/api/presenter"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Identity", func() {
+	var (
+		output []byte
+		id     authorization.Identity
+	)
+
+	BeforeEach(func() {
+		id = authorization.Identity{
+			Name: "the-user",
+			Kind: "User",
+		}
+	})
+
+	JustBeforeEach(func() {
+		response := presenter.ForWhoAmI(id)
+		var err error
+		output, err = json.Marshal(response)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("produces expected identity json", func() {
+		Expect(output).To(MatchJSON(`{
+			"name": "the-user",
+			"kind": "User"
+		}`))
+	})
+})


### PR DESCRIPTION
## Is there a related GitHub Issue?
#2255

## What is this change about?
Move full JSON matching from handlers tests to presenters package

## Does this PR introduce a breaking change?
No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@gcapizzi

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
