### PR TITLE
Put the selfsigned-issuer in the release NS

### DIFF
--- a/helm/korifi/templates/cert-mgr-issuer.yaml
+++ b/helm/korifi/templates/cert-mgr-issuer.yaml
@@ -2,5 +2,6 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: selfsigned-issuer
+  namespace: {{ .Release.Namespace }}
 spec:
   selfSigned: {}


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
We noticed that the Cert Manager self-signed issuer in the Helm templates was being created in the default namespace. While this worked (perhaps because Cert Manager falls back to the issuer in the default namespace if it cannot find one in the same namespace as the certificate request), it seems better to put the issuer in the same namespace as the rest of Korifi to indicate that Korifi is the one using it. We also want to avoid polluting the default namespace.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Deploy and run tests.

## Tag your pair, your PM, and/or team
@clintyoshimura 