### PR TITLE
Add custom label field to VCAP_SERVICES

### DIFF
--- a/controllers/controllers/workloads/env/vcap_services_builder.go
+++ b/controllers/controllers/workloads/env/vcap_services_builder.go
@@ -87,13 +87,14 @@ func buildSingleServiceEnv(ctx context.Context, k8sClient client.Client, service
 		serviceLabel = *serviceInstance.Spec.ServiceLabel
 	}
 
-	return fromServiceBinding(serviceBinding, serviceInstance, secret), serviceLabel, nil
+	return fromServiceBinding(serviceBinding, serviceInstance, secret, serviceLabel), serviceLabel, nil
 }
 
 func fromServiceBinding(
 	serviceBinding korifiv1alpha1.CFServiceBinding,
 	serviceInstance korifiv1alpha1.CFServiceInstance,
 	serviceBindingSecret corev1.Secret,
+	serviceLabel string,
 ) ServiceDetails {
 	var serviceName string
 	var bindingName *string
@@ -112,7 +113,7 @@ func fromServiceBinding(
 	}
 
 	return ServiceDetails{
-		Label:          "user-provided",
+		Label:          serviceLabel,
 		Name:           serviceName,
 		Tags:           tags,
 		InstanceGUID:   serviceInstance.Name,

--- a/controllers/controllers/workloads/env/vcap_services_builder_test.go
+++ b/controllers/controllers/workloads/env/vcap_services_builder_test.go
@@ -1,11 +1,11 @@
 package env_test
 
 import (
-	"code.cloudfoundry.org/korifi/tools"
 	"encoding/json"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"code.cloudfoundry.org/korifi/controllers/controllers/workloads/env"
+	"code.cloudfoundry.org/korifi/tools"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -164,7 +164,7 @@ var _ = Describe("Builder", func() {
 			Expect(extractServiceInfo(vcapServices, "custom-service-2", 1)).To(ContainElements(
 				SatisfyAll(
 					HaveLen(10),
-					HaveKeyWithValue("label", "user-provided"),
+					HaveKeyWithValue("label", "custom-service-2"),
 					HaveKeyWithValue("name", "my-service-binding-2"),
 					HaveKeyWithValue("tags", ConsistOf("t1", "t2")),
 					HaveKeyWithValue("instance_guid", "my-service-instance-guid-2"),


### PR DESCRIPTION
## Is there a related GitHub Issue?
#2417<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
- when spec.serviceLabel is set on the ServiceInstance, we want to set "label" on the service itself in addition to placing it under a key with the same name.<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
#2417<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@acosta11 <!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
