### PR TITLE
Use a single kpack.Image per CFApp for optimal build caching

### DIFF
--- a/kpack-image-builder/controllers/buildworkload_controller_test.go
+++ b/kpack-image-builder/controllers/buildworkload_controller_test.go
@@ -106,7 +106,7 @@ var _ = Describe("BuildWorkloadReconciler", func() {
 		It("creates a kpack image with the source, env and services set", func() {
 			Eventually(func(g Gomega) {
 				kpackImage := new(buildv1alpha2.Image)
-				g.Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: cfBuildGUID, Namespace: namespaceGUID}, kpackImage)).To(Succeed())
+				g.Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: "app-guid", Namespace: namespaceGUID}, kpackImage)).To(Succeed())
 				g.Expect(kpackImage.Spec.Build).ToNot(BeNil())
 				g.Expect(kpackImage.Spec.Source.Registry.Image).To(BeEquivalentTo(source.Registry.Image))
 				g.Expect(kpackImage.Spec.Source.Registry.ImagePullSecrets).To(BeEquivalentTo(source.Registry.ImagePullSecrets))
@@ -121,7 +121,7 @@ var _ = Describe("BuildWorkloadReconciler", func() {
 			BeforeEach(func() {
 				existingKpackImage = &buildv1alpha2.Image{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      cfBuildGUID,
+						Name:      "app-guid",
 						Namespace: namespaceGUID,
 						Labels: map[string]string{
 							controllers.BuildWorkloadLabelKey: cfBuildGUID,
@@ -147,7 +147,7 @@ var _ = Describe("BuildWorkloadReconciler", func() {
 			It("updates the image and sets the status condition on BuildWorkload", func() {
 				Eventually(func(g Gomega) {
 					kpackImage := new(buildv1alpha2.Image)
-					g.Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: cfBuildGUID, Namespace: namespaceGUID}, kpackImage)).To(Succeed())
+					g.Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: "app-guid", Namespace: namespaceGUID}, kpackImage)).To(Succeed())
 					g.Expect(kpackImage.Spec.Build).ToNot(BeNil())
 					g.Expect(kpackImage.Spec.Source.Registry.Image).To(BeEquivalentTo(source.Registry.Image))
 					g.Expect(kpackImage.Spec.Source.Registry.ImagePullSecrets).To(BeEquivalentTo(source.Registry.ImagePullSecrets))
@@ -195,7 +195,7 @@ var _ = Describe("BuildWorkloadReconciler", func() {
 
 			It("doesn't create the kpack Image as long as the secret is missing", func() {
 				Consistently(func(g Gomega) bool {
-					lookupKey := types.NamespacedName{Name: cfBuildGUID, Namespace: namespaceGUID}
+					lookupKey := types.NamespacedName{Name: "app-guid", Namespace: namespaceGUID}
 					return k8serrors.IsNotFound(k8sClient.Get(context.Background(), lookupKey, new(buildv1alpha2.Image)))
 				}).Should(BeTrue())
 			})
@@ -221,7 +221,7 @@ var _ = Describe("BuildWorkloadReconciler", func() {
 
 			It("doesn't create a kpack Image", func() {
 				Consistently(func(g Gomega) bool {
-					lookupKey := types.NamespacedName{Name: cfBuildGUID, Namespace: namespaceGUID}
+					lookupKey := types.NamespacedName{Name: "app-guid", Namespace: namespaceGUID}
 					return k8serrors.IsNotFound(k8sClient.Get(context.Background(), lookupKey, new(buildv1alpha2.Image)))
 				}).Should(BeTrue())
 			})
@@ -235,17 +235,17 @@ var _ = Describe("BuildWorkloadReconciler", func() {
 			It("does not create a kpack image resource", func() {
 				Consistently(func(g Gomega) {
 					kpackImage := new(buildv1alpha2.Image)
-					err := k8sClient.Get(context.Background(), types.NamespacedName{Name: cfBuildGUID, Namespace: namespaceGUID}, kpackImage)
-					g.Expect(err).To(MatchError(fmt.Sprintf("images.kpack.io %q not found", cfBuildGUID)))
+					err := k8sClient.Get(context.Background(), types.NamespacedName{Name: "app-guid", Namespace: namespaceGUID}, kpackImage)
+					g.Expect(err).To(MatchError(fmt.Sprintf("images.kpack.io %q not found", "app-guid")))
 				}).Should(Succeed())
 			})
 
 			When("the other reconciler has partially reconciled the object and created an Image", func() {
 				BeforeEach(func() {
-					image := buildKpackImageObject(cfBuildGUID, namespaceGUID, source, env, services)
+					image := buildKpackImageObject("app-guid", namespaceGUID, source, env, services)
 					Expect(k8sClient.Create(context.Background(), image)).To(Succeed())
 
-					kpackImageLookupKey := types.NamespacedName{Name: cfBuildGUID, Namespace: namespaceGUID}
+					kpackImageLookupKey := types.NamespacedName{Name: "app-guid", Namespace: namespaceGUID}
 					createdKpackImage := new(buildv1alpha2.Image)
 					Eventually(func() error {
 						return k8sClient.Get(context.Background(), kpackImageLookupKey, createdKpackImage)
@@ -294,7 +294,7 @@ var _ = Describe("BuildWorkloadReconciler", func() {
 			buildWorkload = buildWorkloadObject(cfBuildGUID, namespaceGUID, source, env, services, reconcilerName, buildpacks)
 			Expect(k8sClient.Create(context.Background(), buildWorkload)).To(Succeed())
 
-			kpackImageLookupKey := types.NamespacedName{Name: cfBuildGUID, Namespace: namespaceGUID}
+			kpackImageLookupKey := types.NamespacedName{Name: "app-guid", Namespace: namespaceGUID}
 			createdKpackImage = new(buildv1alpha2.Image)
 			Eventually(func() error {
 				return k8sClient.Get(context.Background(), kpackImageLookupKey, createdKpackImage)

--- a/kpack-image-builder/controllers/suite_test.go
+++ b/kpack-image-builder/controllers/suite_test.go
@@ -65,9 +65,9 @@ var (
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
 
-	SetDefaultEventuallyTimeout(10 * time.Second)
+	SetDefaultEventuallyTimeout(4 * time.Second)
 	SetDefaultEventuallyPollingInterval(200 * time.Millisecond)
-	SetDefaultConsistentlyDuration(10 * time.Second)
+	SetDefaultConsistentlyDuration(4 * time.Second)
 	SetDefaultConsistentlyPollingInterval(200 * time.Millisecond)
 
 	RunSpecs(t, "Controller Suite")


### PR DESCRIPTION
## Is there a related GitHub Issue?
#2440

## What is this change about?
A single kpack.Image is now used for an app. It is named using the app GUID.

Each `cf push` now creates a new kpack.Build on the kpack.Image. The buildworkload status is updated from the corresponding kpack.Build using the ImageGeneration label on the build which must match the image generation now stored in the buildworkload labels.

We have changed the reconciliation of buildworkloads to always update the kpack.Image, whether it exists or not, since we need to reuse existing images.

## Does this PR introduce a breaking change?
No. Although we are changing the relationship between buildworkloads and kpack images / builds.

Existing BuildWorkloads will have a 1:1 relationship with a kpack.Image. The kpack.Image will have 1 kpack.Build generated from the initial `cf push`. It may have subsequent builds generated in the background by stack or buildpack changes, but these are currently ignored in korifi.

Everything will work as usual for these existing images and builds. They will be garbage collected correctly; OCI images will be deleted when builds are deleted; and images and builds will be deleted when an app is deleted.

A new push on an existing app will generate a new kpack.Image with a name matching the app GUID. All subsequent pushes will update that image and generate new builds on it. This is what will enable caches to be used correctly. There is no problem with the dangling old kpack.Images with names matching the BuildWorkload names. These will eventually be garbage collected or deleted when the app is deleted.

New apps will only ever have a single kpack.Image.

## Acceptance Steps
Push an app. It should work.

Modify the source, push again. It should build lots faster than the first time. And the build logs should say caches were used.

## Tag your pair, your PM, and/or team
@gcapizzi
