### PR TITLE
Simplify `deploy-on-kind`

### DIFF
--- a/scripts/assets/values-template.yaml
+++ b/scripts/assets/values-template.yaml
@@ -3,7 +3,6 @@ adminUserName: cf-admin
 global:
   defaultAppDomainName: apps-127-0-0-1.nip.io
   generateIngressCertificates: true
-  containerRepositoryPrefix: localregistry-docker-registry.default.svc.cluster.local:30050/
   logLevel: debug
 
 api:
@@ -19,6 +18,5 @@ jobTaskRunner:
   jobTTL: 5s
 
 kpackImageBuilder:
-  builderRepository: localregistry-docker-registry.default.svc.cluster.local:30050/kpack-builder
   clusterStackBuildImage: paketobuildpacks/build:base-cnb
   clusterStackRunImage: paketobuildpacks/run:base-cnb


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Also, remove some dead code:
* Remove references to `global.containerRegistryServiceAccount` - there
  is no such property in the helm chart anymore
* Remove defaults for `global.containerRepositoryPrefix` and
  `kpackImageBuilder.builderRepository` from the values template - being
  explicit about them when applying the helm chart helps for less
  complicated code
* Do not create a dedicated service account when using a custom registry
  - this has not been needed for some time

<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
`deploy-on-kind` works for both local registry and custom registry as it used to
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@danail-branekov
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
