### PR TITLE
Standard repository filtering

### DIFF
--- a/api/repositories/domain_repository.go
+++ b/api/repositories/domain_repository.go
@@ -152,12 +152,7 @@ func (r *DomainRepo) ListDomains(ctx context.Context, authInfo authorization.Inf
 		return []DomainRecord{}, fmt.Errorf("failed to list domains in namespace %s: %w", r.rootNamespace, apierrors.FromK8sError(err, DomainResourceType))
 	}
 
-	var preds []func(korifiv1alpha1.CFDomain) bool
-	if len(message.Names) > 0 {
-		nameSet := NewSet(message.Names...)
-		preds = append(preds, func(a korifiv1alpha1.CFDomain) bool { return nameSet.Includes(a.Spec.Name) })
-	}
-	filtered := Filter(cfdomainList.Items, preds...)
+	filtered := Filter(cfdomainList.Items, SetPredicate(message.Names, func(s korifiv1alpha1.CFDomain) string { return s.Spec.Name }))
 
 	sort.Slice(filtered, func(i, j int) bool {
 		return filtered[i].CreationTimestamp.Before(&filtered[j].CreationTimestamp)

--- a/api/repositories/org_repository.go
+++ b/api/repositories/org_repository.go
@@ -179,14 +179,8 @@ func (r *OrgRepo) ListOrgs(ctx context.Context, info authorization.Info, filter 
 		func(o korifiv1alpha1.CFOrg) bool {
 			return meta.IsStatusConditionTrue(o.Status.Conditions, StatusConditionReady)
 		},
-	}
-	if len(filter.GUIDs) > 0 {
-		guidsSet := NewSet(filter.GUIDs...)
-		preds = append(preds, func(o korifiv1alpha1.CFOrg) bool { return guidsSet.Includes(o.Name) })
-	}
-	if len(filter.Names) > 0 {
-		namesSet := NewSet(filter.Names...)
-		preds = append(preds, func(o korifiv1alpha1.CFOrg) bool { return namesSet.Includes(o.Spec.DisplayName) })
+		SetPredicate(filter.GUIDs, func(s korifiv1alpha1.CFOrg) string { return s.Name }),
+		SetPredicate(filter.Names, func(s korifiv1alpha1.CFOrg) string { return s.Spec.DisplayName }),
 	}
 
 	var records []OrgRecord

--- a/api/repositories/package_repository.go
+++ b/api/repositories/package_repository.go
@@ -201,10 +201,8 @@ func (r *PackageRepo) ListPackages(ctx context.Context, authInfo authorization.I
 		return []PackageRecord{}, fmt.Errorf("failed to build user client: %w", err)
 	}
 
-	preds := []func(korifiv1alpha1.CFPackage) bool{}
-	if len(message.AppGUIDs) > 0 {
-		appGUIDsSet := NewSet(message.AppGUIDs...)
-		preds = append(preds, func(p korifiv1alpha1.CFPackage) bool { return appGUIDsSet.Includes(p.Spec.AppRef.Name) })
+	preds := []func(korifiv1alpha1.CFPackage) bool{
+		SetPredicate(message.AppGUIDs, func(s korifiv1alpha1.CFPackage) string { return s.Spec.AppRef.Name }),
 	}
 	if len(message.States) > 0 {
 		stateSet := NewSet(message.States...)

--- a/api/repositories/process_repository.go
+++ b/api/repositories/process_repository.go
@@ -135,10 +135,8 @@ func (r *ProcessRepo) ListProcesses(ctx context.Context, authInfo authorization.
 		return []ProcessRecord{}, fmt.Errorf("get-process: failed to build user k8s client: %w", err)
 	}
 
-	preds := []func(korifiv1alpha1.CFProcess) bool{}
-	if len(message.AppGUIDs) > 0 {
-		appGUIDsSet := NewSet(message.AppGUIDs...)
-		preds = append(preds, func(p korifiv1alpha1.CFProcess) bool { return appGUIDsSet.Includes(p.Spec.AppRef.Name) })
+	preds := []func(korifiv1alpha1.CFProcess) bool{
+		SetPredicate(message.AppGUIDs, func(s korifiv1alpha1.CFProcess) string { return s.Spec.AppRef.Name }),
 	}
 
 	processList := &korifiv1alpha1.CFProcessList{}

--- a/api/repositories/service_instance_repository.go
+++ b/api/repositories/service_instance_repository.go
@@ -195,10 +195,8 @@ func (r *ServiceInstanceRepo) ListServiceInstances(ctx context.Context, authInfo
 		return []ServiceInstanceRecord{}, fmt.Errorf("failed to build user client: %w", err)
 	}
 
-	preds := []func(korifiv1alpha1.CFServiceInstance) bool{}
-	if len(message.Names) > 0 {
-		set := NewSet(message.Names...)
-		preds = append(preds, func(i korifiv1alpha1.CFServiceInstance) bool { return set.Includes(i.Spec.DisplayName) })
+	preds := []func(korifiv1alpha1.CFServiceInstance) bool{
+		SetPredicate(message.Names, func(s korifiv1alpha1.CFServiceInstance) string { return s.Spec.DisplayName }),
 	}
 
 	spaceGUIDSet := NewSet(message.SpaceGuids...)

--- a/api/repositories/service_instance_repository_test.go
+++ b/api/repositories/service_instance_repository_test.go
@@ -427,6 +427,7 @@ var _ = Describe("ServiceInstanceRepository", func() {
 						},
 					}
 				})
+
 				It("returns only records for the ServiceInstances with matching spec.name fields", func() {
 					Expect(serviceInstanceList).To(ConsistOf(
 						MatchFields(IgnoreExtras, Fields{"GUID": Equal(cfServiceInstance1.Name)}),

--- a/api/repositories/shared.go
+++ b/api/repositories/shared.go
@@ -74,20 +74,6 @@ func getLabelOrAnnotation(mapObj map[string]string, key string) string {
 	return mapObj[key]
 }
 
-func matchesFilter(field string, filter []string) bool {
-	if len(filter) == 0 {
-		return true
-	}
-
-	for _, value := range filter {
-		if field == value {
-			return true
-		}
-	}
-
-	return false
-}
-
 type Set[T comparable] map[T]struct{}
 
 func (s Set[T]) Includes(element T) bool {

--- a/api/repositories/shared.go
+++ b/api/repositories/shared.go
@@ -103,3 +103,16 @@ outer:
 
 	return res
 }
+
+func SetPredicate[T comparable, S any](elements []T, mapFn func(S) T) func(S) bool {
+	if len(elements) == 0 {
+		return AlwaysTrue[S]
+	}
+
+	set := NewSet(elements...)
+	return func(e S) bool {
+		return set.Includes(mapFn(e))
+	}
+}
+
+func AlwaysTrue[T any](_ T) bool { return true }

--- a/api/repositories/space_repository.go
+++ b/api/repositories/space_repository.go
@@ -183,14 +183,8 @@ func (r *SpaceRepo) ListSpaces(ctx context.Context, info authorization.Info, mes
 		func(s korifiv1alpha1.CFSpace) bool {
 			return meta.IsStatusConditionTrue(s.Status.Conditions, StatusConditionReady)
 		},
-	}
-	if len(message.GUIDs) > 0 {
-		set := NewSet(message.GUIDs...)
-		preds = append(preds, func(s korifiv1alpha1.CFSpace) bool { return set.Includes(s.Name) })
-	}
-	if len(message.Names) > 0 {
-		set := NewSet(message.Names...)
-		preds = append(preds, func(s korifiv1alpha1.CFSpace) bool { return set.Includes(s.Spec.DisplayName) })
+		SetPredicate(message.GUIDs, func(s korifiv1alpha1.CFSpace) string { return s.Name }),
+		SetPredicate(message.Names, func(s korifiv1alpha1.CFSpace) string { return s.Spec.DisplayName }),
 	}
 
 	orgGUIDs := NewSet(message.OrganizationGUIDs...)

--- a/api/repositories/task_repository.go
+++ b/api/repositories/task_repository.go
@@ -170,14 +170,9 @@ func (r *TaskRepo) ListTasks(ctx context.Context, authInfo authorization.Info, m
 		return nil, fmt.Errorf("failed to build user client: %w", err)
 	}
 
-	preds := []func(korifiv1alpha1.CFTask) bool{}
-	if len(msg.SequenceIDs) > 0 {
-		set := NewSet(msg.SequenceIDs...)
-		preds = append(preds, func(t korifiv1alpha1.CFTask) bool { return set.Includes(t.Status.SequenceID) })
-	}
-	if len(msg.AppGUIDs) > 0 {
-		set := NewSet(msg.AppGUIDs...)
-		preds = append(preds, func(t korifiv1alpha1.CFTask) bool { return set.Includes(t.Spec.AppRef.Name) })
+	preds := []func(korifiv1alpha1.CFTask) bool{
+		SetPredicate(msg.SequenceIDs, func(s korifiv1alpha1.CFTask) int64 { return s.Status.SequenceID }),
+		SetPredicate(msg.AppGUIDs, func(s korifiv1alpha1.CFTask) string { return s.Spec.AppRef.Name }),
 	}
 
 	var tasks []korifiv1alpha1.CFTask


### PR DESCRIPTION
## Is there a related GitHub Issue?
#2422

## What is this change about?
- Use standard filtering for ListDomains
- Apply common filtering logic to ListDroplets
- Apply common filtering logic to ListOrgs
- Apply common filtering logic to ListPackages
- Use common filter logic in ListProcesses
- Use common filter logic for ListRoutes
- Use common filter logic for ListServiceBindings
- Use common filtering logic for ListServiceInstances
- Use common filter logic for ListSpaces
- Use common filter logic for ListTasks
- Deduplicate set include checking

## Does this PR introduce a breaking change?
No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@gcapizzi

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
