### PR TITLE
Combine the Korifi controller ConfigMap configuration files

### DIFF
--- a/helm/korifi/controllers/configmap.yaml
+++ b/helm/korifi/controllers/configmap.yaml
@@ -4,12 +4,11 @@ metadata:
   name: korifi-controllers-config
   namespace: {{ .Release.Namespace }}
 data:
-  components_config.yaml: |-
+  config.yaml: |-
     includeKpackImageBuilder: {{ .Values.kpackImageBuilder.include }}
     includeJobTaskRunner: {{ .Values.jobTaskRunner.include }}
     includeStatefulsetRunner: {{ .Values.statefulsetRunner.include }}
     includeContourRouter: {{ .Values.contourRouter.include }}
-  korifi_controllers_config.yaml: |-
     builderName: {{ .Values.controllers.reconcilers.build }}
     runnerName: {{ .Values.controllers.reconcilers.app }}
     cfProcessDefaults:
@@ -34,17 +33,14 @@ data:
     maxRetainedPackagesPerApp: {{ .Values.controllers.maxRetainedPackagesPerApp }}
     maxRetainedBuildsPerApp: {{ .Values.controllers.maxRetainedBuildsPerApp }}
     logLevel: {{ .Values.global.logLevel }}
-{{- if .Values.kpackImageBuilder.include }}
-  kpack_build_controllers_config.yaml: |
-    cfRootNamespace: {{ .Values.global.rootNamespace }}
+    {{- if .Values.kpackImageBuilder.include }}
     clusterBuilderName: {{ .Values.kpackImageBuilder.clusterBuilderName | default "cf-kpack-cluster-builder" }}
     containerRepositoryPrefix: {{ .Values.global.containerRepositoryPrefix | quote }}
     builderServiceAccount: kpack-service-account
     {{- if .Values.global.eksContainerRegistryRoleARN }}
     containerRegistryType: "ECR"
     {{- end }}
-{{- end }}
-{{- if .Values.jobTaskRunner.include }}
-  job_task_runner_config.yaml: |
+    {{- end }}
+    {{- if .Values.jobTaskRunner.include }}
     jobTTL: {{ required "jobTTL is required" .Values.jobTaskRunner.jobTTL }}
-{{- end }}
+    {{- end }}


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
Combine the Korifi controller ConfigMap configuration files. They are currently still separated as they were before all the controllers were unified. There doesn't seem to be a reason to keep them separate anymore.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
All tests pass

## Tag your pair, your PM, and/or team
@Birdrock @julian-hj 
