### PR TITLE
Configurable grace period for builder readiness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-**/cover.out
+**/cover.out*
 **/bin
 **/testbin
 .idea/

--- a/README.helm.md
+++ b/README.helm.md
@@ -87,6 +87,7 @@ Here are all the values that can be set for the chart:
       - `cpu` (_String_): CPU request.
       - `memory` (_String_): Memory request.
 - `kpackImageBuilder`:
+  - `builderReadinessTimeout` (_String_): The time that the kpack Builder will be waited for if not in ready state, berfore the build workload fails. See [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration) for details on the format, an additional `d` suffix for days is supported.
   - `builderRepository` (_String_): Container image repository to store the `ClusterBuilder` image. Required when `clusterBuilderName` is not provided.
   - `clusterBuilderName` (_String_): The name of the `ClusterBuilder` Kpack has been configured with. Leave blank to let `kpack-image-builder` create an example `ClusterBuilder`.
   - `clusterStackBuildImage` (_String_): The image to use for building defined in the `ClusterStack`. Used when `kpack-image-builder` is blank.

--- a/controllers/config/config.go
+++ b/controllers/config/config.go
@@ -37,6 +37,7 @@ type ControllerConfig struct {
 	// kpack-image-builder
 	ClusterBuilderName        string `yaml:"clusterBuilderName"`
 	BuilderServiceAccount     string `yaml:"builderServiceAccount"`
+	BuilderReadinessTimeout   string `yaml:"builderReadinessTimeout"`
 	ContainerRepositoryPrefix string `yaml:"containerRepositoryPrefix"`
 	ContainerRegistryType     string `yaml:"containerRegistryType"`
 }
@@ -89,6 +90,10 @@ func (c ControllerConfig) ParseTaskTTL() (time.Duration, error) {
 	}
 
 	return tools.ParseDuration(c.TaskTTL)
+}
+
+func (c ControllerConfig) ParseBuilderReadinessTimeout() (time.Duration, error) {
+	return tools.ParseDuration(c.BuilderReadinessTimeout)
 }
 
 func (c ControllerConfig) ParseJobTTL() (time.Duration, error) {

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -267,6 +267,12 @@ func main() {
 		}
 
 		if controllerConfig.IncludeKpackImageBuilder {
+			var builderReadinessTimeout time.Duration
+			builderReadinessTimeout, err = controllerConfig.ParseBuilderReadinessTimeout()
+			if err != nil {
+				setupLog.Error(err, "error parsing builderReadinessTimeout")
+				os.Exit(1)
+			}
 			if err = controllers.NewBuildWorkloadReconciler(
 				mgr.GetClient(),
 				mgr.GetScheme(),
@@ -275,6 +281,7 @@ func main() {
 				image.NewClient(k8sClient),
 				controllerConfig.ContainerRepositoryPrefix,
 				registry.NewRepositoryCreator(controllerConfig.ContainerRegistryType),
+				builderReadinessTimeout,
 			).SetupWithManager(mgr); err != nil {
 				setupLog.Error(err, "unable to create controller", "controller", "BuildWorkload")
 				os.Exit(1)

--- a/helm/korifi/controllers/configmap.yaml
+++ b/helm/korifi/controllers/configmap.yaml
@@ -35,6 +35,7 @@ data:
     logLevel: {{ .Values.global.logLevel }}
     {{- if .Values.kpackImageBuilder.include }}
     clusterBuilderName: {{ .Values.kpackImageBuilder.clusterBuilderName | default "cf-kpack-cluster-builder" }}
+    builderReadinessTimeout: {{ required "builderReadinessTimeout is required" .Values.kpackImageBuilder.builderReadinessTimeout }}
     containerRepositoryPrefix: {{ .Values.global.containerRepositoryPrefix | quote }}
     builderServiceAccount: kpack-service-account
     {{- if .Values.global.eksContainerRegistryRoleARN }}

--- a/helm/korifi/values.schema.json
+++ b/helm/korifi/values.schema.json
@@ -359,6 +359,10 @@
           "description": "The name of the `ClusterBuilder` Kpack has been configured with. Leave blank to let `kpack-image-builder` create an example `ClusterBuilder`.",
           "type": "string"
         },
+        "builderReadinessTimeout": {
+          "description": "The time that the kpack Builder will be waited for if not in ready state, berfore the build workload fails. See [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration) for details on the format, an additional `d` suffix for days is supported.",
+          "type": "string"
+        },
         "clusterStackBuildImage": {
           "description": "The image to use for building defined in the `ClusterStack`. Used when `kpack-image-builder` is blank.",
           "type": "string"
@@ -372,7 +376,7 @@
           "type": "string"
         }
       },
-      "required": ["include"],
+      "required": ["include", "builderReadinessTimeout"],
       "type": "object"
     },
     "statefulsetRunner": {

--- a/helm/korifi/values.yaml
+++ b/helm/korifi/values.yaml
@@ -88,6 +88,7 @@ kpackImageBuilder:
       memory: 100Mi
 
   clusterBuilderName: ""
+  builderReadinessTimeout: 30s
   clusterStackBuildImage: paketobuildpacks/build:full-cnb
   clusterStackRunImage: paketobuildpacks/run:full-cnb
   builderRepository: ""

--- a/kpack-image-builder/controllers/builderinfo_controller_test.go
+++ b/kpack-image-builder/controllers/builderinfo_controller_test.go
@@ -292,10 +292,14 @@ var _ = Describe("BuilderInfoReconciler", Serial, func() {
 			})
 
 			It("doesn't modify that resource", func() {
-				Consistently(func(g Gomega) []v1alpha1.BuilderInfoStatusBuildpack {
+				Eventually(func(g Gomega) {
 					g.Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(info), info)).To(Succeed())
-					return info.Status.Buildpacks
-				}).Should(BeEmpty())
+				}).Should(Succeed())
+
+				Consistently(func(g Gomega) {
+					g.Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(info), info)).To(Succeed())
+					g.Expect(info.Status.Buildpacks).To(BeEmpty())
+				}).Should(Succeed())
 			})
 		})
 
@@ -318,10 +322,14 @@ var _ = Describe("BuilderInfoReconciler", Serial, func() {
 			})
 
 			It("doesn't modify that resource", func() {
-				Consistently(func(g Gomega) []v1alpha1.BuilderInfoStatusBuildpack {
+				Eventually(func(g Gomega) {
 					g.Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(info), info)).To(Succeed())
-					return info.Status.Buildpacks
-				}).Should(BeEmpty())
+				}).Should(Succeed())
+
+				Consistently(func(g Gomega) {
+					g.Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(info), info)).To(Succeed())
+					g.Expect(info.Status.Buildpacks).To(BeEmpty())
+				}).Should(Succeed())
 			})
 		})
 	})

--- a/kpack-image-builder/controllers/buildworkload_controller_test.go
+++ b/kpack-image-builder/controllers/buildworkload_controller_test.go
@@ -213,7 +213,7 @@ var _ = Describe("BuildWorkloadReconciler", func() {
 				Consistently(func(g Gomega) {
 					kpackImage := new(buildv1alpha2.Image)
 					err := k8sClient.Get(ctx, types.NamespacedName{Name: "app-guid", Namespace: namespaceGUID}, kpackImage)
-					g.Expect(err).To(MatchError(fmt.Sprintf("images.kpack.io %q not found", "app-guid")))
+					g.Expect(err).To(MatchError(fmt.Sprintf("Image.kpack.io %q not found", "app-guid")))
 				}).Should(Succeed())
 			})
 
@@ -252,10 +252,14 @@ var _ = Describe("BuildWorkloadReconciler", func() {
 				})
 
 				It("doesn't continue to reconcile the object", func() {
-					updatedBuildWorkload := new(korifiv1alpha1.BuildWorkload)
+					Eventually(func(g Gomega) {
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(buildWorkload), buildWorkload)).To(Succeed())
+						g.Expect(mustHaveCondition(g, buildWorkload.Status.Conditions, "Succeeded").Status).To(Equal(metav1.ConditionUnknown))
+					}).Should(Succeed())
+
 					Consistently(func(g Gomega) {
-						g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: cfBuildGUID, Namespace: namespaceGUID}, updatedBuildWorkload)).To(Succeed())
-						g.Expect(mustHaveCondition(g, updatedBuildWorkload.Status.Conditions, "Succeeded").Status).To(Equal(metav1.ConditionUnknown))
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(buildWorkload), buildWorkload)).To(Succeed())
+						g.Expect(mustHaveCondition(g, buildWorkload.Status.Conditions, "Succeeded").Status).To(Equal(metav1.ConditionUnknown))
 					}).Should(Succeed())
 				})
 			})

--- a/kpack-image-builder/controllers/kpack_build_controller_test.go
+++ b/kpack-image-builder/controllers/kpack_build_controller_test.go
@@ -120,10 +120,13 @@ var _ = Describe("KpackBuildReconciler", func() {
 		})
 
 		It("does not trigger the reconciler", func() {
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(&build), &build)).To(Succeed())
+			}).Should(Succeed())
+
 			Consistently(func(g Gomega) {
-				gotBuild := kpackv1alpha2.Build{}
-				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(&build), &gotBuild)).To(Succeed())
-				g.Expect(gotBuild.Finalizers).To(BeEmpty())
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(&build), &build)).To(Succeed())
+				g.Expect(build.Finalizers).To(BeEmpty())
 			}).Should(Succeed())
 		})
 	})

--- a/kpack-image-builder/controllers/suite_test.go
+++ b/kpack-image-builder/controllers/suite_test.go
@@ -128,6 +128,7 @@ var _ = BeforeSuite(func() {
 		fakeImageConfigGetter,
 		"my.repository/my-prefix/",
 		imageRepoCreator,
+		4*time.Second,
 	)
 	err = buildWorkloadReconciler.SetupWithManager(k8sManager)
 	Expect(err).NotTo(HaveOccurred())

--- a/kpack-image-builder/controllers/suite_test.go
+++ b/kpack-image-builder/controllers/suite_test.go
@@ -109,6 +109,8 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).NotTo(HaveOccurred())
 
+	k8sClient = k8sManager.GetClient()
+
 	controllerConfig := &config.ControllerConfig{
 		CFRootNamespace:           PrefixedGUID("cf"),
 		ClusterBuilderName:        "cf-kpack-builder",
@@ -151,10 +153,6 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	//+kubebuilder:scaffold:scheme
-
-	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
-	Expect(err).NotTo(HaveOccurred())
-	Expect(k8sClient).NotTo(BeNil())
 
 	rootNamespace = &v1.Namespace{
 		ObjectMeta: ctrl.ObjectMeta{


### PR DESCRIPTION

<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
Indirectly #1784

## What is this change about?
- Address flakes
- Give cluster builder a chance to be ready before failing a build

When the cluster builder is not ready, we examine the LastTransitionTime on the status condition. If it is more recent than the last N seconds (configurable by the new property `builderReadinessTimeout`, we retry the reconciliation. We fail as before otherwise.

## Does this PR introduce a breaking change?
New controllers config property builderReadinessTimeout.

## Acceptance Steps
Make the cluster builder unready and see how cf pushes fail

## Tag your pair, your PM, and/or team
@kieron-dev

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
