### PR TITLE
Embed rbac subject in identity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,13 +46,16 @@ lint: fmt vet
 	golangci-lint run -v
 
 test: lint
-	@for comp in $(COMPONENTS); do make -C $$comp test; done
+	make test-unit
 	make test-tools
 	make test-e2e
 
 
 test-tools:
 	./scripts/run-tests.sh tools
+
+test-unit:
+	for comp in $(COMPONENTS); do make -C $$comp test; done
 
 test-e2e:
 	./scripts/run-tests.sh tests/e2e

--- a/api/authorization/cert_inspector.go
+++ b/api/authorization/cert_inspector.go
@@ -23,7 +23,7 @@ func NewCertInspector(restConfig *rest.Config) *CertInspector {
 	}
 }
 
-func (c *CertInspector) WhoAmI(ctx context.Context, certPEM []byte) (Identity, error) {
+func (c *CertInspector) WhoAmI(_ context.Context, certPEM []byte) (Identity, error) {
 	certBlock, rst := pem.Decode(certPEM)
 	if certBlock == nil {
 		return Identity{}, apierrors.NewInvalidAuthError(errors.New("failed to decode cert PEM"))
@@ -51,8 +51,5 @@ func (c *CertInspector) WhoAmI(ctx context.Context, certPEM []byte) (Identity, e
 		return Identity{}, apierrors.FromK8sError(err, "")
 	}
 
-	return Identity{
-		Name: cert.Subject.CommonName,
-		Kind: rbacv1.UserKind,
-	}, nil
+	return NewIdentity(rbacv1.UserKind, cert.Subject.CommonName, "")
 }

--- a/api/repositories/role_repository.go
+++ b/api/repositories/role_repository.go
@@ -107,12 +107,15 @@ func (r *RoleRepo) CreateRole(ctx context.Context, authInfo authorization.Info, 
 	}
 
 	userIdentity := authorization.Identity{
-		Name: role.User,
 		Kind: role.Kind,
 	}
 
 	if role.Kind == rbacv1.ServiceAccountKind {
 		userIdentity.Name = fmt.Sprintf("system:serviceaccount:%s:%s", role.ServiceAccountNamespace, role.User)
+		userIdentity.Namespace = role.ServiceAccountNamespace
+	} else {
+		userIdentity.Name = role.User
+		userIdentity.APIGroup = "rbac.authorization.k8s.io"
 	}
 
 	if role.Space != "" {


### PR DESCRIPTION
## Is there a related GitHub Issue?
No.

## What is this change about?
Embed RBAC v1 Subject in Identity. Identical field names are used, so we can more directly use the provided Kubernetes structs. This also allows us to clean up some of the comparison code.

## Does this PR introduce a breaking change?
No.

## Acceptance Steps
Run tests as normal.
