### PR TITLE
Use appropriate name for default app in e2e

### DIFF
--- a/tests/e2e/apps_test.go
+++ b/tests/e2e/apps_test.go
@@ -263,7 +263,7 @@ var _ = Describe("Apps", func() {
 		)
 
 		BeforeEach(func() {
-			appGUID, _ = pushTestApp(space1GUID, procfileAppBitsFile)
+			appGUID, _ = pushTestApp(space1GUID, defaultAppBitsFile)
 			processGUID = getProcess(appGUID, "web").GUID
 		})
 
@@ -300,7 +300,7 @@ var _ = Describe("Apps", func() {
 			createSpaceRole("space_developer", certUserName, space1GUID)
 			appGUID = createApp(space1GUID, generateGUID("app"))
 			pkgGUID = createPackage(appGUID)
-			uploadTestApp(pkgGUID, procfileAppBitsFile)
+			uploadTestApp(pkgGUID, defaultAppBitsFile)
 		})
 
 		JustBeforeEach(func() {
@@ -346,7 +346,7 @@ var _ = Describe("Apps", func() {
 		BeforeEach(func() {
 			appGUID = createApp(space1GUID, generateGUID("app"))
 			pkgGUID = createPackage(appGUID)
-			uploadTestApp(pkgGUID, procfileAppBitsFile)
+			uploadTestApp(pkgGUID, defaultAppBitsFile)
 			buildGUID = createBuild(pkgGUID)
 			waitForDroplet(buildGUID)
 

--- a/tests/e2e/droplets_test.go
+++ b/tests/e2e/droplets_test.go
@@ -20,7 +20,7 @@ var _ = Describe("Droplets", func() {
 		createSpaceRole("space_developer", certUserName, spaceGUID)
 		appGUID := createApp(spaceGUID, generateGUID("app"))
 		pkgGUID := createPackage(appGUID)
-		uploadTestApp(pkgGUID, procfileAppBitsFile)
+		uploadTestApp(pkgGUID, defaultAppBitsFile)
 		buildGUID = createBuild(pkgGUID)
 	})
 

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -54,7 +54,7 @@ var (
 	doraAppBitsFile         string
 	golangAppBitsFile       string
 	multiProcessAppBitsFile string
-	procfileAppBitsFile     string
+	defaultAppBitsFile      string
 )
 
 type resource struct {
@@ -263,7 +263,7 @@ type sharedSetupData struct {
 	DoraAppBitsFile         string `json:"doraAppBitsFile"`
 	GolangAppBitsFile       string `json:"golangAppBitsFile"`
 	MultiProcessAppBitsFile string `json:"multiProcessAppBitsFile"`
-	ProcfileAppBitsFile     string `json:"procfileAppBitsFile"`
+	DefaultAppBitsFile      string `json:"defaultAppBitsFile"`
 }
 
 var _ = SynchronizedBeforeSuite(func() []byte {
@@ -277,12 +277,12 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	Expect(err).NotTo(HaveOccurred())
 
 	// Some environments where Korifi does not manage the ClusterBuilder lack a standalone Procfile buildpack
-	// The APP_BITS_PATH and APP_BITS_OUTPUT environment variables are a workaround to allow e2e tests to run
+	// The DEFAULT_APP_BITS_PATH and DEFAULT_APP_RESPONSE environment variables are a workaround to allow e2e tests to run
 	// with a different app in these environments.
 	// See https://github.com/cloudfoundry/korifi/issues/2355 for refactoring ideas
-	appBitsPath, ok := os.LookupEnv("APP_BITS_PATH")
+	defaultAppBitsPath, ok := os.LookupEnv("DEFAULT_APP_BITS_PATH")
 	if !ok {
-		appBitsPath = "assets/procfile"
+		defaultAppBitsPath = "assets/procfile"
 	}
 
 	sharedData := sharedSetupData{
@@ -292,7 +292,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 		DoraAppBitsFile:         zipAsset("assets/vendored/dora"),
 		GolangAppBitsFile:       zipAsset("assets/golang"),
 		MultiProcessAppBitsFile: zipAsset("assets/multi-process"),
-		ProcfileAppBitsFile:     zipAsset(appBitsPath),
+		DefaultAppBitsFile:      zipAsset(defaultAppBitsPath),
 	}
 
 	bs, err := json.Marshal(sharedData)
@@ -307,7 +307,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	var wg sync.WaitGroup
 	wg.Add(5)
 	for _, f := range []string{
-		sharedData.ProcfileAppBitsFile,
+		sharedData.DefaultAppBitsFile,
 		sharedData.NodeAppBitsFile,
 		sharedData.DoraAppBitsFile,
 		sharedData.GolangAppBitsFile,
@@ -330,7 +330,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 
 	commonTestOrgGUID = sharedSetup.CommonOrgGUID
 	commonTestOrgName = sharedSetup.CommonOrgName
-	procfileAppBitsFile = sharedSetup.ProcfileAppBitsFile
+	defaultAppBitsFile = sharedSetup.DefaultAppBitsFile
 	nodeAppBitsFile = sharedSetup.NodeAppBitsFile
 	doraAppBitsFile = sharedSetup.DoraAppBitsFile
 	golangAppBitsFile = sharedSetup.GolangAppBitsFile

--- a/tests/e2e/packages_test.go
+++ b/tests/e2e/packages_test.go
@@ -186,7 +186,7 @@ var _ = Describe("Package", func() {
 		JustBeforeEach(func() {
 			var err error
 			resp, err = certClient.R().
-				SetFile("bits", procfileAppBitsFile).
+				SetFile("bits", defaultAppBitsFile).
 				SetError(&resultErr).
 				SetResult(&result).
 				Post("/v3/packages/" + packageGUID + "/upload")
@@ -258,7 +258,7 @@ var _ = Describe("Package", func() {
 		BeforeEach(func() {
 			resultList = resourceList[resource]{}
 			packageGUID = createPackage(appGUID)
-			uploadTestApp(packageGUID, procfileAppBitsFile)
+			uploadTestApp(packageGUID, defaultAppBitsFile)
 			buildGUID = createBuild(packageGUID)
 
 			Eventually(func() (*resty.Response, error) {

--- a/tests/e2e/processes_test.go
+++ b/tests/e2e/processes_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Processes", func() {
 		restyClient = certClient
 		errResp = cfErrs{}
 		spaceGUID = createSpace(generateGUID("space"), commonTestOrgGUID)
-		appGUID, _ = pushTestApp(spaceGUID, procfileAppBitsFile)
+		appGUID, _ = pushTestApp(spaceGUID, defaultAppBitsFile)
 		processGUID = getProcess(appGUID, "web").GUID
 	})
 
@@ -67,7 +67,7 @@ var _ = Describe("Processes", func() {
 		When("the user is NOT authorized in the space", func() {
 			BeforeEach(func() {
 				space2GUID = createSpace(generateGUID("space2"), commonTestOrgGUID)
-				app2GUID, _ = pushTestApp(space2GUID, procfileAppBitsFile)
+				app2GUID, _ = pushTestApp(space2GUID, defaultAppBitsFile)
 				requestAppGUID = app2GUID
 			})
 

--- a/tests/e2e/routes_test.go
+++ b/tests/e2e/routes_test.go
@@ -361,7 +361,7 @@ var _ = Describe("Routes", func() {
 
 		When("the user is a space developer in the space", func() {
 			BeforeEach(func() {
-				appGUID, _ = pushTestApp(spaceGUID, procfileAppBitsFile)
+				appGUID, _ = pushTestApp(spaceGUID, defaultAppBitsFile)
 				createSpaceRole("space_developer", certUserName, spaceGUID)
 			})
 
@@ -381,8 +381,8 @@ var _ = Describe("Routes", func() {
 				Expect(result.Destinations).To(HaveLen(1))
 				Expect(result.Destinations[0].App.GUID).To(Equal(appGUID))
 
-				// This enables replacing the default app output via APP_BITS_PATH and APP_BITS_OUTPUT
-				expectedOutput, ok := os.LookupEnv("APP_BITS_OUTPUT")
+				// This enables replacing the default app output via DEFAULT_APP_BITS_PATH and DEFAULT_APP_RESPONSE
+				expectedOutput, ok := os.LookupEnv("DEFAULT_APP_RESPONSE")
 				if !ok {
 					expectedOutput = "hello-world"
 				}

--- a/tests/e2e/tasks_test.go
+++ b/tests/e2e/tasks_test.go
@@ -19,7 +19,7 @@ var _ = Describe("Tasks", func() {
 
 	BeforeEach(func() {
 		spaceGUID = createSpace(generateGUID("space"), commonTestOrgGUID)
-		appGUID, _ = pushTestApp(spaceGUID, procfileAppBitsFile)
+		appGUID, _ = pushTestApp(spaceGUID, defaultAppBitsFile)
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
## Is there a related GitHub Issue?
#2355 

## What is this change about?
Rename variables used to configure apps used in e2e tests

## Does this PR introduce a breaking change?
No, this is a test interface change that does not get used by default.

## Acceptance Steps
Get an app that pushes successfully and set the newly named env var to point at that app directory. Run E2E tests and see that pass.

## Tag your pair, your PM, and/or team
@matt-royal 
