### PR TITLE
Use latest kpack build image on restage

### DIFF
--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -57,7 +57,7 @@ var (
 	doraAppBitsFile                  string
 	golangAppBitsFile                string
 	multiProcessAppBitsFile          string
-	defaultAppBitsFile              string
+	defaultAppBitsFile               string
 )
 
 type resource struct {

--- a/tests/helpers/eventually_should_hold.go
+++ b/tests/helpers/eventually_should_hold.go
@@ -1,0 +1,10 @@
+package helpers
+
+import (
+	. "github.com/onsi/gomega"
+)
+
+func EventuallyShouldHold(condition func(g Gomega)) {
+	Eventually(condition).Should(Succeed())
+	Consistently(condition).Should(Succeed())
+}


### PR DESCRIPTION
- Set build worload droplet to latest kpack build image

<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
#2469
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Set build worload droplet to latest kpack build image. This way cf restage will
update the droplet of existing apps. This can be useful when kpack triggered a
rebuild as a result of chaged stack or buildpack versions
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
See story
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@danail-branekov
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
