### PR TITLE
Remove install contour apple silicon hack from install deps script

### DIFF
--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -68,13 +68,7 @@ echo "********************"
 echo " Installing Contour"
 echo "********************"
 
-# Temporarily resolve an issue with contour running on Apple silicon.
-# This fix can be removed once the latest version of contour uses envoy v1.23.1 or newer
-if command -v kbld &>/dev/null; then
-  kbld --image-map-file "${DEP_DIR}/contour/kbld-image-mapping-to-fix-envoy-v1.23-bug.json" -f "$VENDOR_DIR/contour" | kubectl apply -f -
-else
-  kubectl apply -f "$VENDOR_DIR/contour"
-fi
+kubectl apply -f "$VENDOR_DIR/contour"
 
 echo "************************************"
 echo " Installing Service Binding Runtime"


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
Removing code that said it can be removed after contour deploys envoy > 1.23. The kbld fix now fails, and contour deploys envoy 1.25 so the fix can be removed.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
CI works.

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
