### PR TITLE
Allow selection of buildpacks from those contained in the default store

### DIFF
--- a/helm/korifi/kpack-image-builder/role.yaml
+++ b/helm/korifi/kpack-image-builder/role.yaml
@@ -60,6 +60,17 @@ rules:
 - apiGroups:
   - kpack.io
   resources:
+  - builders
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kpack.io
+  resources:
   - builds
   verbs:
   - deletecollection

--- a/tests/e2e/apps_test.go
+++ b/tests/e2e/apps_test.go
@@ -399,6 +399,32 @@ var _ = Describe("Apps", func() {
 		})
 	})
 
+	Describe("building an app with a specified buildpack", func() {
+		var buildGUID string
+
+		BeforeEach(func() {
+			manifest := manifestResource{
+				Version: 1,
+				Applications: []applicationResource{{
+					Name:         generateGUID("app"),
+					Memory:       "128MB",
+					DefaultRoute: true,
+					Buildpacks:   []string{"paketo-buildpacks/nodejs"},
+				}},
+			}
+			applySpaceManifest(manifest, space1GUID)
+
+			appGUID = getAppGUIDFromName(manifest.Applications[0].Name)
+			pkgGUID := createPackage(appGUID)
+			uploadTestApp(pkgGUID, nodeAppBitsFile)
+			buildGUID = createBuild(pkgGUID)
+		})
+
+		It("creates the droplet", func() {
+			waitForDroplet(buildGUID)
+		})
+	})
+
 	Describe("Built apps", func() {
 		var (
 			pkgGUID   string

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -167,6 +167,7 @@ type applicationResource struct {
 	Routes       []manifestRouteResource              `yaml:"routes"`
 	Memory       string                               `yaml:"memory,omitempty"`
 	Metadata     metadata                             `yaml:"metadata,omitempty"`
+	Buildpacks   []string                             `yaml:"buildpacks"`
 }
 
 type manifestApplicationProcessResource struct {


### PR DESCRIPTION
## Is there a related GitHub Issue?
Story: #2474
Bug: #1784

## What is this change about?
Allow use of app's buildpack or buildpacks field in the manifest, and `cf push -b BUILDPACK_NAME ...`

This uses a kpack.builder with the same stack and store as the default cluster builder, but with a limited order list matching the requested buildpacks. A builder is created if one doesn't already exist in the namespace (CF space). Deterministic naming is used to guarantee uniqueness for the particular buildpack ordering. Builders are owned by buildworkloads, so will be garbage collected when all referencing buildpacks are deleted.

Note there is a kpack issue, where changing a builder on an image does not trigger a new build. This code watches for that condition and fails the buildworkload with a message, relayed to the user, that modifying the source and re-pushing will fix the issue.

## Does this PR introduce a breaking change?
It stops an error when the -b flag is passed to cf push.

## Acceptance Steps
cf push node-app -b paketo-buildpacks/nodejs -p $NODE_APP_PATH

This should succeed, and you should see a kpack builder created.

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
