### PR TITLE
Do not accept invalid repo names and prefixes

### DIFF
--- a/api/repositories/image_repository.go
+++ b/api/repositories/image_repository.go
@@ -9,6 +9,7 @@ import (
 	"code.cloudfoundry.org/korifi/api/authorization"
 	apierrors "code.cloudfoundry.org/korifi/api/errors"
 	"code.cloudfoundry.org/korifi/tools/image"
+	"github.com/google/go-containerregistry/pkg/name"
 
 	authv1 "k8s.io/api/authorization/v1"
 	k8sclient "k8s.io/client-go/kubernetes"
@@ -57,6 +58,11 @@ func (r *ImageRepository) UploadSourceImage(ctx context.Context, authInfo author
 
 	if !authorized {
 		return "", apierrors.NewForbiddenError(errors.New("not authorized to patch cfpackage"), PackageResourceType)
+	}
+
+	_, err = name.ParseReference(imageRef)
+	if err != nil {
+		return "", apierrors.NewUnprocessableEntityError(err, fmt.Sprintf("invalid image ref: %q", imageRef))
 	}
 
 	pushedRef, err := r.pusher.Push(ctx, image.Creds{

--- a/helm/korifi/values.schema.json
+++ b/helm/korifi/values.schema.json
@@ -31,7 +31,8 @@
         },
         "containerRepositoryPrefix": {
           "description": "The prefix of the container repository where package and droplet images will be pushed. This is suffixed with the app GUID and `-packages` or `-droplets`. For example, a value of `index.docker.io/korifi/` will result in `index.docker.io/korifi/<appGUID>-packages` and `index.docker.io/korifi/<appGUID>-droplets` being pushed.",
-          "type": "string"
+          "type": "string",
+          "pattern": "^[a-z0-9]+([._-][a-z0-9]+)*(:[0-9]+)?(/[a-z0-9]+([._-][a-z0-9]+)*)*/?$"
         },
         "containerRegistrySecret": {
           "description": "Name of the `Secret` to use when pushing or pulling from package, droplet and kpack-build repositories. Required if eksContainerRegistryRoleARN not set. Ignored if eksContainerRegistryRoleARN is set.",
@@ -373,7 +374,8 @@
         },
         "builderRepository": {
           "description": "Container image repository to store the `ClusterBuilder` image. Required when `clusterBuilderName` is not provided.",
-          "type": "string"
+          "type": "string",
+          "pattern": "^[a-z0-9]+([._-][a-z0-9]+)*(:[0-9]+)?(/[a-z0-9]+([._-][a-z0-9]+)*)*$"
         }
       },
       "required": ["include", "builderReadinessTimeout"],


### PR DESCRIPTION
## Is there a related GitHub Issue?
#2466
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
There are certain [rules](https://github.com/distribution/distribution/blob/main/docs/spec/api.md#overview) that apply to the naming of oci images. This commit is a best effort to detect invalid image refs and warn the user as early as possible

- The korifi helm chart does a basic pattern check so rule out invalid
  fromat for `global.containerRepositoryPrefix` as well as `kpackImageBuilder.builderRepository`.
- The pattern check is insufficient, because it cannot detect whether
  the final length of the image name after potentially stripping the
  host is too long. It is simply too hard to tell if the
  containerRepositoryPrefix starts with a host name, in which case it
  should not be counted in the check
- [This code](https://github.com/cloudfoundry/korifi/blob/6d138abcee5564cdc17b670d6118e3731d6960ca/tools/image/client.go#L73-L76) is the best way of doing the image ref validation, since
  this is what our pusher uses when it tries to push the image
- We are invoking the aforementioned check upfront and bubbling it up as
  a more user friendly error in case the patterns in the helm chart did
  not stop an image ref that is correctly formatted, but too long.

In summary this commit will cause korifi deployment to fail in most cases of malformated
images and will result in a user friendly runtime error in all other
cases.
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
The Korifi helm chart no longer accepts every string as `global.containerRepositoryPrefix` and `kpackImageBuilder.builderRepository`, but the rejected values wouldn't have worked.
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
See #2466
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@eirini
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
