### PR TITLE
Fix the builderRepository pattern

### DIFF
--- a/helm/korifi/values.schema.json
+++ b/helm/korifi/values.schema.json
@@ -375,7 +375,7 @@
         "builderRepository": {
           "description": "Container image repository to store the `ClusterBuilder` image. Required when `clusterBuilderName` is not provided.",
           "type": "string",
-          "pattern": "^[a-z0-9]+([._-][a-z0-9]+)*(:[0-9]+)?(/[a-z0-9]+([._-][a-z0-9]+)*)*$"
+          "pattern": "^([a-z0-9]+([._-][a-z0-9]+)*(:[0-9]+)?(/[a-z0-9]+([._-][a-z0-9]+)*)*)?$"
         }
       },
       "required": ["include", "builderReadinessTimeout"],


### PR DESCRIPTION
## Is there a related GitHub Issue?
Related to #2486 

## What is this change about?
This PR updates the pattern for the `builderRepository` value in the Helm chart to allow an empty value since it is optional.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Users are able to deploy without a value for `builderRepository`.

## Tag your pair, your PM, and/or team
@julian-hj 