### PR TITLE
[Proposal] Support `--strategy rolling` for cf `push`, `restart` and `restage`

### DIFF
--- a/api/handlers/deployment.go
+++ b/api/handlers/deployment.go
@@ -1,0 +1,96 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+
+	"code.cloudfoundry.org/korifi/api/authorization"
+	apierrors "code.cloudfoundry.org/korifi/api/errors"
+	"code.cloudfoundry.org/korifi/api/payloads"
+	"code.cloudfoundry.org/korifi/api/presenter"
+	"code.cloudfoundry.org/korifi/api/routing"
+
+	"github.com/go-logr/logr"
+
+	"code.cloudfoundry.org/korifi/api/repositories"
+)
+
+const (
+	DeploymentsPath      = "/v3/deployments"
+	DeploymentPath       = "/v3/deployments/{guid}"
+	DeploymentCancelPath = "/v3/deployments/{guid}/actions/cancel"
+)
+
+type CFDeploymentRepository interface {
+	GetDeployment(context.Context, authorization.Info, string) (repositories.DeploymentRecord, error)
+	CreateDeployment(context.Context, authorization.Info, repositories.CreateDeploymentMessage) (repositories.DeploymentRecord, error)
+	CancelDeployment(context.Context, authorization.Info, string) (repositories.DeploymentRecord, error)
+}
+
+type Deployment struct {
+	serverURL            url.URL
+	requestJSONValidator RequestJSONValidator
+	deploymentRepo       CFDeploymentRepository
+}
+
+func NewDeployment(
+	serverURL url.URL,
+	requestJSONValidator RequestJSONValidator,
+	deploymentRepo CFDeploymentRepository,
+) *Deployment {
+	return &Deployment{
+		serverURL:            serverURL,
+		requestJSONValidator: requestJSONValidator,
+		deploymentRepo:       deploymentRepo,
+	}
+}
+
+func (h *Deployment) create(r *http.Request) (*routing.Response, error) {
+	authInfo, _ := authorization.InfoFromContext(r.Context())
+	logger := logr.FromContextOrDiscard(r.Context()).WithName("handlers.deployment.create")
+
+	var payload payloads.DeploymentCreate
+	if err := h.requestJSONValidator.DecodeAndValidateJSONPayload(r, &payload); err != nil {
+		return nil, apierrors.LogAndReturn(logger, err, "failed to decode payload")
+	}
+
+	deploymentCreateMessage := payload.ToMessage()
+
+	deployment, err := h.deploymentRepo.CreateDeployment(r.Context(), authInfo, deploymentCreateMessage)
+	if err != nil {
+		return nil, apierrors.LogAndReturn(logger, err, "Error creating deployment in repository")
+	}
+
+	return routing.NewResponse(http.StatusCreated).WithBody(presenter.ForDeployment(deployment, h.serverURL)), nil
+}
+
+func (h *Deployment) get(r *http.Request) (*routing.Response, error) {
+	authInfo, _ := authorization.InfoFromContext(r.Context())
+	logger := logr.FromContextOrDiscard(r.Context()).WithName("handlers.deployment.get")
+
+	deploymentGUID := routing.URLParam(r, "guid")
+
+	deployment, err := h.deploymentRepo.GetDeployment(r.Context(), authInfo, deploymentGUID)
+	if err != nil {
+		return nil, apierrors.LogAndReturn(logger, apierrors.ForbiddenAsNotFound(err), "Error getting deployment in repository")
+	}
+
+	return routing.NewResponse(http.StatusOK).WithBody(presenter.ForDeployment(deployment, h.serverURL)), nil
+}
+
+func (h *Deployment) cancel(r *http.Request) (*routing.Response, error) {
+	return routing.NewResponse(http.StatusOK), nil
+}
+
+func (h *Deployment) UnauthenticatedRoutes() []routing.Route {
+	return nil
+}
+
+func (h *Deployment) AuthenticatedRoutes() []routing.Route {
+	return []routing.Route{
+		{Method: "GET", Pattern: DeploymentPath, Handler: h.get},
+		{Method: "POST", Pattern: DeploymentsPath, Handler: h.create},
+		{Method: "POST", Pattern: DeploymentCancelPath, Handler: h.cancel},
+	}
+}

--- a/api/main.go
+++ b/api/main.go
@@ -157,6 +157,11 @@ func main() {
 		namespaceRetriever,
 		cfg.RootNamespace,
 	)
+	deploymentRepo := repositories.NewDeploymentRepo(
+		userClientFactory,
+		namespaceRetriever,
+		cfg.RootNamespace,
+	)
 	buildRepo := repositories.NewBuildRepo(
 		namespaceRetriever,
 		userClientFactory,
@@ -302,6 +307,11 @@ func main() {
 			*serverURL,
 			decoderValidator,
 			domainRepo,
+		),
+		handlers.NewDeployment(
+			*serverURL,
+			decoderValidator,
+			deploymentRepo,
 		),
 		handlers.NewJob(
 			*serverURL,

--- a/api/payloads/deployment.go
+++ b/api/payloads/deployment.go
@@ -1,0 +1,25 @@
+package payloads
+
+import (
+	"code.cloudfoundry.org/korifi/api/repositories"
+)
+
+type DropletGUID struct {
+	Guid string `json:"guid"`
+}
+
+type DeploymentCreate struct {
+	Droplet       DropletGUID             `json:"droplet"`
+	Relationships DeploymentRelationships `json:"relationships" validate:"required"`
+}
+
+type DeploymentRelationships struct {
+	App Relationship `json:"app" validate:"required"`
+}
+
+func (c *DeploymentCreate) ToMessage() repositories.CreateDeploymentMessage {
+	return repositories.CreateDeploymentMessage{
+		AppGUID:     c.Relationships.App.Data.GUID,
+		DropletGUID: c.Droplet.Guid,
+	}
+}

--- a/api/presenter/deployment.go
+++ b/api/presenter/deployment.go
@@ -1,0 +1,64 @@
+package presenter
+
+import (
+	"net/url"
+
+	"code.cloudfoundry.org/korifi/api/repositories"
+)
+
+const (
+	deploymentsBase = "/v3/deployments"
+)
+
+type DeploymentStatus struct {
+	Value  string `json:"value"`
+	Reason string `json:"reason"`
+}
+
+type DropletGUID struct {
+	Guid string `json:"guid"`
+}
+type DeploymentResponse struct {
+	GUID          string           `json:"guid"`
+	Status        DeploymentStatus `json:"status"`
+	Droplet       DropletGUID      `json:"droplet"`
+	Relationships Relationships    `json:"relationships"`
+	Links         DeploymentLinks  `json:"links"`
+}
+
+type DeploymentLinks struct {
+	Self   Link  `json:"self"`
+	App    Link  `json:"app"`
+	Cancel *Link `json:"cancel"`
+}
+
+func ForDeployment(responseDeployment repositories.DeploymentRecord, baseURL url.URL) DeploymentResponse {
+	return DeploymentResponse{
+		GUID: responseDeployment.GUID,
+		Status: DeploymentStatus{
+			Value:  responseDeployment.Status.Value,
+			Reason: responseDeployment.Status.Reason,
+		},
+		Droplet: DropletGUID{
+			Guid: responseDeployment.DropletGUID,
+		},
+		Relationships: map[string]Relationship{
+			"app": {
+				Data: &RelationshipData{
+					GUID: responseDeployment.GUID,
+				},
+			},
+		},
+		Links: DeploymentLinks{
+			Self: Link{
+				HRef: buildURL(baseURL).appendPath(deploymentsBase, responseDeployment.GUID).build(),
+			},
+			App: Link{
+				HRef: buildURL(baseURL).appendPath(appsBase, responseDeployment.GUID).build(),
+			},
+			Cancel: &Link{
+				HRef: buildURL(baseURL).appendPath(deploymentsBase, responseDeployment.GUID).appendPath("actions").appendPath("cancel").build(),
+			},
+		},
+	}
+}

--- a/api/repositories/deployment_repository.go
+++ b/api/repositories/deployment_repository.go
@@ -1,0 +1,142 @@
+package repositories
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"code.cloudfoundry.org/korifi/api/authorization"
+	apierrors "code.cloudfoundry.org/korifi/api/errors"
+	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
+	"code.cloudfoundry.org/korifi/controllers/controllers/workloads"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const DeploymentResourceType = "Deployment"
+
+type DeploymentRepo struct {
+	userClientFactory  authorization.UserK8sClientFactory
+	namespaceRetriever NamespaceRetriever
+	rootNamespace      string
+}
+
+func NewDeploymentRepo(
+	userClientFactory authorization.UserK8sClientFactory,
+	namespaceRetriever NamespaceRetriever,
+	rootNamespace string,
+) *DeploymentRepo {
+	return &DeploymentRepo{
+		userClientFactory:  userClientFactory,
+		namespaceRetriever: namespaceRetriever,
+		rootNamespace:      rootNamespace,
+	}
+}
+
+type DeploymentRecord struct {
+	GUID        string
+	CreatedAt   string
+	UpdatedAt   string
+	DropletGUID string
+	Status      DeploymentStatus
+}
+
+type DeploymentStatus struct {
+	Value  string
+	Reason string
+}
+
+type CreateDeploymentMessage struct {
+	AppGUID     string
+	DropletGUID string
+}
+
+func (r *DeploymentRepo) GetDeployment(ctx context.Context, authInfo authorization.Info, deploymentGUID string) (DeploymentRecord, error) {
+	ns, err := r.namespaceRetriever.NamespaceFor(ctx, deploymentGUID, AppResourceType)
+	if err != nil {
+		return DeploymentRecord{}, err
+	}
+
+	userClient, err := r.userClientFactory.BuildClient(authInfo)
+	if err != nil {
+		return DeploymentRecord{}, fmt.Errorf("get-deployment failed to create user client: %w", err)
+	}
+
+	app := &korifiv1alpha1.CFApp{}
+	err = userClient.Get(ctx, client.ObjectKey{Namespace: ns, Name: deploymentGUID}, app)
+	if err != nil {
+		return DeploymentRecord{}, apierrors.FromK8sError(err, DeploymentResourceType)
+	}
+
+	return appToDeploymentRecord(app), nil
+}
+
+func (r *DeploymentRepo) CreateDeployment(ctx context.Context, authInfo authorization.Info, message CreateDeploymentMessage) (DeploymentRecord, error) {
+	ns, err := r.namespaceRetriever.NamespaceFor(ctx, message.AppGUID, AppResourceType)
+	if err != nil {
+		return DeploymentRecord{}, err
+	}
+
+	userClient, err := r.userClientFactory.BuildClient(authInfo)
+	if err != nil {
+		return DeploymentRecord{}, fmt.Errorf("create-deployment failed to create user client: %w", err)
+	}
+
+	app := &korifiv1alpha1.CFApp{}
+	err = userClient.Get(ctx, client.ObjectKey{Namespace: ns, Name: message.AppGUID}, app)
+	if err != nil {
+		return DeploymentRecord{}, apierrors.FromK8sError(err, DeploymentResourceType)
+	}
+
+	dropletGUID := app.Spec.CurrentDropletRef.Name
+	if message.DropletGUID != "" {
+		dropletGUID = message.DropletGUID
+	}
+
+	_, err = controllerutil.CreateOrPatch(ctx, userClient, app, func() error {
+		app.Spec.CurrentDropletRef.Name = dropletGUID
+		if app.Annotations == nil {
+			app.Annotations = map[string]string{}
+		}
+		app.Annotations["korifi.cloudfoundry.org/restartedAt"] = time.Now().Format(time.RFC3339)
+		app.Spec.DesiredState = korifiv1alpha1.StartedState
+		return nil
+	})
+	if err != nil {
+		return DeploymentRecord{}, apierrors.FromK8sError(err, DeploymentResourceType)
+	}
+
+	deploymentRecord := appToDeploymentRecord(app)
+	deploymentRecord.DropletGUID = dropletGUID
+
+	return deploymentRecord, nil
+}
+
+func (r *DeploymentRepo) CancelDeployment(ctx context.Context, authInfo authorization.Info, deploymentGUID string) (DeploymentRecord, error) {
+	return DeploymentRecord{}, nil
+}
+
+func appToDeploymentRecord(cfApp *korifiv1alpha1.CFApp) DeploymentRecord {
+	updatedAtTime, _ := getTimeLastUpdatedTimestamp(&cfApp.ObjectMeta)
+	deploymentRecord := DeploymentRecord{
+		GUID:        cfApp.Name,
+		CreatedAt:   updatedAtTime,
+		UpdatedAt:   updatedAtTime,
+		DropletGUID: cfApp.Spec.CurrentDropletRef.Name,
+		Status: DeploymentStatus{
+			Value:  "ACTIVE",
+			Reason: "DEPLOYING",
+		},
+	}
+
+	if meta.IsStatusConditionTrue(cfApp.Status.Conditions, workloads.StatusConditionReady) {
+		deploymentRecord.Status = DeploymentStatus{
+			Value:  "FINALIZED",
+			Reason: "DEPLOYED",
+		}
+	}
+
+	return deploymentRecord
+}

--- a/controllers/webhooks/workloads/apprev_webhook.go
+++ b/controllers/webhooks/workloads/apprev_webhook.go
@@ -45,7 +45,8 @@ func (r *AppRevWebhook) Handle(ctx context.Context, req admission.Request) admis
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
-	if cfApp.Spec.DesiredState == korifiv1alpha1.StoppedState && oldCFApp.Spec.DesiredState == korifiv1alpha1.StartedState {
+	if cfApp.Spec.DesiredState == korifiv1alpha1.StoppedState && oldCFApp.Spec.DesiredState == korifiv1alpha1.StartedState ||
+		cfApp.Annotations["korifi.cloudfoundry.org/restartedAt"] != oldCFApp.Annotations["korifi.cloudfoundry.org/restartedAt"] {
 		cfApp.Annotations[korifiv1alpha1.CFAppRevisionKey] = bumpAppRev(cfApp.Annotations[korifiv1alpha1.CFAppRevisionKey])
 	}
 

--- a/statefulset-runner/controllers/appworkload_to_stset.go
+++ b/statefulset-runner/controllers/appworkload_to_stset.go
@@ -1,12 +1,8 @@
 package controllers
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
-	"regexp"
 	"sort"
-	"strings"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"code.cloudfoundry.org/korifi/tools"
@@ -25,18 +21,6 @@ func NewAppWorkloadToStatefulsetConverter(scheme *runtime.Scheme) *AppWorkloadTo
 	return &AppWorkloadToStatefulsetConverter{
 		scheme: scheme,
 	}
-}
-
-func getStatefulSetName(appWorkload *korifiv1alpha1.AppWorkload) (string, error) {
-	nameSuffix, err := hash(fmt.Sprintf("%s-%s", appWorkload.Spec.GUID, appWorkload.Spec.Version))
-	if err != nil {
-		return "", fmt.Errorf("failed to generate hash for statefulset name: %w", err)
-	}
-
-	namePrefix := fmt.Sprintf("%s-%s", appWorkload.Spec.AppGUID, appWorkload.Namespace)
-	namePrefix = sanitizeName(namePrefix, appWorkload.Spec.GUID)
-
-	return fmt.Sprintf("%s-%s", namePrefix, nameSuffix), nil
 }
 
 func (r *AppWorkloadToStatefulsetConverter) Convert(appWorkload *korifiv1alpha1.AppWorkload) (*appsv1.StatefulSet, error) {
@@ -113,14 +97,9 @@ func (r *AppWorkloadToStatefulsetConverter) Convert(appWorkload *korifiv1alpha1.
 		},
 	}
 
-	statefulsetName, err := getStatefulSetName(appWorkload)
-	if err != nil {
-		return nil, err
-	}
-
 	statefulSet := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      statefulsetName,
+			Name:      appWorkload.Name,
 			Namespace: appWorkload.Namespace,
 		},
 		Spec: appsv1.StatefulSetSpec{
@@ -158,7 +137,7 @@ func (r *AppWorkloadToStatefulsetConverter) Convert(appWorkload *korifiv1alpha1.
 		},
 	}
 
-	err = controllerutil.SetOwnerReference(appWorkload, statefulSet, r.scheme)
+	err := controllerutil.SetOwnerReference(appWorkload, statefulSet, r.scheme)
 	if err != nil {
 		return nil, fmt.Errorf("failed to set OwnerRef on StatefulSet :%w", err)
 	}
@@ -180,35 +159,14 @@ func (r *AppWorkloadToStatefulsetConverter) Convert(appWorkload *korifiv1alpha1.
 		AnnotationVersion:     appWorkload.Spec.Version,
 		AnnotationProcessGUID: fmt.Sprintf("%s-%s", appWorkload.Spec.GUID, appWorkload.Spec.Version),
 	}
+	if restartedAt, hasRestartedAt := appWorkload.Annotations["korifi.cloudfoundry.org/restartedAt"]; hasRestartedAt {
+		annotations["korifi.cloudfoundry.org/restartedAt"] = restartedAt
+	}
 
 	statefulSet.Annotations = annotations
 	statefulSet.Spec.Template.Annotations = annotations
 
 	return statefulSet, nil
-}
-
-func sanitizeName(name, fallback string) string {
-	const sanitizedNameMaxLen = 40
-	return sanitizeNameWithMaxStringLen(name, fallback, sanitizedNameMaxLen)
-}
-
-func sanitizeNameWithMaxStringLen(name, fallback string, maxStringLen int) string {
-	validNameRegex := regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`)
-	sanitizedName := strings.ReplaceAll(strings.ToLower(name), "_", "-")
-
-	if validNameRegex.MatchString(sanitizedName) {
-		return truncateString(sanitizedName, maxStringLen)
-	}
-
-	return truncateString(fallback, maxStringLen)
-}
-
-func truncateString(str string, num int) string {
-	if len(str) > num {
-		return str[0:num]
-	}
-
-	return str
 }
 
 func toLabelSelectorRequirements(selector *metav1.LabelSelector) []metav1.LabelSelectorRequirement {
@@ -233,22 +191,7 @@ func toLabelSelectorRequirements(selector *metav1.LabelSelector) []metav1.LabelS
 func statefulSetLabelSelector(appWorkload *korifiv1alpha1.AppWorkload) *metav1.LabelSelector {
 	return &metav1.LabelSelector{
 		MatchLabels: map[string]string{
-			LabelGUID:    appWorkload.Spec.GUID,
-			LabelVersion: appWorkload.Spec.Version,
+			LabelGUID: appWorkload.Spec.GUID,
 		},
 	}
-}
-
-func hash(s string) (string, error) {
-	const MaxHashLength = 10
-
-	sha := sha256.New()
-
-	if _, err := sha.Write([]byte(s)); err != nil {
-		return "", fmt.Errorf("failed to calculate sha: %w", err)
-	}
-
-	hashValue := hex.EncodeToString(sha.Sum(nil))
-
-	return hashValue[:MaxHashLength], nil
 }


### PR DESCRIPTION
# Background 
This PR explores the idea of supproting the rolling cf `push`,
`restage` and `restart` operations. In CF for VMs these are backed by the
[`/v3/deployments`](https://v3-apidocs.cloudfoundry.org/version/3.138.0/index.html#deployments)
endpoints.

By doing this we are taking advantage of the built-in rollout capabilities of
Kubernetes.


# Proposal

This draft PR contains a spike implementation of the rolling cf operations. It
is meant to trigger a discussion and should not be merged in its current state.
We have tried to minimize the diff so that it is easier to understand what
needs to be changed. Below is a summary of the proposed changes.

## `/v3/deployments` endpoints

We have decided to not introduce a new resource for deployments, because the
only thing a deployment has to do is set a new droplet on its related app. This
means that we could just reuse the CFApp as a backing resource.

### `POST /v3/deployments`
- Updates the current droplet on the related CFApp if one is specified in the
  request.
- Annotate the CFApp with the `korifi.cloudfoundry.org/restartedAt` annotation
  with current time as a value. This annotation is propagated all the way down
  to the Statefulset's pod template spec annotations so that the statefulset is
  rolled out.
- Sets the CFApp desired state to `STARTED`
- The returned deployment:
  - Shares the CFApp guid
  - Is `FINALIZED` when the related app has a `Ready` status contition.
    Otherwise it is `ACTIVE`


### `GET /v3/deployments/:guid` 

Returns a deployment object that:
  - Shares the CFApp guid
  - Is `FINALIZED` when the related app has a `Ready` status contition.
    Otherwise it is `ACTIVE`

### `POST /v3/deployments/:guid/actions/cancel` 

Given that we get the rollout
behaviour for free and we do not keep any state for deployments, this operation
is a noop and always returns 200 OK. The only reason for implementing it is
that the cf cli tries to cancel a deployment if it times out.

## AppWorkload and Statefulset naming 

In order to take advantage of the
Kubernetes rollout, we must not recreate the AppWorkload as well as the
underlying Statefulset. Therefore we are using stable names and update them
(propagate the restartedAt annotation and instance count).
- We reuse the cf process guid as the guid of the AppWorkload and Statefulset.
- As a consequence we have to drop the app revision from the statefulset label
  selector. Otherwise the statefulset update fails, as metadata is immutable.

## Limitations 

While the proposed implementation generally works there are some
limitations:
- If the app has only one instance the rolling restart/restaage will result in
  downtime. This how Kubernetes statefulsets work. A possible mitigation is
  introducing an alternative corev1.Deployment based workload runner.
- As the v3 deployment status reflects the ready condition of the app it means
  that the rolling operation may not wait for the app to actually start, but
  may return too early. This is because the app becomes ready once a droplet is
  set. A possible mitigation is a better implementation of the app ready state.
- The fact that we are not introducing a new Kubernetes resource to back the v3
  deployments means that we cannot directly specify which user roles have
  permission to operate on them. Instead the cfapp permissions will drive out
  the deployment permissions. This may or may not be a problem. A possible
  mitigation is to introduce a backing resource for v3 deployments (along with
  a controller).

## Upgrade Considerations 

Given that we are changing how we name AppWorkloads
and Statefulsets we have to think about the upgrade path.
- Given that we are using stable names for AppWorkloads and Statefulsets we
  have changed the way we cleanup AppWorkloads. Instead of deleting all
  AppWorkloads with an old app revision we now delete all app workloads that
  have unexpected names. This means that after an upgrade there will be no
  garbage left behind.
- Recreating all existing AppWorkloads means a short downtime for all apps.




