### PR TITLE
Reduce the golang version to 1.19 to support older kpack installs

### DIFF
--- a/tests/e2e/assets/golang/go.mod
+++ b/tests/e2e/assets/golang/go.mod
@@ -1,3 +1,3 @@
 module dorifi
 
-go 1.20
+go 1.19 // Support installations with a slightly older version of kpack


### PR DESCRIPTION

## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ --> No

## What is this change about?
<!-- _Please describe the change here._ --> Reduce the golang version required by the golang test asset to 1.19. This version is still supported and not all installs have a kpack that's new enough to include golang 1.20.

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ --> No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ --> PR checks pass

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
