### PR TITLE
Provide a way to change the buildpack used with the default app

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,55 @@
+# E2E Tests
+
+## Required Environment Variables
+- `API_SERVER_ROOT`: The API URL of the korifi deployment being tested (e.g. "https://localhost").
+
+- `APP_FQDN`: The subdomain that's used for applications pushed to the korifi deployment (e.g. "apps-127-0-0-1.nip.io").
+
+- `CLUSTER_VERSION_MAJOR`: The major version of the kubernetes cluster where korifi is deployed (e.g. `1` for version `1.22`).
+
+- `CLUSTER_VERSION_MINOR`: The minor version of the kubernetes cluster where korifi is deployed (e.g. `22` for version `1.22`).
+
+- `E2E_LONGCERT_USER_NAME`: The username for a user with a certificate that expires far in the future. Used in tests that
+  ensure the user is warned about the security implications of their certificate expiration.
+
+- `E2E_SERVICE_ACCOUNT`: The name of a service account that exists in the korifi root namespace. Will be used to test
+  service account auth (e.g. "my-service-account").
+
+- `E2E_SERVICE_ACCOUNT_TOKEN`: The token for the E2E_SERVICE_ACCOUNT service account.
+
+- `E2E_UNPRIVILEGED_SERVICE_ACCOUNT`: The name of a service account that exists in the korifi root namespace. Will be used to test
+ auth for service accounts that have no korifi privileges (e.g. "my-unprivileged-service-account").
+
+- `E2E_UNPRIVILEGED_SERVICE_ACCOUNT_TOKEN`: The token for the E2E_UNPRIVILEGED_SERVICE_ACCOUNT service account.
+
+- `E2E_USER_NAME`: The name of a user on the kubernetes cluster where korifi is deployed. It can authenticate using either
+  a certificate or token. See the E2E_USER_PEM and E2E_USER_TOKEN below. 
+ 
+- `ROOT_NAMESPACE`: The root namespace for the korifi deployment (e.g. "cf").
+
+## Optional Environment Variables
+- `CF_ADMIN_PEM`: The certificate PEM for a korifi admin user. Either CF_ADMIN_PEM or CF_ADMIN_TOKEN must be provided.
+
+- `CF_ADMIN_TOKEN`: The token for a korifi admin user. Either CF_ADMIN_PEM or CF_ADMIN_TOKEN must be provided.
+
+- `CLUSTER_TYPE`: The type of kubernetes cluster where korifi is deployed (e.g. "EKS", "GKE").
+
+- `DEFAULT_APP_BITS_PATH`: path to the source code for the application pushed by most tests (by default, the "dorifi" app
+  is used).
+
+- `DEFAULT_APP_RESPONSE`: the expected response when curling the default app's root endpoint (by default, "Hi, I'm
+  Dorifi").
+
+- `DEFAULT_APP_SPECIFIED_BUILDPACK`: the buildpack to use when pushing the default app with a set buildpack (by default, "
+  paketo-buildpacks/procfile").
+
+- `E2E_LONGCERT_USER_PEM`: The certificate PEM for the E2E_LONGCERT_USER_NAME user. If this var is omitted, then some
+  tests will be skipped.
+
+- `E2E_USER_PEM`: The certificate PEM for the E2E_USER_NAME user. If this var is omitted, then some tests will be skipped.
+  Either E2E_USER_PEM or E2E_USER_TOKEN must be provided.
+
+- `E2E_USER_TOKEN`: The token for the E2E_USER_NAME user. Either E2E_USER_PEM or E2E_USER_TOKEN must be provided.
+
+- `FULL_LOG_ON_ERR`:  If set to a non-blank value, logs for all API requests will be displayed when a test fails.
+  Otherwise, only logs that match the current test's correlation ID will be shown.

--- a/tests/e2e/apps_test.go
+++ b/tests/e2e/apps_test.go
@@ -2,12 +2,12 @@ package e2e_test
 
 import (
 	"encoding/json"
-	"net/http"
-
 	"github.com/go-resty/resty/v2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
+	"net/http"
+	"os"
 )
 
 var _ = Describe("Apps", func() {
@@ -403,13 +403,18 @@ var _ = Describe("Apps", func() {
 		var buildGUID string
 
 		BeforeEach(func() {
+			buildpackName := os.Getenv("DEFAULT_APP_SPECIFIED_BUILDPACK")
+			if buildpackName == "" {
+				buildpackName = "paketo-buildpacks/procfile"
+			}
+
 			manifest := manifestResource{
 				Version: 1,
 				Applications: []applicationResource{{
 					Name:         generateGUID("app"),
 					Memory:       "128MB",
 					DefaultRoute: true,
-					Buildpacks:   []string{"paketo-buildpacks/procfile"},
+					Buildpacks:   []string{buildpackName},
 				}},
 			}
 			applySpaceManifest(manifest, space1GUID)


### PR DESCRIPTION

## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ --> No

## What is this change about?
<!-- _Please describe the change here._ -->
- Provide a way to change the buildpack used with the default app
- Also add a README.md for the e2e tests
- Also loosen assertion for /v3/app/:guid/processes endpoint to test for inclusion of the web process instead of ONLY the web process existing.


## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ --> No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ --> Tests still pass

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ --> @davewalter 

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
