### PR TITLE
Use correct service account when creating custom kpack builders

### DIFF
--- a/kpack-image-builder/controllers/buildworkload_controller.go
+++ b/kpack-image-builder/controllers/buildworkload_controller.go
@@ -420,7 +420,7 @@ func (r *BuildWorkloadReconciler) ensureKpackBuilder(ctx context.Context, buildW
 		builder.Spec.Tag = builderRepo
 		builder.Spec.Stack = defaultBuilder.Spec.Stack
 		builder.Spec.Store = defaultBuilder.Spec.Store
-		builder.Spec.ServiceAccountName = defaultBuilder.Spec.ServiceAccountRef.Name
+		builder.Spec.ServiceAccountName = r.controllerConfig.BuilderServiceAccount
 		builder.Spec.Order = nil
 		for _, bp := range buildWorkload.Spec.Buildpacks {
 			builder.Spec.Order = append(builder.Spec.Order, corev1alpha1.OrderEntry{

--- a/kpack-image-builder/controllers/buildworkload_controller_test.go
+++ b/kpack-image-builder/controllers/buildworkload_controller_test.go
@@ -259,7 +259,7 @@ var _ = Describe("BuildWorkloadReconciler", func() {
 					g.Expect(builder.Spec.Tag).To(Equal("my.repository/my-prefix/builders-" + builderName))
 					g.Expect(builder.Spec.Stack).To(Equal(clusterBuilder.Spec.Stack))
 					g.Expect(builder.Spec.Store).To(Equal(clusterBuilder.Spec.Store))
-					g.Expect(builder.Spec.ServiceAccountName).To(Equal(clusterBuilder.Spec.ServiceAccountRef.Name))
+					g.Expect(builder.Spec.ServiceAccountName).To(Equal("builder-service-account"))
 					g.Expect(builder.Spec.Order).To(HaveLen(1))
 					g.Expect(builder.Spec.Order[0]).To(Equal(corev1alpha1.OrderEntry{
 						Group: []corev1alpha1.BuildpackRef{


### PR DESCRIPTION
## Is there a related GitHub Issue?
#2474

## What is this change about?
The builder pushes its image to the same registry as droplets, so use the same service account for the registry credentials as for droplets.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Set up a kpack cluster builder using a different registry for its build image and with a different service account for credentials from the droplet registry.

See that `cf push my-app -b MY_BUILDPACK` works.

## Tag your pair, your PM, and/or team
@gcapizzi

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
