### PR TITLE
Compute Korifi version based on git tags

### DIFF
--- a/scripts/assets/korifi-debug-kbld.yml
+++ b/scripts/assets/korifi-debug-kbld.yml
@@ -7,11 +7,9 @@ sources:
   docker:
     buildx:
       file: api/remote-debug/Dockerfile
-      rawOptions: ["--build-arg", "version=v9999.99.99-local.dev-debug"]
 
 - image: cloudfoundry/korifi-controllers:latest
   path: .
   docker:
     buildx:
       file: controllers/remote-debug/Dockerfile
-      rawOptions: ["--build-arg", "version=v9999.99.99-local.dev-debug"]

--- a/scripts/assets/korifi-kbld.yml
+++ b/scripts/assets/korifi-kbld.yml
@@ -7,11 +7,9 @@ sources:
   docker:
     buildx:
       file: api/Dockerfile
-      rawOptions: ["--build-arg", "version=v9999.99.99-local.dev"]
 
 - image: cloudfoundry/korifi-controllers:latest
   path: .
   docker:
     buildx:
       file: controllers/Dockerfile
-      rawOptions: ["--build-arg", "version=v9999.99.99-local.dev"]


### PR DESCRIPTION
rather than hardcoding it

Co-authored-by: Kieron Browne <kbrowne@vmware.com>

<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
#2537

<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Compute Korifi version by looking at git tags instead of hardcoding it to `9999`. Thus we would get a realistic version in the local development scenario

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
Deploy korifi, look at logs, see a reasaonable version there
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@kieron-dev
