### PR TITLE
Annotate all Korifi objects with creation version

### DIFF
--- a/controllers/api/v1alpha1/cfapp_webhook_test.go
+++ b/controllers/api/v1alpha1/cfapp_webhook_test.go
@@ -62,7 +62,6 @@ var _ = Describe("CFAppMutatingWebhook", func() {
 		})
 
 		It("adds a label mathching metadata.name", func() {
-			Expect(cfApp.Labels).To(HaveLen(1))
 			Expect(cfApp.Labels).To(HaveKeyWithValue(cfAppLabelKey, cfApp.Name))
 		})
 	})
@@ -73,7 +72,6 @@ var _ = Describe("CFAppMutatingWebhook", func() {
 		})
 
 		It("adds an app revision annotation", func() {
-			Expect(cfApp.Annotations).To(HaveLen(1))
 			Expect(cfApp.Annotations).To(HaveKeyWithValue(cfAppRevisionKey, "0"))
 		})
 	})

--- a/controllers/api/v1alpha1/webhook_suite_test.go
+++ b/controllers/api/v1alpha1/webhook_suite_test.go
@@ -31,6 +31,7 @@ import (
 	"code.cloudfoundry.org/korifi/controllers/coordination"
 	"code.cloudfoundry.org/korifi/controllers/webhooks"
 	"code.cloudfoundry.org/korifi/controllers/webhooks/networking"
+	"code.cloudfoundry.org/korifi/controllers/webhooks/version"
 	"code.cloudfoundry.org/korifi/controllers/webhooks/workloads"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -140,6 +141,7 @@ var _ = BeforeSuite(func() {
 	spaceNameDuplicateValidator := webhooks.NewDuplicateValidator(coordination.NewNameRegistry(mgr.GetClient(), workloads.CFSpaceEntityType))
 	spacePlacementValidator := webhooks.NewPlacementValidator(mgr.GetClient(), namespace)
 	Expect(workloads.NewCFSpaceValidator(spaceNameDuplicateValidator, spacePlacementValidator).SetupWebhookWithManager(mgr)).To(Succeed())
+	version.NewVersionWebhook("some-version").SetupWebhookWithManager(mgr)
 
 	//+kubebuilder:scaffold:webhook
 

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -37,6 +37,7 @@ import (
 	"code.cloudfoundry.org/korifi/controllers/webhooks"
 	"code.cloudfoundry.org/korifi/controllers/webhooks/networking"
 	"code.cloudfoundry.org/korifi/controllers/webhooks/services"
+	versionwebhook "code.cloudfoundry.org/korifi/controllers/webhooks/version"
 	"code.cloudfoundry.org/korifi/controllers/webhooks/workloads"
 	jobtaskrunnercontrollers "code.cloudfoundry.org/korifi/job-task-runner/controllers"
 	"code.cloudfoundry.org/korifi/kpack-image-builder/controllers"
@@ -456,6 +457,8 @@ func main() {
 			setupLog.Error(err, "unable to create webhook", "webhook", "CFTask")
 			os.Exit(1)
 		}
+
+		versionwebhook.NewVersionWebhook(version.Version).SetupWebhookWithManager(mgr)
 
 		if controllerConfig.IncludeStatefulsetRunner {
 			if err = statesetfulrunnerv1.NewSTSPodDefaulter().SetupWebhookWithManager(mgr); err != nil {

--- a/controllers/webhooks/version/version_webhook.go
+++ b/controllers/webhooks/version/version_webhook.go
@@ -1,0 +1,66 @@
+package version
+
+//+kubebuilder:webhook:path=/mutate-korifi-cloudfoundry-org-v1alpha1-all-version,mutating=true,failurePolicy=fail,sideEffects=None,groups=korifi.cloudfoundry.org,resources=cforgs;cfspaces;builderinfos;cfdomains;cfserviceinstances;cfapps;cfpackages;cftasks;cfprocesses;cfbuilds;cfroutes;cfservicebindings;taskworkloads;appworkloads;buildworkloads,verbs=create,versions=v1alpha1,name=mcfversion.korifi.cloudfoundry.org,admissionReviewVersions={v1,v1beta1}
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"code.cloudfoundry.org/korifi/version"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+type VersionWebhook struct {
+	version string
+	decoder *admission.Decoder
+}
+
+func NewVersionWebhook(version string) *VersionWebhook {
+	return &VersionWebhook{version: version}
+}
+
+var versionlog = logf.Log.WithName("version-webhook")
+
+func (r *VersionWebhook) SetupWebhookWithManager(mgr ctrl.Manager) {
+	mgr.GetWebhookServer().Register("/mutate-korifi-cloudfoundry-org-v1alpha1-all-version", &admission.Webhook{
+		Handler: r,
+	})
+}
+
+func (r *VersionWebhook) InjectDecoder(d *admission.Decoder) error {
+	r.decoder = d
+	return nil
+}
+
+func (r *VersionWebhook) Handle(ctx context.Context, req admission.Request) admission.Response {
+	versionlog.Info("adding-version")
+
+	var obj metav1.PartialObjectMetadata
+
+	if err := r.decoder.Decode(req, &obj); err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	origMarshalled, err := json.Marshal(obj)
+	if err != nil {
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+
+	anns := obj.GetAnnotations()
+	if anns == nil {
+		anns = map[string]string{}
+	}
+	anns[version.KorifiCreationVersionKey] = r.version
+	obj.SetAnnotations(anns)
+
+	marshalled, err := json.Marshal(obj)
+	if err != nil {
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+
+	return admission.PatchResponseFromRaw(origMarshalled, marshalled)
+}

--- a/controllers/webhooks/version/version_webhook_test.go
+++ b/controllers/webhooks/version/version_webhook_test.go
@@ -1,0 +1,214 @@
+package version_test
+
+import (
+	"context"
+	"fmt"
+
+	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
+	"code.cloudfoundry.org/korifi/tools/k8s"
+	"code.cloudfoundry.org/korifi/version"
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	defaultMemoryMB    = 128
+	defaultDiskQuotaMB = 256
+	defaultTimeout     = 60
+)
+
+var _ = Describe("Setting the version annotation", func() {
+	Describe("create", func() {
+		var testObjects []client.Object
+		createObject := func(obj client.Object) client.Object {
+			Expect(k8sClient.Create(context.Background(), obj)).To(Succeed())
+			return obj
+		}
+
+		BeforeEach(func() {
+			orgNamespace := "test-org-" + uuid.NewString()
+			Expect(k8sClient.Create(context.Background(), &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   orgNamespace,
+					Labels: map[string]string{korifiv1alpha1.OrgNameKey: orgNamespace},
+				},
+			})).To(Succeed())
+
+			domainName := uuid.NewString()
+			testObjects = []client.Object{
+				createObject(&korifiv1alpha1.CFOrg{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      orgNamespace,
+						Namespace: rootNamespace,
+					},
+					Spec: korifiv1alpha1.CFOrgSpec{
+						DisplayName: orgNamespace,
+					},
+				}),
+				createObject(&korifiv1alpha1.CFSpace{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: orgNamespace,
+						Name:      uuid.NewString(),
+					},
+					Spec: korifiv1alpha1.CFSpaceSpec{
+						DisplayName: "asdf",
+					},
+				}),
+				createObject(&korifiv1alpha1.BuilderInfo{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: rootNamespace,
+						Name:      uuid.NewString(),
+					},
+				}),
+				createObject(&korifiv1alpha1.CFDomain{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: rootNamespace,
+						Name:      domainName,
+					},
+					Spec: korifiv1alpha1.CFDomainSpec{
+						Name: "my.domain",
+					},
+				}),
+				createObject(&korifiv1alpha1.CFServiceInstance{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: orgNamespace,
+						Name:      uuid.NewString(),
+					},
+					Spec: korifiv1alpha1.CFServiceInstanceSpec{
+						Type: "user-provided",
+					},
+				}),
+				createObject(&korifiv1alpha1.CFApp{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: orgNamespace,
+						Name:      uuid.NewString(),
+					},
+					Spec: korifiv1alpha1.CFAppSpec{
+						DisplayName:  "cfapp",
+						DesiredState: "STOPPED",
+						Lifecycle: korifiv1alpha1.Lifecycle{
+							Type: "buildpack",
+						},
+					},
+				}),
+				createObject(&korifiv1alpha1.CFPackage{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: orgNamespace,
+						Name:      uuid.NewString(),
+					},
+					Spec: korifiv1alpha1.CFPackageSpec{
+						Type: "bits",
+					},
+				}),
+				createObject(&korifiv1alpha1.CFTask{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: orgNamespace,
+						Name:      uuid.NewString(),
+					},
+					Spec: korifiv1alpha1.CFTaskSpec{
+						Command: "foo",
+						AppRef: corev1.LocalObjectReference{
+							Name: "bob",
+						},
+					},
+				}),
+				createObject(&korifiv1alpha1.CFProcess{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: orgNamespace,
+						Name:      uuid.NewString(),
+					},
+					Spec: korifiv1alpha1.CFProcessSpec{
+						Ports: []int32{80},
+					},
+				}),
+				createObject(&korifiv1alpha1.CFBuild{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: orgNamespace,
+						Name:      uuid.NewString(),
+					},
+					Spec: korifiv1alpha1.CFBuildSpec{
+						Lifecycle: korifiv1alpha1.Lifecycle{
+							Type: "buildpack",
+						},
+					},
+				}),
+				createObject(&korifiv1alpha1.CFRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: orgNamespace,
+						Name:      uuid.NewString(),
+					},
+					Spec: korifiv1alpha1.CFRouteSpec{
+						DomainRef: corev1.ObjectReference{
+							Name:      domainName,
+							Namespace: rootNamespace,
+						},
+						Host: "myhost",
+					},
+				}),
+				createObject(&korifiv1alpha1.CFServiceBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: orgNamespace,
+						Name:      uuid.NewString(),
+					},
+				}),
+				createObject(&korifiv1alpha1.TaskWorkload{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: orgNamespace,
+						Name:      uuid.NewString(),
+					},
+					Spec: korifiv1alpha1.TaskWorkloadSpec{
+						Command: []string{"foo"},
+					},
+				}),
+				createObject(&korifiv1alpha1.AppWorkload{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: orgNamespace,
+						Name:      uuid.NewString(),
+					},
+				}),
+				createObject(&korifiv1alpha1.BuildWorkload{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: orgNamespace,
+						Name:      uuid.NewString(),
+					},
+				}),
+			}
+		})
+
+		It("sets the version annotation", func() {
+			for _, o := range testObjects {
+				Expect(o.GetAnnotations()).To(HaveKeyWithValue(version.KorifiCreationVersionKey, "some-version"),
+					func() string { return fmt.Sprintf("%T does not have the expected version", o) },
+				)
+			}
+		})
+	})
+
+	Describe("update", func() {
+		var builderInfo *korifiv1alpha1.BuilderInfo
+
+		BeforeEach(func() {
+			builderInfo = &korifiv1alpha1.BuilderInfo{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: rootNamespace,
+					Name:      uuid.NewString(),
+				},
+			}
+			Expect(k8sClient.Create(context.Background(), builderInfo)).To(Succeed())
+		})
+
+		JustBeforeEach(func() {
+			Expect(k8s.Patch(context.Background(), k8sClient, builderInfo, func() {
+				delete(builderInfo.Annotations, version.KorifiCreationVersionKey)
+			})).To(Succeed())
+		})
+
+		It("does not add the version annotation again", func() {
+			Expect(builderInfo.Annotations).NotTo(HaveKey(version.KorifiCreationVersionKey))
+		})
+	})
+})

--- a/helm/korifi/controllers/manifests.yaml
+++ b/helm/korifi/controllers/manifests.yaml
@@ -118,6 +118,40 @@ webhooks:
       service:
         name: korifi-controllers-webhook-service
         namespace: '{{ .Release.Namespace }}'
+        path: /mutate-korifi-cloudfoundry-org-v1alpha1-all-version
+    failurePolicy: Fail
+    name: mcfversion.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+        resources:
+          - cforgs
+          - cfspaces
+          - builderinfos
+          - cfdomains
+          - cfserviceinstances
+          - cfapps
+          - cfpackages
+          - cftasks
+          - cfprocesses
+          - cfbuilds
+          - cfroutes
+          - cfservicebindings
+          - taskworkloads
+          - appworkloads
+          - buildworkloads
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-controllers-webhook-service
+        namespace: '{{ .Release.Namespace }}'
         path: /mutate-korifi-cloudfoundry-org-v1alpha1-cfapp-apprev
     failurePolicy: Fail
     name: mcfapprev.korifi.cloudfoundry.org

--- a/tests/e2e/service_instances_test.go
+++ b/tests/e2e/service_instances_test.go
@@ -132,8 +132,8 @@ var _ = Describe("Service Instances", func() {
 
 				serviceInstance := serviceInstances.Resources[0]
 				Expect(serviceInstance.Name).To(Equal("new-instance-name"))
-				Expect(serviceInstance.Metadata.Labels).To(Equal(map[string]string{"a-label": "a-label-value"}))
-				Expect(serviceInstance.Metadata.Annotations).To(Equal(map[string]string{"an-annotation": "an-annotation-value"}))
+				Expect(serviceInstance.Metadata.Labels).To(HaveKeyWithValue("a-label", "a-label-value"))
+				Expect(serviceInstance.Metadata.Annotations).To(HaveKeyWithValue("an-annotation", "an-annotation-value"))
 				Expect(serviceInstance.Tags).To(ConsistOf("some", "tags"))
 			})
 		})

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,7 @@
 package version
 
+const KorifiCreationVersionKey = "korifi.cloudfoundry.org/creation-version"
+
 // version is overwritten at compile time by passing
 // -ldflags -X code.cloudfoundry.org/korifi/version.Version=<version>
 var Version = "v9999.99.99-local.dev"


### PR DESCRIPTION
## Is there a related GitHub Issue?
https://github.com/cloudfoundry/korifi/issues/2537
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Implemented as a generic webhook that adds an annotation with the Korifi
version at the time of the object creation.
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
Create a Korifi object (such as CFApp), see it is annotated with the Korifi version

<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@gcapizzi
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
