### PR TITLE
Optimize korifi resource finalization

### DIFF
--- a/controllers/controllers/networking/cfdomain_controller.go
+++ b/controllers/controllers/networking/cfdomain_controller.go
@@ -18,6 +18,7 @@ package networking
 
 import (
 	"context"
+	"time"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"code.cloudfoundry.org/korifi/controllers/controllers/shared"
@@ -116,7 +117,7 @@ func (r *CFDomainReconciler) finalizeCFDomain(ctx context.Context, log logr.Logg
 		}
 	}
 
-	return ctrl.Result{Requeue: true}, nil
+	return ctrl.Result{RequeueAfter: time.Second}, nil
 }
 
 func (r *CFDomainReconciler) listRoutesForDomain(ctx context.Context, cfDomain *korifiv1alpha1.CFDomain) ([]korifiv1alpha1.CFRoute, error) {

--- a/controllers/controllers/workloads/cfapp_controller.go
+++ b/controllers/controllers/workloads/cfapp_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"code.cloudfoundry.org/korifi/controllers/controllers/shared"
@@ -361,7 +362,7 @@ func (r *CFAppReconciler) finalizeCFServiceBindings(ctx context.Context, log log
 		}
 	}
 
-	return ctrl.Result{Requeue: true}, nil
+	return ctrl.Result{RequeueAfter: time.Second}, nil
 }
 
 func (r *CFAppReconciler) updateRouteDestinations(ctx context.Context, log logr.Logger, cfAppGUID string, cfRoutes []korifiv1alpha1.CFRoute) error {

--- a/controllers/controllers/workloads/cfpackage_controller.go
+++ b/controllers/controllers/workloads/cfpackage_controller.go
@@ -18,7 +18,6 @@ package workloads
 
 import (
 	"context"
-	"fmt"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"code.cloudfoundry.org/korifi/controllers/controllers/shared"
@@ -164,14 +163,8 @@ func (r *CFPackageReconciler) finalize(ctx context.Context, log logr.Logger, cfP
 		}
 	}
 
-	err := k8s.Patch(ctx, r.k8sClient, cfPackage, func() {
-		if controllerutil.RemoveFinalizer(cfPackage, cfPackageFinalizer) {
-			log.V(1).Info("finalizer removed")
-		}
-	})
-	if err != nil {
-		r.log.Info("failed to patch package", "reason", err)
-		return ctrl.Result{}, fmt.Errorf("failed to patch package: %w", err)
+	if controllerutil.RemoveFinalizer(cfPackage, cfPackageFinalizer) {
+		log.V(1).Info("finalizer removed")
 	}
 
 	return ctrl.Result{}, nil


### PR DESCRIPTION
## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
It turns out that controller runtime appplies an exponential backoff
strategy for both error and requeue reconciliation results: https://github.com/kubernetes-sigs/controller-runtime/blob/30eae58f1b984c1b8139dd9b9f68dd2d530ed429/pkg/internal/controller/controller.go#L315-L335

This commit uses RequeueAfter on every korifi object finalization to
avoid potentially slowing down object deletion exponentially
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
Green tests
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@danail-branekov
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
