### PR TITLE
Disallow rolling strategy for appworkloads <= v0.7.1

### DIFF
--- a/controllers/webhooks/version/version_webhook.go
+++ b/controllers/webhooks/version/version_webhook.go
@@ -1,6 +1,6 @@
 package version
 
-//+kubebuilder:webhook:path=/mutate-korifi-cloudfoundry-org-v1alpha1-all-version,mutating=true,failurePolicy=fail,sideEffects=None,groups=korifi.cloudfoundry.org,resources=cforgs;cfspaces;builderinfos;cfdomains;cfserviceinstances;cfapps;cfpackages;cftasks;cfprocesses;cfbuilds;cfroutes;cfservicebindings;taskworkloads;appworkloads;buildworkloads,verbs=create,versions=v1alpha1,name=mcfversion.korifi.cloudfoundry.org,admissionReviewVersions={v1,v1beta1}
+//+kubebuilder:webhook:path=/mutate-korifi-cloudfoundry-org-v1alpha1-all-version,mutating=true,failurePolicy=fail,sideEffects=None,groups=korifi.cloudfoundry.org,resources=cforgs;cfspaces;builderinfos;cfdomains;cfserviceinstances;cfapps;cfpackages;cftasks;cfprocesses;cfbuilds;cfroutes;cfservicebindings;taskworkloads;appworkloads;buildworkloads,verbs=create;update,versions=v1alpha1,name=mcfversion.korifi.cloudfoundry.org,admissionReviewVersions={v1,v1beta1}
 
 import (
 	"context"
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	"code.cloudfoundry.org/korifi/version"
+	corev1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -45,6 +46,17 @@ func (r *VersionWebhook) Handle(ctx context.Context, req admission.Request) admi
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
+	switch req.Operation {
+	case corev1.Create:
+		return r.setVersion(ctx, obj, r.version)
+	case corev1.Update:
+		return r.resetVersion(ctx, obj, req)
+	default:
+		return admission.Denied("we only accept create/update")
+	}
+}
+
+func (r *VersionWebhook) setVersion(ctx context.Context, obj metav1.PartialObjectMetadata, ver string) admission.Response {
 	origMarshalled, err := json.Marshal(obj)
 	if err != nil {
 		return admission.Errored(http.StatusInternalServerError, err)
@@ -63,4 +75,21 @@ func (r *VersionWebhook) Handle(ctx context.Context, req admission.Request) admi
 	}
 
 	return admission.PatchResponseFromRaw(origMarshalled, marshalled)
+}
+
+func (r *VersionWebhook) resetVersion(ctx context.Context, obj metav1.PartialObjectMetadata, req admission.Request) admission.Response {
+	if _, ok := obj.Annotations[version.KorifiCreationVersionKey]; ok {
+		return admission.Allowed("already set")
+	}
+
+	var oldObj metav1.PartialObjectMetadata
+	if err := r.decoder.DecodeRaw(req.OldObject, &oldObj); err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	if oldVersion, ok := oldObj.Annotations[version.KorifiCreationVersionKey]; ok {
+		return r.setVersion(ctx, obj, oldVersion)
+	}
+
+	return admission.Allowed("no old version")
 }

--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	github.com/Azure/go-autorest/autorest/date v0.3.0 // indirect
 	github.com/Azure/go-autorest/logger v0.2.1 // indirect
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
-	github.com/Masterminds/semver/v3 v3.2.0 // indirect
+	github.com/Masterminds/semver/v3 v3.2.0
 	github.com/PaesslerAG/gval v1.0.0 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.18.0 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.13.24 // indirect

--- a/helm/korifi/controllers/cf_roles/cf_admin.yaml
+++ b/helm/korifi/controllers/cf_roles/cf_admin.yaml
@@ -161,6 +161,13 @@ rules:
   - watch
 
 - apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - appworkloads
+  verbs:
+  - list
+
+- apiGroups:
     - korifi.cloudfoundry.org
   resources:
     - builderinfos

--- a/helm/korifi/controllers/cf_roles/cf_space_developer.yaml
+++ b/helm/korifi/controllers/cf_roles/cf_space_developer.yaml
@@ -49,6 +49,13 @@ rules:
 - apiGroups:
   - korifi.cloudfoundry.org
   resources:
+  - appworkloads
+  verbs:
+  - list
+
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
   - cfprocesses
   verbs:
   - create

--- a/helm/korifi/controllers/manifests.yaml
+++ b/helm/korifi/controllers/manifests.yaml
@@ -128,6 +128,7 @@ webhooks:
           - v1alpha1
         operations:
           - CREATE
+          - UPDATE
         resources:
           - cforgs
           - cfspaces

--- a/version/version.go
+++ b/version/version.go
@@ -1,7 +1,30 @@
 package version
 
+import (
+	"github.com/Masterminds/semver/v3"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
 const KorifiCreationVersionKey = "korifi.cloudfoundry.org/creation-version"
 
 // version is overwritten at compile time by passing
 // -ldflags -X code.cloudfoundry.org/korifi/version.Version=<version>
 var Version = "v9999.99.99-local.dev"
+
+type Checker struct {
+	version *semver.Version
+}
+
+func NewChecker(ver string) Checker {
+	return Checker{version: semver.MustParse(ver)}
+}
+
+func (c Checker) ObjectIsNewer(obj client.Object) (bool, error) {
+	korifiVersion := obj.GetAnnotations()[KorifiCreationVersionKey]
+	semVersion, err := semver.NewVersion(korifiVersion)
+	if err != nil {
+		return false, err
+	}
+
+	return semVersion.GreaterThan(c.version), nil
+}

--- a/version/version_suite_test.go
+++ b/version/version_suite_test.go
@@ -1,0 +1,13 @@
+package version_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestVersion(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Version Suite")
+}

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -1,0 +1,92 @@
+package version_test
+
+import (
+	"code.cloudfoundry.org/korifi/version"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Version comparison", func() {
+	var (
+		objectVersion string
+		checker       version.Checker
+		obj           client.Object
+		res           bool
+		err           error
+	)
+
+	BeforeEach(func() {
+		objectVersion = ""
+	})
+
+	JustBeforeEach(func() {
+		checker = version.NewChecker("v0.7.1")
+		obj = &v1.Pod{ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				version.KorifiCreationVersionKey: objectVersion,
+			},
+		}}
+		res, err = checker.ObjectIsNewer(obj)
+	})
+
+	When("object version is greater", func() {
+		BeforeEach(func() {
+			objectVersion = "v1.0.0"
+		})
+
+		It("returns true", func() {
+			Expect(res).To(BeTrue())
+		})
+	})
+
+	When("object version is less", func() {
+		BeforeEach(func() {
+			objectVersion = "v0.7.0"
+		})
+
+		It("returns false", func() {
+			Expect(res).To(BeFalse())
+		})
+	})
+
+	When("object version is the same", func() {
+		BeforeEach(func() {
+			objectVersion = "v0.7.1"
+		})
+
+		It("returns false", func() {
+			Expect(res).To(BeFalse())
+		})
+	})
+
+	When("object version is incorrect", func() {
+		BeforeEach(func() {
+			objectVersion = "foo"
+		})
+
+		It("returns an error", func() {
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	When("object version is empty", func() {
+		BeforeEach(func() {
+			objectVersion = ""
+		})
+
+		It("returns an error", func() {
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})
+
+var _ = Describe("construction", func() {
+	When("checker version is incorrect", func() {
+		It("panics on construction", func() {
+			Expect(func() { version.NewChecker("blah") }).To(Panic())
+		})
+	})
+})


### PR DESCRIPTION
- Disallow rolling upgrades for appworkloads <= v0.7.1
- Use webhook to reset the version annotation if removed

<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
#2537

## What is this change about?
Check the korifi creation version annotation on the appworkload and reject deployment creation if version <= 0.7.1.

Also extend the version annotation hook so that it restores the previous version if an update removes it.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Push an app on korifi v0.7.1.
Upgrade to latest korifi.
`cf restart --strategy=rolling` and see it fail.
`cf restart`
`cf restart --strategy=rolling` and see it pass.

## Tag your pair, your PM, and/or team
@gcapizzi

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
