### PR TITLE
Use SetControllerReference where possible

### DIFF
--- a/controllers/controllers/networking/cfroute_controller.go
+++ b/controllers/controllers/networking/cfroute_controller.go
@@ -241,7 +241,7 @@ func (r *CFRouteReconciler) createOrPatchServices(ctx context.Context, log logr.
 				korifiv1alpha1.CFRouteGUIDLabelKey: cfRoute.Name,
 			}
 
-			err := controllerutil.SetOwnerReference(cfRoute, service, r.scheme)
+			err := controllerutil.SetControllerReference(cfRoute, service, r.scheme)
 			if err != nil {
 				loopLog.Info("failed to set OwnerRef on Service", "reason", err)
 				return err
@@ -302,7 +302,7 @@ func (r *CFRouteReconciler) createOrPatchRouteProxy(ctx context.Context, log log
 			}
 		}
 
-		err := controllerutil.SetOwnerReference(cfRoute, routeHTTPProxy, r.scheme)
+		err := controllerutil.SetControllerReference(cfRoute, routeHTTPProxy, r.scheme)
 		if err != nil {
 			log.Info("failed to set OwnerRef on route HTTPProxy", "reason", err)
 			return err
@@ -361,6 +361,7 @@ func (r *CFRouteReconciler) createOrPatchFQDNProxy(ctx context.Context, log logr
 			})
 		}
 
+		// Cannot use SetControllerReference here as multiple CFRoutes can "own" the same FQDN HTTPProxy.
 		err = controllerutil.SetOwnerReference(cfRoute, fqdnHTTPProxy, r.scheme)
 		if err != nil {
 			log.Info("failed to set OwnerRef on FQDN HTTPProxy", "reason", err)

--- a/controllers/controllers/networking/cfroute_controller_test.go
+++ b/controllers/controllers/networking/cfroute_controller_test.go
@@ -7,6 +7,7 @@ import (
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	. "code.cloudfoundry.org/korifi/controllers/controllers/workloads/testutils"
+	"code.cloudfoundry.org/korifi/tools"
 	"code.cloudfoundry.org/korifi/tools/k8s"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -129,10 +130,12 @@ var _ = Describe("CFRouteReconciler Integration Tests", func() {
 			g.Expect(proxy.Spec.VirtualHost).To(BeNil())
 			g.Expect(proxy.Spec.Routes).To(BeEmpty())
 			g.Expect(proxy.ObjectMeta.OwnerReferences).To(ConsistOf(metav1.OwnerReference{
-				APIVersion: "korifi.cloudfoundry.org/v1alpha1",
-				Kind:       "CFRoute",
-				Name:       cfRoute.Name,
-				UID:        cfRoute.GetUID(),
+				APIVersion:         "korifi.cloudfoundry.org/v1alpha1",
+				Kind:               "CFRoute",
+				Name:               cfRoute.Name,
+				UID:                cfRoute.GetUID(),
+				Controller:         tools.PtrTo(true),
+				BlockOwnerDeletion: tools.PtrTo(true),
 			}))
 		}).Should(Succeed())
 	})
@@ -225,10 +228,12 @@ var _ = Describe("CFRouteReconciler Integration Tests", func() {
 					HaveKeyWithValue("korifi.cloudfoundry.org/process-type", "web"),
 				))
 				g.Expect(svc.ObjectMeta.OwnerReferences).To(ConsistOf(metav1.OwnerReference{
-					APIVersion: "korifi.cloudfoundry.org/v1alpha1",
-					Kind:       "CFRoute",
-					Name:       cfRoute.Name,
-					UID:        cfRoute.GetUID(),
+					APIVersion:         "korifi.cloudfoundry.org/v1alpha1",
+					Kind:               "CFRoute",
+					Name:               cfRoute.Name,
+					UID:                cfRoute.GetUID(),
+					Controller:         tools.PtrTo(true),
+					BlockOwnerDeletion: tools.PtrTo(true),
 				}))
 			}).Should(Succeed())
 		})
@@ -427,10 +432,12 @@ var _ = Describe("CFRouteReconciler Integration Tests", func() {
 				))
 				g.Expect(svc.ObjectMeta.OwnerReferences).To(ConsistOf([]metav1.OwnerReference{
 					{
-						APIVersion: "korifi.cloudfoundry.org/v1alpha1",
-						Kind:       "CFRoute",
-						Name:       cfRoute.Name,
-						UID:        cfRoute.GetUID(),
+						APIVersion:         "korifi.cloudfoundry.org/v1alpha1",
+						Kind:               "CFRoute",
+						Name:               cfRoute.Name,
+						UID:                cfRoute.GetUID(),
+						Controller:         tools.PtrTo(true),
+						BlockOwnerDeletion: tools.PtrTo(true),
 					},
 				}))
 			})

--- a/controllers/controllers/workloads/cfapp_controller.go
+++ b/controllers/controllers/workloads/cfapp_controller.go
@@ -430,7 +430,7 @@ func (r *CFAppReconciler) reconcileVCAPSecret(
 	_, err = controllerutil.CreateOrPatch(ctx, r.k8sClient, secret, func() error {
 		secret.StringData = envValue
 
-		return controllerutil.SetOwnerReference(cfApp, secret, r.scheme)
+		return controllerutil.SetControllerReference(cfApp, secret, r.scheme)
 	})
 	if err != nil {
 		log.Info("unable to create or patch Secret", "reason", err)

--- a/controllers/controllers/workloads/cfbuild_controller.go
+++ b/controllers/controllers/workloads/cfbuild_controller.go
@@ -126,7 +126,7 @@ func (r *CFBuildReconciler) ReconcileResource(ctx context.Context, cfBuild *kori
 		return ctrl.Result{}, err
 	}
 
-	err = controllerutil.SetOwnerReference(cfApp, cfBuild, r.scheme)
+	err = controllerutil.SetControllerReference(cfApp, cfBuild, r.scheme)
 	if err != nil {
 		log.Info("unable to set owner reference on CFBuild", "reason", err)
 		return ctrl.Result{}, err

--- a/controllers/controllers/workloads/cfbuild_controller_test.go
+++ b/controllers/controllers/workloads/cfbuild_controller_test.go
@@ -3,10 +3,9 @@ package workloads_test
 import (
 	"context"
 
-	"code.cloudfoundry.org/korifi/tools"
-
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	. "code.cloudfoundry.org/korifi/controllers/controllers/workloads/testutils"
+	"code.cloudfoundry.org/korifi/tools"
 	"code.cloudfoundry.org/korifi/tools/k8s"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -114,10 +113,12 @@ var _ = Describe("CFBuildReconciler Integration Tests", func() {
 				g.Expect(k8sClient.Get(context.Background(), lookupKey, &createdCFBuild)).To(Succeed())
 				g.Expect(createdCFBuild.GetOwnerReferences()).To(ConsistOf(
 					metav1.OwnerReference{
-						APIVersion: korifiv1alpha1.GroupVersion.Identifier(),
-						Kind:       "CFApp",
-						Name:       desiredCFApp.Name,
-						UID:        desiredCFApp.UID,
+						APIVersion:         korifiv1alpha1.GroupVersion.Identifier(),
+						Kind:               "CFApp",
+						Name:               desiredCFApp.Name,
+						UID:                desiredCFApp.UID,
+						Controller:         tools.PtrTo(true),
+						BlockOwnerDeletion: tools.PtrTo(true),
 					},
 				))
 			}).Should(Succeed())

--- a/controllers/controllers/workloads/cftask_controller.go
+++ b/controllers/controllers/workloads/cftask_controller.go
@@ -112,8 +112,9 @@ func (r *CFTaskReconciler) ReconcileResource(ctx context.Context, cfTask *korifi
 		return ctrl.Result{}, err
 	}
 
-	err = controllerutil.SetOwnerReference(cfApp, cfTask, r.scheme)
+	err = controllerutil.SetControllerReference(cfApp, cfTask, r.scheme)
 	if err != nil {
+		log.Info("unable to set owner reference on CFTask", "reason", err)
 		return ctrl.Result{}, err
 	}
 

--- a/kpack-image-builder/controllers/buildworkload_controller.go
+++ b/kpack-image-builder/controllers/buildworkload_controller.go
@@ -472,7 +472,8 @@ func (r *BuildWorkloadReconciler) ensureKpackBuilder(ctx context.Context, log lo
 		},
 	}
 	_, err = ctrl.CreateOrUpdate(ctx, r.k8sClient, builder, func() error {
-		if err = controllerutil.SetOwnerReference(buildWorkload, builder, r.scheme); err != nil {
+		if err = controllerutil.SetControllerReference(buildWorkload, builder, r.scheme); err != nil {
+			log.Info("unable to set owner reference on Builder", "reason", err)
 			return err
 		}
 
@@ -684,6 +685,7 @@ func (r *BuildWorkloadReconciler) reconcileKpackImage(
 			desiredKpackImage.Spec.Builder.Namespace = buildWorkload.Namespace
 		}
 
+		// Cannot use SetControllerReference here as multiple BuildWorkloads can "own" the same Image.
 		err := controllerutil.SetOwnerReference(buildWorkload, &desiredKpackImage, r.scheme)
 		if err != nil {
 			log.Info("failed to set OwnerRef on Kpack Image", "reason", err)

--- a/scripts/deploy-on-kind.sh
+++ b/scripts/deploy-on-kind.sh
@@ -70,6 +70,10 @@ function parse_cmdline_args() {
   fi
 }
 
+function install_yq() {
+  GOBIN="${ROOT_DIR}/bin" go install github.com/mikefarah/yq/v4@latest
+}
+
 function validate_registry_params() {
   local registry_env_vars
   registry_env_vars="\$DOCKER_SERVER \$DOCKER_USERNAME \$DOCKER_PASSWORD \$REPOSITORY_PREFIX \$KPACK_BUILDER_REPOSITORY"
@@ -145,7 +149,7 @@ function deploy_korifi() {
 
       VERSION=$(git describe --tags | awk -F'[.-]' '{$3++; print $1 "." $2 "." $3 "-" $4 "-" $5}')
 
-      yq "with(.sources[]; .docker.buildx.rawOptions += [\"--build-arg\", \"version=$VERSION\"])" $kbld_file |
+      "${ROOT_DIR}/bin/yq" "with(.sources[]; .docker.buildx.rawOptions += [\"--build-arg\", \"version=$VERSION\"])" $kbld_file |
         kbld \
           --images-annotation=false \
           -f "scripts/assets/values-template.yaml" \
@@ -197,6 +201,7 @@ function create_registry_secret() {
 
 function main() {
   parse_cmdline_args "$@"
+  install_yq
   validate_registry_params
   ensure_kind_cluster "$CLUSTER_NAME"
   ensure_local_registry

--- a/statefulset-runner/controllers/appworkload_to_stset.go
+++ b/statefulset-runner/controllers/appworkload_to_stset.go
@@ -162,7 +162,7 @@ func (r *AppWorkloadToStatefulsetConverter) Convert(appWorkload *korifiv1alpha1.
 		},
 	}
 
-	err = controllerutil.SetOwnerReference(appWorkload, statefulSet, r.scheme)
+	err = controllerutil.SetControllerReference(appWorkload, statefulSet, r.scheme)
 	if err != nil {
 		return nil, fmt.Errorf("failed to set OwnerRef on StatefulSet :%w", err)
 	}

--- a/statefulset-runner/controllers/pdb.go
+++ b/statefulset-runner/controllers/pdb.go
@@ -53,8 +53,8 @@ func (c *PDBUpdater) createPDB(ctx context.Context, statefulSet *appsv1.Stateful
 		},
 	}
 
-	if err := controllerutil.SetOwnerReference(statefulSet, pdb, scheme.Scheme); err != nil {
-		return fmt.Errorf("pdb updater failed to set owner ref : %w", err)
+	if err := controllerutil.SetControllerReference(statefulSet, pdb, scheme.Scheme); err != nil {
+		return fmt.Errorf("pdb updater failed to set owner ref: %w", err)
 	}
 
 	err := c.client.Create(ctx, pdb)


### PR DESCRIPTION
## Is there a related GitHub Issue?
No.

## What is this change about?
This PR updates the controllers to use `SetControllerReference` to set the owner reference for created resources, instead of `SetOwnerReference`. This has the benefit of setting the `BlockOwnerDeletion` flag in the owner reference to true.

## Does this PR introduce a breaking change?
No.

## Acceptance Steps
Deploy and run tests.

## Tag your pair, your PM, and/or team
@clintyoshimura 