### PR TITLE
Remove EphemeralContainers feature gate from Kind config

### DIFF
--- a/scripts/assets/kind-config.yaml
+++ b/scripts/assets/kind-config.yaml
@@ -9,8 +9,6 @@ containerdConfigPatches:
     [plugins."io.containerd.grpc.v1.cri".registry.configs]
       [plugins."io.containerd.grpc.v1.cri".registry.configs."127.0.0.1:30050".tls]
         insecure_skip_verify = true
-featureGates:
-  EphemeralContainers: true
 nodes:
 - role: control-plane
   extraPortMappings:


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
- Ephemeral Containers have been promoted to GA as of Kubernetes 1.27 and this feature gate has been removed See: https://github.com/kubernetes/kubernetes/pull/111402
- Having it set prevents Kind clusters from starting successfully with versions >= 1.27

## Does this PR introduce a breaking change?
~Korifi devs using `deploy-on-kind.sh` to deploy to older Kind cluster versions may no longer have ephemeral debug containers enabled.~ Actually they likely will. It has defaulted to `true` since K8s 1.23. (Search for "EphemeralContainers" here: https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates-removed/)

This does not impact users running Korifi.

## Acceptance Steps
Run `deploy-on-kind.sh` and have it create a Kind cluster with K8s >= 1.27.

## Tag your pair, your PM, and/or team
@davewalter 

