### PR TITLE
Revert "Temporarily pin golangci-lint to v1.52.2"

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -18,8 +18,6 @@ jobs:
         go-version: 'stable'
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
-      with:
-        version: v1.52.2
 
   controllers-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Unpin golangci-lint from github actions. The issue that caused pinning it is now fixed
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
The `lint` action passes
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

