### PR TITLE
Fix flake: when status.lastStopAppRev is not empty [It] doesn't set it

### DIFF
--- a/controllers/controllers/workloads/cfbuild_controller_test.go
+++ b/controllers/controllers/workloads/cfbuild_controller_test.go
@@ -81,7 +81,6 @@ var _ = Describe("CFBuildReconciler Integration Tests", func() {
 		var cleanCallCount int
 
 		BeforeEach(func() {
-			ctx := context.Background()
 			cleanCallCount = buildCleaner.CleanCallCount()
 			desiredCFPackage = BuildCFPackageCRObject(cfPackageGUID, cfSpace.Status.GUID, cfAppGUID, "ref")
 			Expect(k8sClient.Create(ctx, desiredCFPackage)).To(Succeed())
@@ -238,8 +237,6 @@ var _ = Describe("CFBuildReconciler Integration Tests", func() {
 			)
 
 			BeforeEach(func() {
-				ctx := context.Background()
-
 				secret1Data := map[string]string{
 					"foo": "bar",
 				}
@@ -422,7 +419,6 @@ var _ = Describe("CFBuildReconciler Integration Tests", func() {
 			)
 
 			BeforeEach(func() {
-				ctx := context.Background()
 				newCFBuildGUID = PrefixedGUID("new-cf-build")
 				existingBuildWorkload = &korifiv1alpha1.BuildWorkload{
 					ObjectMeta: metav1.ObjectMeta{
@@ -523,8 +519,6 @@ var _ = Describe("CFBuildReconciler Integration Tests", func() {
 			)
 
 			BeforeEach(func() {
-				ctx := context.Background()
-
 				returnedPorts = []int32{42}
 				returnedProcessTypes = []korifiv1alpha1.ProcessType{
 					{


### PR DESCRIPTION
## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Create the cfapp in `JustBeforeEach` so that nested `BeforeEach`es can
configure the app before it has been created. Thus we avoid the
CFApp controller noticing the app and populate `lastStopAppRev` with
`CFAppRevisionKey`
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
N/A
