### PR TITLE
Add the get default domain for org endpoint

### DIFF
--- a/api/handlers/domain.go
+++ b/api/handlers/domain.go
@@ -25,6 +25,7 @@ const (
 
 type CFDomainRepository interface {
 	GetDomain(context.Context, authorization.Info, string) (repositories.DomainRecord, error)
+	GetDomainByName(ctx context.Context, authInfo authorization.Info, domainName string) (repositories.DomainRecord, error)
 	CreateDomain(context.Context, authorization.Info, repositories.CreateDomainMessage) (repositories.DomainRecord, error)
 	UpdateDomain(context.Context, authorization.Info, repositories.UpdateDomainMessage) (repositories.DomainRecord, error)
 	ListDomains(context.Context, authorization.Info, repositories.ListDomainsMessage) ([]repositories.DomainRecord, error)

--- a/api/handlers/fake/cfdomain_repository.go
+++ b/api/handlers/fake/cfdomain_repository.go
@@ -54,6 +54,21 @@ type CFDomainRepository struct {
 		result1 repositories.DomainRecord
 		result2 error
 	}
+	GetDomainByNameStub        func(context.Context, authorization.Info, string) (repositories.DomainRecord, error)
+	getDomainByNameMutex       sync.RWMutex
+	getDomainByNameArgsForCall []struct {
+		arg1 context.Context
+		arg2 authorization.Info
+		arg3 string
+	}
+	getDomainByNameReturns struct {
+		result1 repositories.DomainRecord
+		result2 error
+	}
+	getDomainByNameReturnsOnCall map[int]struct {
+		result1 repositories.DomainRecord
+		result2 error
+	}
 	ListDomainsStub        func(context.Context, authorization.Info, repositories.ListDomainsMessage) ([]repositories.DomainRecord, error)
 	listDomainsMutex       sync.RWMutex
 	listDomainsArgsForCall []struct {
@@ -283,6 +298,72 @@ func (fake *CFDomainRepository) GetDomainReturnsOnCall(i int, result1 repositori
 	}{result1, result2}
 }
 
+func (fake *CFDomainRepository) GetDomainByName(arg1 context.Context, arg2 authorization.Info, arg3 string) (repositories.DomainRecord, error) {
+	fake.getDomainByNameMutex.Lock()
+	ret, specificReturn := fake.getDomainByNameReturnsOnCall[len(fake.getDomainByNameArgsForCall)]
+	fake.getDomainByNameArgsForCall = append(fake.getDomainByNameArgsForCall, struct {
+		arg1 context.Context
+		arg2 authorization.Info
+		arg3 string
+	}{arg1, arg2, arg3})
+	stub := fake.GetDomainByNameStub
+	fakeReturns := fake.getDomainByNameReturns
+	fake.recordInvocation("GetDomainByName", []interface{}{arg1, arg2, arg3})
+	fake.getDomainByNameMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *CFDomainRepository) GetDomainByNameCallCount() int {
+	fake.getDomainByNameMutex.RLock()
+	defer fake.getDomainByNameMutex.RUnlock()
+	return len(fake.getDomainByNameArgsForCall)
+}
+
+func (fake *CFDomainRepository) GetDomainByNameCalls(stub func(context.Context, authorization.Info, string) (repositories.DomainRecord, error)) {
+	fake.getDomainByNameMutex.Lock()
+	defer fake.getDomainByNameMutex.Unlock()
+	fake.GetDomainByNameStub = stub
+}
+
+func (fake *CFDomainRepository) GetDomainByNameArgsForCall(i int) (context.Context, authorization.Info, string) {
+	fake.getDomainByNameMutex.RLock()
+	defer fake.getDomainByNameMutex.RUnlock()
+	argsForCall := fake.getDomainByNameArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *CFDomainRepository) GetDomainByNameReturns(result1 repositories.DomainRecord, result2 error) {
+	fake.getDomainByNameMutex.Lock()
+	defer fake.getDomainByNameMutex.Unlock()
+	fake.GetDomainByNameStub = nil
+	fake.getDomainByNameReturns = struct {
+		result1 repositories.DomainRecord
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *CFDomainRepository) GetDomainByNameReturnsOnCall(i int, result1 repositories.DomainRecord, result2 error) {
+	fake.getDomainByNameMutex.Lock()
+	defer fake.getDomainByNameMutex.Unlock()
+	fake.GetDomainByNameStub = nil
+	if fake.getDomainByNameReturnsOnCall == nil {
+		fake.getDomainByNameReturnsOnCall = make(map[int]struct {
+			result1 repositories.DomainRecord
+			result2 error
+		})
+	}
+	fake.getDomainByNameReturnsOnCall[i] = struct {
+		result1 repositories.DomainRecord
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *CFDomainRepository) ListDomains(arg1 context.Context, arg2 authorization.Info, arg3 repositories.ListDomainsMessage) ([]repositories.DomainRecord, error) {
 	fake.listDomainsMutex.Lock()
 	ret, specificReturn := fake.listDomainsReturnsOnCall[len(fake.listDomainsArgsForCall)]
@@ -424,6 +505,8 @@ func (fake *CFDomainRepository) Invocations() map[string][][]interface{} {
 	defer fake.deleteDomainMutex.RUnlock()
 	fake.getDomainMutex.RLock()
 	defer fake.getDomainMutex.RUnlock()
+	fake.getDomainByNameMutex.RLock()
+	defer fake.getDomainByNameMutex.RUnlock()
 	fake.listDomainsMutex.RLock()
 	defer fake.listDomainsMutex.RUnlock()
 	fake.updateDomainMutex.RLock()

--- a/api/main.go
+++ b/api/main.go
@@ -330,6 +330,7 @@ func main() {
 			domainRepo,
 			decoderValidator,
 			cfg.GetUserCertificateDuration(),
+			cfg.DefaultDomainName,
 		),
 		handlers.NewSpace(
 			*serverURL,

--- a/api/repositories/domain_repository_test.go
+++ b/api/repositories/domain_repository_test.go
@@ -329,6 +329,18 @@ var _ = Describe("DomainRepository", func() {
 			Expect(foundDomain.Name).To(Equal(domainName))
 		})
 
+		When("the user has no permission to list domains in the root namespace", func() {
+			BeforeEach(func() {
+				userName = generateGUID()
+				cert, key := testhelpers.ObtainClientCert(testEnv, userName)
+				authInfo.CertData = testhelpers.JoinCertAndKey(cert, key)
+			})
+
+			It("returns a not found error", func() {
+				Expect(getErr).To(BeAssignableToTypeOf(apierrors.NotFoundError{}))
+			})
+		})
+
 		When("No matches exist for the provided name", func() {
 			BeforeEach(func() {
 				searchName = "fubar"

--- a/tests/e2e/orgs_test.go
+++ b/tests/e2e/orgs_test.go
@@ -333,4 +333,35 @@ var _ = Describe("Orgs", func() {
 			})
 		})
 	})
+
+	Describe("get default domain", func() {
+		var (
+			result  bareResource
+			orgGUID string
+		)
+
+		BeforeEach(func() {
+			orgGUID = createOrg(generateGUID("org"))
+			createOrgRole("organization_user", certUserName, orgGUID)
+		})
+
+		AfterEach(func() {
+			deleteOrg(orgGUID)
+		})
+
+		JustBeforeEach(func() {
+			var err error
+			resp, err = restyClient.R().
+				SetResult(&result).
+				Get("/v3/organizations/" + orgGUID + "/domains/default")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("succeeds", func() {
+			Expect(resp).To(HaveRestyStatusCode(http.StatusOK))
+			domainName := mustHaveEnv("APP_FQDN")
+			Expect(result.Name).To(Equal(domainName))
+			Expect(result.GUID).NotTo(BeEmpty())
+		})
+	})
 })


### PR DESCRIPTION
## Is there a related GitHub Issue?
#2407

## What is this change about?
Implement GET /v3/organizations/ORG_GUID/domains/default endpoint

This returns the domain info associated with the DefaultDomainName from the API config

## Does this PR introduce a breaking change?
No

## Acceptance Steps
See story

## Tag your pair, your PM, and/or team
@gcapizzi

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
