### PR TITLE
Set finalizers on Korifi resources in a webhook

### DIFF
--- a/controllers/api/v1alpha1/buildworkload_types.go
+++ b/controllers/api/v1alpha1/buildworkload_types.go
@@ -21,6 +21,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	BuildWorkloadFinalizerName = "kpack-image-builder.korifi.cloudfoundry.org/buildworkload"
+)
+
 // BuildWorkloadSpec defines the desired state of BuildWorkload
 type BuildWorkloadSpec struct {
 	// A reference to the CFBuild that requested the build. The CFBuild must be in the same namespace

--- a/controllers/api/v1alpha1/cfapp_webhook.go
+++ b/controllers/api/v1alpha1/cfapp_webhook.go
@@ -22,6 +22,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
+const (
+	CFAppFinalizerName = "cfApp.korifi.cloudfoundry.org"
+)
+
 // log is for logging in this package.
 var cfapplog = logf.Log.WithName("cfapp-resource")
 

--- a/controllers/api/v1alpha1/cfdomain_types.go
+++ b/controllers/api/v1alpha1/cfdomain_types.go
@@ -20,6 +20,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	CFDomainFinalizerName = "cfDomain.korifi.cloudfoundry.org"
+)
+
 // CFDomainSpec defines the desired state of CFDomain
 type CFDomainSpec struct {
 	// The domain name. It is required and must conform to RFC 1035

--- a/controllers/api/v1alpha1/cforg_types.go
+++ b/controllers/api/v1alpha1/cforg_types.go
@@ -21,6 +21,8 @@ import (
 )
 
 const (
+	CFOrgFinalizerName = "cfOrg.korifi.cloudfoundry.org"
+
 	OrgNameKey             = "cloudfoundry.org/org-name"
 	OrgGUIDKey             = "cloudfoundry.org/org-guid"
 	OrgSpaceDeprecatedName = "XXX-deprecated-XXX"

--- a/controllers/api/v1alpha1/cforg_types_test.go
+++ b/controllers/api/v1alpha1/cforg_types_test.go
@@ -22,7 +22,7 @@ var _ = Describe("CF Org", func() {
 					Name:      uuid.NewString(),
 				},
 				Spec: korifiv1alpha1.CFOrgSpec{
-					DisplayName: "org-name",
+					DisplayName: "org-name-" + uuid.NewString(),
 				},
 			}
 		})
@@ -33,6 +33,24 @@ var _ = Describe("CF Org", func() {
 
 		It("accepts a valid name", func() {
 			Expect(createErr).NotTo(HaveOccurred())
+		})
+
+		When("an org with the same display name already exists", func() {
+			BeforeEach(func() {
+				Expect(k8sClient.Create(ctx, &korifiv1alpha1.CFOrg{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: namespace,
+						Name:      uuid.NewString(),
+					},
+					Spec: korifiv1alpha1.CFOrgSpec{
+						DisplayName: cfOrg.Spec.DisplayName,
+					},
+				})).To(Succeed())
+			})
+
+			It("fails", func() {
+				Expect(createErr).To(HaveOccurred())
+			})
 		})
 
 		When("name contains a space", func() {

--- a/controllers/api/v1alpha1/cfpackage_types.go
+++ b/controllers/api/v1alpha1/cfpackage_types.go
@@ -21,6 +21,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	CFPackageFinalizerName = "korifi.cloudfoundry.org/cfPackageController"
+)
+
 // CFPackageSpec defines the desired state of CFPackage
 type CFPackageSpec struct {
 	// The package type. Only "bits" is currently allowed.

--- a/controllers/api/v1alpha1/cfpackage_webhook.go
+++ b/controllers/api/v1alpha1/cfpackage_webhook.go
@@ -38,10 +38,10 @@ var _ webhook.Defaulter = &CFPackage{}
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *CFPackage) Default() {
 	cfpackagelog.V(1).Info("mutating CFPackage webhook handler", "name", r.Name)
-	packageLabels := r.ObjectMeta.GetLabels()
+	packageLabels := r.GetLabels()
 	if packageLabels == nil {
 		packageLabels = make(map[string]string)
 	}
 	packageLabels[CFAppGUIDLabelKey] = r.Spec.AppRef.Name
-	r.ObjectMeta.SetLabels(packageLabels)
+	r.SetLabels(packageLabels)
 }

--- a/controllers/api/v1alpha1/cfroute_types.go
+++ b/controllers/api/v1alpha1/cfroute_types.go
@@ -22,6 +22,8 @@ import (
 )
 
 const (
+	CFRouteFinalizerName = "cfRoute.korifi.cloudfoundry.org"
+
 	ValidStatus   CurrentStatus = "valid"
 	InvalidStatus CurrentStatus = "invalid"
 )

--- a/controllers/api/v1alpha1/cfroute_webhook_test.go
+++ b/controllers/api/v1alpha1/cfroute_webhook_test.go
@@ -4,6 +4,7 @@ import (
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	. "code.cloudfoundry.org/korifi/controllers/controllers/workloads/testutils"
 
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
@@ -29,7 +30,7 @@ var _ = Describe("CFRouteMutatingWebhook Integration Tests", func() {
 					Namespace: namespace,
 				},
 				Spec: korifiv1alpha1.CFDomainSpec{
-					Name: "example.com",
+					Name: "a" + uuid.NewString() + ".com",
 				},
 			}
 			Expect(k8sClient.Create(ctx, cfDomain)).To(Succeed())

--- a/controllers/api/v1alpha1/cfspace_types.go
+++ b/controllers/api/v1alpha1/cfspace_types.go
@@ -21,6 +21,8 @@ import (
 )
 
 const (
+	CFSpaceFinalizerName = "cfSpace.korifi.cloudfoundry.org"
+
 	SpaceNameKey = "cloudfoundry.org/space-name"
 	SpaceGUIDKey = "cloudfoundry.org/space-guid"
 )

--- a/controllers/api/v1alpha1/webhook_suite_test.go
+++ b/controllers/api/v1alpha1/webhook_suite_test.go
@@ -30,6 +30,7 @@ import (
 	"code.cloudfoundry.org/korifi/controllers/controllers/workloads/testutils"
 	"code.cloudfoundry.org/korifi/controllers/coordination"
 	"code.cloudfoundry.org/korifi/controllers/webhooks"
+	"code.cloudfoundry.org/korifi/controllers/webhooks/finalizer"
 	"code.cloudfoundry.org/korifi/controllers/webhooks/networking"
 	"code.cloudfoundry.org/korifi/controllers/webhooks/version"
 	"code.cloudfoundry.org/korifi/controllers/webhooks/workloads"
@@ -142,6 +143,7 @@ var _ = BeforeSuite(func() {
 	spacePlacementValidator := webhooks.NewPlacementValidator(mgr.GetClient(), namespace)
 	Expect(workloads.NewCFSpaceValidator(spaceNameDuplicateValidator, spacePlacementValidator).SetupWebhookWithManager(mgr)).To(Succeed())
 	version.NewVersionWebhook("some-version").SetupWebhookWithManager(mgr)
+	finalizer.NewControllersFinalizerWebhook().SetupWebhookWithManager(mgr)
 
 	//+kubebuilder:scaffold:webhook
 

--- a/controllers/controllers/networking/cfdomain_controller.go
+++ b/controllers/controllers/networking/cfdomain_controller.go
@@ -34,10 +34,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-const (
-	CFDomainFinalizerName = "cfDomain.korifi.cloudfoundry.org"
-)
-
 type CFDomainReconciler struct {
 	client client.Client
 	scheme *runtime.Scheme
@@ -72,11 +68,6 @@ func (r *CFDomainReconciler) ReconcileResource(ctx context.Context, cfDomain *ko
 	cfDomain.Status.ObservedGeneration = cfDomain.Generation
 	log.V(1).Info("set observed generation", "generation", cfDomain.Status.ObservedGeneration)
 
-	if controllerutil.AddFinalizer(cfDomain, CFDomainFinalizerName) {
-		log.V(1).Info("added finalizer")
-		return ctrl.Result{Requeue: true}, nil
-	}
-
 	meta.SetStatusCondition(&cfDomain.Status.Conditions, metav1.Condition{
 		Type:               "Valid",
 		Status:             metav1.ConditionTrue,
@@ -91,7 +82,7 @@ func (r *CFDomainReconciler) ReconcileResource(ctx context.Context, cfDomain *ko
 func (r *CFDomainReconciler) finalizeCFDomain(ctx context.Context, log logr.Logger, cfDomain *korifiv1alpha1.CFDomain) (ctrl.Result, error) {
 	log = log.WithName("finalizeCFDomain")
 
-	if !controllerutil.ContainsFinalizer(cfDomain, CFDomainFinalizerName) {
+	if !controllerutil.ContainsFinalizer(cfDomain, korifiv1alpha1.CFDomainFinalizerName) {
 		return ctrl.Result{}, nil
 	}
 
@@ -102,7 +93,7 @@ func (r *CFDomainReconciler) finalizeCFDomain(ctx context.Context, log logr.Logg
 	}
 
 	if len(domainRoutes) == 0 {
-		if controllerutil.RemoveFinalizer(cfDomain, CFDomainFinalizerName) {
+		if controllerutil.RemoveFinalizer(cfDomain, korifiv1alpha1.CFDomainFinalizerName) {
 			log.V(1).Info("finalizer removed")
 		}
 

--- a/controllers/controllers/networking/cfroute_controller_test.go
+++ b/controllers/controllers/networking/cfroute_controller_test.go
@@ -61,9 +61,6 @@ var _ = Describe("CFRouteReconciler Integration Tests", func() {
 			},
 		}
 		Expect(k8sClient.Create(ctx, cfDomain)).To(Succeed())
-		Eventually(func(g Gomega) {
-			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cfDomain), cfDomain)).To(Succeed())
-		}).Should(Succeed())
 
 		cfApp := &korifiv1alpha1.CFApp{
 			ObjectMeta: metav1.ObjectMeta{
@@ -79,9 +76,6 @@ var _ = Describe("CFRouteReconciler Integration Tests", func() {
 			},
 		}
 		Expect(k8sClient.Create(ctx, cfApp)).To(Succeed())
-		Eventually(func(g Gomega) {
-			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cfApp), cfApp)).To(Succeed())
-		}).Should(Succeed())
 
 		cfRoute = &korifiv1alpha1.CFRoute{
 			ObjectMeta: metav1.ObjectMeta{

--- a/controllers/controllers/networking/suite_test.go
+++ b/controllers/controllers/networking/suite_test.go
@@ -16,6 +16,7 @@ import (
 	"code.cloudfoundry.org/korifi/controllers/webhooks/networking"
 	"code.cloudfoundry.org/korifi/controllers/webhooks/version"
 	"code.cloudfoundry.org/korifi/controllers/webhooks/workloads"
+	"code.cloudfoundry.org/korifi/tests/helpers"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -84,13 +85,7 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
-	k8sClient = k8sManager.GetClient()
-
-	Expect(k8sClient.Create(ctx, &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: rootNamespace,
-		},
-	})).To(Succeed())
+	k8sClient = helpers.NewCacheSyncingClient(k8sManager.GetClient())
 
 	err = (NewCFRouteReconciler(
 		k8sManager.GetClient(),
@@ -136,6 +131,12 @@ var _ = BeforeSuite(func() {
 		err = k8sManager.Start(ctx)
 		Expect(err).ToNot(HaveOccurred())
 	}()
+
+	Expect(k8sClient.Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: rootNamespace,
+		},
+	})).To(Succeed())
 })
 
 var _ = AfterSuite(func() {

--- a/controllers/controllers/services/suite_test.go
+++ b/controllers/controllers/services/suite_test.go
@@ -25,6 +25,7 @@ import (
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	. "code.cloudfoundry.org/korifi/controllers/controllers/services"
 	. "code.cloudfoundry.org/korifi/controllers/controllers/shared"
+	"code.cloudfoundry.org/korifi/tests/helpers"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -78,10 +79,6 @@ var _ = BeforeSuite(func() {
 
 	//+kubebuilder:scaffold:scheme
 
-	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
-	Expect(err).NotTo(HaveOccurred())
-	Expect(k8sClient).NotTo(BeNil())
-
 	webhookInstallOptions := &testEnv.WebhookInstallOptions
 	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme:             scheme.Scheme,
@@ -92,6 +89,8 @@ var _ = BeforeSuite(func() {
 		MetricsBindAddress: "0",
 	})
 	Expect(err).ToNot(HaveOccurred())
+
+	k8sClient = helpers.NewCacheSyncingClient(k8sManager.GetClient())
 
 	err = (NewCFServiceBindingReconciler(
 		k8sManager.GetClient(),

--- a/controllers/controllers/workloads/cfapp_controller.go
+++ b/controllers/controllers/workloads/cfapp_controller.go
@@ -25,10 +25,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-const (
-	cfAppFinalizerName = "cfApp.korifi.cloudfoundry.org"
-)
-
 type EnvValueBuilder interface {
 	BuildEnvValue(context.Context, *korifiv1alpha1.CFApp) (map[string]string, error)
 }
@@ -112,11 +108,6 @@ func (r *CFAppReconciler) ReconcileResource(ctx context.Context, cfApp *korifiv1
 
 	if !cfApp.GetDeletionTimestamp().IsZero() {
 		return r.finalizeCFApp(ctx, log, cfApp)
-	}
-
-	if controllerutil.AddFinalizer(cfApp, cfAppFinalizerName) {
-		log.V(1).Info("added finalizer")
-		return ctrl.Result{Requeue: true}, nil
 	}
 
 	if cfApp.Annotations[korifiv1alpha1.CFAppLastStopRevisionKey] == "" {
@@ -302,7 +293,7 @@ func (r *CFAppReconciler) fetchProcessByType(ctx context.Context, log logr.Logge
 func (r *CFAppReconciler) finalizeCFApp(ctx context.Context, log logr.Logger, cfApp *korifiv1alpha1.CFApp) (ctrl.Result, error) {
 	log = log.WithName("finalize")
 
-	if !controllerutil.ContainsFinalizer(cfApp, cfAppFinalizerName) {
+	if !controllerutil.ContainsFinalizer(cfApp, korifiv1alpha1.CFAppFinalizerName) {
 		return ctrl.Result{}, nil
 	}
 
@@ -320,7 +311,7 @@ func (r *CFAppReconciler) finalizeCFApp(ctx context.Context, log logr.Logger, cf
 		return sbFinalizationResult, nil
 	}
 
-	if controllerutil.RemoveFinalizer(cfApp, cfAppFinalizerName) {
+	if controllerutil.RemoveFinalizer(cfApp, korifiv1alpha1.CFAppFinalizerName) {
 		log.V(1).Info("finalizer removed")
 	}
 

--- a/controllers/controllers/workloads/cfapp_controller_test.go
+++ b/controllers/controllers/workloads/cfapp_controller_test.go
@@ -120,9 +120,6 @@ var _ = Describe("CFAppReconciler Integration Tests", func() {
 
 		JustBeforeEach(func() {
 			Expect(k8sClient.Create(ctx, cfApp)).To(Succeed())
-			Eventually(func(g Gomega) {
-				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cfApp), cfApp)).To(Succeed())
-			}).Should(Succeed())
 		})
 
 		It("sets the last-stop-app-rev annotation to the value of the app-rev annotation", func() {

--- a/controllers/controllers/workloads/cforg_controller_test.go
+++ b/controllers/controllers/workloads/cforg_controller_test.go
@@ -7,6 +7,7 @@ import (
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	. "code.cloudfoundry.org/korifi/controllers/controllers/workloads/testutils"
 
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
@@ -21,9 +22,6 @@ import (
 )
 
 var _ = Describe("CFOrgReconciler Integration Tests", func() {
-	const (
-		orgName = "my-org"
-	)
 	var (
 		orgGUID                                      string
 		cfOrg                                        korifiv1alpha1.CFOrg
@@ -59,7 +57,7 @@ var _ = Describe("CFOrgReconciler Integration Tests", func() {
 				Namespace: cfRootNamespace,
 			},
 			Spec: korifiv1alpha1.CFOrgSpec{
-				DisplayName: orgName,
+				DisplayName: uuid.NewString(),
 			},
 		}
 	})

--- a/controllers/controllers/workloads/cfpackage_controller.go
+++ b/controllers/controllers/workloads/cfpackage_controller.go
@@ -36,7 +36,6 @@ import (
 )
 
 const (
-	cfPackageFinalizer       string = "korifi.cloudfoundry.org/cfPackageController"
 	InitializedConditionType string = "Initialized"
 )
 
@@ -99,11 +98,6 @@ func (r *CFPackageReconciler) ReconcileResource(ctx context.Context, cfPackage *
 		return r.finalize(ctx, log, cfPackage)
 	}
 
-	if controllerutil.AddFinalizer(cfPackage, cfPackageFinalizer) {
-		log.V(1).Info("added finalizer")
-		return ctrl.Result{Requeue: true}, nil
-	}
-
 	var cfApp korifiv1alpha1.CFApp
 	err := r.k8sClient.Get(ctx, types.NamespacedName{Name: cfPackage.Spec.AppRef.Name, Namespace: cfPackage.Namespace}, &cfApp)
 	if err != nil {
@@ -150,7 +144,7 @@ func (r *CFPackageReconciler) ReconcileResource(ctx context.Context, cfPackage *
 func (r *CFPackageReconciler) finalize(ctx context.Context, log logr.Logger, cfPackage *korifiv1alpha1.CFPackage) (ctrl.Result, error) {
 	log = log.WithName("finalize")
 
-	if !controllerutil.ContainsFinalizer(cfPackage, cfPackageFinalizer) {
+	if !controllerutil.ContainsFinalizer(cfPackage, korifiv1alpha1.CFPackageFinalizerName) {
 		return ctrl.Result{}, nil
 	}
 
@@ -163,7 +157,7 @@ func (r *CFPackageReconciler) finalize(ctx context.Context, log logr.Logger, cfP
 		}
 	}
 
-	if controllerutil.RemoveFinalizer(cfPackage, cfPackageFinalizer) {
+	if controllerutil.RemoveFinalizer(cfPackage, korifiv1alpha1.CFPackageFinalizerName) {
 		log.V(1).Info("finalizer removed")
 	}
 

--- a/controllers/controllers/workloads/cfprocess_controller_test.go
+++ b/controllers/controllers/workloads/cfprocess_controller_test.go
@@ -9,6 +9,7 @@ import (
 	"code.cloudfoundry.org/korifi/tools"
 	"code.cloudfoundry.org/korifi/tools/k8s"
 
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
@@ -369,7 +370,7 @@ var _ = Describe("CFProcessReconciler Integration Tests", func() {
 					Name:      GenerateGUID(),
 				},
 				Spec: korifiv1alpha1.CFDomainSpec{
-					Name: "my.domain",
+					Name: "a" + uuid.NewString() + ".com",
 				},
 			}
 			Expect(k8sClient.Create(ctx, cfDomain)).To(Succeed())

--- a/controllers/controllers/workloads/cfspace_controller_test.go
+++ b/controllers/controllers/workloads/cfspace_controller_test.go
@@ -7,6 +7,7 @@ import (
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	. "code.cloudfoundry.org/korifi/controllers/controllers/workloads/testutils"
 	"code.cloudfoundry.org/korifi/tools/k8s"
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
@@ -21,10 +22,6 @@ import (
 )
 
 var _ = Describe("CFSpaceReconciler Integration Tests", func() {
-	const (
-		spaceName = "my-space"
-	)
-
 	var (
 		spaceGUID                                       string
 		cfSpace                                         *korifiv1alpha1.CFSpace
@@ -64,7 +61,7 @@ var _ = Describe("CFSpaceReconciler Integration Tests", func() {
 				Namespace: cfOrg.Status.GUID,
 			},
 			Spec: korifiv1alpha1.CFSpaceSpec{
-				DisplayName: spaceName,
+				DisplayName: uuid.NewString(),
 			},
 		}
 	})

--- a/controllers/controllers/workloads/suite_test.go
+++ b/controllers/controllers/workloads/suite_test.go
@@ -22,6 +22,7 @@ import (
 	"code.cloudfoundry.org/korifi/controllers/webhooks/services"
 	"code.cloudfoundry.org/korifi/controllers/webhooks/version"
 	"code.cloudfoundry.org/korifi/controllers/webhooks/workloads"
+	"code.cloudfoundry.org/korifi/tests/helpers"
 	"code.cloudfoundry.org/korifi/tools/k8s"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -108,7 +109,7 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).NotTo(HaveOccurred())
 
-	k8sClient = k8sManager.GetClient()
+	k8sClient = helpers.NewCacheSyncingClient(k8sManager.GetClient())
 
 	cfRootNamespace = testutils.PrefixedGUID("root-namespace")
 

--- a/controllers/controllers/workloads/testutils/shared_test_utils.go
+++ b/controllers/controllers/workloads/testutils/shared_test_utils.go
@@ -256,7 +256,3 @@ func UpdateCFBuildWithDropletStatus(cfbuild *korifiv1alpha1.CFBuild) {
 		Ports: []int32{8080},
 	}
 }
-
-func UpdateCFAppWithCurrentDropletRef(cfApp *korifiv1alpha1.CFApp, buildGUID string) {
-	cfApp.Spec.CurrentDropletRef = corev1.LocalObjectReference{Name: buildGUID}
-}

--- a/controllers/webhooks/finalizer/finalizer_webhook.go
+++ b/controllers/webhooks/finalizer/finalizer_webhook.go
@@ -1,0 +1,40 @@
+package finalizer
+
+//+kubebuilder:webhook:path=/mutate-korifi-cloudfoundry-org-v1alpha1-controllers-finalizer,mutating=true,failurePolicy=fail,sideEffects=None,groups=korifi.cloudfoundry.org,resources=cfapps;cfspaces;cfpackages;cforgs;cfroutes;cfdomains,verbs=create,versions=v1alpha1,name=mcffinalizer.korifi.cloudfoundry.org,admissionReviewVersions={v1,v1beta1}
+
+import (
+	"context"
+
+	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
+	"code.cloudfoundry.org/korifi/tools/k8s"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+type ControllersFinalizerWebhook struct {
+	delegate *k8s.FinalizerWebhook
+}
+
+func NewControllersFinalizerWebhook() *ControllersFinalizerWebhook {
+	return &ControllersFinalizerWebhook{
+		delegate: k8s.NewFinalizerWebhook(map[string]k8s.FinalizerDescriptor{
+			"CFApp":     {FinalizerName: korifiv1alpha1.CFAppFinalizerName, SetPolicy: k8s.Always},
+			"CFSpace":   {FinalizerName: korifiv1alpha1.CFSpaceFinalizerName, SetPolicy: k8s.Always},
+			"CFPackage": {FinalizerName: korifiv1alpha1.CFPackageFinalizerName, SetPolicy: k8s.Always},
+			"CFOrg":     {FinalizerName: korifiv1alpha1.CFOrgFinalizerName, SetPolicy: k8s.Always},
+			"CFRoute":   {FinalizerName: korifiv1alpha1.CFRouteFinalizerName, SetPolicy: k8s.Always},
+			"CFDomain":  {FinalizerName: korifiv1alpha1.CFDomainFinalizerName, SetPolicy: k8s.Always},
+		}),
+	}
+}
+
+func (r *ControllersFinalizerWebhook) SetupWebhookWithManager(mgr ctrl.Manager) {
+	mgr.GetWebhookServer().Register("/mutate-korifi-cloudfoundry-org-v1alpha1-controllers-finalizer", &admission.Webhook{
+		Handler: r,
+	})
+	r.delegate.SetupWebhookWithManager(mgr)
+}
+
+func (r *ControllersFinalizerWebhook) Handle(ctx context.Context, req admission.Request) admission.Response {
+	return r.delegate.Handle(ctx, req)
+}

--- a/controllers/webhooks/finalizer/finalizer_webhook_test.go
+++ b/controllers/webhooks/finalizer/finalizer_webhook_test.go
@@ -1,0 +1,129 @@
+package finalizer_test
+
+import (
+	"context"
+
+	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Controllers Finalizers Webhook", func() {
+	DescribeTable("Adding finalizers",
+		func(obj client.Object, expectedFinalizers ...string) {
+			if obj.GetNamespace() != rootNamespace {
+				Expect(k8sClient.Create(context.Background(), &korifiv1alpha1.CFOrg{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      obj.GetNamespace(),
+						Namespace: rootNamespace,
+					},
+					Spec: korifiv1alpha1.CFOrgSpec{
+						DisplayName: obj.GetNamespace(),
+					},
+				})).To(Succeed())
+
+				Expect(k8sClient.Create(context.Background(), &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   obj.GetNamespace(),
+						Labels: map[string]string{korifiv1alpha1.OrgNameKey: obj.GetNamespace()},
+					},
+				})).To(Succeed())
+			}
+
+			Expect(k8sClient.Create(context.Background(), obj)).To(Succeed())
+			Expect(obj.GetFinalizers()).To(ConsistOf(expectedFinalizers))
+		},
+		Entry("cfapp",
+			&korifiv1alpha1.CFApp{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test-org-" + uuid.NewString(),
+					Name:      uuid.NewString(),
+				},
+				Spec: korifiv1alpha1.CFAppSpec{
+					DisplayName:  "cfapp",
+					DesiredState: "STOPPED",
+					Lifecycle: korifiv1alpha1.Lifecycle{
+						Type: "buildpack",
+					},
+				},
+			},
+			korifiv1alpha1.CFAppFinalizerName,
+		),
+		Entry("cfspace",
+			&korifiv1alpha1.CFSpace{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test-org-" + uuid.NewString(),
+					Name:      uuid.NewString(),
+				},
+				Spec: korifiv1alpha1.CFSpaceSpec{
+					DisplayName: "asdf",
+				},
+			},
+			korifiv1alpha1.CFSpaceFinalizerName,
+		),
+		Entry("cfpackage",
+			&korifiv1alpha1.CFPackage{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test-org-" + uuid.NewString(),
+					Name:      uuid.NewString(),
+				},
+				Spec: korifiv1alpha1.CFPackageSpec{
+					Type: "bits",
+				},
+			},
+			korifiv1alpha1.CFPackageFinalizerName,
+		),
+		Entry("cforg",
+			&korifiv1alpha1.CFOrg{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: rootNamespace,
+					Name:      "test-org-" + uuid.NewString(),
+				},
+				Spec: korifiv1alpha1.CFOrgSpec{
+					DisplayName: "test-org-" + uuid.NewString(),
+				},
+			},
+			korifiv1alpha1.CFOrgFinalizerName,
+		),
+		Entry("cfroute",
+			&korifiv1alpha1.CFRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test-org-" + uuid.NewString(),
+					Name:      uuid.NewString(),
+				},
+				Spec: korifiv1alpha1.CFRouteSpec{
+					DomainRef: corev1.ObjectReference{
+						Name:      defaultDomainName,
+						Namespace: rootNamespace,
+					},
+					Host: "myhost",
+				},
+			},
+			korifiv1alpha1.CFRouteFinalizerName,
+		),
+		Entry("cfdomain",
+			&korifiv1alpha1.CFDomain{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: rootNamespace,
+					Name:      uuid.NewString(),
+				},
+				Spec: korifiv1alpha1.CFDomainSpec{
+					Name: uuid.NewString() + ".foo",
+				},
+			},
+			korifiv1alpha1.CFDomainFinalizerName,
+		),
+		Entry("builderinfo (no finalizer is added)",
+			&korifiv1alpha1.BuilderInfo{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: rootNamespace,
+					Name:      uuid.NewString(),
+				},
+			},
+		),
+	)
+})

--- a/controllers/webhooks/finalizer/suite_integration_test.go
+++ b/controllers/webhooks/finalizer/suite_integration_test.go
@@ -16,6 +16,7 @@ import (
 	"code.cloudfoundry.org/korifi/controllers/webhooks/networking"
 	"code.cloudfoundry.org/korifi/controllers/webhooks/version"
 	"code.cloudfoundry.org/korifi/controllers/webhooks/workloads"
+	"code.cloudfoundry.org/korifi/tests/helpers"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -88,7 +89,7 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).NotTo(HaveOccurred())
 
-	k8sClient = mgr.GetClient()
+	k8sClient = helpers.NewCacheSyncingClient(mgr.GetClient())
 
 	finalizer.NewControllersFinalizerWebhook().SetupWebhookWithManager(mgr)
 

--- a/controllers/webhooks/finalizer/suite_integration_test.go
+++ b/controllers/webhooks/finalizer/suite_integration_test.go
@@ -1,4 +1,4 @@
-package workloads_test
+package finalizer_test
 
 import (
 	"context"
@@ -10,13 +10,13 @@ import (
 	"time"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
-	"code.cloudfoundry.org/korifi/controllers/config"
 	"code.cloudfoundry.org/korifi/controllers/coordination"
 	"code.cloudfoundry.org/korifi/controllers/webhooks"
-
 	"code.cloudfoundry.org/korifi/controllers/webhooks/finalizer"
+	"code.cloudfoundry.org/korifi/controllers/webhooks/networking"
 	"code.cloudfoundry.org/korifi/controllers/webhooks/version"
 	"code.cloudfoundry.org/korifi/controllers/webhooks/workloads"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
@@ -33,13 +33,15 @@ import (
 )
 
 var (
-	cancel                   context.CancelFunc
-	testEnv                  *envtest.Environment
-	k8sClient                client.Client
-	internalWebhookK8sClient client.Client
+	cancel    context.CancelFunc
+	testEnv   *envtest.Environment
+	k8sClient client.Client
 )
 
-const rootNamespace = "cf"
+const (
+	rootNamespace     = "cf"
+	defaultDomainName = "default-domain"
+)
 
 func TestWorkloadsWebhooks(t *testing.T) {
 	SetDefaultEventuallyTimeout(10 * time.Second)
@@ -75,20 +77,6 @@ var _ = BeforeSuite(func() {
 	Expect(corev1.AddToScheme(scheme)).To(Succeed())
 	Expect(coordinationv1.AddToScheme(scheme)).To(Succeed())
 
-	//+kubebuilder:scaffold:scheme
-
-	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
-	Expect(err).NotTo(HaveOccurred())
-	Expect(k8sClient).NotTo(BeNil())
-
-	// Create root namespace
-	Expect(k8sClient.Create(ctx, &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: rootNamespace,
-		},
-	})).To(Succeed())
-
-	// start webhook server using Manager
 	webhookInstallOptions := &testEnv.WebhookInstallOptions
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme:             scheme,
@@ -100,14 +88,15 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).NotTo(HaveOccurred())
 
-	internalWebhookK8sClient = mgr.GetClient()
+	k8sClient = mgr.GetClient()
 
+	finalizer.NewControllersFinalizerWebhook().SetupWebhookWithManager(mgr)
+
+	version.NewVersionWebhook("some-version").SetupWebhookWithManager(mgr)
 	Expect((&korifiv1alpha1.CFApp{}).SetupWebhookWithManager(mgr)).To(Succeed())
-
-	(&workloads.AppRevWebhook{}).SetupWebhookWithManager(mgr)
-
-	appNameDuplicateValidator := webhooks.NewDuplicateValidator(coordination.NewNameRegistry(mgr.GetClient(), workloads.AppEntityType))
-	Expect(workloads.NewCFAppValidator(appNameDuplicateValidator).SetupWebhookWithManager(mgr)).To(Succeed())
+	Expect(workloads.NewCFAppValidator(
+		webhooks.NewDuplicateValidator(coordination.NewNameRegistry(mgr.GetClient(), workloads.AppEntityType)),
+	).SetupWebhookWithManager(mgr)).To(Succeed())
 
 	orgNameDuplicateValidator := webhooks.NewDuplicateValidator(coordination.NewNameRegistry(mgr.GetClient(), workloads.CFOrgEntityType))
 	orgPlacementValidator := webhooks.NewPlacementValidator(mgr.GetClient(), rootNamespace)
@@ -117,15 +106,16 @@ var _ = BeforeSuite(func() {
 	spacePlacementValidator := webhooks.NewPlacementValidator(mgr.GetClient(), rootNamespace)
 	Expect(workloads.NewCFSpaceValidator(spaceNameDuplicateValidator, spacePlacementValidator).SetupWebhookWithManager(mgr)).To(Succeed())
 
-	Expect(workloads.NewCFTaskDefaulter(config.CFProcessDefaults{
-		MemoryMB:    500,
-		DiskQuotaMB: 512,
-	}).SetupWebhookWithManager(mgr)).To(Succeed())
-	Expect(workloads.NewCFTaskValidator().SetupWebhookWithManager(mgr)).To(Succeed())
-	version.NewVersionWebhook("some-version").SetupWebhookWithManager(mgr)
-	finalizer.NewControllersFinalizerWebhook().SetupWebhookWithManager(mgr)
+	Expect(networking.NewCFDomainValidator(mgr.GetClient()).SetupWebhookWithManager(mgr)).To(Succeed())
 
-	//+kubebuilder:scaffold:webhook
+	Expect((&korifiv1alpha1.CFPackage{}).SetupWebhookWithManager(mgr)).To(Succeed())
+
+	Expect((&korifiv1alpha1.CFRoute{}).SetupWebhookWithManager(mgr)).To(Succeed())
+	Expect(networking.NewCFRouteValidator(
+		webhooks.NewDuplicateValidator(coordination.NewNameRegistry(mgr.GetClient(), networking.RouteEntityType)),
+		rootNamespace,
+		mgr.GetClient(),
+	).SetupWebhookWithManager(mgr)).To(Succeed())
 
 	go func() {
 		defer GinkgoRecover()
@@ -146,6 +136,23 @@ var _ = BeforeSuite(func() {
 		conn.Close()
 		return nil
 	}).Should(Succeed())
+
+	// Create root namespace
+	Expect(k8sClient.Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: rootNamespace,
+		},
+	})).To(Succeed())
+
+	Expect(k8sClient.Create(ctx, &korifiv1alpha1.CFDomain{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: rootNamespace,
+			Name:      defaultDomainName,
+		},
+		Spec: korifiv1alpha1.CFDomainSpec{
+			Name: "my.domain",
+		},
+	})).To(Succeed())
 })
 
 var _ = AfterSuite(func() {

--- a/controllers/webhooks/networking/cfdomain_validator.go
+++ b/controllers/webhooks/networking/cfdomain_validator.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"strings"
 
-	"code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"code.cloudfoundry.org/korifi/controllers/webhooks"
 
@@ -61,7 +60,7 @@ func NewCFDomainValidator(client client.Client) *CFDomainValidator {
 
 func (v *CFDomainValidator) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(&v1alpha1.CFDomain{}).
+		For(&korifiv1alpha1.CFDomain{}).
 		WithValidator(v).
 		Complete()
 }

--- a/controllers/webhooks/version/suite_integration_test.go
+++ b/controllers/webhooks/version/suite_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"code.cloudfoundry.org/korifi/controllers/coordination"
 	"code.cloudfoundry.org/korifi/controllers/webhooks"
 
+	"code.cloudfoundry.org/korifi/controllers/webhooks/finalizer"
 	"code.cloudfoundry.org/korifi/controllers/webhooks/networking"
 	"code.cloudfoundry.org/korifi/controllers/webhooks/services"
 	"code.cloudfoundry.org/korifi/controllers/webhooks/version"
@@ -130,6 +131,7 @@ var _ = BeforeSuite(func() {
 	Expect(services.NewCFServiceBindingValidator(
 		webhooks.NewDuplicateValidator(coordination.NewNameRegistry(mgr.GetClient(), services.ServiceBindingEntityType)),
 	).SetupWebhookWithManager(mgr)).To(Succeed())
+	finalizer.NewControllersFinalizerWebhook().SetupWebhookWithManager(mgr)
 
 	go func() {
 		defer GinkgoRecover()

--- a/controllers/webhooks/version/suite_integration_test.go
+++ b/controllers/webhooks/version/suite_integration_test.go
@@ -12,6 +12,7 @@ import (
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"code.cloudfoundry.org/korifi/controllers/coordination"
 	"code.cloudfoundry.org/korifi/controllers/webhooks"
+	"code.cloudfoundry.org/korifi/tests/helpers"
 
 	"code.cloudfoundry.org/korifi/controllers/webhooks/finalizer"
 	"code.cloudfoundry.org/korifi/controllers/webhooks/networking"
@@ -86,14 +87,7 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).NotTo(HaveOccurred())
 
-	k8sClient = mgr.GetClient()
-
-	// Create root namespace
-	Expect(k8sClient.Create(ctx, &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: rootNamespace,
-		},
-	})).To(Succeed())
+	k8sClient = helpers.NewCacheSyncingClient(mgr.GetClient())
 
 	version.NewVersionWebhook("some-version").SetupWebhookWithManager(mgr)
 
@@ -152,6 +146,13 @@ var _ = BeforeSuite(func() {
 		conn.Close()
 		return nil
 	}).Should(Succeed())
+
+	// Create root namespace
+	Expect(k8sClient.Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: rootNamespace,
+		},
+	})).To(Succeed())
 })
 
 var _ = AfterSuite(func() {

--- a/helm/korifi/controllers/manifests.yaml
+++ b/helm/korifi/controllers/manifests.yaml
@@ -118,6 +118,31 @@ webhooks:
       service:
         name: korifi-controllers-webhook-service
         namespace: '{{ .Release.Namespace }}'
+        path: /mutate-korifi-cloudfoundry-org-v1alpha1-controllers-finalizer
+    failurePolicy: Fail
+    name: mcffinalizer.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+        resources:
+          - cfapps
+          - cfspaces
+          - cfpackages
+          - cforgs
+          - cfroutes
+          - cfdomains
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-controllers-webhook-service
+        namespace: '{{ .Release.Namespace }}'
         path: /mutate-korifi-cloudfoundry-org-v1alpha1-all-version
     failurePolicy: Fail
     name: mcfversion.korifi.cloudfoundry.org

--- a/helm/korifi/kpack-image-builder/manifests.yaml
+++ b/helm/korifi/kpack-image-builder/manifests.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: korifi-kpack-image-builder-mutating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/korifi-controllers-serving-cert'
+webhooks:
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-controllers-webhook-service
+        namespace: '{{ .Release.Namespace }}'
+        path: /mutate-korifi-cloudfoundry-org-v1alpha1-kpack-image-builder-finalizer
+    failurePolicy: Fail
+    name: mcf-kib-finalizer.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+          - kpack.io
+        apiVersions:
+          - v1alpha1
+          - v1alpha2
+        operations:
+          - CREATE
+        resources:
+          - buildworkloads
+          - builds
+    sideEffects: None

--- a/kpack-image-builder/Makefile
+++ b/kpack-image-builder/Makefile
@@ -40,11 +40,23 @@ help: ## Display this help.
 ##@ Development
 
 .PHONY: manifests
+manifests: install-controller-gen install-yq
+webhooks-file = ../helm/korifi/kpack-image-builder/manifests.yaml
 manifests: install-controller-gen
 	$(CONTROLLER_GEN) \
 		paths="./..." \
 		rbac:roleName=korifi-kpack-build-manager-role \
-		output:rbac:artifacts:config=../helm/korifi/kpack-image-builder
+		webhook \
+		output:rbac:artifacts:config=../helm/korifi/kpack-image-builder \
+		output:webhook:artifacts:config=../helm/korifi/kpack-image-builder
+
+	$(YQ) -i 'with(.metadata; .annotations["cert-manager.io/inject-ca-from"]="{{ .Release.Namespace }}/korifi-controllers-serving-cert")' $(webhooks-file)
+	$(YQ) -i 'with(.metadata; .name="korifi-kpack-image-builder-" + .name)' $(webhooks-file)
+	$(YQ) -i 'with(.webhooks[]; .clientConfig.service.namespace="{{ .Release.Namespace }}")' $(webhooks-file)
+	$(YQ) -i 'with(.webhooks[]; .clientConfig.service.name="korifi-controllers-" + .clientConfig.service.name)' $(webhooks-file)
+
+
+
 
 .PHONY: generate
 generate: install-controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
@@ -61,3 +73,7 @@ install-controller-gen:
 
 install-ginkgo:
 	go install github.com/onsi/ginkgo/v2/ginkgo
+
+YQ = $(shell pwd)/bin/yq
+install-yq:
+	GOBIN=$(shell pwd)/bin go install github.com/mikefarah/yq/v4@latest

--- a/kpack-image-builder/config/webhook/manifests.yaml
+++ b/kpack-image-builder/config/webhook/manifests.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-korifi-cloudfoundry-org-v1alpha1-kpack-image-builder-finalizer
+  failurePolicy: Fail
+  name: mcffinalizer.korifi.cloudfoundry.org
+  rules:
+  - apiGroups:
+    - korifi.cloudfoundry.org
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    resources:
+    - buildworkloads
+  sideEffects: None

--- a/kpack-image-builder/controllers/buildworkload_controller.go
+++ b/kpack-image-builder/controllers/buildworkload_controller.go
@@ -58,7 +58,6 @@ const (
 	ImageGenerationKey          = "korifi.cloudfoundry.org/kpack-image-generation"
 	kpackReconcilerName         = "kpack-image-builder"
 	buildpackBuildMetadataLabel = "io.buildpacks.build.metadata"
-	buildWorkloadFinalizerName  = "kpack-image-builder.korifi.cloudfoundry.org/buildworkload"
 )
 
 //counterfeiter:generate -o fake -fake-name ImageConfigGetter . ImageConfigGetter
@@ -174,13 +173,7 @@ func (r *BuildWorkloadReconciler) ReconcileResource(ctx context.Context, buildWo
 	log.V(1).Info("set observed generation", "generation", buildWorkload.Status.ObservedGeneration)
 
 	if !buildWorkload.GetDeletionTimestamp().IsZero() {
-		err := r.finalize(ctx, log, buildWorkload)
-		return ctrl.Result{}, err
-	}
-
-	if controllerutil.AddFinalizer(buildWorkload, buildWorkloadFinalizerName) {
-		log.V(1).Info("added finalizer")
-		return ctrl.Result{Requeue: true}, nil
+		return r.finalize(ctx, log, buildWorkload)
 	}
 
 	var err error
@@ -770,36 +763,76 @@ func extractFullCommand(process process) string {
 	return cmdString
 }
 
-func (r *BuildWorkloadReconciler) finalize(ctx context.Context, log logr.Logger, buildWorkload *korifiv1alpha1.BuildWorkload) error {
-	if !controllerutil.ContainsFinalizer(buildWorkload, buildWorkloadFinalizerName) {
-		return nil
+func (r *BuildWorkloadReconciler) finalize(ctx context.Context, log logr.Logger, buildWorkload *korifiv1alpha1.BuildWorkload) (ctrl.Result, error) {
+	if !controllerutil.ContainsFinalizer(buildWorkload, korifiv1alpha1.BuildWorkloadFinalizerName) {
+		return ctrl.Result{}, nil
 	}
 
+	lastBuildWorkload, err := r.isLastBuildWorkload(ctx, buildWorkload)
+	if err != nil {
+		log.Error(err, "failed to check for last build workloads")
+		return ctrl.Result{}, err
+	}
+
+	if lastBuildWorkload {
+		err = r.deleteBuildsForBuildWorkload(ctx, buildWorkload)
+		if err != nil {
+			log.Error(err, "failed to delete builds for build workload")
+			return ctrl.Result{}, err
+		}
+
+		hasRemainingBuilds, err := r.hasRemainingBuilds(ctx, buildWorkload)
+		if err != nil {
+			log.Error(err, "failed to check for remaining builds for build workload")
+			return ctrl.Result{}, err
+		}
+
+		if hasRemainingBuilds {
+			return ctrl.Result{RequeueAfter: time.Second}, nil
+		}
+	}
+
+	if controllerutil.RemoveFinalizer(buildWorkload, korifiv1alpha1.BuildWorkloadFinalizerName) {
+		log.V(1).Info("finalizer removed")
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *BuildWorkloadReconciler) isLastBuildWorkload(ctx context.Context, buildWorkload *korifiv1alpha1.BuildWorkload) (bool, error) {
 	appBuildWorkloads := &korifiv1alpha1.BuildWorkloadList{}
 	err := r.k8sClient.List(ctx, appBuildWorkloads, client.InNamespace(buildWorkload.Namespace), client.MatchingLabels{
 		korifiv1alpha1.CFAppGUIDLabelKey: buildWorkload.Labels[korifiv1alpha1.CFAppGUIDLabelKey],
 		ImageGenerationKey:               buildWorkload.Labels[ImageGenerationKey],
 	})
 	if err != nil {
-		log.Info("failed to list build workloads", "reason", err)
-		return err
+		return false, fmt.Errorf("failed to list build workloads: %w", err)
 	}
 
-	if len(appBuildWorkloads.Items) == 1 {
-		err = r.k8sClient.DeleteAllOf(ctx, new(buildv1alpha2.Build), client.InNamespace(buildWorkload.Namespace), client.MatchingLabels{
-			buildv1alpha2.ImageLabel:           buildWorkload.Labels[korifiv1alpha1.CFAppGUIDLabelKey],
-			buildv1alpha2.ImageGenerationLabel: buildWorkload.Labels[ImageGenerationKey],
-		})
-		if err != nil {
-			log.Info("failed to delete kpack.Build", "reason", err)
-		}
-	}
+	return len(appBuildWorkloads.Items) == 1, nil
+}
 
-	if controllerutil.RemoveFinalizer(buildWorkload, buildWorkloadFinalizerName) {
-		log.V(1).Info("finalizer removed")
+func (r *BuildWorkloadReconciler) deleteBuildsForBuildWorkload(ctx context.Context, buildWorkload *korifiv1alpha1.BuildWorkload) error {
+	err := r.k8sClient.DeleteAllOf(ctx, new(buildv1alpha2.Build), client.InNamespace(buildWorkload.Namespace), client.MatchingLabels{
+		buildv1alpha2.ImageLabel:           buildWorkload.Labels[korifiv1alpha1.CFAppGUIDLabelKey],
+		buildv1alpha2.ImageGenerationLabel: buildWorkload.Labels[ImageGenerationKey],
+	})
+	if err != nil {
+		return fmt.Errorf("failed to delete builds: %w", err)
 	}
-
 	return nil
+}
+
+func (r *BuildWorkloadReconciler) hasRemainingBuilds(ctx context.Context, buildWorkload *korifiv1alpha1.BuildWorkload) (bool, error) {
+	buildList := &buildv1alpha2.BuildList{}
+	if err := r.k8sClient.List(ctx, buildList, client.InNamespace(buildWorkload.Namespace), client.MatchingLabels{
+		buildv1alpha2.ImageLabel:           buildWorkload.Labels[korifiv1alpha1.CFAppGUIDLabelKey],
+		buildv1alpha2.ImageGenerationLabel: buildWorkload.Labels[ImageGenerationKey],
+	}); err != nil {
+		return false, fmt.Errorf("failed to list build workloads: %w", err)
+	}
+
+	return len(buildList.Items) != 0, nil
 }
 
 func (r *BuildWorkloadReconciler) repositoryRef(appGUID string) string {

--- a/kpack-image-builder/controllers/buildworkload_controller_test.go
+++ b/kpack-image-builder/controllers/buildworkload_controller_test.go
@@ -33,7 +33,7 @@ var _ = Describe("BuildWorkloadReconciler", func() {
 
 	var (
 		namespaceGUID             string
-		cfBuildGUID               string
+		buildWorkloadGUID         string
 		clusterBuilder            *buildv1alpha2.ClusterBuilder
 		buildWorkload             *korifiv1alpha1.BuildWorkload
 		source                    korifiv1alpha1.PackageSource
@@ -92,7 +92,7 @@ var _ = Describe("BuildWorkloadReconciler", func() {
 			}
 		})).To(Succeed())
 
-		cfBuildGUID = PrefixedGUID("cf-build")
+		buildWorkloadGUID = PrefixedGUID("build-workload")
 		env = []corev1.EnvVar{{
 			Name: "VCAP_SERVICES",
 			ValueFrom: &corev1.EnvVarSource{
@@ -143,7 +143,7 @@ var _ = Describe("BuildWorkloadReconciler", func() {
 
 	Describe("BuildWorkload initialization phase", func() {
 		JustBeforeEach(func() {
-			buildWorkload = buildWorkloadObject(cfBuildGUID, namespaceGUID, source, env, services, reconcilerName, buildpacks)
+			buildWorkload = buildWorkloadObject(buildWorkloadGUID, namespaceGUID, source, env, services, reconcilerName, buildpacks)
 			Expect(k8sClient.Create(ctx, buildWorkload)).To(Succeed())
 		})
 
@@ -164,7 +164,7 @@ var _ = Describe("BuildWorkloadReconciler", func() {
 			})
 
 			It("sets the build workload succeeded condition to unknown", func() {
-				cfBuildLookupKey := types.NamespacedName{Name: cfBuildGUID, Namespace: namespaceGUID}
+				cfBuildLookupKey := types.NamespacedName{Name: buildWorkloadGUID, Namespace: namespaceGUID}
 				updatedBuildWorkload := new(korifiv1alpha1.BuildWorkload)
 				Eventually(func(g Gomega) {
 					g.Expect(k8sClient.Get(ctx, cfBuildLookupKey, updatedBuildWorkload)).To(Succeed())
@@ -191,7 +191,7 @@ var _ = Describe("BuildWorkloadReconciler", func() {
 						Name:      "app-guid",
 						Namespace: namespaceGUID,
 						Labels: map[string]string{
-							controllers.BuildWorkloadLabelKey: cfBuildGUID,
+							controllers.BuildWorkloadLabelKey: buildWorkloadGUID,
 						},
 					},
 					Spec: buildv1alpha2.ImageSpec{
@@ -290,7 +290,7 @@ var _ = Describe("BuildWorkloadReconciler", func() {
 				})
 
 				It("fails the build", func() {
-					updatedWorkload := &korifiv1alpha1.BuildWorkload{ObjectMeta: metav1.ObjectMeta{Name: cfBuildGUID, Namespace: namespaceGUID}}
+					updatedWorkload := &korifiv1alpha1.BuildWorkload{ObjectMeta: metav1.ObjectMeta{Name: buildWorkloadGUID, Namespace: namespaceGUID}}
 					Eventually(func(g Gomega) {
 						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(updatedWorkload), updatedWorkload)).To(Succeed())
 						g.Expect(mustHaveCondition(g, updatedWorkload.Status.Conditions, "Succeeded").Status).To(Equal(metav1.ConditionFalse))
@@ -337,7 +337,7 @@ var _ = Describe("BuildWorkloadReconciler", func() {
 				JustBeforeEach(func() {
 					updatedBuildWorkload := new(korifiv1alpha1.BuildWorkload)
 					Eventually(func() error {
-						return k8sClient.Get(ctx, types.NamespacedName{Name: cfBuildGUID, Namespace: namespaceGUID}, updatedBuildWorkload)
+						return k8sClient.Get(ctx, types.NamespacedName{Name: buildWorkloadGUID, Namespace: namespaceGUID}, updatedBuildWorkload)
 					}).Should(Succeed())
 
 					Expect(k8s.Patch(ctx, k8sClient, updatedBuildWorkload, func() {
@@ -376,7 +376,7 @@ var _ = Describe("BuildWorkloadReconciler", func() {
 		)
 
 		BeforeEach(func() {
-			buildWorkload = buildWorkloadObject(cfBuildGUID, namespaceGUID, source, env, services, reconcilerName, buildpacks)
+			buildWorkload = buildWorkloadObject(buildWorkloadGUID, namespaceGUID, source, env, services, reconcilerName, buildpacks)
 			Expect(k8sClient.Create(ctx, buildWorkload)).To(Succeed())
 
 			kpackImageLookupKey := types.NamespacedName{Name: "app-guid", Namespace: namespaceGUID}
@@ -424,7 +424,7 @@ var _ = Describe("BuildWorkloadReconciler", func() {
 			)
 
 			BeforeEach(func() {
-				cfBuildGUID2 = cfBuildGUID + "-2"
+				cfBuildGUID2 = buildWorkloadGUID + "-2"
 				source2 := source
 				source2.Registry.Image += "2"
 				buildWorkload2 := buildWorkloadObject(cfBuildGUID2, namespaceGUID, source2, env, services, reconcilerName, buildpacks)
@@ -454,7 +454,7 @@ var _ = Describe("BuildWorkloadReconciler", func() {
 			})
 
 			It("updates both the build workload statuses", func() {
-				lookupKey := types.NamespacedName{Name: cfBuildGUID, Namespace: namespaceGUID}
+				lookupKey := types.NamespacedName{Name: buildWorkloadGUID, Namespace: namespaceGUID}
 				updatedWorkload := new(korifiv1alpha1.BuildWorkload)
 				Eventually(func(g Gomega) {
 					g.Expect(k8sClient.Get(ctx, lookupKey, updatedWorkload)).To(Succeed())
@@ -476,7 +476,7 @@ var _ = Describe("BuildWorkloadReconciler", func() {
 			})
 
 			It("sets the Succeeded condition to False", func() {
-				lookupKey := types.NamespacedName{Name: cfBuildGUID, Namespace: namespaceGUID}
+				lookupKey := types.NamespacedName{Name: buildWorkloadGUID, Namespace: namespaceGUID}
 				updatedWorkload := new(korifiv1alpha1.BuildWorkload)
 				Eventually(func(g Gomega) {
 					err := k8sClient.Get(ctx, lookupKey, updatedWorkload)
@@ -499,7 +499,7 @@ var _ = Describe("BuildWorkloadReconciler", func() {
 			})
 
 			It("sets the Succeeded condition to True", func() {
-				lookupKey := types.NamespacedName{Name: cfBuildGUID, Namespace: namespaceGUID}
+				lookupKey := types.NamespacedName{Name: buildWorkloadGUID, Namespace: namespaceGUID}
 				updatedWorkload := new(korifiv1alpha1.BuildWorkload)
 				Eventually(func(g Gomega) {
 					err := k8sClient.Get(ctx, lookupKey, updatedWorkload)
@@ -509,7 +509,7 @@ var _ = Describe("BuildWorkloadReconciler", func() {
 			})
 
 			It("sets status.droplet", func() {
-				lookupKey := types.NamespacedName{Name: cfBuildGUID, Namespace: namespaceGUID}
+				lookupKey := types.NamespacedName{Name: buildWorkloadGUID, Namespace: namespaceGUID}
 				updatedBuildWorkload := new(korifiv1alpha1.BuildWorkload)
 				Eventually(func(g Gomega) *korifiv1alpha1.BuildDropletStatus {
 					err := k8sClient.Get(ctx, lookupKey, updatedBuildWorkload)
@@ -605,7 +605,7 @@ var _ = Describe("BuildWorkloadReconciler", func() {
 
 	Describe("awaiting kpack builder readiness", func() {
 		BeforeEach(func() {
-			buildWorkload = buildWorkloadObject(cfBuildGUID, namespaceGUID, source, env, services, reconcilerName, buildpacks)
+			buildWorkload = buildWorkloadObject(buildWorkloadGUID, namespaceGUID, source, env, services, reconcilerName, buildpacks)
 			Expect(k8sClient.Create(ctx, buildWorkload)).To(Succeed())
 
 			Expect(k8s.Patch(ctx, k8sClient, clusterBuilder, func() {
@@ -686,7 +686,7 @@ var _ = Describe("BuildWorkloadReconciler", func() {
 		var buildWorkload2 *korifiv1alpha1.BuildWorkload
 
 		BeforeEach(func() {
-			buildWorkload = buildWorkloadObject(cfBuildGUID, namespaceGUID, source, env, services, reconcilerName, buildpacks)
+			buildWorkload = buildWorkloadObject(buildWorkloadGUID, namespaceGUID, source, env, services, reconcilerName, buildpacks)
 			Expect(k8sClient.Create(ctx, buildWorkload)).To(Succeed())
 			Eventually(func(g Gomega) {
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(buildWorkload), buildWorkload)).To(Succeed())
@@ -803,7 +803,7 @@ var _ = Describe("BuildWorkloadReconciler", func() {
 
 		BeforeEach(func() {
 			readyStatus = "True"
-			buildWorkload = buildWorkloadObject(cfBuildGUID, namespaceGUID, source, env, services, reconcilerName, buildpacks)
+			buildWorkload = buildWorkloadObject(buildWorkloadGUID, namespaceGUID, source, env, services, reconcilerName, buildpacks)
 			Expect(k8sClient.Create(ctx, buildWorkload)).To(Succeed())
 			Eventually(func(g Gomega) {
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(buildWorkload), buildWorkload)).To(Succeed())
@@ -812,7 +812,7 @@ var _ = Describe("BuildWorkloadReconciler", func() {
 
 			source2 := source
 			source2.Registry.Image += "x"
-			buildWorkload2 = buildWorkloadObject(cfBuildGUID+"x", namespaceGUID, source, env, services, reconcilerName, buildpacks)
+			buildWorkload2 = buildWorkloadObject(buildWorkloadGUID+"x", namespaceGUID, source, env, services, reconcilerName, buildpacks)
 			Expect(k8sClient.Create(ctx, buildWorkload2)).To(Succeed())
 			Eventually(func(g Gomega) {
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(buildWorkload2), buildWorkload2)).To(Succeed())
@@ -890,7 +890,7 @@ var _ = Describe("BuildWorkloadReconciler", func() {
 		var kpackBuild *buildv1alpha2.Build
 
 		BeforeEach(func() {
-			buildWorkload = buildWorkloadObject(cfBuildGUID, namespaceGUID, source, env, services, reconcilerName, buildpacks)
+			buildWorkload = buildWorkloadObject(buildWorkloadGUID, namespaceGUID, source, env, services, reconcilerName, buildpacks)
 			Expect(k8sClient.Create(ctx, buildWorkload)).To(Succeed())
 
 			kpackBuild = &buildv1alpha2.Build{
@@ -898,8 +898,11 @@ var _ = Describe("BuildWorkloadReconciler", func() {
 					Name:      "build",
 					Namespace: namespaceGUID,
 					Labels: map[string]string{
+						korifiv1alpha1.CFAppGUIDLabelKey:   "app-guid",
 						buildv1alpha2.ImageLabel:           "app-guid",
 						buildv1alpha2.ImageGenerationLabel: "1",
+						buildv1alpha2.BuildNumberLabel:     "1",
+						controllers.BuildWorkloadLabelKey:  buildWorkload.Name,
 					},
 				},
 			}
@@ -988,10 +991,10 @@ func PrefixedGUID(prefix string) string {
 	return prefix + "-" + uuid.NewString()[:8]
 }
 
-func buildWorkloadObject(cfBuildGUID string, namespace string, source korifiv1alpha1.PackageSource, env []corev1.EnvVar, services []corev1.ObjectReference, reconcilerName string, buildpacks []string) *korifiv1alpha1.BuildWorkload {
+func buildWorkloadObject(buildWorkloadGUID string, namespace string, source korifiv1alpha1.PackageSource, env []corev1.EnvVar, services []corev1.ObjectReference, reconcilerName string, buildpacks []string) *korifiv1alpha1.BuildWorkload {
 	return &korifiv1alpha1.BuildWorkload{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      cfBuildGUID,
+			Name:      buildWorkloadGUID,
 			Namespace: namespace,
 			Labels: map[string]string{
 				korifiv1alpha1.CFAppGUIDLabelKey: "app-guid",
@@ -999,7 +1002,7 @@ func buildWorkloadObject(cfBuildGUID string, namespace string, source korifiv1al
 		},
 		Spec: korifiv1alpha1.BuildWorkloadSpec{
 			BuildRef: korifiv1alpha1.RequiredLocalObjectReference{
-				Name: cfBuildGUID,
+				Name: buildWorkloadGUID,
 			},
 			Source:      source,
 			Buildpacks:  buildpacks,

--- a/kpack-image-builder/controllers/kpack_build_controller_test.go
+++ b/kpack-image-builder/controllers/kpack_build_controller_test.go
@@ -107,27 +107,4 @@ var _ = Describe("KpackBuildReconciler", func() {
 			})
 		})
 	})
-
-	Context("non-Korifi builds", func() {
-		BeforeEach(func() {
-			build = kpackv1alpha2.Build{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "bar",
-					Namespace: namespaceGUID,
-				},
-			}
-			Expect(k8sClient.Create(ctx, &build)).To(Succeed())
-		})
-
-		It("does not trigger the reconciler", func() {
-			Eventually(func(g Gomega) {
-				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(&build), &build)).To(Succeed())
-			}).Should(Succeed())
-
-			Consistently(func(g Gomega) {
-				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(&build), &build)).To(Succeed())
-				g.Expect(build.Finalizers).To(BeEmpty())
-			}).Should(Succeed())
-		})
-	})
 })

--- a/kpack-image-builder/controllers/suite_test.go
+++ b/kpack-image-builder/controllers/suite_test.go
@@ -38,6 +38,7 @@ import (
 	"code.cloudfoundry.org/korifi/controllers/config"
 	"code.cloudfoundry.org/korifi/kpack-image-builder/controllers"
 	"code.cloudfoundry.org/korifi/kpack-image-builder/controllers/fake"
+	"code.cloudfoundry.org/korifi/kpack-image-builder/controllers/webhooks/finalizer"
 	"code.cloudfoundry.org/korifi/tools/k8s"
 	//+kubebuilder:scaffold:imports
 )
@@ -84,6 +85,11 @@ var _ = BeforeSuite(func() {
 			filepath.Join("..", "..", "helm", "korifi", "controllers", "crds"),
 			filepath.Join("..", "..", "tests", "vendor", "kpack"),
 		},
+		WebhookInstallOptions: envtest.WebhookInstallOptions{
+			Paths: []string{
+				filepath.Join("..", "..", "helm", "korifi", "kpack-image-builder", "manifests.yaml"),
+			},
+		},
 		ErrorIfCRDPathMissing: true,
 	}
 
@@ -110,6 +116,8 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	k8sClient = k8sManager.GetClient()
+
+	finalizer.NewKpackImageBuilderFinalizerWebhook().SetupWebhookWithManager(k8sManager)
 
 	controllerConfig := &config.ControllerConfig{
 		CFRootNamespace:           PrefixedGUID("cf"),

--- a/kpack-image-builder/controllers/webhooks/finalizer/finalizer_webhook.go
+++ b/kpack-image-builder/controllers/webhooks/finalizer/finalizer_webhook.go
@@ -1,0 +1,43 @@
+package finalizer
+
+//+kubebuilder:webhook:path=/mutate-korifi-cloudfoundry-org-v1alpha1-kpack-image-builder-finalizer,mutating=true,failurePolicy=fail,sideEffects=None,groups=korifi.cloudfoundry.org;kpack.io,resources=buildworkloads;builds,verbs=create,versions=v1alpha1;v1alpha2,name=mcf-kib-finalizer.korifi.cloudfoundry.org,admissionReviewVersions={v1,v1beta1}
+
+import (
+	"context"
+
+	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
+	"code.cloudfoundry.org/korifi/kpack-image-builder/controllers"
+	"code.cloudfoundry.org/korifi/tools/k8s"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+type KpackImageBuilderFinalizerWebhook struct {
+	delegate *k8s.FinalizerWebhook
+}
+
+func NewKpackImageBuilderFinalizerWebhook() *KpackImageBuilderFinalizerWebhook {
+	return &KpackImageBuilderFinalizerWebhook{
+		delegate: k8s.NewFinalizerWebhook(map[string]k8s.FinalizerDescriptor{
+			"BuildWorkload": {FinalizerName: korifiv1alpha1.BuildWorkloadFinalizerName, SetPolicy: k8s.Always},
+			"Build":         {FinalizerName: controllers.KpackBuildFinalizer, SetPolicy: korifiBuildsOnly},
+		}),
+	}
+}
+
+func korifiBuildsOnly(obj client.Object) bool {
+	_, hasBuildWorkloadLabel := obj.GetLabels()[controllers.BuildWorkloadLabelKey]
+	return hasBuildWorkloadLabel
+}
+
+func (r *KpackImageBuilderFinalizerWebhook) SetupWebhookWithManager(mgr ctrl.Manager) {
+	mgr.GetWebhookServer().Register("/mutate-korifi-cloudfoundry-org-v1alpha1-kpack-image-builder-finalizer", &admission.Webhook{
+		Handler: r,
+	})
+	r.delegate.SetupWebhookWithManager(mgr)
+}
+
+func (r *KpackImageBuilderFinalizerWebhook) Handle(ctx context.Context, req admission.Request) admission.Response {
+	return r.delegate.Handle(ctx, req)
+}

--- a/kpack-image-builder/controllers/webhooks/finalizer/finalizer_webhook_test.go
+++ b/kpack-image-builder/controllers/webhooks/finalizer/finalizer_webhook_test.go
@@ -1,0 +1,53 @@
+package finalizer_test
+
+import (
+	"context"
+
+	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
+	"code.cloudfoundry.org/korifi/kpack-image-builder/controllers"
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	kpackv1alpha2 "github.com/pivotal/kpack/pkg/apis/build/v1alpha2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("KpackImageBuilder Finalizers Webhook", func() {
+	DescribeTable("Adding finalizers",
+		func(obj client.Object, expectedFinalizers []string) {
+			Expect(k8sClient.Create(context.Background(), obj)).To(Succeed())
+			Expect(obj.GetFinalizers()).To(Equal(expectedFinalizers))
+		},
+		Entry("buildworkload",
+			&korifiv1alpha1.BuildWorkload{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: rootNamespace,
+					Name:      uuid.NewString(),
+				},
+			},
+			[]string{korifiv1alpha1.BuildWorkloadFinalizerName},
+		),
+		Entry("korifi-kpackbuild",
+			&kpackv1alpha2.Build{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      uuid.NewString(),
+					Namespace: rootNamespace,
+					Labels: map[string]string{
+						controllers.BuildWorkloadLabelKey: "my-build-workload",
+					},
+				},
+			},
+			[]string{controllers.KpackBuildFinalizer},
+		),
+		Entry("non-korifi-kpackbuild",
+			&kpackv1alpha2.Build{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      uuid.NewString(),
+					Namespace: rootNamespace,
+				},
+			},
+			nil,
+		),
+	)
+})

--- a/tests/helpers/cache_syncing_client.go
+++ b/tests/helpers/cache_syncing_client.go
@@ -1,0 +1,92 @@
+package helpers
+
+import (
+	"context"
+
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type CacheSyncingClient struct {
+	client.Client
+}
+
+func NewCacheSyncingClient(client client.Client) *CacheSyncingClient {
+	return &CacheSyncingClient{
+		Client: client,
+	}
+}
+
+func (c *CacheSyncingClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	if err := c.Client.Create(ctx, obj, opts...); err != nil {
+		return err
+	}
+
+	EventuallyWithOffset(1, func(g Gomega) {
+		g.Expect(c.Client.Get(ctx, client.ObjectKeyFromObject(obj), obj)).To(Succeed())
+	}).Should(Succeed())
+	return nil
+}
+
+func (c *CacheSyncingClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, _ ...client.PatchOption) error {
+	err := c.Client.Patch(ctx, obj, patch)
+	if err != nil {
+		return err
+	}
+
+	generation := obj.GetGeneration()
+
+	EventuallyWithOffset(1, func(g Gomega) {
+		g.Expect(c.Client.Get(ctx, client.ObjectKeyFromObject(obj), obj)).To(Succeed())
+		g.Expect(obj.GetGeneration()).To(BeNumerically(">=", generation))
+	}).Should(Succeed())
+
+	return nil
+}
+
+func (c *CacheSyncingClient) Status() client.SubResourceWriter {
+	return &syncStatusWriter{
+		SubResourceWriter: c.Client.Status(),
+		client:            c,
+	}
+}
+
+type syncStatusWriter struct {
+	client.SubResourceWriter
+	client client.Client
+}
+
+func (w *syncStatusWriter) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+	err := w.SubResourceWriter.Patch(ctx, obj, patch, opts...)
+	if err != nil {
+		return err
+	}
+
+	dryRunClient := client.NewDryRunClient(w.client)
+	EventuallyWithOffset(1, func(g Gomega) {
+		g.Expect(w.client.Get(ctx, client.ObjectKeyFromObject(obj), obj)).To(Succeed())
+		currentStatus, err := getStatus(obj)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		objCopy, ok := obj.DeepCopyObject().(client.Object)
+		g.Expect(ok).To(BeTrue())
+
+		g.Expect(dryRunClient.Status().Patch(ctx, objCopy, patch, opts...)).To(Succeed())
+		patchedStatus, err := getStatus(objCopy)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		g.Expect(patchedStatus).To(Equal(currentStatus))
+	}).Should(Succeed())
+
+	return nil
+}
+
+func getStatus(obj runtime.Object) (any, error) {
+	unstructuredObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	return unstructuredObj["status"], nil
+}

--- a/tools/k8s/finalizer_webhook.go
+++ b/tools/k8s/finalizer_webhook.go
@@ -1,0 +1,75 @@
+package k8s
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+type FinalizerDescriptor struct {
+	FinalizerName string
+	SetPolicy     func(client.Object) bool
+}
+
+func Always(_ client.Object) bool {
+	return true
+}
+
+type FinalizerWebhook struct {
+	decoder                             *admission.Decoder
+	resourceTypeToFinalizerNameRegistry map[string]FinalizerDescriptor
+}
+
+func NewFinalizerWebhook(resourceTypeToFinalizerNameRegistry map[string]FinalizerDescriptor) *FinalizerWebhook {
+	return &FinalizerWebhook{resourceTypeToFinalizerNameRegistry: resourceTypeToFinalizerNameRegistry}
+}
+
+var finalizerlog = logf.Log.WithName("finalizer-webhook")
+
+func (r *FinalizerWebhook) SetupWebhookWithManager(mgr ctrl.Manager) {
+	r.decoder = admission.NewDecoder(mgr.GetScheme())
+}
+
+func (r *FinalizerWebhook) Handle(ctx context.Context, req admission.Request) admission.Response {
+	var obj metav1.PartialObjectMetadata
+
+	if err := r.decoder.Decode(req, &obj); err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	origMarshalled, err := json.Marshal(obj)
+	if err != nil {
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+
+	objKind := obj.GetObjectKind().GroupVersionKind().Kind
+	if finalizer, hasFinalizer := r.resourceTypeToFinalizerNameRegistry[objKind]; hasFinalizer {
+		if !finalizer.SetPolicy(&obj) {
+			return admission.Allowed(fmt.Sprintf("not applicable to %s %s/%s", objKind, obj.GetNamespace(), obj.GetName()))
+		}
+
+		if controllerutil.AddFinalizer(&obj, finalizer.FinalizerName) {
+			finalizerlog.Info("added finalizer on object",
+				"kind", obj.GetObjectKind().GroupVersionKind().Kind,
+				"namespace", obj.GetNamespace(),
+				"name", obj.GetName())
+		}
+	} else {
+		finalizerlog.Info("no finalizer registered for " + objKind)
+	}
+
+	marshalled, err := json.Marshal(obj)
+	if err != nil {
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+
+	return admission.PatchResponseFromRaw(origMarshalled, marshalled)
+}


### PR DESCRIPTION
## Is there a related GitHub Issue?
#2367
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
By setting the finalizer in a webhook we ensure that the finalizer is
installed as part of the object creation thus avoiding potential race
conditions. Previously, finalizers used to be installed in the
resources' controllers that could happen before the resource has been
deleted.

We have introduced 2 webhooks:
* one for the "core" Korifi resources, such as CFOrg, CFSpace, CFApp,
  etc.
* one for the kpack-image-builder related resources - BuildWorkload and
  korifi kpack builds

The reason to have them split in this manner is that the
kpack-image-builder is an optional component, if disabled, we should not
be installing our finalizers as custom BuildWorkload controllers may not
need them.

Now that we are setting finalizers in webhooks, we had to enabled
webhooks for all integration tests that tested finalization. This
results in massive webhook wiring as all the webhooks listed on the
webhooks manifest.yaml has to be wired. Not doing that causes envtest
complaining that no implementation has been registered per webhook
configuration.

Installing webhooks (both validating and mutating) means that we need to
ensure that tests are creating valid objects, which caused another chunk
of changes in tests' setup.
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
Not a functional change, everything should work as before
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@gcapizzi
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
