### PR TITLE
Allow page parameter in list endpoints

### DIFF
--- a/api/errors/errors.go
+++ b/api/errors/errors.go
@@ -220,13 +220,10 @@ type BadQueryParamValueError struct {
 }
 
 func NewBadQueryParamValueError(key string, validValues ...string) BadQueryParamValueError {
-	for i := range validValues {
-		validValues[i] = fmt.Sprintf("'%s'", validValues[i])
-	}
 	return BadQueryParamValueError{
 		apiError: apiError{
 			title:      "CF-BadQueryParameter",
-			detail:     fmt.Sprintf("The query parameter is invalid: %s can only be: %s", key, strings.Join(validValues, ", ")),
+			detail:     fmt.Sprintf("The query parameter is invalid: %s can only be: %s", key, quotedCommaSeparatedList(validValues)),
 			code:       10005,
 			httpStatus: http.StatusBadRequest,
 		},
@@ -242,11 +239,19 @@ func NewUnknownKeyError(cause error, validKeys []string) UnknownKeyError {
 		apiError: apiError{
 			cause:      cause,
 			title:      "CF-BadQueryParameter",
-			detail:     fmt.Sprintf("The query parameter is invalid: Valid parameters are: '%s'", strings.Join(validKeys, ", ")),
+			detail:     fmt.Sprintf("The query parameter is invalid: Valid parameters are: %s", quotedCommaSeparatedList(validKeys)),
 			code:       10005,
 			httpStatus: http.StatusBadRequest,
 		},
 	}
+}
+
+func quotedCommaSeparatedList(in []string) string {
+	var out []string
+	for _, i := range in {
+		out = append(out, fmt.Sprintf("'%s'", i))
+	}
+	return strings.Join(out, ", ")
 }
 
 type UniquenessError struct {

--- a/api/errors/errors_test.go
+++ b/api/errors/errors_test.go
@@ -306,6 +306,18 @@ var _ = Describe("LogAndReturn", func() {
 	})
 })
 
+var _ = Describe("invalid lists", func() {
+	It("formats the invalid keys correctly", func() {
+		err := apierrors.NewUnknownKeyError(errors.New("oops"), []string{"one", "two"})
+		Expect(err.Detail()).To(Equal("The query parameter is invalid: Valid parameters are: 'one', 'two'"))
+	})
+
+	It("formats the invalid values correctly", func() {
+		err := apierrors.NewBadQueryParamValueError("bob", "one", "two")
+		Expect(err.Detail()).To(Equal("The query parameter is invalid: bob can only be: 'one', 'two'"))
+	})
+})
+
 type testApiError struct {
 	apierrors.ApiError
 }

--- a/api/handlers/app_test.go
+++ b/api/handlers/app_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"strings"
 
 	apierrors "code.cloudfoundry.org/korifi/api/errors"
@@ -241,7 +242,7 @@ var _ = Describe("App", func() {
 			})
 
 			It("returns an error", func() {
-				expectUnprocessableEntityError("Environment_variables must be a map[string]string")
+				expectUnprocessableEntityError(regexp.QuoteMeta("Environment_variables must be a map[string]string"))
 			})
 		})
 
@@ -432,7 +433,7 @@ var _ = Describe("App", func() {
 				})
 
 				It("returns an Unknown key error", func() {
-					expectUnknownKeyError("The query parameter is invalid: Order by can only be: 'created_at', 'updated_at', 'name', 'state'")
+					expectUnknownKeyError("The query parameter is invalid: Order by can only be: .*")
 				})
 			})
 		})
@@ -468,7 +469,7 @@ var _ = Describe("App", func() {
 			})
 
 			It("returns an Unknown key error", func() {
-				expectUnknownKeyError("The query parameter is invalid: Valid parameters are: 'names, guids, space_guids, order_by'")
+				expectUnknownKeyError("The query parameter is invalid: Valid parameters are: .*")
 			})
 		})
 	})

--- a/api/handlers/buildpack_test.go
+++ b/api/handlers/buildpack_test.go
@@ -104,7 +104,7 @@ var _ = Describe("Buildpack", func() {
 				})
 
 				It("returns an Unknown key error", func() {
-					expectUnknownKeyError("The query parameter is invalid: Order by can only be: 'created_at', 'updated_at', 'position'")
+					expectUnknownKeyError("The query parameter is invalid: Order by can only be: .*")
 				})
 			})
 		})
@@ -117,7 +117,7 @@ var _ = Describe("Buildpack", func() {
 			})
 
 			It("returns an Unknown key error", func() {
-				expectUnknownKeyError("The query parameter is invalid: Valid parameters are: 'order_by'")
+				expectUnknownKeyError("The query parameter is invalid: Valid parameters are: .*")
 			})
 		})
 	})

--- a/api/handlers/handlers_suite_test.go
+++ b/api/handlers/handlers_suite_test.go
@@ -10,6 +10,7 @@ import (
 
 	"code.cloudfoundry.org/korifi/api/authorization"
 	"code.cloudfoundry.org/korifi/api/routing"
+	. "code.cloudfoundry.org/korifi/tests/matchers"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -52,13 +53,11 @@ var _ = BeforeEach(func() {
 func expectErrorResponse(status int, title, detail string, code int) {
 	ExpectWithOffset(2, rr).To(HaveHTTPStatus(status))
 	ExpectWithOffset(2, rr).To(HaveHTTPHeaderWithValue("Content-Type", "application/json"))
-	ExpectWithOffset(2, rr).To(HaveHTTPBody(MatchJSON(fmt.Sprintf(`{
-		"errors": [{
-			"title": %q,
-			"detail": %q,
-			"code": %d
-		}]
-	}`, title, detail, code))))
+	ExpectWithOffset(2, rr).To(HaveHTTPBody(SatisfyAll(
+		MatchJSONPath("$.errors[0].title", MatchRegexp(title)),
+		MatchJSONPath("$.errors[0].detail", MatchRegexp(detail)),
+		MatchJSONPath("$.errors[0].code", BeEquivalentTo(code)),
+	)))
 }
 
 func expectUnknownError() {

--- a/api/handlers/log_cache_test.go
+++ b/api/handlers/log_cache_test.go
@@ -136,7 +136,7 @@ var _ = Describe("LogCache", func() {
 			})
 
 			It("returns an Unknown key error", func() {
-				expectUnknownKeyError("The query parameter is invalid: Valid parameters are: 'start_time, end_time, envelope_types, limit, descending'")
+				expectUnknownKeyError("The query parameter is invalid: Valid parameters are: .*")
 			})
 		})
 

--- a/api/handlers/org_test.go
+++ b/api/handlers/org_test.go
@@ -491,7 +491,7 @@ var _ = Describe("Org", func() {
 			})
 
 			It("returns an Unknown key error", func() {
-				expectUnknownKeyError("The query parameter is invalid: Valid parameters are: 'names'")
+				expectUnknownKeyError("The query parameter is invalid: Valid parameters are: .*")
 			})
 		})
 	})

--- a/api/handlers/package_test.go
+++ b/api/handlers/package_test.go
@@ -235,7 +235,7 @@ var _ = Describe("Package", func() {
 				})
 
 				It("returns an Unknown key error", func() {
-					expectUnknownKeyError("The query parameter is invalid: Order by can only be: 'created_at', 'updated_at'")
+					expectUnknownKeyError("The query parameter is invalid: Order by can only be: .*")
 				})
 			})
 		})
@@ -271,7 +271,7 @@ var _ = Describe("Package", func() {
 			})
 
 			It("returns an Unknown key error", func() {
-				expectUnknownKeyError("The query parameter is invalid: Valid parameters are: 'app_guids, order_by, per_page, states'")
+				expectUnknownKeyError("The query parameter is invalid: Valid parameters are: .*")
 			})
 		})
 
@@ -880,7 +880,7 @@ var _ = Describe("Package", func() {
 			})
 
 			It("returns an Unknown key error", func() {
-				expectUnknownKeyError("The query parameter is invalid: Valid parameters are: 'states, per_page'")
+				expectUnknownKeyError("The query parameter is invalid: Valid parameters are: .*")
 			})
 		})
 	})

--- a/api/handlers/process_test.go
+++ b/api/handlers/process_test.go
@@ -355,7 +355,7 @@ var _ = Describe("Process", func() {
 			})
 
 			It("returns an Unknown key error", func() {
-				expectUnknownKeyError("The query parameter is invalid: Valid parameters are: 'app_guids'")
+				expectUnknownKeyError("The query parameter is invalid: Valid parameters are: .*")
 			})
 		})
 

--- a/api/handlers/role_test.go
+++ b/api/handlers/role_test.go
@@ -260,7 +260,7 @@ var _ = Describe("Role", func() {
 			})
 
 			It("returns an Unknown key error", func() {
-				expectUnknownKeyError("The query parameter is invalid: Order by can only be: 'created_at', 'updated_at'")
+				expectUnknownKeyError("The query parameter is invalid: Order by can only be: .*")
 			})
 		})
 

--- a/api/handlers/route_test.go
+++ b/api/handlers/route_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"regexp"
 	"strings"
 
 	apierrors "code.cloudfoundry.org/korifi/api/errors"
@@ -249,7 +250,7 @@ var _ = Describe("Route", func() {
 			})
 
 			It("returns an Unknown key error", func() {
-				expectUnknownKeyError("The query parameter is invalid: Valid parameters are: 'app_guids, space_guids, domain_guids, hosts, paths'")
+				expectUnknownKeyError("The query parameter is invalid: Valid parameters are: .*")
 			})
 		})
 	})
@@ -874,7 +875,7 @@ var _ = Describe("Route", func() {
 			})
 
 			It("returns an error and doesn't add the destinations", func() {
-				expectUnprocessableEntityError("Protocol must be one of [http1]")
+				expectUnprocessableEntityError(regexp.QuoteMeta("Protocol must be one of [http1]"))
 				Expect(routeRepo.AddDestinationsToRouteCallCount()).To(Equal(0))
 			})
 		})

--- a/api/handlers/service_binding_test.go
+++ b/api/handlers/service_binding_test.go
@@ -3,6 +3,7 @@ package handlers_test
 import (
 	"errors"
 	"net/http"
+	"regexp"
 	"strings"
 
 	apierrors "code.cloudfoundry.org/korifi/api/errors"
@@ -147,7 +148,7 @@ var _ = Describe("ServiceBinding", func() {
 			})
 
 			It("returns an error and doesn't create the ServiceBinding", func() {
-				expectUnprocessableEntityError(`Type must be one of [app]`)
+				expectUnprocessableEntityError(regexp.QuoteMeta("Type must be one of [app]"))
 				Expect(serviceBindingRepo.CreateServiceBindingCallCount()).To(Equal(0))
 			})
 		})
@@ -371,7 +372,7 @@ var _ = Describe("ServiceBinding", func() {
 			})
 
 			It("returns an Unknown key error", func() {
-				expectUnknownKeyError("The query parameter is invalid: Valid parameters are: 'app_guids, service_instance_guids, include, type'")
+				expectUnknownKeyError("The query parameter is invalid: Valid parameters are: .*")
 			})
 		})
 	})

--- a/api/handlers/service_instance.go
+++ b/api/handlers/service_instance.go
@@ -118,7 +118,7 @@ func (h *ServiceInstance) list(r *http.Request) (*routing.Response, error) {
 	}
 
 	for k := range r.Form {
-		if strings.HasPrefix(k, "fields[") || k == "per_page" {
+		if strings.HasPrefix(k, "fields[") {
 			r.Form.Del(k)
 		}
 	}

--- a/api/handlers/service_instance_test.go
+++ b/api/handlers/service_instance_test.go
@@ -288,7 +288,7 @@ var _ = Describe("ServiceInstance", func() {
 				})
 
 				It("returns an Unknown key error", func() {
-					expectUnknownKeyError("The query parameter is invalid: Order by can only be: 'created_at', 'updated_at', 'name'")
+					expectUnknownKeyError("The query parameter is invalid: Order by can only be: .*")
 				})
 			})
 		})
@@ -319,7 +319,7 @@ var _ = Describe("ServiceInstance", func() {
 			})
 
 			It("returns an Unknown key error", func() {
-				expectUnknownKeyError("The query parameter is invalid: Valid parameters are: 'names, space_guids, fields, order_by, per_page'")
+				expectUnknownKeyError("The query parameter is invalid: Valid parameters are: .*")
 			})
 		})
 	})

--- a/api/handlers/space_manifest_test.go
+++ b/api/handlers/space_manifest_test.go
@@ -3,6 +3,7 @@ package handlers_test
 import (
 	"errors"
 	"net/http"
+	"regexp"
 	"strings"
 
 	apierrors "code.cloudfoundry.org/korifi/api/errors"
@@ -124,7 +125,7 @@ var _ = Describe("SpaceManifest", func() {
 			})
 
 			It("response with an unprocessable entity error listing all the errors", func() {
-				expectUnprocessableEntityError("applications[0].memory must use a supported unit (B, K, KB, M, MB, G, GB, T, or TB), applications[0].processes[0].health-check-type must be a valid value, applications[0].routes[0].route is not a valid route")
+				expectUnprocessableEntityError(regexp.QuoteMeta("applications[0].memory must use a supported unit (B, K, KB, M, MB, G, GB, T, or TB), applications[0].processes[0].health-check-type must be a valid value, applications[0].routes[0].route is not a valid route"))
 			})
 		})
 

--- a/api/handlers/task_test.go
+++ b/api/handlers/task_test.go
@@ -296,7 +296,7 @@ var _ = Describe("Task", func() {
 				})
 
 				It("returns an unknown key error", func() {
-					expectUnknownKeyError("The query parameter is invalid: Valid parameters are: 'sequence_ids'")
+					expectUnknownKeyError("The query parameter is invalid: Valid parameters are: .*")
 				})
 			})
 

--- a/api/payloads/app.go
+++ b/api/payloads/app.go
@@ -69,7 +69,7 @@ func (a *AppList) ToMessage() repositories.ListAppsMessage {
 }
 
 func (a *AppList) SupportedKeys() []string {
-	return []string{"names", "guids", "space_guids", "order_by"}
+	return []string{"names", "guids", "space_guids", "order_by", "per_page", "page"}
 }
 
 func (a *AppList) DecodeFromURLValues(values url.Values) error {

--- a/api/payloads/buildpack.go
+++ b/api/payloads/buildpack.go
@@ -5,7 +5,7 @@ import "net/url"
 type BuildpackList struct{}
 
 func (d *BuildpackList) SupportedKeys() []string {
-	return []string{"order_by"}
+	return []string{"order_by", "per_page", "page"}
 }
 
 func (d *BuildpackList) DecodeFromURLValues(values url.Values) error {

--- a/api/payloads/domain.go
+++ b/api/payloads/domain.go
@@ -57,7 +57,7 @@ func (d *DomainList) ToMessage() repositories.ListDomainsMessage {
 }
 
 func (d *DomainList) SupportedKeys() []string {
-	return []string{"names"}
+	return []string{"names", "per_page", "page"}
 }
 
 func (d *DomainList) DecodeFromURLValues(values url.Values) error {

--- a/api/payloads/package.go
+++ b/api/payloads/package.go
@@ -55,7 +55,7 @@ func (p *PackageListQueryParameters) ToMessage() repositories.ListPackagesMessag
 }
 
 func (p *PackageListQueryParameters) SupportedKeys() []string {
-	return []string{"app_guids", "order_by", "per_page", "states"}
+	return []string{"app_guids", "order_by", "per_page", "states", "page"}
 }
 
 func (p *PackageListQueryParameters) DecodeFromURLValues(values url.Values) error {
@@ -73,7 +73,7 @@ func (p *PackageListDropletsQueryParameters) ToMessage(packageGUIDs []string) re
 }
 
 func (p *PackageListDropletsQueryParameters) SupportedKeys() []string {
-	return []string{"states", "per_page"}
+	return []string{"states", "per_page", "page"}
 }
 
 func (p *PackageListDropletsQueryParameters) DecodeFromURLValues(values url.Values) error {

--- a/api/payloads/process.go
+++ b/api/payloads/process.go
@@ -48,7 +48,7 @@ func (p *ProcessList) ToMessage() repositories.ListProcessesMessage {
 }
 
 func (p *ProcessList) SupportedKeys() []string {
-	return []string{"app_guids"}
+	return []string{"app_guids", "per_page", "page"}
 }
 
 func (p *ProcessList) DecodeFromURLValues(values url.Values) error {

--- a/api/payloads/role.go
+++ b/api/payloads/role.go
@@ -71,7 +71,7 @@ func (p RoleCreate) ToMessage() repositories.CreateRoleMessage {
 }
 
 func (r *RoleListFilter) SupportedKeys() []string {
-	return []string{"guids", "types", "space_guids", "organization_guids", "user_guids", "order_by", "include"}
+	return []string{"guids", "types", "space_guids", "organization_guids", "user_guids", "order_by", "include", "per_page", "page"}
 }
 
 func (r *RoleListFilter) DecodeFromURLValues(values url.Values) error {

--- a/api/payloads/route.go
+++ b/api/payloads/route.go
@@ -50,7 +50,7 @@ func (p *RouteList) ToMessage() repositories.ListRoutesMessage {
 }
 
 func (p *RouteList) SupportedKeys() []string {
-	return []string{"app_guids", "space_guids", "domain_guids", "hosts", "paths"}
+	return []string{"app_guids", "space_guids", "domain_guids", "hosts", "paths", "per_page", "page"}
 }
 
 func (p *RouteList) DecodeFromURLValues(values url.Values) error {

--- a/api/payloads/service_binding.go
+++ b/api/payloads/service_binding.go
@@ -40,7 +40,7 @@ func (l *ServiceBindingList) ToMessage() repositories.ListServiceBindingsMessage
 }
 
 func (l *ServiceBindingList) SupportedKeys() []string {
-	return []string{"app_guids", "service_instance_guids", "include", "type"}
+	return []string{"app_guids", "service_instance_guids", "include", "type", "per_page", "page"}
 }
 
 func (l *ServiceBindingList) DecodeFromURLValues(values url.Values) error {

--- a/api/payloads/service_instance.go
+++ b/api/payloads/service_instance.go
@@ -95,7 +95,7 @@ func (l *ServiceInstanceList) ToMessage() repositories.ListServiceInstanceMessag
 }
 
 func (l *ServiceInstanceList) SupportedKeys() []string {
-	return []string{"names", "space_guids", "fields", "order_by", "per_page"}
+	return []string{"names", "space_guids", "fields", "order_by", "per_page", "page"}
 }
 
 func (l *ServiceInstanceList) DecodeFromURLValues(values url.Values) error {

--- a/api/payloads/task.go
+++ b/api/payloads/task.go
@@ -33,7 +33,7 @@ func (t *TaskList) ToMessage() repositories.ListTaskMessage {
 }
 
 func (t *TaskList) SupportedKeys() []string {
-	return []string{"sequence_ids"}
+	return []string{"sequence_ids", "per_page", "page"}
 }
 
 func (a *TaskList) DecodeFromURLValues(values url.Values) error {


### PR DESCRIPTION
## Is there a related GitHub Issue?
#2301, #2306, #2308

## What is this change about?
- Relax expectErrorResponse to accept regexes
- Allow `per_page` and `page` query params to all list endpoints

## Does this PR introduce a breaking change?
No.

## Tag your pair, your PM, and/or team
@gcapizzi
