### PR TITLE
Validate domain payloads with jellydator

### DIFF
--- a/api/handlers/app_test.go
+++ b/api/handlers/app_test.go
@@ -762,7 +762,7 @@ var _ = Describe("App", func() {
 			})
 
 			It("returns an error", func() {
-				expectUnprocessableEntityError("GUID is a required field")
+				expectUnprocessableEntityError("data.guid cannot be blank")
 			})
 		})
 

--- a/api/handlers/domain_test.go
+++ b/api/handlers/domain_test.go
@@ -15,6 +15,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
 )
 
 var _ = Describe("Domain", func() {
@@ -75,11 +76,15 @@ var _ = Describe("Domain", func() {
 			}, nil)
 
 			var err error
-			req, err = http.NewRequestWithContext(ctx, "POST", "/v3/domains", strings.NewReader(""))
+			req, err = http.NewRequestWithContext(ctx, "POST", "/v3/domains", strings.NewReader("the-json-payload"))
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("creates a domain", func() {
+			Expect(requestJSONValidator.DecodeAndValidateJSONPayloadCallCount()).To(Equal(1))
+			request, _ := requestJSONValidator.DecodeAndValidateJSONPayloadArgsForCall(0)
+			Eventually(gbytes.BufferReader(request.Body)).Should(gbytes.Say("the-json-payload"))
+
 			Expect(domainRepo.CreateDomainCallCount()).To(Equal(1))
 			_, actualAuthInfo, createMessage := domainRepo.CreateDomainArgsForCall(0)
 			Expect(actualAuthInfo).To(Equal(authInfo))
@@ -217,11 +222,15 @@ var _ = Describe("Domain", func() {
 			}, nil)
 
 			var err error
-			req, err = http.NewRequestWithContext(ctx, "PATCH", "/v3/domains/my-domain", strings.NewReader(""))
+			req, err = http.NewRequestWithContext(ctx, "PATCH", "/v3/domains/my-domain", strings.NewReader("the-json-payload"))
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("updates the domain", func() {
+			Expect(requestJSONValidator.DecodeAndValidateJSONPayloadCallCount()).To(Equal(1))
+			request, _ := requestJSONValidator.DecodeAndValidateJSONPayloadArgsForCall(0)
+			Eventually(gbytes.BufferReader(request.Body)).Should(gbytes.Say("the-json-payload"))
+
 			Expect(domainRepo.UpdateDomainCallCount()).To(Equal(1))
 			_, _, updateMessage := domainRepo.UpdateDomainArgsForCall(0)
 			Expect(updateMessage).To(Equal(repositories.UpdateDomainMessage{

--- a/api/payloads/domain.go
+++ b/api/payloads/domain.go
@@ -5,13 +5,22 @@ import (
 	"net/url"
 
 	"code.cloudfoundry.org/korifi/api/repositories"
+	"github.com/jellydator/validation"
 )
 
 type DomainCreate struct {
-	Name          string                  `json:"name" validate:"required"`
+	Name          string                  `json:"name"`
 	Internal      bool                    `json:"internal"`
 	Metadata      Metadata                `json:"metadata"`
 	Relationships map[string]Relationship `json:"relationships"`
+}
+
+func (c *DomainCreate) Validate() error {
+	return validation.ValidateStruct(c,
+		validation.Field(&c.Name, validation.Required),
+		validation.Field(&c.Metadata),
+		validation.Field(&c.Relationships),
+	)
 }
 
 func (c *DomainCreate) ToMessage() (repositories.CreateDomainMessage, error) {
@@ -44,6 +53,12 @@ func (c *DomainUpdate) ToMessage(domainGUID string) repositories.UpdateDomainMes
 			Annotations: c.Metadata.Annotations,
 		},
 	}
+}
+
+func (c *DomainUpdate) Validate() error {
+	return validation.ValidateStruct(c,
+		validation.Field(&c.Metadata),
+	)
 }
 
 type DomainList struct {

--- a/api/payloads/domain_test.go
+++ b/api/payloads/domain_test.go
@@ -59,11 +59,11 @@ var _ = Describe("DomainCreate", func() {
 			})
 
 			It("returns an appropriate error", func() {
-				expectUnprocessableEntityError(validatorErr, "Name is a required field")
+				expectUnprocessableEntityError(validatorErr, "name cannot be blank")
 			})
 		})
 
-		When("metadata.labels contains an invalid key", func() {
+		When("metadata is invalid", func() {
 			BeforeEach(func() {
 				createPayload.Metadata = payloads.Metadata{
 					Labels: map[string]string{
@@ -73,21 +73,19 @@ var _ = Describe("DomainCreate", func() {
 			})
 
 			It("returns an appropriate error", func() {
-				expectUnprocessableEntityError(validatorErr, "cannot begin with \"cloudfoundry.org\"")
+				expectUnprocessableEntityError(validatorErr, "cannot use the cloudfoundry.org domain")
 			})
 		})
 
-		When("metadata.annotations contains an invalid key", func() {
+		When("relationship is invalid", func() {
 			BeforeEach(func() {
-				createPayload.Metadata = payloads.Metadata{
-					Annotations: map[string]string{
-						"foo.cloudfoundry.org/bar": "jim",
-					},
+				createPayload.Relationships = map[string]payloads.Relationship{
+					"foo": {Data: nil},
 				}
 			})
 
 			It("returns an appropriate error", func() {
-				expectUnprocessableEntityError(validatorErr, "cannot begin with \"cloudfoundry.org\"")
+				expectUnprocessableEntityError(validatorErr, "data cannot be blank")
 			})
 		})
 	})
@@ -195,21 +193,7 @@ var _ = Describe("DomainUpdate", func() {
 		})
 
 		It("returns an appropriate error", func() {
-			expectUnprocessableEntityError(validatorErr, "cannot begin with \"cloudfoundry.org\"")
-		})
-	})
-
-	When("metadata.annotations contains an invalid key", func() {
-		BeforeEach(func() {
-			updatePayload.Metadata = payloads.MetadataPatch{
-				Annotations: map[string]*string{
-					"foo.cloudfoundry.org/bar": tools.PtrTo("jim"),
-				},
-			}
-		})
-
-		It("returns an appropriate error", func() {
-			expectUnprocessableEntityError(validatorErr, "cannot begin with \"cloudfoundry.org\"")
+			expectUnprocessableEntityError(validatorErr, "cannot use the cloudfoundry.org domain")
 		})
 	})
 })

--- a/api/payloads/lifecycle.go
+++ b/api/payloads/lifecycle.go
@@ -1,0 +1,11 @@
+package payloads
+
+type Lifecycle struct {
+	Type string        `json:"type" validate:"required"`
+	Data LifecycleData `json:"data" validate:"required"`
+}
+
+type LifecycleData struct {
+	Buildpacks []string `json:"buildpacks" validate:"required"`
+	Stack      string   `json:"stack" validate:"required"`
+}

--- a/api/payloads/log.go
+++ b/api/payloads/log.go
@@ -2,6 +2,7 @@ package payloads
 
 import (
 	"net/url"
+	"strconv"
 )
 
 type LogRead struct {
@@ -28,4 +29,26 @@ func (l *LogRead) DecodeFromURLValues(values url.Values) error {
 		return err
 	}
 	return nil
+}
+
+func getInt(values url.Values, key string) (int64, error) {
+	if !values.Has(key) {
+		return 0, nil
+	}
+	s := values.Get(key)
+	if s == "" {
+		return 0, nil
+	}
+	return strconv.ParseInt(s, 10, 64)
+}
+
+func getBool(values url.Values, key string) (bool, error) {
+	if !values.Has(key) {
+		return false, nil
+	}
+	s := values.Get(key)
+	if s == "" {
+		return false, nil
+	}
+	return strconv.ParseBool(s)
 }

--- a/api/payloads/metadata.go
+++ b/api/payloads/metadata.go
@@ -1,0 +1,56 @@
+package payloads
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/jellydator/validation"
+)
+
+type BuildMetadata struct {
+	Annotations map[string]string `json:"annotations" validate:"buildmetadatavalidator"`
+	Labels      map[string]string `json:"labels" validate:"buildmetadatavalidator"`
+}
+
+type Metadata struct {
+	Annotations map[string]string `json:"annotations" yaml:"annotations" validate:"metadatavalidator"`
+	Labels      map[string]string `json:"labels"      yaml:"labels"      validate:"metadatavalidator"`
+}
+
+func (m Metadata) Validate() error {
+	return validation.ValidateStruct(&m,
+		validation.Field(&m.Annotations, validation.Map().Keys(validation.By(cloudfoundryKeyCheck)).AllowExtraKeys()),
+		validation.Field(&m.Labels, validation.Map().Keys(validation.By(cloudfoundryKeyCheck)).AllowExtraKeys()),
+	)
+}
+
+type MetadataPatch struct {
+	Annotations map[string]*string `json:"annotations" validate:"metadatavalidator"`
+	Labels      map[string]*string `json:"labels"      validate:"metadatavalidator"`
+}
+
+func (p MetadataPatch) Validate() error {
+	return validation.ValidateStruct(&p,
+		validation.Field(&p.Annotations, validation.Map().Keys(validation.By(cloudfoundryKeyCheck)).AllowExtraKeys()),
+		validation.Field(&p.Labels, validation.Map().Keys(validation.By(cloudfoundryKeyCheck)).AllowExtraKeys()),
+	)
+}
+
+func cloudfoundryKeyCheck(key any) error {
+	keyStr, ok := key.(string)
+	if !ok {
+		return fmt.Errorf("expected string key, got %T", key)
+	}
+
+	u, err := url.ParseRequestURI("https://" + keyStr) // without the scheme, the hostname will be parsed as a path
+	if err != nil {
+		return nil
+	}
+
+	if strings.HasSuffix(u.Hostname(), "cloudfoundry.org") {
+		return errors.New("label/annotation key cannot use the cloudfoundry.org domain")
+	}
+	return nil
+}

--- a/api/payloads/metadata_test.go
+++ b/api/payloads/metadata_test.go
@@ -1,0 +1,123 @@
+package payloads_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+
+	"code.cloudfoundry.org/korifi/api/payloads"
+	"code.cloudfoundry.org/korifi/tools"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gstruct"
+)
+
+var _ = Describe("Metadata", func() {
+	var (
+		metadataPayload        payloads.Metadata
+		decodedMetadataPayload *payloads.Metadata
+		validatorErr           error
+	)
+
+	BeforeEach(func() {
+		decodedMetadataPayload = new(payloads.Metadata)
+		metadataPayload = payloads.Metadata{
+			Labels: map[string]string{
+				"foo": "bar",
+			},
+			Annotations: map[string]string{
+				"example.org/jim": "hello",
+			},
+		}
+	})
+
+	JustBeforeEach(func() {
+		body, err := json.Marshal(metadataPayload)
+		Expect(err).NotTo(HaveOccurred())
+
+		req, err := http.NewRequest("", "", bytes.NewReader(body))
+		Expect(err).NotTo(HaveOccurred())
+
+		validatorErr = validator.DecodeAndValidateJSONPayload(req, decodedMetadataPayload)
+	})
+
+	It("succeeds", func() {
+		Expect(validatorErr).NotTo(HaveOccurred())
+		Expect(decodedMetadataPayload).To(gstruct.PointTo(Equal(metadataPayload)))
+	})
+
+	When("labels contains an invalid key", func() {
+		BeforeEach(func() {
+			metadataPayload.Labels["foo.cloudfoundry.org/bar"] = "jim"
+		})
+
+		It("returns an appropriate error", func() {
+			expectUnprocessableEntityError(validatorErr, "cannot use the cloudfoundry.org domain")
+		})
+	})
+
+	When("annotations contains an invalid key", func() {
+		BeforeEach(func() {
+			metadataPayload.Annotations["foo.cloudfoundry.org/bar"] = "jim"
+		})
+
+		It("returns an appropriate error", func() {
+			expectUnprocessableEntityError(validatorErr, "cannot use the cloudfoundry.org domain")
+		})
+	})
+})
+
+var _ = Describe("MetadataPatch", func() {
+	var (
+		metadataPatchPayload        payloads.MetadataPatch
+		decodedMetadataPatchPayload *payloads.MetadataPatch
+		validatorErr                error
+	)
+
+	BeforeEach(func() {
+		decodedMetadataPatchPayload = new(payloads.MetadataPatch)
+		metadataPatchPayload = payloads.MetadataPatch{
+			Labels: map[string]*string{
+				"foo": tools.PtrTo("bar"),
+			},
+			Annotations: map[string]*string{
+				"example.org/jim": tools.PtrTo("hello"),
+			},
+		}
+	})
+
+	JustBeforeEach(func() {
+		body, err := json.Marshal(metadataPatchPayload)
+		Expect(err).NotTo(HaveOccurred())
+
+		req, err := http.NewRequest("", "", bytes.NewReader(body))
+		Expect(err).NotTo(HaveOccurred())
+
+		validatorErr = validator.DecodeAndValidateJSONPayload(req, decodedMetadataPatchPayload)
+	})
+
+	It("succeeds", func() {
+		Expect(validatorErr).NotTo(HaveOccurred())
+		Expect(decodedMetadataPatchPayload).To(gstruct.PointTo(Equal(metadataPatchPayload)))
+	})
+
+	When("metadata.labels contains an invalid key", func() {
+		BeforeEach(func() {
+			metadataPatchPayload.Labels["foo.cloudfoundry.org/bar"] = tools.PtrTo("jim")
+		})
+
+		It("returns an appropriate error", func() {
+			expectUnprocessableEntityError(validatorErr, "cannot use the cloudfoundry.org domain")
+		})
+	})
+
+	When("metadata.annotations contains an invalid key", func() {
+		BeforeEach(func() {
+			metadataPatchPayload.Annotations["foo.cloudfoundry.org/bar"] = tools.PtrTo("jim")
+		})
+
+		It("returns an appropriate error", func() {
+			expectUnprocessableEntityError(validatorErr, "cannot use the cloudfoundry.org domain")
+		})
+	})
+})

--- a/api/payloads/payloads_suite_test.go
+++ b/api/payloads/payloads_suite_test.go
@@ -23,7 +23,7 @@ func TestPayloads(t *testing.T) {
 }
 
 func expectUnprocessableEntityError(err error, detail string) {
-	Expect(err).To(HaveOccurred())
-	Expect(err).To(BeAssignableToTypeOf(apierrors.UnprocessableEntityError{}))
-	Expect(err.(apierrors.UnprocessableEntityError).Detail()).To(ContainSubstring(detail))
+	ExpectWithOffset(1, err).To(HaveOccurred())
+	ExpectWithOffset(1, err).To(BeAssignableToTypeOf(apierrors.UnprocessableEntityError{}))
+	ExpectWithOffset(1, err.(apierrors.UnprocessableEntityError).Detail()).To(ContainSubstring(detail))
 }

--- a/api/payloads/relationship.go
+++ b/api/payloads/relationship.go
@@ -1,0 +1,21 @@
+package payloads
+
+import (
+	"github.com/jellydator/validation"
+)
+
+type Relationship struct {
+	Data *RelationshipData `json:"data" validate:"required"`
+}
+
+func (r Relationship) Validate() error {
+	return validation.ValidateStruct(&r, validation.Field(&r.Data, validation.Required))
+}
+
+type RelationshipData struct {
+	GUID string `json:"guid" validate:"required"`
+}
+
+func (r RelationshipData) Validate() error {
+	return validation.ValidateStruct(&r, validation.Field(&r.GUID, validation.Required))
+}

--- a/api/payloads/relationship_test.go
+++ b/api/payloads/relationship_test.go
@@ -1,0 +1,64 @@
+package payloads_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+
+	"code.cloudfoundry.org/korifi/api/payloads"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gstruct"
+)
+
+var _ = Describe("Relationship", func() {
+	var (
+		relationshipPayload        payloads.Relationship
+		decodedRelationshipPayload *payloads.Relationship
+		validatorErr               error
+	)
+
+	BeforeEach(func() {
+		decodedRelationshipPayload = new(payloads.Relationship)
+		relationshipPayload = payloads.Relationship{
+			Data: &payloads.RelationshipData{
+				GUID: "the-guid",
+			},
+		}
+	})
+
+	JustBeforeEach(func() {
+		body, err := json.Marshal(relationshipPayload)
+		Expect(err).NotTo(HaveOccurred())
+
+		req, err := http.NewRequest("", "", bytes.NewReader(body))
+		Expect(err).NotTo(HaveOccurred())
+
+		validatorErr = validator.DecodeAndValidateJSONPayload(req, decodedRelationshipPayload)
+	})
+
+	It("succeeds", func() {
+		Expect(validatorErr).NotTo(HaveOccurred())
+		Expect(decodedRelationshipPayload).To(gstruct.PointTo(Equal(relationshipPayload)))
+	})
+
+	When("data is empty", func() {
+		BeforeEach(func() {
+			relationshipPayload.Data = nil
+		})
+
+		It("returns an appropriate error", func() {
+			expectUnprocessableEntityError(validatorErr, "data cannot be blank")
+		})
+	})
+
+	When("data has empty guid", func() {
+		BeforeEach(func() {
+			relationshipPayload.Data.GUID = ""
+		})
+
+		It("returns an appropriate error", func() {
+			expectUnprocessableEntityError(validatorErr, "guid cannot be blank")
+		})
+	})
+})

--- a/api/payloads/shared.go
+++ b/api/payloads/shared.go
@@ -1,28 +1,6 @@
 package payloads
 
-import (
-	"net/url"
-	"strconv"
-	"strings"
-)
-
-type Lifecycle struct {
-	Type string        `json:"type" validate:"required"`
-	Data LifecycleData `json:"data" validate:"required"`
-}
-
-type LifecycleData struct {
-	Buildpacks []string `json:"buildpacks" validate:"required"`
-	Stack      string   `json:"stack" validate:"required"`
-}
-
-type Relationship struct {
-	Data *RelationshipData `json:"data" validate:"required"`
-}
-
-type RelationshipData struct {
-	GUID string `json:"guid" validate:"required"`
-}
+import "strings"
 
 func ParseArrayParam(arrayParam string) []string {
 	if arrayParam == "" {
@@ -35,41 +13,4 @@ func ParseArrayParam(arrayParam string) []string {
 	}
 
 	return elements
-}
-
-type BuildMetadata struct {
-	Annotations map[string]string `json:"annotations" validate:"buildmetadatavalidator"`
-	Labels      map[string]string `json:"labels" validate:"buildmetadatavalidator"`
-}
-
-type Metadata struct {
-	Annotations map[string]string `json:"annotations" yaml:"annotations" validate:"metadatavalidator"`
-	Labels      map[string]string `json:"labels"      yaml:"labels"      validate:"metadatavalidator"`
-}
-
-type MetadataPatch struct {
-	Annotations map[string]*string `json:"annotations" validate:"metadatavalidator"`
-	Labels      map[string]*string `json:"labels"      validate:"metadatavalidator"`
-}
-
-func getInt(values url.Values, key string) (int64, error) {
-	if !values.Has(key) {
-		return 0, nil
-	}
-	s := values.Get(key)
-	if s == "" {
-		return 0, nil
-	}
-	return strconv.ParseInt(s, 10, 64)
-}
-
-func getBool(values url.Values, key string) (bool, error) {
-	if !values.Has(key) {
-		return false, nil
-	}
-	s := values.Get(key)
-	if s == "" {
-		return false, nil
-	}
-	return strconv.ParseBool(s)
 }


### PR DESCRIPTION
## Is there a related GitHub Issue?
#1996

## What is this change about?
Validate domain payloads with `jellydator/validation`

also:
- move validation tests to the playloads package
- test metadata and relationships independently in order to reduce
  duplication

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Green tests

## Tag your pair, your PM, and/or team
@georgethebeatle 