### PR TITLE
kpack-image-builder must only add finalizers to its BuildWorkloads

### DIFF
--- a/kpack-image-builder/controllers/buildworkload_controller.go
+++ b/kpack-image-builder/controllers/buildworkload_controller.go
@@ -56,7 +56,7 @@ const (
 	clusterBuilderAPIVersion    = "kpack.io/v1alpha2"
 	BuildWorkloadLabelKey       = "korifi.cloudfoundry.org/build-workload-name"
 	ImageGenerationKey          = "korifi.cloudfoundry.org/kpack-image-generation"
-	kpackReconcilerName         = "kpack-image-builder"
+	KpackReconcilerName         = "kpack-image-builder"
 	buildpackBuildMetadataLabel = "io.buildpacks.build.metadata"
 )
 
@@ -152,7 +152,7 @@ func filterBuildWorkloads(object client.Object) bool {
 	}
 
 	// Only reconcile buildworkloads that have their Spec.BuilderName matching this builder
-	return buildWorkload.Spec.BuilderName == kpackReconcilerName
+	return buildWorkload.Spec.BuilderName == KpackReconcilerName
 }
 
 //+kubebuilder:rbac:groups=korifi.cloudfoundry.org,resources=buildworkloads,verbs=get;list;watch;create;patch;delete

--- a/kpack-image-builder/controllers/webhooks/finalizer/finalizer_webhook_test.go
+++ b/kpack-image-builder/controllers/webhooks/finalizer/finalizer_webhook_test.go
@@ -19,14 +19,29 @@ var _ = Describe("KpackImageBuilder Finalizers Webhook", func() {
 			Expect(k8sClient.Create(context.Background(), obj)).To(Succeed())
 			Expect(obj.GetFinalizers()).To(Equal(expectedFinalizers))
 		},
-		Entry("buildworkload",
+		Entry("kpack-image-builder-buildworkload",
 			&korifiv1alpha1.BuildWorkload{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: rootNamespace,
 					Name:      uuid.NewString(),
 				},
+				Spec: korifiv1alpha1.BuildWorkloadSpec{
+					BuilderName: "kpack-image-builder",
+				},
 			},
 			[]string{korifiv1alpha1.BuildWorkloadFinalizerName},
+		),
+		Entry("non-kpack-image-builder-buildworkload",
+			&korifiv1alpha1.BuildWorkload{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: rootNamespace,
+					Name:      uuid.NewString(),
+				},
+				Spec: korifiv1alpha1.BuildWorkloadSpec{
+					BuilderName: "another-image-builder",
+				},
+			},
+			nil,
 		),
 		Entry("korifi-kpackbuild",
 			&kpackv1alpha2.Build{


### PR DESCRIPTION

<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
See #2598

## What is this change about?
Add a new `SetPolicy` for the BuildWorkload finalizer in kpack-image-builder which checks the BuildName on the spec, just like its reconciler does. This way multiple builders can co-exist in korifi without interfering.

This requires the signature of SetPolicy to be changed to give access to the Spec of the object. We now use an unstructured object which can be easily converted to an actual resource type if required.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Use kpack-image-builder in parallel with another builder. Check BuildWorkloads (and kpack.Builds) associated with the other builder do not get kpack-image-builder finalizers added.

## Tag your pair, your PM, and/or team
@matt-royal

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
