### PR TITLE
Use jellydator in `/v3/apps` payload validation

### DIFF
--- a/api/handlers/app.go
+++ b/api/handlers/app.go
@@ -55,15 +55,15 @@ type CFAppRepository interface {
 }
 
 type App struct {
-	serverURL        url.URL
-	appRepo          CFAppRepository
-	dropletRepo      CFDropletRepository
-	processRepo      CFProcessRepository
-	routeRepo        CFRouteRepository
-	domainRepo       CFDomainRepository
-	spaceRepo        SpaceRepository
-	packageRepo      CFPackageRepository
-	decoderValidator *DecoderValidator
+	serverURL            url.URL
+	appRepo              CFAppRepository
+	dropletRepo          CFDropletRepository
+	processRepo          CFProcessRepository
+	routeRepo            CFRouteRepository
+	domainRepo           CFDomainRepository
+	spaceRepo            SpaceRepository
+	packageRepo          CFPackageRepository
+	requestJSONValidator RequestJSONValidator
 }
 
 func NewApp(
@@ -75,18 +75,18 @@ func NewApp(
 	domainRepo CFDomainRepository,
 	spaceRepo SpaceRepository,
 	packageRepo CFPackageRepository,
-	decoderValidator *DecoderValidator,
+	requestJSONValidator RequestJSONValidator,
 ) *App {
 	return &App{
-		serverURL:        serverURL,
-		appRepo:          appRepo,
-		dropletRepo:      dropletRepo,
-		processRepo:      processRepo,
-		routeRepo:        routeRepo,
-		domainRepo:       domainRepo,
-		decoderValidator: decoderValidator,
-		packageRepo:      packageRepo,
-		spaceRepo:        spaceRepo,
+		serverURL:            serverURL,
+		appRepo:              appRepo,
+		dropletRepo:          dropletRepo,
+		processRepo:          processRepo,
+		routeRepo:            routeRepo,
+		domainRepo:           domainRepo,
+		spaceRepo:            spaceRepo,
+		packageRepo:          packageRepo,
+		requestJSONValidator: requestJSONValidator,
 	}
 }
 
@@ -107,7 +107,7 @@ func (h *App) create(r *http.Request) (*routing.Response, error) {
 	authInfo, _ := authorization.InfoFromContext(r.Context())
 	logger := logr.FromContextOrDiscard(r.Context()).WithName("handlers.app.create")
 	var payload payloads.AppCreate
-	if err := h.decoderValidator.DecodeAndValidateJSONPayload(r, &payload); err != nil {
+	if err := h.requestJSONValidator.DecodeAndValidateJSONPayload(r, &payload); err != nil {
 		return nil, apierrors.LogAndReturn(logger, err, "failed to decode json payload")
 	}
 
@@ -195,7 +195,7 @@ func (h *App) setCurrentDroplet(r *http.Request) (*routing.Response, error) {
 	appGUID := routing.URLParam(r, "guid")
 
 	var payload payloads.AppSetCurrentDroplet
-	if err := h.decoderValidator.DecodeAndValidateJSONPayload(r, &payload); err != nil {
+	if err := h.requestJSONValidator.DecodeAndValidateJSONPayload(r, &payload); err != nil {
 		return nil, apierrors.LogAndReturn(logger, err, "failed to decode json payload")
 	}
 
@@ -377,7 +377,7 @@ func (h *App) scaleProcess(r *http.Request) (*routing.Response, error) {
 		WithValues("appGUID", appGUID, "processType", processType)
 
 	var payload payloads.ProcessScale
-	if err := h.decoderValidator.DecodeAndValidateJSONPayload(r, &payload); err != nil {
+	if err := h.requestJSONValidator.DecodeAndValidateJSONPayload(r, &payload); err != nil {
 		return nil, apierrors.LogAndReturn(logger, err, "failed to decode json payload")
 	}
 
@@ -503,7 +503,7 @@ func (h *App) updateEnvVars(r *http.Request) (*routing.Response, error) {
 	appGUID := routing.URLParam(r, "guid")
 
 	var payload payloads.AppPatchEnvVars
-	if err := h.decoderValidator.DecodeAndValidateJSONPayload(r, &payload); err != nil {
+	if err := h.requestJSONValidator.DecodeAndValidateJSONPayload(r, &payload); err != nil {
 		return nil, apierrors.LogAndReturn(logger, err, "failed to decode payload")
 	}
 
@@ -587,7 +587,7 @@ func (h *App) update(r *http.Request) (*routing.Response, error) {
 	}
 
 	var payload payloads.AppPatch
-	if err = h.decoderValidator.DecodeAndValidateJSONPayload(r, &payload); err != nil {
+	if err = h.requestJSONValidator.DecodeAndValidateJSONPayload(r, &payload); err != nil {
 		return nil, apierrors.LogAndReturn(logger, err, "failed to decode payload")
 	}
 

--- a/api/handlers/build_test.go
+++ b/api/handlers/build_test.go
@@ -115,7 +115,6 @@ var _ = Describe("Build", func() {
 			buildRepo                   *fake.CFBuildRepository
 			requestJSONValidator        *fake.RequestJSONValidator
 			expectedLifecycleBuildpacks []string
-			payload                     payloads.BuildCreate
 		)
 
 		const (
@@ -134,20 +133,12 @@ var _ = Describe("Build", func() {
 		)
 
 		BeforeEach(func() {
-			payload = payloads.BuildCreate{
+			requestJSONValidator = new(fake.RequestJSONValidator)
+			requestJSONValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidateJSONPayloadStub(&payloads.BuildCreate{
 				Package: &payloads.RelationshipData{
 					GUID: packageGUID,
 				},
-			}
-
-			requestJSONValidator = new(fake.RequestJSONValidator)
-			requestJSONValidator.DecodeAndValidateJSONPayloadStub = func(_ *http.Request, i interface{}) error {
-				build, ok := i.(*payloads.BuildCreate)
-				Expect(ok).To(BeTrue())
-				*build = payload
-
-				return nil
-			}
+			})
 
 			expectedLifecycleBuildpacks = []string{"buildpack-a", "buildpack-b"}
 

--- a/api/handlers/domain_test.go
+++ b/api/handlers/domain_test.go
@@ -42,10 +42,10 @@ var _ = Describe("Domain", func() {
 	})
 
 	Describe("POST /v3/domain", func() {
-		var payload payloads.DomainCreate
+		var payload *payloads.DomainCreate
 
 		BeforeEach(func() {
-			payload = payloads.DomainCreate{
+			payload = &payloads.DomainCreate{
 				Name:     "my.domain",
 				Internal: false,
 				Metadata: payloads.Metadata{
@@ -57,13 +57,7 @@ var _ = Describe("Domain", func() {
 					},
 				},
 			}
-			requestJSONValidator.DecodeAndValidateJSONPayloadStub = func(_ *http.Request, i interface{}) error {
-				domain, ok := i.(*payloads.DomainCreate)
-				Expect(ok).To(BeTrue())
-				*domain = payload
-
-				return nil
-			}
+			requestJSONValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidateJSONPayloadStub(payload)
 
 			domainRepo.CreateDomainReturns(repositories.DomainRecord{
 				Name:        "my.domain",
@@ -190,10 +184,10 @@ var _ = Describe("Domain", func() {
 	})
 
 	Describe("PATCH /v3/domains/:guid", func() {
-		var payload payloads.DomainUpdate
+		var payload *payloads.DomainUpdate
 
 		BeforeEach(func() {
-			payload = payloads.DomainUpdate{
+			payload = &payloads.DomainUpdate{
 				Metadata: payloads.MetadataPatch{
 					Labels: map[string]*string{
 						"foo": tools.PtrTo("bar"),
@@ -203,13 +197,7 @@ var _ = Describe("Domain", func() {
 					},
 				},
 			}
-			requestJSONValidator.DecodeAndValidateJSONPayloadStub = func(_ *http.Request, i interface{}) error {
-				update, ok := i.(*payloads.DomainUpdate)
-				Expect(ok).To(BeTrue())
-				*update = payload
-
-				return nil
-			}
+			requestJSONValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidateJSONPayloadStub(payload)
 
 			domainRepo.UpdateDomainReturns(repositories.DomainRecord{
 				Name:        "my.domain",

--- a/api/handlers/handlers_suite_test.go
+++ b/api/handlers/handlers_suite_test.go
@@ -93,3 +93,14 @@ func generateGUID(prefix string) string {
 
 	return fmt.Sprintf("%s-%s", prefix, guid[:13])
 }
+
+func decodeAndValidateJSONPayloadStub[T any](desiredPayload *T) func(_ *http.Request, decodedPayload any) error {
+	return func(_ *http.Request, decodedPayload any) error {
+		decodedPayloadPtr, ok := decodedPayload.(*T)
+		Expect(ok).To(BeTrue())
+
+		*decodedPayloadPtr = *desiredPayload
+
+		return nil
+	}
+}

--- a/api/handlers/package_test.go
+++ b/api/handlers/package_test.go
@@ -306,7 +306,8 @@ var _ = Describe("Package", func() {
 
 		BeforeEach(func() {
 			appUID = "appUID"
-			body := &payloads.PackageCreate{
+
+			requestJSONValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidateJSONPayloadStub(&payloads.PackageCreate{
 				Type: "bits",
 				Relationships: &payloads.PackageRelationships{
 					App: &payloads.Relationship{
@@ -323,13 +324,7 @@ var _ = Describe("Package", func() {
 						"jim": "foo",
 					},
 				},
-			}
-			requestJSONValidator.DecodeAndValidateJSONPayloadStub = func(_ *http.Request, i interface{}) error {
-				b, ok := i.(*payloads.PackageCreate)
-				Expect(ok).To(BeTrue())
-				*b = *body
-				return nil
-			}
+			})
 
 			packageRepo.CreatePackageReturns(repositories.PackageRecord{
 				Type:        "bits",
@@ -452,7 +447,7 @@ var _ = Describe("Package", func() {
 		BeforeEach(func() {
 			packageGUID = generateGUID("package")
 
-			body := &payloads.PackageUpdate{
+			requestJSONValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidateJSONPayloadStub(&payloads.PackageUpdate{
 				Metadata: payloads.MetadataPatch{
 					Labels: map[string]*string{
 						"bob": tools.PtrTo("foo"),
@@ -461,14 +456,7 @@ var _ = Describe("Package", func() {
 						"jim": tools.PtrTo("foo"),
 					},
 				},
-			}
-
-			requestJSONValidator.DecodeAndValidateJSONPayloadStub = func(_ *http.Request, i interface{}) error {
-				b, ok := i.(*payloads.PackageUpdate)
-				Expect(ok).To(BeTrue())
-				*b = *body
-				return nil
-			}
+			})
 
 			packageRepo.UpdatePackageReturns(repositories.PackageRecord{
 				Type:        "bits",

--- a/api/payloads/app_test.go
+++ b/api/payloads/app_test.go
@@ -3,9 +3,12 @@ package payloads_test
 import (
 	"net/url"
 
+	"code.cloudfoundry.org/korifi/api/handlers"
 	"code.cloudfoundry.org/korifi/api/payloads"
+	"code.cloudfoundry.org/korifi/tools"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gstruct"
 )
 
 var _ = Describe("AppList", func() {
@@ -23,5 +26,232 @@ var _ = Describe("AppList", func() {
 			GUIDs:      "guid",
 			SpaceGuids: "space_guid",
 		}))
+	})
+})
+
+var _ = Describe("App payload validation", func() {
+	var (
+		decoderValidator *handlers.DecoderValidator
+		validatorErr     error
+	)
+
+	BeforeEach(func() {
+		var err error
+		decoderValidator, err = handlers.NewDefaultDecoderValidator()
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	Describe("AppCreate", func() {
+		var (
+			payload        payloads.AppCreate
+			decodedPayload *payloads.AppCreate
+		)
+
+		BeforeEach(func() {
+			payload = payloads.AppCreate{
+				Name: "my-app",
+				Relationships: payloads.AppRelationships{
+					Space: payloads.Relationship{
+						Data: &payloads.RelationshipData{
+							GUID: "app-guid",
+						},
+					},
+				},
+			}
+
+			decodedPayload = new(payloads.AppCreate)
+		})
+
+		JustBeforeEach(func() {
+			validatorErr = decoderValidator.DecodeAndValidateJSONPayload(createRequest(payload), decodedPayload)
+		})
+
+		It("succeeds", func() {
+			Expect(validatorErr).NotTo(HaveOccurred())
+			Expect(decodedPayload).To(gstruct.PointTo(Equal(payload)))
+		})
+
+		When("name is not set", func() {
+			BeforeEach(func() {
+				payload.Name = ""
+			})
+
+			It("returns an error", func() {
+				expectUnprocessableEntityError(validatorErr, "name cannot be blank")
+			})
+		})
+
+		When("lifecycle is invalid", func() {
+			BeforeEach(func() {
+				payload.Lifecycle = &payloads.Lifecycle{}
+			})
+
+			It("returns an unprocessable entity error", func() {
+				expectUnprocessableEntityError(validatorErr, "lifecycle.type cannot be blank")
+			})
+		})
+
+		When("relationships are not set", func() {
+			BeforeEach(func() {
+				payload.Relationships = payloads.AppRelationships{}
+			})
+
+			It("returns an unprocessable entity error", func() {
+				expectUnprocessableEntityError(validatorErr, "relationships cannot be blank")
+			})
+		})
+
+		When("metadata is invalid", func() {
+			BeforeEach(func() {
+				payload.Metadata = payloads.Metadata{
+					Labels: map[string]string{
+						"foo.cloudfoundry.org/bar": "jim",
+					},
+				}
+			})
+
+			It("returns an appropriate error", func() {
+				expectUnprocessableEntityError(validatorErr, "label/annotation key cannot use the cloudfoundry.org domain")
+			})
+		})
+	})
+
+	Describe("AppPatch", func() {
+		var (
+			payload        payloads.AppPatch
+			decodedPayload *payloads.AppPatch
+		)
+
+		BeforeEach(func() {
+			payload = payloads.AppPatch{
+				Metadata: payloads.MetadataPatch{
+					Labels: map[string]*string{
+						"foo": tools.PtrTo("bar"),
+					},
+					Annotations: map[string]*string{
+						"example.org/jim": tools.PtrTo("hello"),
+					},
+				},
+			}
+
+			decodedPayload = new(payloads.AppPatch)
+		})
+
+		JustBeforeEach(func() {
+			validatorErr = decoderValidator.DecodeAndValidateJSONPayload(createRequest(payload), decodedPayload)
+		})
+
+		It("succeeds", func() {
+			Expect(validatorErr).NotTo(HaveOccurred())
+			Expect(decodedPayload).To(gstruct.PointTo(Equal(payload)))
+		})
+
+		When("metadata is invalid", func() {
+			BeforeEach(func() {
+				payload.Metadata = payloads.MetadataPatch{
+					Labels: map[string]*string{
+						"foo.cloudfoundry.org/bar": tools.PtrTo("jim"),
+					},
+				}
+			})
+
+			It("returns an appropriate error", func() {
+				expectUnprocessableEntityError(validatorErr, `Labels and annotations cannot begin with "cloudfoundry.org" or its subdomains`)
+			})
+		})
+	})
+
+	Describe("AppSetCurrentDroplet", func() {
+		var (
+			payload        payloads.AppSetCurrentDroplet
+			decodedPayload *payloads.AppSetCurrentDroplet
+		)
+
+		BeforeEach(func() {
+			payload = payloads.AppSetCurrentDroplet{
+				Relationship: payloads.Relationship{
+					Data: &payloads.RelationshipData{
+						GUID: "the-guid",
+					},
+				},
+			}
+
+			decodedPayload = new(payloads.AppSetCurrentDroplet)
+		})
+
+		JustBeforeEach(func() {
+			validatorErr = decoderValidator.DecodeAndValidateJSONPayload(createRequest(payload), decodedPayload)
+		})
+
+		It("succeeds", func() {
+			Expect(validatorErr).NotTo(HaveOccurred())
+			Expect(decodedPayload).To(gstruct.PointTo(Equal(payload)))
+		})
+
+		When("relationship is invalid", func() {
+			BeforeEach(func() {
+				payload.Relationship = payloads.Relationship{}
+			})
+
+			It("returns an appropriate error", func() {
+				expectUnprocessableEntityError(validatorErr, "Relationship cannot be blank")
+			})
+		})
+	})
+
+	Describe("AppPatchEnvVars", func() {
+		var (
+			payload        payloads.AppPatchEnvVars
+			decodedPayload *payloads.AppPatchEnvVars
+		)
+
+		BeforeEach(func() {
+			payload = payloads.AppPatchEnvVars{
+				Var: map[string]interface{}{
+					"foo": "bar",
+				},
+			}
+
+			decodedPayload = new(payloads.AppPatchEnvVars)
+		})
+
+		JustBeforeEach(func() {
+			validatorErr = decoderValidator.DecodeAndValidateJSONPayload(createRequest(payload), decodedPayload)
+		})
+
+		It("succeeds", func() {
+			Expect(validatorErr).NotTo(HaveOccurred())
+			Expect(decodedPayload).To(gstruct.PointTo(Equal(payload)))
+		})
+
+		When("it contains a 'PORT' key", func() {
+			BeforeEach(func() {
+				payload.Var["PORT"] = "2222"
+			})
+
+			It("returns an appropriate error", func() {
+				expectUnprocessableEntityError(validatorErr, "value PORT is not allowed")
+			})
+		})
+
+		When("it contains a key with prefix 'VCAP_'", func() {
+			BeforeEach(func() {
+				payload.Var["VCAP_foo"] = "bar"
+			})
+
+			It("returns an appropriate error", func() {
+				expectUnprocessableEntityError(validatorErr, "prefix VCAP_ is not allowed")
+			})
+		})
+
+		When("it contains a key with prefix 'VMC_'", func() {
+			BeforeEach(func() {
+				payload.Var["VMC_foo"] = "bar"
+			})
+
+			It("returns an appropriate error", func() {
+				expectUnprocessableEntityError(validatorErr, "prefix VMC_ is not allowed")
+			})
+		})
 	})
 })

--- a/api/payloads/build_test.go
+++ b/api/payloads/build_test.go
@@ -1,10 +1,6 @@
 package payloads_test
 
 import (
-	"bytes"
-	"encoding/json"
-	"net/http"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gstruct"
@@ -30,13 +26,7 @@ var _ = Describe("BuildCreate", func() {
 		})
 
 		JustBeforeEach(func() {
-			body, err := json.Marshal(createPayload)
-			Expect(err).NotTo(HaveOccurred())
-
-			req, err := http.NewRequest("", "", bytes.NewReader(body))
-			Expect(err).NotTo(HaveOccurred())
-
-			validatorErr = validator.DecodeAndValidateJSONPayload(req, decodedBuildPayload)
+			validatorErr = validator.DecodeAndValidateJSONPayload(createRequest(createPayload), decodedBuildPayload)
 		})
 
 		It("succeeds", func() {

--- a/api/payloads/deployment_test.go
+++ b/api/payloads/deployment_test.go
@@ -1,10 +1,6 @@
 package payloads_test
 
 import (
-	"bytes"
-	"encoding/json"
-	"net/http"
-
 	"code.cloudfoundry.org/korifi/api/payloads"
 	"code.cloudfoundry.org/korifi/api/repositories"
 	"github.com/onsi/gomega/gstruct"
@@ -42,13 +38,7 @@ var _ = Describe("DeploymentCreate", func() {
 		})
 
 		JustBeforeEach(func() {
-			body, err := json.Marshal(createDeployment)
-			Expect(err).NotTo(HaveOccurred())
-
-			req, err := http.NewRequest("", "", bytes.NewReader(body))
-			Expect(err).NotTo(HaveOccurred())
-
-			validatorErr = validator.DecodeAndValidateJSONPayload(req, decodedDeploymentPayload)
+			validatorErr = validator.DecodeAndValidateJSONPayload(createRequest(createDeployment), decodedDeploymentPayload)
 		})
 
 		It("succeeds", func() {

--- a/api/payloads/domain.go
+++ b/api/payloads/domain.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"net/url"
 
+	"code.cloudfoundry.org/korifi/api/payloads/parse"
+	payload_validation "code.cloudfoundry.org/korifi/api/payloads/validation"
 	"code.cloudfoundry.org/korifi/api/repositories"
 	"github.com/jellydator/validation"
 )
@@ -15,9 +17,9 @@ type DomainCreate struct {
 	Relationships map[string]Relationship `json:"relationships"`
 }
 
-func (c *DomainCreate) Validate() error {
-	return validation.ValidateStruct(c,
-		validation.Field(&c.Name, validation.Required),
+func (c DomainCreate) Validate() error {
+	return validation.ValidateStruct(&c,
+		validation.Field(&c.Name, payload_validation.StrictlyRequired),
 		validation.Field(&c.Metadata),
 		validation.Field(&c.Relationships),
 	)
@@ -55,8 +57,8 @@ func (c *DomainUpdate) ToMessage(domainGUID string) repositories.UpdateDomainMes
 	}
 }
 
-func (c *DomainUpdate) Validate() error {
-	return validation.ValidateStruct(c,
+func (c DomainUpdate) Validate() error {
+	return validation.ValidateStruct(&c,
 		validation.Field(&c.Metadata),
 	)
 }
@@ -67,7 +69,7 @@ type DomainList struct {
 
 func (d *DomainList) ToMessage() repositories.ListDomainsMessage {
 	return repositories.ListDomainsMessage{
-		Names: ParseArrayParam(d.Names),
+		Names: parse.ArrayParam(d.Names),
 	}
 }
 

--- a/api/payloads/domain_test.go
+++ b/api/payloads/domain_test.go
@@ -1,9 +1,6 @@
 package payloads_test
 
 import (
-	"bytes"
-	"encoding/json"
-	"net/http"
 	"net/url"
 
 	"code.cloudfoundry.org/korifi/api/payloads"
@@ -39,13 +36,7 @@ var _ = Describe("DomainCreate", func() {
 		})
 
 		JustBeforeEach(func() {
-			body, err := json.Marshal(createPayload)
-			Expect(err).NotTo(HaveOccurred())
-
-			req, err := http.NewRequest("", "", bytes.NewReader(body))
-			Expect(err).NotTo(HaveOccurred())
-
-			validatorErr = validator.DecodeAndValidateJSONPayload(req, decodedDomainPayload)
+			validatorErr = validator.DecodeAndValidateJSONPayload(createRequest(createPayload), decodedDomainPayload)
 		})
 
 		It("succeeds", func() {
@@ -169,13 +160,7 @@ var _ = Describe("DomainUpdate", func() {
 	})
 
 	JustBeforeEach(func() {
-		updateBody, err := json.Marshal(updatePayload)
-		Expect(err).NotTo(HaveOccurred())
-
-		req, err := http.NewRequest("", "", bytes.NewReader(updateBody))
-		Expect(err).NotTo(HaveOccurred())
-
-		validatorErr = validator.DecodeAndValidateJSONPayload(req, decodedUpdatePayload)
+		validatorErr = validator.DecodeAndValidateJSONPayload(createRequest(updatePayload), decodedUpdatePayload)
 	})
 
 	It("succeeds", func() {
@@ -183,7 +168,7 @@ var _ = Describe("DomainUpdate", func() {
 		Expect(decodedUpdatePayload).To(gstruct.PointTo(Equal(updatePayload)))
 	})
 
-	When("metadata.labels contains an invalid key", func() {
+	When("metadata is invalid", func() {
 		BeforeEach(func() {
 			updatePayload.Metadata = payloads.MetadataPatch{
 				Labels: map[string]*string{

--- a/api/payloads/droplet_test.go
+++ b/api/payloads/droplet_test.go
@@ -1,10 +1,6 @@
 package payloads_test
 
 import (
-	"bytes"
-	"encoding/json"
-	"net/http"
-
 	"code.cloudfoundry.org/korifi/api/payloads"
 	"code.cloudfoundry.org/korifi/tools"
 	"github.com/onsi/gomega/gstruct"
@@ -36,13 +32,7 @@ var _ = Describe("DropletUpdate", func() {
 		})
 
 		JustBeforeEach(func() {
-			body, err := json.Marshal(updatePayload)
-			Expect(err).NotTo(HaveOccurred())
-
-			req, err := http.NewRequest("", "", bytes.NewReader(body))
-			Expect(err).NotTo(HaveOccurred())
-
-			validatorErr = validator.DecodeAndValidateJSONPayload(req, decodedDropletPayload)
+			validatorErr = validator.DecodeAndValidateJSONPayload(createRequest(updatePayload), decodedDropletPayload)
 		})
 
 		It("succeeds", func() {

--- a/api/payloads/lifecycle.go
+++ b/api/payloads/lifecycle.go
@@ -1,11 +1,30 @@
 package payloads
 
+import (
+	payload_validation "code.cloudfoundry.org/korifi/api/payloads/validation"
+	"github.com/jellydator/validation"
+)
+
 type Lifecycle struct {
 	Type string        `json:"type" validate:"required"`
 	Data LifecycleData `json:"data" validate:"required"`
 }
 
+func (l Lifecycle) Validate() error {
+	return validation.ValidateStruct(&l,
+		validation.Field(&l.Type, payload_validation.StrictlyRequired),
+		validation.Field(&l.Data, payload_validation.StrictlyRequired),
+	)
+}
+
 type LifecycleData struct {
 	Buildpacks []string `json:"buildpacks" validate:"required"`
 	Stack      string   `json:"stack" validate:"required"`
+}
+
+func (d LifecycleData) Validate() error {
+	return validation.ValidateStruct(&d,
+		validation.Field(&d.Buildpacks, payload_validation.StrictlyRequired),
+		validation.Field(&d.Stack, payload_validation.StrictlyRequired),
+	)
 }

--- a/api/payloads/lifecycle_test.go
+++ b/api/payloads/lifecycle_test.go
@@ -1,0 +1,72 @@
+package payloads_test
+
+import (
+	"code.cloudfoundry.org/korifi/api/handlers"
+	"code.cloudfoundry.org/korifi/api/payloads"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gstruct"
+)
+
+var _ = Describe("Lifecycle", func() {
+	var (
+		decoderValidator *handlers.DecoderValidator
+		payload          payloads.Lifecycle
+		decodedPayload   *payloads.Lifecycle
+		validatorErr     error
+	)
+
+	BeforeEach(func() {
+		decoderValidator, validatorErr = handlers.NewDefaultDecoderValidator()
+		Expect(validatorErr).NotTo(HaveOccurred())
+
+		payload = payloads.Lifecycle{
+			Type: "buildpack",
+			Data: payloads.LifecycleData{
+				Buildpacks: []string{"foo", "bar"},
+				Stack:      "baz",
+			},
+		}
+
+		decodedPayload = new(payloads.Lifecycle)
+	})
+
+	JustBeforeEach(func() {
+		validatorErr = decoderValidator.DecodeAndValidateJSONPayload(createRequest(payload), decodedPayload)
+	})
+
+	It("succeeds", func() {
+		Expect(validatorErr).NotTo(HaveOccurred())
+		Expect(decodedPayload).To(gstruct.PointTo(Equal(payload)))
+	})
+
+	When("type is not set", func() {
+		BeforeEach(func() {
+			payload.Type = ""
+		})
+
+		It("returns an appropriate error", func() {
+			expectUnprocessableEntityError(validatorErr, "type cannot be blank")
+		})
+	})
+
+	When("stack is not set", func() {
+		BeforeEach(func() {
+			payload.Data.Stack = ""
+		})
+
+		It("returns an appropriate error", func() {
+			expectUnprocessableEntityError(validatorErr, "data.stack cannot be blank")
+		})
+	})
+
+	When("buildpacks are not set", func() {
+		BeforeEach(func() {
+			payload.Data.Buildpacks = nil
+		})
+
+		It("returns an appropriate error", func() {
+			expectUnprocessableEntityError(validatorErr, "data.buildpacks cannot be blank")
+		})
+	})
+})

--- a/api/payloads/manifest.go
+++ b/api/payloads/manifest.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"regexp"
 
+	payload_validation "code.cloudfoundry.org/korifi/api/payloads/validation"
 	"code.cloudfoundry.org/korifi/api/repositories"
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"code.cloudfoundry.org/korifi/tools"
@@ -191,7 +192,7 @@ func (m Manifest) Validate() error {
 
 func (a ManifestApplication) Validate() error {
 	return validation.ValidateStruct(&a,
-		validation.Field(&a.Name, validation.Required),
+		validation.Field(&a.Name, payload_validation.StrictlyRequired),
 		validation.Field(&a.DefaultRoute, validation.When(a.RandomRoute, validation.Nil.Error("and random-route may not be used together"))),
 		validation.Field(&a.DiskQuota, validation.By(validateAmountWithUnit), validation.When(a.AltDiskQuota != nil, validation.Nil.Error("and disk-quota may not be used together"))),
 		validation.Field(&a.AltDiskQuota, validation.By(validateAmountWithUnit)),
@@ -207,7 +208,7 @@ func (a ManifestApplication) Validate() error {
 
 func (p ManifestApplicationProcess) Validate() error {
 	return validation.ValidateStruct(&p,
-		validation.Field(&p.Type, validation.Required),
+		validation.Field(&p.Type, payload_validation.StrictlyRequired),
 		validation.Field(&p.DiskQuota, validation.By(validateAmountWithUnit), validation.When(p.AltDiskQuota != nil, validation.Nil.Error("and disk-quota may not be used together"))),
 		validation.Field(&p.AltDiskQuota, validation.By(validateAmountWithUnit)),
 		validation.Field(&p.HealthCheckInvocationTimeout, validation.Min(1), validation.NilOrNotEmpty.Error("must be no less than 1")),

--- a/api/payloads/metadata_test.go
+++ b/api/payloads/metadata_test.go
@@ -1,10 +1,6 @@
 package payloads_test
 
 import (
-	"bytes"
-	"encoding/json"
-	"net/http"
-
 	"code.cloudfoundry.org/korifi/api/payloads"
 	"code.cloudfoundry.org/korifi/tools"
 	. "github.com/onsi/ginkgo/v2"
@@ -32,13 +28,7 @@ var _ = Describe("Metadata", func() {
 	})
 
 	JustBeforeEach(func() {
-		body, err := json.Marshal(metadataPayload)
-		Expect(err).NotTo(HaveOccurred())
-
-		req, err := http.NewRequest("", "", bytes.NewReader(body))
-		Expect(err).NotTo(HaveOccurred())
-
-		validatorErr = validator.DecodeAndValidateJSONPayload(req, decodedMetadataPayload)
+		validatorErr = validator.DecodeAndValidateJSONPayload(createRequest(metadataPayload), decodedMetadataPayload)
 	})
 
 	It("succeeds", func() {
@@ -87,13 +77,7 @@ var _ = Describe("MetadataPatch", func() {
 	})
 
 	JustBeforeEach(func() {
-		body, err := json.Marshal(metadataPatchPayload)
-		Expect(err).NotTo(HaveOccurred())
-
-		req, err := http.NewRequest("", "", bytes.NewReader(body))
-		Expect(err).NotTo(HaveOccurred())
-
-		validatorErr = validator.DecodeAndValidateJSONPayload(req, decodedMetadataPatchPayload)
+		validatorErr = validator.DecodeAndValidateJSONPayload(createRequest(metadataPatchPayload), decodedMetadataPatchPayload)
 	})
 
 	It("succeeds", func() {

--- a/api/payloads/package.go
+++ b/api/payloads/package.go
@@ -3,6 +3,7 @@ package payloads
 import (
 	"net/url"
 
+	"code.cloudfoundry.org/korifi/api/payloads/parse"
 	"code.cloudfoundry.org/korifi/api/repositories"
 )
 
@@ -49,8 +50,8 @@ type PackageListQueryParameters struct {
 
 func (p *PackageListQueryParameters) ToMessage() repositories.ListPackagesMessage {
 	return repositories.ListPackagesMessage{
-		AppGUIDs: ParseArrayParam(p.AppGUIDs),
-		States:   ParseArrayParam(p.States),
+		AppGUIDs: parse.ArrayParam(p.AppGUIDs),
+		States:   parse.ArrayParam(p.States),
 	}
 }
 

--- a/api/payloads/package_test.go
+++ b/api/payloads/package_test.go
@@ -1,9 +1,6 @@
 package payloads_test
 
 import (
-	"bytes"
-	"encoding/json"
-	"net/http"
 	"net/url"
 
 	"code.cloudfoundry.org/korifi/api/payloads"
@@ -43,13 +40,7 @@ var _ = Describe("PackageCreate", func() {
 	})
 
 	JustBeforeEach(func() {
-		body, err := json.Marshal(createPayload)
-		Expect(err).NotTo(HaveOccurred())
-
-		req, err := http.NewRequest("", "", bytes.NewReader(body))
-		Expect(err).NotTo(HaveOccurred())
-
-		validatorErr = validator.DecodeAndValidateJSONPayload(req, packageCreate)
+		validatorErr = validator.DecodeAndValidateJSONPayload(createRequest(createPayload), packageCreate)
 	})
 
 	It("succeeds", func() {
@@ -169,13 +160,7 @@ var _ = Describe("PackageUpdate", func() {
 	})
 
 	JustBeforeEach(func() {
-		body, err := json.Marshal(updatePayload)
-		Expect(err).NotTo(HaveOccurred())
-
-		req, err := http.NewRequest("", "", bytes.NewReader(body))
-		Expect(err).NotTo(HaveOccurred())
-
-		validatorErr = validator.DecodeAndValidateJSONPayload(req, packageUpdate)
+		validatorErr = validator.DecodeAndValidateJSONPayload(createRequest(updatePayload), packageUpdate)
 	})
 
 	It("succeeds", func() {

--- a/api/payloads/parse/arrays.go
+++ b/api/payloads/parse/arrays.go
@@ -1,8 +1,8 @@
-package payloads
+package parse
 
 import "strings"
 
-func ParseArrayParam(arrayParam string) []string {
+func ArrayParam(arrayParam string) []string {
 	if arrayParam == "" {
 		return []string{}
 	}

--- a/api/payloads/parse/arrays_test.go
+++ b/api/payloads/parse/arrays_test.go
@@ -1,7 +1,7 @@
-package payloads_test
+package parse_test
 
 import (
-	. "code.cloudfoundry.org/korifi/api/payloads"
+	. "code.cloudfoundry.org/korifi/api/payloads/parse"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -9,19 +9,19 @@ import (
 var _ = Describe("ParseArrayParam", func() {
 	When("a nil value is specified", func() {
 		It("returns an empty array", func() {
-			Expect(ParseArrayParam("")).To(Equal([]string{}))
+			Expect(ArrayParam("")).To(Equal([]string{}))
 		})
 	})
 
 	When("an single value is specified", func() {
 		It("returns an array with the value specified", func() {
-			Expect(ParseArrayParam("foo")).To(Equal([]string{"foo"}))
+			Expect(ArrayParam("foo")).To(Equal([]string{"foo"}))
 		})
 	})
 
 	When("multiple values are specified in a CSV", func() {
 		It("returns an array with the value split on commas and all white-space removed from each value", func() {
-			Expect(ParseArrayParam(" foo,   bar    ,   baz")).To(Equal([]string{"foo", "bar", "baz"}))
+			Expect(ArrayParam(" foo,   bar    ,   baz")).To(Equal([]string{"foo", "bar", "baz"}))
 		})
 	})
 })

--- a/api/payloads/parse/parse_suite_test.go
+++ b/api/payloads/parse/parse_suite_test.go
@@ -1,0 +1,13 @@
+package parse_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestParse(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Parse Suite")
+}

--- a/api/payloads/payloads_suite_test.go
+++ b/api/payloads/payloads_suite_test.go
@@ -1,6 +1,9 @@
 package payloads_test
 
 import (
+	"bytes"
+	"encoding/json"
+	"net/http"
 	"testing"
 
 	apierrors "code.cloudfoundry.org/korifi/api/errors"
@@ -26,4 +29,13 @@ func expectUnprocessableEntityError(err error, detail string) {
 	ExpectWithOffset(1, err).To(HaveOccurred())
 	ExpectWithOffset(1, err).To(BeAssignableToTypeOf(apierrors.UnprocessableEntityError{}))
 	ExpectWithOffset(1, err.(apierrors.UnprocessableEntityError).Detail()).To(ContainSubstring(detail))
+}
+
+func createRequest(payload any) *http.Request {
+	body, err := json.Marshal(payload)
+	Expect(err).NotTo(HaveOccurred())
+
+	req, err := http.NewRequest("", "", bytes.NewReader(body))
+	Expect(err).NotTo(HaveOccurred())
+	return req
 }

--- a/api/payloads/process.go
+++ b/api/payloads/process.go
@@ -3,6 +3,7 @@ package payloads
 import (
 	"net/url"
 
+	"code.cloudfoundry.org/korifi/api/payloads/parse"
 	"code.cloudfoundry.org/korifi/api/repositories"
 )
 
@@ -43,7 +44,7 @@ type ProcessList struct {
 
 func (p *ProcessList) ToMessage() repositories.ListProcessesMessage {
 	return repositories.ListProcessesMessage{
-		AppGUIDs: ParseArrayParam(p.AppGUIDs),
+		AppGUIDs: parse.ArrayParam(p.AppGUIDs),
 	}
 }
 

--- a/api/payloads/relationship.go
+++ b/api/payloads/relationship.go
@@ -1,6 +1,7 @@
 package payloads
 
 import (
+	payload_validation "code.cloudfoundry.org/korifi/api/payloads/validation"
 	"github.com/jellydator/validation"
 )
 
@@ -9,7 +10,7 @@ type Relationship struct {
 }
 
 func (r Relationship) Validate() error {
-	return validation.ValidateStruct(&r, validation.Field(&r.Data, validation.Required))
+	return validation.ValidateStruct(&r, validation.Field(&r.Data, payload_validation.StrictlyRequired))
 }
 
 type RelationshipData struct {
@@ -17,5 +18,5 @@ type RelationshipData struct {
 }
 
 func (r RelationshipData) Validate() error {
-	return validation.ValidateStruct(&r, validation.Field(&r.GUID, validation.Required))
+	return validation.ValidateStruct(&r, validation.Field(&r.GUID, payload_validation.StrictlyRequired))
 }

--- a/api/payloads/relationship_test.go
+++ b/api/payloads/relationship_test.go
@@ -1,10 +1,6 @@
 package payloads_test
 
 import (
-	"bytes"
-	"encoding/json"
-	"net/http"
-
 	"code.cloudfoundry.org/korifi/api/payloads"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -28,13 +24,7 @@ var _ = Describe("Relationship", func() {
 	})
 
 	JustBeforeEach(func() {
-		body, err := json.Marshal(relationshipPayload)
-		Expect(err).NotTo(HaveOccurred())
-
-		req, err := http.NewRequest("", "", bytes.NewReader(body))
-		Expect(err).NotTo(HaveOccurred())
-
-		validatorErr = validator.DecodeAndValidateJSONPayload(req, decodedRelationshipPayload)
+		validatorErr = validator.DecodeAndValidateJSONPayload(createRequest(relationshipPayload), decodedRelationshipPayload)
 	})
 
 	It("succeeds", func() {

--- a/api/payloads/role_test.go
+++ b/api/payloads/role_test.go
@@ -2,7 +2,6 @@ package payloads_test
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"net/http"
 
@@ -45,13 +44,7 @@ var _ = Describe("RoleCreate", func() {
 	})
 
 	JustBeforeEach(func() {
-		body, err := json.Marshal(createPayload)
-		Expect(err).NotTo(HaveOccurred())
-
-		req, err := http.NewRequest("", "", bytes.NewReader(body))
-		Expect(err).NotTo(HaveOccurred())
-
-		validatorErr = validator.DecodeAndValidateJSONPayload(req, roleCreate)
+		validatorErr = validator.DecodeAndValidateJSONPayload(createRequest(createPayload), roleCreate)
 		apiError, _ = validatorErr.(errors.ApiError)
 	})
 

--- a/api/payloads/route.go
+++ b/api/payloads/route.go
@@ -3,6 +3,7 @@ package payloads
 import (
 	"net/url"
 
+	"code.cloudfoundry.org/korifi/api/payloads/parse"
 	"code.cloudfoundry.org/korifi/api/repositories"
 )
 
@@ -41,11 +42,11 @@ type RouteList struct {
 
 func (p *RouteList) ToMessage() repositories.ListRoutesMessage {
 	return repositories.ListRoutesMessage{
-		AppGUIDs:    ParseArrayParam(p.AppGUIDs),
-		SpaceGUIDs:  ParseArrayParam(p.SpaceGUIDs),
-		DomainGUIDs: ParseArrayParam(p.DomainGUIDs),
-		Hosts:       ParseArrayParam(p.Hosts),
-		Paths:       ParseArrayParam(p.Paths),
+		AppGUIDs:    parse.ArrayParam(p.AppGUIDs),
+		SpaceGUIDs:  parse.ArrayParam(p.SpaceGUIDs),
+		DomainGUIDs: parse.ArrayParam(p.DomainGUIDs),
+		Hosts:       parse.ArrayParam(p.Hosts),
+		Paths:       parse.ArrayParam(p.Paths),
 	}
 }
 

--- a/api/payloads/service_binding.go
+++ b/api/payloads/service_binding.go
@@ -3,6 +3,7 @@ package payloads
 import (
 	"net/url"
 
+	"code.cloudfoundry.org/korifi/api/payloads/parse"
 	"code.cloudfoundry.org/korifi/api/repositories"
 )
 
@@ -34,8 +35,8 @@ type ServiceBindingList struct {
 
 func (l *ServiceBindingList) ToMessage() repositories.ListServiceBindingsMessage {
 	return repositories.ListServiceBindingsMessage{
-		ServiceInstanceGUIDs: ParseArrayParam(l.ServiceInstanceGUIDs),
-		AppGUIDs:             ParseArrayParam(l.AppGUIDs),
+		ServiceInstanceGUIDs: parse.ArrayParam(l.ServiceInstanceGUIDs),
+		AppGUIDs:             parse.ArrayParam(l.AppGUIDs),
 	}
 }
 

--- a/api/payloads/service_instance.go
+++ b/api/payloads/service_instance.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/url"
 
+	"code.cloudfoundry.org/korifi/api/payloads/parse"
 	"code.cloudfoundry.org/korifi/api/repositories"
 )
 
@@ -89,8 +90,8 @@ type ServiceInstanceList struct {
 
 func (l *ServiceInstanceList) ToMessage() repositories.ListServiceInstanceMessage {
 	return repositories.ListServiceInstanceMessage{
-		Names:      ParseArrayParam(l.Names),
-		SpaceGuids: ParseArrayParam(l.SpaceGuids),
+		Names:      parse.ArrayParam(l.Names),
+		SpaceGuids: parse.ArrayParam(l.SpaceGuids),
 	}
 }
 

--- a/api/payloads/service_instance_test.go
+++ b/api/payloads/service_instance_test.go
@@ -1,9 +1,7 @@
 package payloads_test
 
 import (
-	"bytes"
 	"encoding/json"
-	"net/http"
 	"net/url"
 	"strings"
 
@@ -64,13 +62,7 @@ var _ = Describe("ServiceInstanceCreate", func() {
 	})
 
 	JustBeforeEach(func() {
-		body, err := json.Marshal(createPayload)
-		Expect(err).NotTo(HaveOccurred())
-
-		req, err := http.NewRequest("", "", bytes.NewReader(body))
-		Expect(err).NotTo(HaveOccurred())
-
-		validatorErr = validator.DecodeAndValidateJSONPayload(req, serviceInstanceCreate)
+		validatorErr = validator.DecodeAndValidateJSONPayload(createRequest(createPayload), serviceInstanceCreate)
 	})
 
 	It("succeeds", func() {
@@ -253,13 +245,7 @@ var _ = Describe("ServiceInstancePatch", func() {
 	})
 
 	JustBeforeEach(func() {
-		body, err := json.Marshal(patchPayload)
-		Expect(err).NotTo(HaveOccurred())
-
-		req, err := http.NewRequest("", "", bytes.NewReader(body))
-		Expect(err).NotTo(HaveOccurred())
-
-		validatorErr = validator.DecodeAndValidateJSONPayload(req, serviceInstancePatch)
+		validatorErr = validator.DecodeAndValidateJSONPayload(createRequest(patchPayload), serviceInstancePatch)
 	})
 
 	It("succeeds", func() {

--- a/api/payloads/task_test.go
+++ b/api/payloads/task_test.go
@@ -1,9 +1,6 @@
 package payloads_test
 
 import (
-	"bytes"
-	"encoding/json"
-	"net/http"
 	"net/url"
 
 	"code.cloudfoundry.org/korifi/api/repositories"
@@ -64,13 +61,7 @@ var _ = Describe("TaskCreate", func() {
 	})
 
 	JustBeforeEach(func() {
-		body, err := json.Marshal(createPayload)
-		Expect(err).NotTo(HaveOccurred())
-
-		req, err := http.NewRequest("", "", bytes.NewReader(body))
-		Expect(err).NotTo(HaveOccurred())
-
-		validatorErr = validator.DecodeAndValidateJSONPayload(req, taskCreate)
+		validatorErr = validator.DecodeAndValidateJSONPayload(createRequest(createPayload), taskCreate)
 	})
 
 	It("succeeds", func() {
@@ -155,13 +146,7 @@ var _ = Describe("TaskUpdate", func() {
 	})
 
 	JustBeforeEach(func() {
-		body, err := json.Marshal(updatePayload)
-		Expect(err).NotTo(HaveOccurred())
-
-		req, err := http.NewRequest("", "", bytes.NewReader(body))
-		Expect(err).NotTo(HaveOccurred())
-
-		validatorErr = validator.DecodeAndValidateJSONPayload(req, taskUpdate)
+		validatorErr = validator.DecodeAndValidateJSONPayload(createRequest(updatePayload), taskUpdate)
 	})
 
 	It("succeeds", func() {

--- a/api/payloads/validation/rules.go
+++ b/api/payloads/validation/rules.go
@@ -1,0 +1,42 @@
+package validation
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/jellydator/validation"
+)
+
+func NotStartWith(prefix string) validation.Rule {
+	return validation.NewStringRule(func(value string) bool {
+		return !strings.HasPrefix(value, prefix)
+	}, fmt.Sprintf("prefix %s is not allowed", prefix))
+}
+
+func NotEqual(value string) validation.Rule {
+	return validation.NewStringRule(func(actualValue string) bool {
+		return actualValue != value
+	}, fmt.Sprintf("value %s is not allowed", value))
+}
+
+var StrictlyRequired = strictlyRequiredRule{}
+
+type strictlyRequiredRule struct {
+	validation.RequiredRule
+}
+
+// We wrap tje original validation.RequiredRule in order to workaround
+// incorrect zero type check:
+// https://github.com/jellydator/validation/blob/44595f5c48dd0da8bbeff0f56ceaa581631e55b1/util.go#L151-L156
+func (r strictlyRequiredRule) Validate(value interface{}) error {
+	if err := r.RequiredRule.Validate(value); err != nil {
+		return err
+	}
+
+	if reflect.DeepEqual(value, reflect.Zero(reflect.TypeOf(value)).Interface()) {
+		return validation.ErrRequired
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Is there a related GitHub Issue?
#1996
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Use jellydator in `v3/apps` payload validation

Also,
* Introduce the `StrictRequired` validation rule to workaround erroneous
  zero value check in jellydator
  (https://github.com/jellydator/validation/blob/44595f5c48dd0da8bbeff0f56ceaa581631e55b1/util.go#L151-L156)
* Rename `ParseArrayParam` to `ArrayParam` and move it into a dedicated
  `parse` package
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
Not a functional change, everything should work as before
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@georgethebeatle
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
