### PR TITLE
Retry acquiring lease lock when NotFound encountered

### DIFF
--- a/controllers/coordination/name_registry_test.go
+++ b/controllers/coordination/name_registry_test.go
@@ -148,7 +148,7 @@ var _ = Describe("NameRegistry", func() {
 
 		When("patching fails", func() {
 			BeforeEach(func() {
-				client.PatchReturns(errors.New("boom!"))
+				client.PatchReturnsOnCall(0, errors.New("boom!"))
 			})
 
 			It("returns the error", func() {
@@ -156,6 +156,17 @@ var _ = Describe("NameRegistry", func() {
 					ContainSubstring("boom!"),
 					ContainSubstring("failed to acquire lock"),
 				)))
+			})
+		})
+
+		When("patching fails with NotFound but eventually succeeds", func() {
+			BeforeEach(func() {
+				client.PatchReturns(k8serrors.NewNotFound(schema.GroupResource{}, "boom!"))
+				client.PatchReturnsOnCall(5, nil)
+			})
+
+			It("succeeds", func() {
+				Expect(err).NotTo(HaveOccurred())
 			})
 		})
 	})


### PR DESCRIPTION
## Is there a related GitHub Issue?
#2587

## What is this change about?
This addresses a flake where a resource is created and quickly renamed in our integration tests. We suspect the 2 etcd instances are not yet sync'ed when we attempt to modified the lease created with the original resource name. We get a NotFound error. By allowing a limited number of retries with an exponential backoff, we should deal with this condition.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Expect not to see the error seen in the issue.

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
