### PR TITLE
Use jellydator for build and droplet payloads

### DIFF
--- a/api/handlers/droplet.go
+++ b/api/handlers/droplet.go
@@ -28,20 +28,20 @@ type CFDropletRepository interface {
 }
 
 type Droplet struct {
-	serverURL        url.URL
-	dropletRepo      CFDropletRepository
-	decoderValidator *DecoderValidator
+	serverURL            url.URL
+	dropletRepo          CFDropletRepository
+	requestJSONValidator RequestJSONValidator
 }
 
 func NewDroplet(
 	serverURL url.URL,
 	dropletRepo CFDropletRepository,
-	decoderValidator *DecoderValidator,
+	requestJSONValidator RequestJSONValidator,
 ) *Droplet {
 	return &Droplet{
-		serverURL:        serverURL,
-		dropletRepo:      dropletRepo,
-		decoderValidator: decoderValidator,
+		serverURL:            serverURL,
+		dropletRepo:          dropletRepo,
+		requestJSONValidator: requestJSONValidator,
 	}
 }
 
@@ -71,7 +71,7 @@ func (h *Droplet) update(r *http.Request) (*routing.Response, error) {
 	dropletGUID := routing.URLParam(r, "guid")
 
 	var payload payloads.DropletUpdate
-	if err := h.decoderValidator.DecodeAndValidateJSONPayload(r, &payload); err != nil {
+	if err := h.requestJSONValidator.DecodeAndValidateJSONPayload(r, &payload); err != nil {
 		return nil, apierrors.LogAndReturn(logger, err, "failed to decode payload")
 	}
 

--- a/api/payloads/build.go
+++ b/api/payloads/build.go
@@ -1,15 +1,24 @@
 package payloads
 
 import (
+	payload_validation "code.cloudfoundry.org/korifi/api/payloads/validation"
 	"code.cloudfoundry.org/korifi/api/repositories"
+	"github.com/jellydator/validation"
 )
 
 type BuildCreate struct {
-	Package         *RelationshipData `json:"package" validate:"required"`
+	Package         *RelationshipData `json:"package"`
 	StagingMemoryMB *int              `json:"staging_memory_in_mb"`
 	StagingDiskMB   *int              `json:"staging_disk_in_mb"`
 	Lifecycle       *Lifecycle        `json:"lifecycle"`
 	Metadata        BuildMetadata     `json:"metadata"`
+}
+
+func (b BuildCreate) Validate() error {
+	return validation.ValidateStruct(&b,
+		validation.Field(&b.Package, payload_validation.StrictlyRequired),
+		validation.Field(&b.Metadata),
+	)
 }
 
 func (c *BuildCreate) ToMessage(appRecord repositories.AppRecord) repositories.CreateBuildMessage {

--- a/api/payloads/build_test.go
+++ b/api/payloads/build_test.go
@@ -40,7 +40,7 @@ var _ = Describe("BuildCreate", func() {
 			})
 
 			It("says package is required", func() {
-				expectUnprocessableEntityError(validatorErr, "Package is a required field")
+				expectUnprocessableEntityError(validatorErr, "package cannot be blank")
 			})
 		})
 
@@ -50,7 +50,7 @@ var _ = Describe("BuildCreate", func() {
 			})
 
 			It("says guid is required", func() {
-				expectUnprocessableEntityError(validatorErr, "GUID is a required field")
+				expectUnprocessableEntityError(validatorErr, "package.guid cannot be blank")
 			})
 		})
 
@@ -62,7 +62,7 @@ var _ = Describe("BuildCreate", func() {
 			})
 
 			It("says labels and annotations are not supported", func() {
-				expectUnprocessableEntityError(validatorErr, "Labels and annotations are not supported for builds")
+				expectUnprocessableEntityError(validatorErr, "metadata.annotations must be blank")
 			})
 		})
 
@@ -74,7 +74,7 @@ var _ = Describe("BuildCreate", func() {
 			})
 
 			It("says labels and annotations are not supported", func() {
-				expectUnprocessableEntityError(validatorErr, "Labels and annotations are not supported for builds")
+				expectUnprocessableEntityError(validatorErr, "metadata.labels must be blank")
 			})
 		})
 	})

--- a/api/payloads/droplet.go
+++ b/api/payloads/droplet.go
@@ -1,9 +1,18 @@
 package payloads
 
-import "code.cloudfoundry.org/korifi/api/repositories"
+import (
+	"code.cloudfoundry.org/korifi/api/repositories"
+	"github.com/jellydator/validation"
+)
 
 type DropletUpdate struct {
 	Metadata MetadataPatch `json:"metadata"`
+}
+
+func (d DropletUpdate) Validate() error {
+	return validation.ValidateStruct(&d,
+		validation.Field(&d.Metadata),
+	)
 }
 
 func (c *DropletUpdate) ToMessage(dropletGUID string) repositories.UpdateDropletMessage {

--- a/api/payloads/droplet_test.go
+++ b/api/payloads/droplet_test.go
@@ -50,7 +50,7 @@ var _ = Describe("DropletUpdate", func() {
 			})
 
 			It("returns an appropriate error", func() {
-				expectUnprocessableEntityError(validatorErr, "cannot begin with \"cloudfoundry.org\"")
+				expectUnprocessableEntityError(validatorErr, "cannot use the cloudfoundry.org domain")
 			})
 		})
 
@@ -64,7 +64,7 @@ var _ = Describe("DropletUpdate", func() {
 			})
 
 			It("returns an appropriate error", func() {
-				expectUnprocessableEntityError(validatorErr, "cannot begin with \"cloudfoundry.org\"")
+				expectUnprocessableEntityError(validatorErr, "cannot use the cloudfoundry.org domain")
 			})
 		})
 	})

--- a/api/payloads/metadata.go
+++ b/api/payloads/metadata.go
@@ -10,8 +10,15 @@ import (
 )
 
 type BuildMetadata struct {
-	Annotations map[string]string `json:"annotations" validate:"buildmetadatavalidator"`
-	Labels      map[string]string `json:"labels" validate:"buildmetadatavalidator"`
+	Annotations map[string]string `json:"annotations"`
+	Labels      map[string]string `json:"labels"`
+}
+
+func (m BuildMetadata) Validate() error {
+	return validation.ValidateStruct(&m,
+		validation.Field(&m.Annotations, validation.Empty),
+		validation.Field(&m.Labels, validation.Empty),
+	)
 }
 
 type Metadata struct {


### PR DESCRIPTION
## Is there a related GitHub Issue?
#1996
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
- Use jellydator to validate build create payloads
- Use jellydator to validate droplet payloads
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
Everything works as before
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@georgethebeatle
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
