### PR TITLE
Avoid issues uninstalling korifi or deleting the root ns

### DIFF
--- a/controllers/api/v1alpha1/shared_types.go
+++ b/controllers/api/v1alpha1/shared_types.go
@@ -23,6 +23,7 @@ const (
 
 	PropagateRoleBindingAnnotation    = "cloudfoundry.org/propagate-cf-role"
 	PropagateServiceAccountAnnotation = "cloudfoundry.org/propagate-service-account"
+	PropagateDeletionAnnotation       = "cloudfoundry.org/propagate-deletion"
 	PropagatedFromLabel               = "cloudfoundry.org/propagated-from"
 )
 

--- a/controllers/config/config.go
+++ b/controllers/config/config.go
@@ -17,19 +17,20 @@ type ControllerConfig struct {
 	IncludeContourRouter     bool `yaml:"includeContourRouter"`
 
 	// core controllers
-	CFProcessDefaults           CFProcessDefaults `yaml:"cfProcessDefaults"`
-	CFRootNamespace             string            `yaml:"cfRootNamespace"`
-	ContainerRegistrySecretName string            `yaml:"containerRegistrySecretName"`
-	TaskTTL                     string            `yaml:"taskTTL"`
-	WorkloadsTLSSecretName      string            `yaml:"workloads_tls_secret_name"`
-	WorkloadsTLSSecretNamespace string            `yaml:"workloads_tls_secret_namespace"`
-	BuilderName                 string            `yaml:"builderName"`
-	RunnerName                  string            `yaml:"runnerName"`
-	NamespaceLabels             map[string]string `yaml:"namespaceLabels"`
-	ExtraVCAPApplicationValues  map[string]any    `yaml:"extraVCAPApplicationValues"`
-	MaxRetainedPackagesPerApp   int               `yaml:"maxRetainedPackagesPerApp"`
-	MaxRetainedBuildsPerApp     int               `yaml:"maxRetainedBuildsPerApp"`
-	LogLevel                    zapcore.Level     `yaml:"logLevel"`
+	CFProcessDefaults                CFProcessDefaults `yaml:"cfProcessDefaults"`
+	CFRootNamespace                  string            `yaml:"cfRootNamespace"`
+	ContainerRegistrySecretName      string            `yaml:"containerRegistrySecretName"`
+	TaskTTL                          string            `yaml:"taskTTL"`
+	WorkloadsTLSSecretName           string            `yaml:"workloads_tls_secret_name"`
+	WorkloadsTLSSecretNamespace      string            `yaml:"workloads_tls_secret_namespace"`
+	BuilderName                      string            `yaml:"builderName"`
+	RunnerName                       string            `yaml:"runnerName"`
+	NamespaceLabels                  map[string]string `yaml:"namespaceLabels"`
+	ExtraVCAPApplicationValues       map[string]any    `yaml:"extraVCAPApplicationValues"`
+	MaxRetainedPackagesPerApp        int               `yaml:"maxRetainedPackagesPerApp"`
+	MaxRetainedBuildsPerApp          int               `yaml:"maxRetainedBuildsPerApp"`
+	LogLevel                         zapcore.Level     `yaml:"logLevel"`
+	SpaceFinalizerAppDeletionTimeout *int64            `yaml:"spaceFinalizerAppDeletionTimeout"`
 
 	// job-task-runner
 	JobTTL string `yaml:"jobTTL"`
@@ -63,6 +64,10 @@ func LoadFromPath(path string) (*ControllerConfig, error) {
 
 	if config.CFProcessDefaults.Timeout == nil {
 		config.CFProcessDefaults.Timeout = tools.PtrTo(defaultTimeout)
+	}
+
+	if config.SpaceFinalizerAppDeletionTimeout == nil {
+		config.SpaceFinalizerAppDeletionTimeout = tools.PtrTo(defaultTimeout)
 	}
 
 	return &config, nil

--- a/controllers/config/config_test.go
+++ b/controllers/config/config_test.go
@@ -5,16 +5,14 @@ import (
 	"path/filepath"
 	"time"
 
-	"go.uber.org/zap/zapcore"
-
-	"gopkg.in/yaml.v3"
-
 	"code.cloudfoundry.org/korifi/controllers/config"
 	"code.cloudfoundry.org/korifi/tools"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gstruct"
+	"go.uber.org/zap/zapcore"
+	"gopkg.in/yaml.v3"
 )
 
 var _ = Describe("LoadFromPath", func() {
@@ -37,15 +35,16 @@ var _ = Describe("LoadFromPath", func() {
 				DiskQuotaMB: 512,
 				Timeout:     tools.PtrTo(int64(30)),
 			},
-			CFRootNamespace:             "rootNamespace",
-			ContainerRegistrySecretName: "packageRegistrySecretName",
-			TaskTTL:                     "taskTTL",
-			WorkloadsTLSSecretName:      "workloadsTLSSecretName",
-			WorkloadsTLSSecretNamespace: "workloadsTLSSecretNamespace",
-			BuilderName:                 "buildReconciler",
-			RunnerName:                  "statefulset-runner",
-			JobTTL:                      "jobTTL",
-			LogLevel:                    zapcore.DebugLevel,
+			CFRootNamespace:                  "rootNamespace",
+			ContainerRegistrySecretName:      "packageRegistrySecretName",
+			TaskTTL:                          "taskTTL",
+			WorkloadsTLSSecretName:           "workloadsTLSSecretName",
+			WorkloadsTLSSecretNamespace:      "workloadsTLSSecretNamespace",
+			BuilderName:                      "buildReconciler",
+			RunnerName:                       "statefulset-runner",
+			JobTTL:                           "jobTTL",
+			LogLevel:                         zapcore.DebugLevel,
+			SpaceFinalizerAppDeletionTimeout: tools.PtrTo(int64(42)),
 		}
 	})
 
@@ -69,21 +68,22 @@ var _ = Describe("LoadFromPath", func() {
 				DiskQuotaMB: 512,
 				Timeout:     tools.PtrTo(int64(30)),
 			},
-			CFRootNamespace:             "rootNamespace",
-			ContainerRegistrySecretName: "packageRegistrySecretName",
-			TaskTTL:                     "taskTTL",
-			WorkloadsTLSSecretName:      "workloadsTLSSecretName",
-			WorkloadsTLSSecretNamespace: "workloadsTLSSecretNamespace",
-			BuilderName:                 "buildReconciler",
-			RunnerName:                  "statefulset-runner",
-			NamespaceLabels:             map[string]string{},
-			ExtraVCAPApplicationValues:  map[string]any{},
-			JobTTL:                      "jobTTL",
-			LogLevel:                    zapcore.DebugLevel,
+			CFRootNamespace:                  "rootNamespace",
+			ContainerRegistrySecretName:      "packageRegistrySecretName",
+			TaskTTL:                          "taskTTL",
+			WorkloadsTLSSecretName:           "workloadsTLSSecretName",
+			WorkloadsTLSSecretNamespace:      "workloadsTLSSecretNamespace",
+			BuilderName:                      "buildReconciler",
+			RunnerName:                       "statefulset-runner",
+			NamespaceLabels:                  map[string]string{},
+			ExtraVCAPApplicationValues:       map[string]any{},
+			JobTTL:                           "jobTTL",
+			LogLevel:                         zapcore.DebugLevel,
+			SpaceFinalizerAppDeletionTimeout: tools.PtrTo(int64(42)),
 		}))
 	})
 
-	When("timeout is not set", func() {
+	When("the CFProcess default timeout is not set", func() {
 		BeforeEach(func() {
 			cfg.CFProcessDefaults.Timeout = nil
 		})
@@ -100,6 +100,16 @@ var _ = Describe("LoadFromPath", func() {
 
 		It("uses the default", func() {
 			Expect(retConfig.LogLevel).To(Equal(zapcore.InfoLevel))
+		})
+	})
+
+	When("the space finalizer app deletion timeout is not set", func() {
+		BeforeEach(func() {
+			cfg.SpaceFinalizerAppDeletionTimeout = nil
+		})
+
+		It("uses the default", func() {
+			Expect(retConfig.SpaceFinalizerAppDeletionTimeout).To(gstruct.PointTo(Equal(int64(60))))
 		})
 	})
 })

--- a/controllers/controllers/shared/index.go
+++ b/controllers/controllers/shared/index.go
@@ -2,9 +2,11 @@ package shared
 
 import (
 	"context"
+	"strings"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 
+	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -113,4 +115,27 @@ func GetConditionOrSetAsUnknown(conditions *[]metav1.Condition, conditionType st
 	})
 
 	return metav1.ConditionUnknown
+}
+
+func RemovePackageManagerAnnotations(src map[string]string, log logr.Logger) map[string]string {
+	if src == nil {
+		return src
+	}
+
+	dest := map[string]string{}
+	for key, value := range src {
+		if strings.HasPrefix(key, "meta.helm.sh/") {
+			log.V(1).Info("skipping helm annotation propagation", "key", key)
+			continue
+		}
+
+		if strings.HasPrefix(key, "kapp.k14s.io/") {
+			log.V(1).Info("skipping kapp annotation propagation", "key", key)
+			continue
+		}
+
+		dest[key] = value
+	}
+
+	return dest
 }

--- a/controllers/controllers/workloads/cfapp_controller.go
+++ b/controllers/controllers/workloads/cfapp_controller.go
@@ -94,7 +94,7 @@ func serviceBindingToApp(ctx context.Context, o client.Object) []reconcile.Reque
 	}
 }
 
-//+kubebuilder:rbac:groups=korifi.cloudfoundry.org,resources=cfapps,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=korifi.cloudfoundry.org,resources=cfapps,verbs=get;list;watch;create;update;patch;delete;deletecollection
 //+kubebuilder:rbac:groups=korifi.cloudfoundry.org,resources=cfapps/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=korifi.cloudfoundry.org,resources=cfapps/finalizers,verbs=update
 

--- a/controllers/controllers/workloads/cforg_controller_test.go
+++ b/controllers/controllers/workloads/cforg_controller_test.go
@@ -108,7 +108,7 @@ var _ = Describe("CFOrgReconciler Integration Tests", func() {
 			})
 
 			AfterEach(func() {
-				imageRegistrySecret = createSecret(ctx, k8sClient, packageRegistrySecretName, cfRootNamespace)
+				imageRegistrySecret = createImageRegistrySecret(ctx, k8sClient, packageRegistrySecretName, cfRootNamespace)
 			})
 
 			It("sets the CFOrg's Ready condition to 'False'", func() {

--- a/controllers/controllers/workloads/cfspace_controller.go
+++ b/controllers/controllers/workloads/cfspace_controller.go
@@ -309,6 +309,10 @@ func (r *CFSpaceReconciler) reconcileServiceAccounts(ctx context.Context, space 
 
 	for index := range propagatedServiceAccounts.Items {
 		propagatedServiceAccount := propagatedServiceAccounts.Items[index]
+		if propagatedServiceAccount.Annotations[korifiv1alpha1.PropagateDeletionAnnotation] == "false" {
+			continue
+		}
+
 		if _, found := serviceAccountMap[propagatedServiceAccount.Name]; !found {
 			err = r.client.Delete(ctx, &propagatedServiceAccount)
 			if err != nil {

--- a/controllers/controllers/workloads/shared.go
+++ b/controllers/controllers/workloads/shared.go
@@ -161,6 +161,10 @@ func reconcileRoleBindings(ctx context.Context, kClient client.Client, log logr.
 
 	for index := range propagatedRoleBindings.Items {
 		propagatedRoleBinding := propagatedRoleBindings.Items[index]
+		if propagatedRoleBinding.Annotations[korifiv1alpha1.PropagateDeletionAnnotation] == "false" {
+			continue
+		}
+
 		if _, found := parentRoleBindingMap[propagatedRoleBinding.Name]; !found {
 			err = kClient.Delete(ctx, &propagatedRoleBinding)
 			if err != nil {

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -230,6 +230,7 @@ func main() {
 			ctrl.Log.WithName("controllers").WithName("CFSpace"),
 			controllerConfig.ContainerRegistrySecretName,
 			controllerConfig.CFRootNamespace,
+			*controllerConfig.SpaceFinalizerAppDeletionTimeout,
 			labelCompiler,
 		).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "CFSpace")

--- a/helm/korifi/controllers/role.yaml
+++ b/helm/korifi/controllers/role.yaml
@@ -177,6 +177,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch

--- a/helm/korifi/job-task-runner/runner-rbac.yaml
+++ b/helm/korifi/job-task-runner/runner-rbac.yaml
@@ -3,5 +3,6 @@ kind: ServiceAccount
 metadata:
   annotations:
     cloudfoundry.org/propagate-service-account: "true"
+    cloudfoundry.org/propagate-deletion: "false"
   name: korifi-task
   namespace: {{ .Values.global.rootNamespace }}

--- a/helm/korifi/kpack-image-builder/service-account.yaml
+++ b/helm/korifi/kpack-image-builder/service-account.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: {{ .Values.global.rootNamespace }}
   annotations:
     cloudfoundry.org/propagate-service-account: "true"
+    cloudfoundry.org/propagate-deletion: "false"
     {{- if .Values.global.eksContainerRegistryRoleARN }}
     eks.amazonaws.com/role-arn: {{ .Values.global.eksContainerRegistryRoleARN }}
     {{- end }}

--- a/helm/korifi/statefulset-runner/runner-rbac.yaml
+++ b/helm/korifi/statefulset-runner/runner-rbac.yaml
@@ -3,5 +3,6 @@ kind: ServiceAccount
 metadata:
   annotations:
     cloudfoundry.org/propagate-service-account: "true"
+    cloudfoundry.org/propagate-deletion: "false"
   name: korifi-app
   namespace: {{ .Values.global.rootNamespace }}


### PR DESCRIPTION

## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ --> No

## What is this change about?
<!-- _Please describe the change here._ --> This PR makes a number of changes to avoid problems uninstalling a korifi deployment:
- Don't propagate helm or kapp labels and annotations to secrets, role bindings or service accounts that are propagated by korifi. This avoids situations where kapp would attempt to tear down the propagated resources directly instead of letting the deletion of the root namespace trigger the process in a predictable order. We haven't seen similar problems for helm, but it seemed appropriate to also remove its labels/annotations, as the resources in question aren't managed by helm either.
- Add the `cloudfoundry.org/propagate-deletion` annotation for service accounts and role bindings. When this is present and set to `"false"`, then deleting the resource in the root namespace or an org namespace won't cause the propagated copies to be deleted from org and space namespaces. This avoids problems where a propagated service account may be required to properly tear down the result of a `BuildWorkload` or `AppWorkload`. Without this change, the root namespace's deletion could trigger the deletion of the service account and its role bindings before they could be used for teardown.
- Remove an earlier check in the CFSpace finalizer logic that attempted to skip propagating deletions when the root namespace was being deleted. It did not work in practice (possibly due to caching or a race condition)
- Along the way, we refactored the CFSpace finalizer logic.

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->
- Deploy korifi
- Create an org and space
- Wait for the kpack-service-account to be propagated to the space's namespace.
- Confirm that neither of those propagated resources has helm labels or annotations on them
- Delete the `kpack-service-account` from the root namespace
- Confirm that the propagated resource in the space's namespace is not deleted

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ --> @davewalter @acosta11 @clintyoshimura 

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
