### PR TITLE
Update default stack to Ubuntu Jammy Jellyfish

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ test-e2e: build-dorifi
 	./scripts/run-tests.sh tests/e2e
 
 build-dorifi:
-	CGO_ENABLED=0 go build -o ../dorifi/dorifi -C tests/e2e/assets/golang .
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ../dorifi/dorifi -C tests/e2e/assets/golang .
 
 GOFUMPT = $(shell go env GOPATH)/bin/gofumpt
 install-gofumpt:

--- a/README.helm.md
+++ b/README.helm.md
@@ -94,8 +94,9 @@ Here are all the values that can be set for the chart:
   - `builderReadinessTimeout` (_String_): The time that the kpack Builder will be waited for if not in ready state, berfore the build workload fails. See [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration) for details on the format, an additional `d` suffix for days is supported.
   - `builderRepository` (_String_): Container image repository to store the `ClusterBuilder` image. Required when `clusterBuilderName` is not provided.
   - `clusterBuilderName` (_String_): The name of the `ClusterBuilder` Kpack has been configured with. Leave blank to let `kpack-image-builder` create an example `ClusterBuilder`.
-  - `clusterStackBuildImage` (_String_): The image to use for building defined in the `ClusterStack`. Used when `kpack-image-builder` is blank.
-  - `clusterStackRunImage` (_String_): The image to use for running defined in the `ClusterStack`. Used when `kpack-image-builder` is blank.
+  - `clusterStackBuildImage` (_String_): The image to use for building defined in the `ClusterStack`. Used when `clusterBuilderName` is blank.
+  - `clusterStackID` (_String_): The ID of the `ClusterStack`. Used when `clusterBuilderName` is blank.
+  - `clusterStackRunImage` (_String_): The image to use for running defined in the `ClusterStack`. Used when `clusterBuilderName` is blank.
   - `include` (_Boolean_): Deploy the `kpack-image-builder` component.
   - `replicas` (_Integer_): Number of replicas.
   - `resources`: [`ResourceRequirements`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#resourcerequirements-v1-core) for the API.

--- a/README.md
+++ b/README.md
@@ -43,4 +43,4 @@ Our [hacking guide](./HACKING.md) has instructions on how to work on the project
 
 This project is licensed under the [Apache License, Version 2.0](/LICENSE).
 
-When using the Korifi or other Cloud Foundry logos, be sure to follow the [guidelines](https://www.cloudfoundry.org/logo/).
+When using the Korifi or other Cloud Foundry logos be sure to follow the [guidelines](https://www.cloudfoundry.org/logo/).

--- a/helm/korifi/kpack-image-builder/cluster-builder.yaml
+++ b/helm/korifi/kpack-image-builder/cluster-builder.yaml
@@ -17,7 +17,7 @@ kind: ClusterStack
 metadata:
   name: cf-default-stack
 spec:
-  id: "io.buildpacks.stacks.bionic"
+  id: "io.buildpacks.stacks.jammy"
   buildImage:
     image: {{ .Values.kpackImageBuilder.clusterStackBuildImage | quote }}
   runImage:

--- a/helm/korifi/kpack-image-builder/cluster-builder.yaml
+++ b/helm/korifi/kpack-image-builder/cluster-builder.yaml
@@ -17,7 +17,7 @@ kind: ClusterStack
 metadata:
   name: cf-default-stack
 spec:
-  id: "io.buildpacks.stacks.jammy"
+  id: {{ .Values.kpackImageBuilder.clusterStackID | quote }}
   buildImage:
     image: {{ .Values.kpackImageBuilder.clusterStackBuildImage | quote }}
   runImage:

--- a/helm/korifi/values.schema.json
+++ b/helm/korifi/values.schema.json
@@ -377,12 +377,16 @@
           "description": "The time that the kpack Builder will be waited for if not in ready state, berfore the build workload fails. See [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration) for details on the format, an additional `d` suffix for days is supported.",
           "type": "string"
         },
+        "clusterStackID": {
+          "description": "The ID of the `ClusterStack`. Used when `clusterBuilderName` is blank.",
+          "type": "string"
+        },
         "clusterStackBuildImage": {
-          "description": "The image to use for building defined in the `ClusterStack`. Used when `kpack-image-builder` is blank.",
+          "description": "The image to use for building defined in the `ClusterStack`. Used when `clusterBuilderName` is blank.",
           "type": "string"
         },
         "clusterStackRunImage": {
-          "description": "The image to use for running defined in the `ClusterStack`. Used when `kpack-image-builder` is blank.",
+          "description": "The image to use for running defined in the `ClusterStack`. Used when `clusterBuilderName` is blank.",
           "type": "string"
         },
         "builderRepository": {

--- a/helm/korifi/values.yaml
+++ b/helm/korifi/values.yaml
@@ -92,8 +92,8 @@ kpackImageBuilder:
 
   clusterBuilderName: ""
   builderReadinessTimeout: 30s
-  clusterStackBuildImage: paketobuildpacks/build:full-cnb
-  clusterStackRunImage: paketobuildpacks/run:full-cnb
+  clusterStackBuildImage: paketobuildpacks/build-jammy-full
+  clusterStackRunImage: paketobuildpacks/run-jammy-full
   builderRepository: ""
 
 statefulsetRunner:

--- a/helm/korifi/values.yaml
+++ b/helm/korifi/values.yaml
@@ -92,6 +92,7 @@ kpackImageBuilder:
 
   clusterBuilderName: ""
   builderReadinessTimeout: 30s
+  clusterStackID: io.buildpacks.stacks.jammy
   clusterStackBuildImage: paketobuildpacks/build-jammy-full
   clusterStackRunImage: paketobuildpacks/run-jammy-full
   builderRepository: ""

--- a/scripts/assets/values-template.yaml
+++ b/scripts/assets/values-template.yaml
@@ -22,5 +22,5 @@ jobTaskRunner:
   jobTTL: 5s
 
 kpackImageBuilder:
-  clusterStackBuildImage: paketobuildpacks/build:base-cnb
-  clusterStackRunImage: paketobuildpacks/run:base-cnb
+  clusterStackBuildImage: paketobuildpacks/build-jammy-base
+  clusterStackRunImage: paketobuildpacks/run-jammy-base

--- a/scripts/assets/values-template.yaml
+++ b/scripts/assets/values-template.yaml
@@ -22,5 +22,6 @@ jobTaskRunner:
   jobTTL: 5s
 
 kpackImageBuilder:
+  clusterStackID: io.buildpacks.stacks.jammy
   clusterStackBuildImage: paketobuildpacks/build-jammy-base
   clusterStackRunImage: paketobuildpacks/run-jammy-base


### PR DESCRIPTION
- Ubuntu Bionic Beaver 18.04 left general support in April 2023 and mainline CF has switched to cflinuxfs4 which is based on Jammy Jellyfish 22.04 LTS
- See https://www.cloudfoundry.org/blog/jammy-jellyfish-cloud-foundry/ for more details on that.

## Is there a related GitHub Issue?
No

## What is this change about?
This change updates our Helm template to install a stack based off of Ubuntu Jammy Jellyfish since Bionic is now at its end-of-life.

## Does this PR introduce a breaking change?
Since this is a change to the base image that apps build and run with there may be subtle difference. However, this should be very similar to the differences that apps might encounter when moving from `cflinuxfs3` to `cflinuxfs4` and there are dedicated Slack channels on CF Slack related to this (e.g. [#bosh-jammy](https://app.slack.com/client/T02FL4A1X/C02M2R39Y8Z)).

I don't expect there to be a major impact to Korifi development.

## Acceptance Steps
1. Deploy with these changes
2. Push an app
3. `kubectl exec` into the app container and run `cat /etc/os-release` to confirm the app is running with Jammy

## Tag your pair, your PM, and/or team
@julian-hj 
