### PR TITLE
Don't modify leases when in dry-run mode

### DIFF
--- a/controllers/coordination/name_registry_test.go
+++ b/controllers/coordination/name_registry_test.go
@@ -6,9 +6,12 @@ import (
 
 	"code.cloudfoundry.org/korifi/controllers/coordination"
 	"code.cloudfoundry.org/korifi/controllers/fake"
+	"code.cloudfoundry.org/korifi/tools"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	admissionv1 "k8s.io/api/admission/v1"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -178,7 +181,7 @@ var _ = Describe("NameRegistry", func() {
 
 		When("patching fails", func() {
 			BeforeEach(func() {
-				client.PatchReturnsOnCall(0, errors.New("boom!"))
+				client.PatchReturns(errors.New("boom!"))
 			})
 
 			It("returns the error", func() {
@@ -186,17 +189,6 @@ var _ = Describe("NameRegistry", func() {
 					ContainSubstring("boom!"),
 					ContainSubstring("failed to acquire lock"),
 				)))
-			})
-		})
-
-		When("patching fails with NotFound but eventually succeeds", func() {
-			BeforeEach(func() {
-				client.PatchReturns(k8serrors.NewNotFound(schema.GroupResource{}, "boom!"))
-				client.PatchReturnsOnCall(5, nil)
-			})
-
-			It("succeeds", func() {
-				Expect(err).NotTo(HaveOccurred())
 			})
 		})
 

--- a/controllers/coordination/name_registry_test.go
+++ b/controllers/coordination/name_registry_test.go
@@ -79,6 +79,21 @@ var _ = Describe("NameRegistry", func() {
 				Expect(err).To(MatchError(ContainSubstring("creating a lease failed")))
 			})
 		})
+
+		When("in a dry-run request context", func() {
+			BeforeEach(func() {
+				ctx = admission.NewContextWithRequest(ctx, admission.Request{
+					AdmissionRequest: admissionv1.AdmissionRequest{
+						DryRun: tools.PtrTo(true),
+					},
+				})
+			})
+
+			It("does not create a lease", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(client.CreateCallCount()).To(BeZero())
+			})
+		})
 	})
 
 	Describe("DeregisterName", func() {
@@ -117,6 +132,21 @@ var _ = Describe("NameRegistry", func() {
 					ContainSubstring("boom!"),
 					ContainSubstring("deleting a lease failed"),
 				)))
+			})
+		})
+
+		When("in a dry-run request context", func() {
+			BeforeEach(func() {
+				ctx = admission.NewContextWithRequest(ctx, admission.Request{
+					AdmissionRequest: admissionv1.AdmissionRequest{
+						DryRun: tools.PtrTo(true),
+					},
+				})
+			})
+
+			It("does not delete the lease", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(client.DeleteCallCount()).To(BeZero())
 			})
 		})
 	})
@@ -169,6 +199,21 @@ var _ = Describe("NameRegistry", func() {
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})
+
+		When("in a dry-run request context", func() {
+			BeforeEach(func() {
+				ctx = admission.NewContextWithRequest(ctx, admission.Request{
+					AdmissionRequest: admissionv1.AdmissionRequest{
+						DryRun: tools.PtrTo(true),
+					},
+				})
+			})
+
+			It("does not patch the lease", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(client.PatchCallCount()).To(BeZero())
+			})
+		})
 	})
 
 	Describe("UnlockName", func() {
@@ -206,6 +251,21 @@ var _ = Describe("NameRegistry", func() {
 					ContainSubstring("boom!"),
 					ContainSubstring("failed to release lock on lease"),
 				)))
+			})
+		})
+
+		When("in a dry-run request context", func() {
+			BeforeEach(func() {
+				ctx = admission.NewContextWithRequest(ctx, admission.Request{
+					AdmissionRequest: admissionv1.AdmissionRequest{
+						DryRun: tools.PtrTo(true),
+					},
+				})
+			})
+
+			It("does not patch the lease", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(client.PatchCallCount()).To(BeZero())
 			})
 		})
 	})

--- a/controllers/webhooks/networking/cfroute_validator.go
+++ b/controllers/webhooks/networking/cfroute_validator.go
@@ -44,7 +44,7 @@ const (
 
 var logger = logf.Log.WithName("route-validation")
 
-//+kubebuilder:webhook:path=/validate-korifi-cloudfoundry-org-v1alpha1-cfroute,mutating=false,failurePolicy=fail,sideEffects=None,groups=korifi.cloudfoundry.org,resources=cfroutes,verbs=create;update;delete,versions=v1alpha1,name=vcfroute.korifi.cloudfoundry.org,admissionReviewVersions={v1,v1beta1}
+//+kubebuilder:webhook:path=/validate-korifi-cloudfoundry-org-v1alpha1-cfroute,mutating=false,failurePolicy=fail,sideEffects=NoneOnDryRun,groups=korifi.cloudfoundry.org,resources=cfroutes,verbs=create;update;delete,versions=v1alpha1,name=vcfroute.korifi.cloudfoundry.org,admissionReviewVersions={v1,v1beta1}
 
 type CFRouteValidator struct {
 	duplicateValidator webhooks.NameValidator

--- a/controllers/webhooks/services/cfservicebinding_validator.go
+++ b/controllers/webhooks/services/cfservicebinding_validator.go
@@ -24,7 +24,7 @@ const (
 // log is for logging in this package.
 var cfservicebindinglog = logf.Log.WithName("cfservicebinding-validator")
 
-//+kubebuilder:webhook:path=/validate-korifi-cloudfoundry-org-v1alpha1-cfservicebinding,mutating=false,failurePolicy=fail,sideEffects=None,groups=korifi.cloudfoundry.org,resources=cfservicebindings,verbs=create;update;delete,versions=v1alpha1,name=vcfservicebinding.korifi.cloudfoundry.org,admissionReviewVersions={v1,v1beta1}
+//+kubebuilder:webhook:path=/validate-korifi-cloudfoundry-org-v1alpha1-cfservicebinding,mutating=false,failurePolicy=fail,sideEffects=NoneOnDryRun,groups=korifi.cloudfoundry.org,resources=cfservicebindings,verbs=create;update;delete,versions=v1alpha1,name=vcfservicebinding.korifi.cloudfoundry.org,admissionReviewVersions={v1,v1beta1}
 
 func (v *CFServiceBindingValidator) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).

--- a/controllers/webhooks/services/cfserviceinstance_validator.go
+++ b/controllers/webhooks/services/cfserviceinstance_validator.go
@@ -23,7 +23,7 @@ const (
 
 var cfserviceinstancelog = logf.Log.WithName("cfserviceinstance-validate")
 
-//+kubebuilder:webhook:path=/validate-korifi-cloudfoundry-org-v1alpha1-cfserviceinstance,mutating=false,failurePolicy=fail,sideEffects=None,groups=korifi.cloudfoundry.org,resources=cfserviceinstances,verbs=create;update;delete,versions=v1alpha1,name=vcfserviceinstance.korifi.cloudfoundry.org,admissionReviewVersions={v1,v1beta1}
+//+kubebuilder:webhook:path=/validate-korifi-cloudfoundry-org-v1alpha1-cfserviceinstance,mutating=false,failurePolicy=fail,sideEffects=NoneOnDryRun,groups=korifi.cloudfoundry.org,resources=cfserviceinstances,verbs=create;update;delete,versions=v1alpha1,name=vcfserviceinstance.korifi.cloudfoundry.org,admissionReviewVersions={v1,v1beta1}
 
 type CFServiceInstanceValidator struct {
 	duplicateValidator webhooks.NameValidator

--- a/controllers/webhooks/workloads/cfapp_validator.go
+++ b/controllers/webhooks/workloads/cfapp_validator.go
@@ -24,7 +24,7 @@ const (
 
 var cfapplog = logf.Log.WithName("cfapp-validate")
 
-//+kubebuilder:webhook:path=/validate-korifi-cloudfoundry-org-v1alpha1-cfapp,mutating=false,failurePolicy=fail,sideEffects=None,groups=korifi.cloudfoundry.org,resources=cfapps,verbs=create;update;delete,versions=v1alpha1,name=vcfapp.korifi.cloudfoundry.org,admissionReviewVersions={v1,v1beta1}
+//+kubebuilder:webhook:path=/validate-korifi-cloudfoundry-org-v1alpha1-cfapp,mutating=false,failurePolicy=fail,sideEffects=NoneOnDryRun,groups=korifi.cloudfoundry.org,resources=cfapps,verbs=create;update;delete,versions=v1alpha1,name=vcfapp.korifi.cloudfoundry.org,admissionReviewVersions={v1,v1beta1}
 
 type CFAppValidator struct {
 	duplicateValidator webhooks.NameValidator

--- a/controllers/webhooks/workloads/cforg_validator.go
+++ b/controllers/webhooks/workloads/cforg_validator.go
@@ -27,7 +27,7 @@ const (
 
 var cfOrgLog = logf.Log.WithName("cforg-validate")
 
-//+kubebuilder:webhook:path=/validate-korifi-cloudfoundry-org-v1alpha1-cforg,mutating=false,failurePolicy=fail,sideEffects=None,groups=korifi.cloudfoundry.org,resources=cforgs,verbs=create;update;delete,versions=v1alpha1,name=vcforg.korifi.cloudfoundry.org,admissionReviewVersions={v1,v1beta1}
+//+kubebuilder:webhook:path=/validate-korifi-cloudfoundry-org-v1alpha1-cforg,mutating=false,failurePolicy=fail,sideEffects=NoneOnDryRun,groups=korifi.cloudfoundry.org,resources=cforgs,verbs=create;update;delete,versions=v1alpha1,name=vcforg.korifi.cloudfoundry.org,admissionReviewVersions={v1,v1beta1}
 
 type CFOrgValidator struct {
 	duplicateValidator webhooks.NameValidator

--- a/controllers/webhooks/workloads/cfspace_validator.go
+++ b/controllers/webhooks/workloads/cfspace_validator.go
@@ -25,7 +25,7 @@ const (
 
 var spaceLogger = logf.Log.WithName("cfspace-validate")
 
-//+kubebuilder:webhook:path=/validate-korifi-cloudfoundry-org-v1alpha1-cfspace,mutating=false,failurePolicy=fail,sideEffects=None,groups=korifi.cloudfoundry.org,resources=cfspaces,verbs=create;update;delete,versions=v1alpha1,name=vcfspace.korifi.cloudfoundry.org,admissionReviewVersions={v1,v1beta1}
+//+kubebuilder:webhook:path=/validate-korifi-cloudfoundry-org-v1alpha1-cfspace,mutating=false,failurePolicy=fail,sideEffects=NoneOnDryRun,groups=korifi.cloudfoundry.org,resources=cfspaces,verbs=create;update;delete,versions=v1alpha1,name=vcfspace.korifi.cloudfoundry.org,admissionReviewVersions={v1,v1beta1}
 
 type CFSpaceValidator struct {
 	duplicateValidator webhooks.NameValidator

--- a/helm/korifi/controllers/manifests.yaml
+++ b/helm/korifi/controllers/manifests.yaml
@@ -261,7 +261,7 @@ webhooks:
           - DELETE
         resources:
           - cfroutes
-    sideEffects: None
+    sideEffects: NoneOnDryRun
   - admissionReviewVersions:
       - v1
       - v1beta1
@@ -283,7 +283,7 @@ webhooks:
           - DELETE
         resources:
           - cfservicebindings
-    sideEffects: None
+    sideEffects: NoneOnDryRun
   - admissionReviewVersions:
       - v1
       - v1beta1
@@ -305,7 +305,7 @@ webhooks:
           - DELETE
         resources:
           - cfserviceinstances
-    sideEffects: None
+    sideEffects: NoneOnDryRun
   - admissionReviewVersions:
       - v1
       - v1beta1
@@ -327,7 +327,7 @@ webhooks:
           - DELETE
         resources:
           - cfapps
-    sideEffects: None
+    sideEffects: NoneOnDryRun
   - admissionReviewVersions:
       - v1
       - v1beta1
@@ -349,7 +349,7 @@ webhooks:
           - DELETE
         resources:
           - cforgs
-    sideEffects: None
+    sideEffects: NoneOnDryRun
   - admissionReviewVersions:
       - v1
       - v1beta1
@@ -371,7 +371,7 @@ webhooks:
           - DELETE
         resources:
           - cfspaces
-    sideEffects: None
+    sideEffects: NoneOnDryRun
   - admissionReviewVersions:
       - v1
       - v1beta1


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?

Our name duplication validating webhooks are side-effecting: i.e. they create and modify leases. If a user runs a request in dry-run mode, the actual update on the resource will not be performed, and our lease updates should also not take place. So we now check the dry-run mode in the name-registry.

This PR also reverts the change to retr take the lease lock, as that does not fix our flake problem.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@gcapizzi

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
