### PR TITLE
Eliminate use of Sprintf in log messages

### DIFF
--- a/api/handlers/build.go
+++ b/api/handlers/build.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 
@@ -59,7 +58,7 @@ func (h *Build) get(r *http.Request) (*routing.Response, error) {
 
 	build, err := h.buildRepo.GetBuild(r.Context(), authInfo, buildGUID)
 	if err != nil {
-		return nil, apierrors.LogAndReturn(logger, apierrors.ForbiddenAsNotFound(err), fmt.Sprintf("Failed to fetch %s from Kubernetes", repositories.BuildResourceType), "guid", buildGUID)
+		return nil, apierrors.LogAndReturn(logger, apierrors.ForbiddenAsNotFound(err), "failed to fetch "+repositories.BuildResourceType, "guid", buildGUID)
 	}
 
 	return routing.NewResponse(http.StatusOK).WithBody(presenter.ForBuild(build, h.serverURL)), nil

--- a/api/handlers/deployment.go
+++ b/api/handlers/deployment.go
@@ -75,7 +75,7 @@ func (h *Deployment) create(r *http.Request) (*routing.Response, error) {
 
 	if !runnerInfo.Capabilities.RollingDeploy {
 		err = fmt.Errorf("The configured runner '%s' does not support rolling deploys", h.runnerName)
-		return nil, apierrors.LogAndReturn(logger, apierrors.NewRollingDeployNotSupportedError(err), fmt.Sprintf("Runner '%s' does not support rolling deploys", h.runnerName))
+		return nil, apierrors.LogAndReturn(logger, apierrors.NewRollingDeployNotSupportedError(err), "runner does not support rolling deploys", "name", h.runnerName)
 	}
 
 	deploymentCreateMessage := payload.ToMessage()

--- a/api/handlers/service_binding.go
+++ b/api/handlers/service_binding.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"net/url"
 
@@ -59,12 +58,12 @@ func (h *ServiceBinding) create(r *http.Request) (*routing.Response, error) {
 
 	app, err := h.appRepo.GetApp(r.Context(), authInfo, payload.Relationships.App.Data.GUID)
 	if err != nil {
-		return nil, apierrors.LogAndReturn(logger, err, fmt.Sprintf("failed to get %s", repositories.AppResourceType))
+		return nil, apierrors.LogAndReturn(logger, err, "failed to get "+repositories.AppResourceType)
 	}
 
 	serviceInstance, err := h.serviceInstanceRepo.GetServiceInstance(r.Context(), authInfo, payload.Relationships.ServiceInstance.Data.GUID)
 	if err != nil {
-		return nil, apierrors.LogAndReturn(logger, err, fmt.Sprintf("failed to get %s", repositories.ServiceInstanceResourceType))
+		return nil, apierrors.LogAndReturn(logger, err, "failed to get "+repositories.ServiceInstanceResourceType)
 	}
 
 	if app.SpaceGUID != serviceInstance.SpaceGUID {
@@ -114,7 +113,7 @@ func (h *ServiceBinding) list(r *http.Request) (*routing.Response, error) {
 
 	serviceBindingList, err := h.serviceBindingRepo.ListServiceBindings(r.Context(), authInfo, listFilter.ToMessage())
 	if err != nil {
-		return nil, apierrors.LogAndReturn(logger, err, fmt.Sprintf("failed to list %s", repositories.ServiceBindingResourceType))
+		return nil, apierrors.LogAndReturn(logger, err, "failed to list "+repositories.ServiceBindingResourceType)
 	}
 
 	var appRecords []repositories.AppRecord
@@ -127,7 +126,7 @@ func (h *ServiceBinding) list(r *http.Request) (*routing.Response, error) {
 
 		appRecords, err = h.appRepo.ListApps(r.Context(), authInfo, listAppsMessage)
 		if err != nil {
-			return nil, apierrors.LogAndReturn(logger, err, fmt.Sprintf("failed to list %s", repositories.AppResourceType))
+			return nil, apierrors.LogAndReturn(logger, err, "failed to list "+repositories.AppResourceType)
 		}
 	}
 

--- a/api/repositories/pod_repository.go
+++ b/api/repositories/pod_repository.go
@@ -81,7 +81,7 @@ func (r *PodRepo) GetRuntimeLogsForApp(ctx context.Context, logger logr.Logger, 
 		logReadCloser, err = k8sClient.CoreV1().Pods(message.SpaceGUID).GetLogs(pod.Name, &corev1.PodLogOptions{Timestamps: true, TailLines: &message.Limit}).Stream(ctx)
 		if err != nil {
 			// untested
-			logger.Info(fmt.Sprintf("failed to fetch logs for pod: %s", pod.Name), "reason", err)
+			logger.Info("failed to fetch logs", "pod", pod.Name, "reason", err)
 			continue
 		}
 

--- a/controllers/controllers/workloads/cfspace_controller.go
+++ b/controllers/controllers/workloads/cfspace_controller.go
@@ -325,7 +325,7 @@ func (r *CFSpaceReconciler) finalize(ctx context.Context, space client.Object) (
 	}
 
 	duration := time.Since(space.GetDeletionTimestamp().Time)
-	log.V(1).Info(fmt.Sprintf("finalizing CFSpace for %fs", duration.Seconds()))
+	log.V(1).Info("finalizing CFSpace", "duration", duration.Seconds())
 
 	spaceNamespace := new(corev1.Namespace)
 	err := r.client.Get(ctx, types.NamespacedName{Name: space.GetName()}, spaceNamespace)

--- a/statefulset-runner/api/v1/pod_webhook.go
+++ b/statefulset-runner/api/v1/pod_webhook.go
@@ -72,7 +72,7 @@ func (r *STSPodDefaulter) Default(ctx context.Context, obj runtime.Object) error
 			cfInstanceVar := corev1.EnvVar{Name: controllers.EnvCFInstanceIndex, Value: index}
 			container.Env = append(container.Env, cfInstanceVar)
 
-			podlog.V(1).Info(fmt.Sprintf("patching-instance-index env-var - %s: %s", controllers.EnvCFInstanceIndex, index))
+			podlog.V(1).Info("patching instance index env var", controllers.EnvCFInstanceIndex, index)
 
 			return nil
 		}


### PR DESCRIPTION
## Is there a related GitHub Issue?
#1929

## What is this change about?
This PR eliminates the use of Sprintf in log messages. It moves injected values to named values instead.

## Does this PR introduce a breaking change?
No.

## Acceptance Steps
Deploy and run tests. Check the logs and confirm that the intended data is still being recorded.
