### PR TITLE
Use GinkgoHelper in tests

### DIFF
--- a/api/handlers/handlers_suite_test.go
+++ b/api/handlers/handlers_suite_test.go
@@ -52,9 +52,11 @@ var _ = BeforeEach(func() {
 })
 
 func expectErrorResponse(status int, title, detail string, code int) {
-	ExpectWithOffset(2, rr).To(HaveHTTPStatus(status))
-	ExpectWithOffset(2, rr).To(HaveHTTPHeaderWithValue("Content-Type", "application/json"))
-	ExpectWithOffset(2, rr).To(HaveHTTPBody(SatisfyAll(
+	GinkgoHelper()
+
+	Expect(rr).To(HaveHTTPStatus(status))
+	Expect(rr).To(HaveHTTPHeaderWithValue("Content-Type", "application/json"))
+	Expect(rr).To(HaveHTTPBody(SatisfyAll(
 		MatchJSONPath("$.errors[0].title", MatchRegexp(title)),
 		MatchJSONPath("$.errors[0].detail", MatchRegexp(detail)),
 		MatchJSONPath("$.errors[0].code", BeEquivalentTo(code)),
@@ -62,30 +64,44 @@ func expectErrorResponse(status int, title, detail string, code int) {
 }
 
 func expectUnknownError() {
+	GinkgoHelper()
+
 	expectErrorResponse(http.StatusInternalServerError, "UnknownError", "An unknown error occurred.", 10001)
 }
 
 func expectNotAuthorizedError() {
+	GinkgoHelper()
+
 	expectErrorResponse(http.StatusForbidden, "CF-NotAuthorized", "You are not authorized to perform the requested action", 10003)
 }
 
 func expectNotFoundError(resourceType string) {
+	GinkgoHelper()
+
 	expectErrorResponse(http.StatusNotFound, "CF-ResourceNotFound", resourceType+" not found. Ensure it exists and you have access to it.", 10010)
 }
 
 func expectUnprocessableEntityError(detail string) {
+	GinkgoHelper()
+
 	expectErrorResponse(http.StatusUnprocessableEntity, "CF-UnprocessableEntity", detail, 10008)
 }
 
 func expectBadRequestError() {
+	GinkgoHelper()
+
 	expectErrorResponse(http.StatusBadRequest, "CF-MessageParseError", "Request invalid due to parse error: invalid request body", 1001)
 }
 
 func expectBlobstoreUnavailableError() {
+	GinkgoHelper()
+
 	expectErrorResponse(http.StatusBadGateway, "CF-BlobstoreUnavailable", "Error uploading source package to the container registry", 150006)
 }
 
 func expectUnknownKeyError(detail string) {
+	GinkgoHelper()
+
 	expectErrorResponse(http.StatusBadRequest, "CF-BadQueryParameter", detail, 10005)
 }
 
@@ -97,6 +113,8 @@ func generateGUID(prefix string) string {
 
 func decodeAndValidateJSONPayloadStub[T any](desiredPayload *T) func(_ *http.Request, decodedPayload any) error {
 	return func(_ *http.Request, decodedPayload any) error {
+		GinkgoHelper()
+
 		decodedPayloadPtr, ok := decodedPayload.(*T)
 		Expect(ok).To(BeTrue())
 
@@ -113,6 +131,8 @@ type keyedPayloadImpl[P any] interface {
 
 func decodeAndValidateURLValuesStub[P any, I keyedPayloadImpl[P]](desiredPayload I) func(*http.Request, handlers.KeyedPayload) error {
 	return func(_ *http.Request, output handlers.KeyedPayload) error {
+		GinkgoHelper()
+
 		outputPtr, ok := output.(I)
 		Expect(ok).To(BeTrue())
 

--- a/api/payloads/payloads_suite_test.go
+++ b/api/payloads/payloads_suite_test.go
@@ -8,6 +8,7 @@ import (
 
 	apierrors "code.cloudfoundry.org/korifi/api/errors"
 	"code.cloudfoundry.org/korifi/api/handlers"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -26,12 +27,16 @@ func TestPayloads(t *testing.T) {
 }
 
 func expectUnprocessableEntityError(err error, detail string) {
-	ExpectWithOffset(1, err).To(HaveOccurred())
-	ExpectWithOffset(1, err).To(BeAssignableToTypeOf(apierrors.UnprocessableEntityError{}))
-	ExpectWithOffset(1, err.(apierrors.UnprocessableEntityError).Detail()).To(ContainSubstring(detail))
+	GinkgoHelper()
+
+	Expect(err).To(HaveOccurred())
+	Expect(err).To(BeAssignableToTypeOf(apierrors.UnprocessableEntityError{}))
+	Expect(err.(apierrors.UnprocessableEntityError).Detail()).To(ContainSubstring(detail))
 }
 
 func createRequest(payload any) *http.Request {
+	GinkgoHelper()
+
 	body, err := json.Marshal(payload)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/api/repositories/role_repository_test.go
+++ b/api/repositories/role_repository_test.go
@@ -11,7 +11,6 @@ import (
 	"code.cloudfoundry.org/korifi/api/repositories/fake"
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"code.cloudfoundry.org/korifi/tests/matchers"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
@@ -20,6 +19,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("RoleRepository", func() {
@@ -58,8 +58,10 @@ var _ = Describe("RoleRepository", func() {
 	})
 
 	getTheRoleBinding := func(name, namespace string) rbacv1.RoleBinding {
+		GinkgoHelper()
+
 		roleBinding := rbacv1.RoleBinding{}
-		ExpectWithOffset(1, k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, &roleBinding)).To(Succeed())
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, &roleBinding)).To(Succeed())
 
 		return roleBinding
 	}

--- a/api/repositories/task_repository_test.go
+++ b/api/repositories/task_repository_test.go
@@ -7,13 +7,13 @@ import (
 	"time"
 
 	"code.cloudfoundry.org/korifi/tools/k8s"
-
 	"code.cloudfoundry.org/korifi/api/authorization"
 	apierrors "code.cloudfoundry.org/korifi/api/errors"
 	"code.cloudfoundry.org/korifi/api/repositories"
 	"code.cloudfoundry.org/korifi/api/repositories/conditions"
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"code.cloudfoundry.org/korifi/tests/matchers"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -33,6 +33,8 @@ var _ = Describe("TaskRepository", func() {
 	)
 
 	setStatusAndUpdate := func(task *korifiv1alpha1.CFTask, conditionTypes ...string) {
+		GinkgoHelper()
+
 		if task.Status.Conditions == nil {
 			task.Status.Conditions = []metav1.Condition{}
 		}
@@ -46,7 +48,7 @@ var _ = Describe("TaskRepository", func() {
 			})
 		}
 
-		ExpectWithOffset(1, k8sClient.Status().Update(ctx, task)).To(Succeed())
+		Expect(k8sClient.Status().Update(ctx, task)).To(Succeed())
 	}
 
 	defaultStatusValues := func(task *korifiv1alpha1.CFTask, seqId int64, dropletId string) *korifiv1alpha1.CFTask {

--- a/controllers/controllers/workloads/cfbuild_controller_test.go
+++ b/controllers/controllers/workloads/cfbuild_controller_test.go
@@ -37,7 +37,9 @@ var _ = Describe("CFBuildReconciler Integration Tests", func() {
 	)
 
 	eventuallyBuildWorkloadShould := func(assertion func(*korifiv1alpha1.BuildWorkload, Gomega)) {
-		EventuallyWithOffset(1, func(g Gomega) {
+		GinkgoHelper()
+
+		Eventually(func(g Gomega) {
 			workload := new(korifiv1alpha1.BuildWorkload)
 			lookupKey := types.NamespacedName{Name: cfBuildGUID, Namespace: cfSpace.Status.GUID}
 			g.Expect(k8sClient.Get(context.Background(), lookupKey, workload)).To(Succeed())

--- a/controllers/controllers/workloads/cfprocess_controller_test.go
+++ b/controllers/controllers/workloads/cfprocess_controller_test.go
@@ -569,7 +569,9 @@ var _ = Describe("CFProcessReconciler Integration Tests", func() {
 })
 
 func eventuallyCreatedAppWorkloadShould(processGUID, namespace string, shouldFn func(Gomega, korifiv1alpha1.AppWorkload)) {
-	EventuallyWithOffset(1, func(g Gomega) {
+	GinkgoHelper()
+
+	Eventually(func(g Gomega) {
 		var appWorkloads korifiv1alpha1.AppWorkloadList
 		err := k8sClient.List(context.Background(), &appWorkloads, client.InNamespace(namespace), client.MatchingLabels{
 			korifiv1alpha1.CFProcessGUIDLabelKey: processGUID,

--- a/kpack-image-builder/controllers/buildworkload_controller_test.go
+++ b/kpack-image-builder/controllers/buildworkload_controller_test.go
@@ -1014,8 +1014,10 @@ func buildWorkloadObject(buildWorkloadGUID string, namespace string, source kori
 }
 
 func mustHaveCondition(g Gomega, conditions []metav1.Condition, conditionType string) *metav1.Condition {
+	GinkgoHelper()
+
 	foundCondition := meta.FindStatusCondition(conditions, conditionType)
-	g.ExpectWithOffset(1, foundCondition).NotTo(BeNil())
+	g.Expect(foundCondition).NotTo(BeNil())
 	return foundCondition
 }
 


### PR DESCRIPTION
## Is there a related GitHub Issue?
No.

## What is this change about?
This PR updates test helpers to call GinkgoHelper() as a better way to help Ginkgo compute failure locations. See [the docs](https://onsi.github.io/ginkgo/#mental-model-how-ginkgo-handles-failure) for details.

## Does this PR introduce a breaking change?
No, just test changes.

## Acceptance Steps
Deploy and run the tests.
