### PR TITLE
Fix manifest validation for `random-route`

### DIFF
--- a/api/payloads/manifest.go
+++ b/api/payloads/manifest.go
@@ -193,7 +193,7 @@ func (m Manifest) Validate() error {
 func (a ManifestApplication) Validate() error {
 	return validation.ValidateStruct(&a,
 		validation.Field(&a.Name, payload_validation.StrictlyRequired),
-		validation.Field(&a.DefaultRoute, validation.When(a.RandomRoute, validation.Nil.Error("and random-route may not be used together"))),
+		validation.Field(&a.DefaultRoute, validation.When(a.RandomRoute && a.DefaultRoute, validation.Nil.Error("and random-route may not be used together"))),
 		validation.Field(&a.DiskQuota, validation.By(validateAmountWithUnit), validation.When(a.AltDiskQuota != nil, validation.Nil.Error("and disk-quota may not be used together"))),
 		validation.Field(&a.AltDiskQuota, validation.By(validateAmountWithUnit)),
 		validation.Field(&a.Instances, validation.Min(0)),

--- a/api/payloads/manifest_test.go
+++ b/api/payloads/manifest_test.go
@@ -198,6 +198,17 @@ var _ = Describe("Manifest payload", func() {
 					Expect(validateErr).To(MatchError("default-route: and random-route may not be used together."))
 				})
 			})
+
+			When("only the random-route flag is set", func() {
+				BeforeEach(func() {
+					testManifest.DefaultRoute = false
+					testManifest.RandomRoute = true
+				})
+
+				It("does not return a validation error", func() {
+					Expect(validateErr).NotTo(HaveOccurred())
+				})
+			})
 		})
 	})
 


### PR DESCRIPTION
The validator was always raising the following error when random-route was specified:
`"default-route and random-route may not be used together"`

This change makes it so that it only errors when both default-route and random-route are set to true.

Related Slack discussion: https://cloudfoundry.slack.com/archives/C0297673ASK/p1687556306576749

## Is there a related GitHub Issue?
No

## What is this change about?
Fixes a bug where any manifest containing `random-route: true` would cause an error. Minimal example:

```yaml
--- 
applications: 
- name: dora
  random-route: true
```


```
15:57 $ cf push node
Pushing app node to org o / space s as cf-admin...
Applying manifest file /Users/tdowney/go/src/github.com/cloudfoundry/cf-acceptance-tests/assets/node/manifest.yml...

Updating with these attributes...
  applications:
  - name: node
    random-route: true
applications[0].default-route and random-route may not be used together
```

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Push an app with manifests containing `random-route`, `default-route`, and mixtures of both. They should work in isolation and fail when both are set to `true`.

## Tag your pair, your PM, and/or team
@acosta11 

