### PR TITLE
Make controller logging tests more robust

### DIFF
--- a/controllers/controllers/workloads/cforg_controller_test.go
+++ b/controllers/controllers/workloads/cforg_controller_test.go
@@ -315,8 +315,8 @@ var _ = Describe("CFOrgReconciler Integration Tests", func() {
 			}).Should(BeFalse(), "timed out waiting for deletion timestamps to be set on namespace")
 		})
 
-		It("writes a log message", func() {
-			Eventually(logOutput).Should(gbytes.Say("finalizer removed"))
+		It("writes some log message from the finalizer helper", func() {
+			Eventually(logOutput).Should(gbytes.Say("controllers.CFOrg.finalize"))
 		})
 	})
 })

--- a/controllers/controllers/workloads/cfspace_controller_test.go
+++ b/controllers/controllers/workloads/cfspace_controller_test.go
@@ -607,8 +607,8 @@ var _ = Describe("CFSpaceReconciler Integration Tests", func() {
 			}).Should(BeFalse(), "timed out waiting for deletion timestamps to be set on namespace")
 		})
 
-		It("writes a log message", func() {
-			Eventually(logOutput).Should(gbytes.Say("finalizer removed"))
+		It("writes some log message from the finalizer helper", func() {
+			Eventually(logOutput).Should(gbytes.Say("controllers.CFSpace.finalize"))
 		})
 
 		When("there are CFApps in the space", func() {


### PR DESCRIPTION

  

<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
#1935

## What is this change about?
- tests to ensure that the loggin is wired up correctly were looking for a log message indicating that a finalizer finished finalizing, which wasn't happening in the context of the test.
- Since we only care that we are getting log messages from the helper, this commit changes the test to look for a string indicating the source of the log message, rather than a specifc message that only happens when the finalizer succeeds.
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->
No
## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->
- run tests

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->
@davewalter @acosta11 

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
