### PR TITLE
Add `buildCacheMB` helm chart value

### DIFF
--- a/README.helm.md
+++ b/README.helm.md
@@ -42,6 +42,7 @@ Here are all the values that can be set for the chart:
   - `lifecycle`: Default lifecycle for apps.
     - `stack` (_String_): Stack.
     - `stagingRequirements`:
+      - `buildCacheMB` (_Integer_): Persistent disk in MB for caching staging artifacts across builds.
       - `diskMB` (_Integer_): Disk in MB for staging.
       - `memoryMB` (_Integer_): Memory in MB for staging.
     - `type` (_String_): Lifecycle type (only `buildpack` accepted currently).

--- a/api/repositories/task_repository_test.go
+++ b/api/repositories/task_repository_test.go
@@ -6,13 +6,13 @@ import (
 	"sync"
 	"time"
 
-	"code.cloudfoundry.org/korifi/tools/k8s"
 	"code.cloudfoundry.org/korifi/api/authorization"
 	apierrors "code.cloudfoundry.org/korifi/api/errors"
 	"code.cloudfoundry.org/korifi/api/repositories"
 	"code.cloudfoundry.org/korifi/api/repositories/conditions"
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"code.cloudfoundry.org/korifi/tests/matchers"
+	"code.cloudfoundry.org/korifi/tools/k8s"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/controllers/config/config.go
+++ b/controllers/config/config.go
@@ -41,6 +41,7 @@ type ControllerConfig struct {
 	BuilderReadinessTimeout   string `yaml:"builderReadinessTimeout"`
 	ContainerRepositoryPrefix string `yaml:"containerRepositoryPrefix"`
 	ContainerRegistryType     string `yaml:"containerRegistryType"`
+	BuildCacheMB              int    `yaml:"buildCacheMB"`
 }
 
 type CFProcessDefaults struct {
@@ -50,9 +51,10 @@ type CFProcessDefaults struct {
 }
 
 const (
-	defaultTaskTTL       = 30 * 24 * time.Hour
-	defaultTimeout int64 = 60
-	defaultJobTTL        = 24 * time.Hour
+	defaultTaskTTL            = 30 * 24 * time.Hour
+	defaultTimeout      int64 = 60
+	defaultJobTTL             = 24 * time.Hour
+	defaultBuildCacheMB       = 2048
 )
 
 func LoadFromPath(path string) (*ControllerConfig, error) {
@@ -68,6 +70,10 @@ func LoadFromPath(path string) (*ControllerConfig, error) {
 
 	if config.SpaceFinalizerAppDeletionTimeout == nil {
 		config.SpaceFinalizerAppDeletionTimeout = tools.PtrTo(defaultTimeout)
+	}
+
+	if config.BuildCacheMB == 0 {
+		config.BuildCacheMB = defaultBuildCacheMB
 	}
 
 	return &config, nil

--- a/controllers/config/config_test.go
+++ b/controllers/config/config_test.go
@@ -45,6 +45,7 @@ var _ = Describe("LoadFromPath", func() {
 			JobTTL:                           "jobTTL",
 			LogLevel:                         zapcore.DebugLevel,
 			SpaceFinalizerAppDeletionTimeout: tools.PtrTo(int64(42)),
+			BuildCacheMB:                     1024,
 		}
 	})
 
@@ -80,6 +81,7 @@ var _ = Describe("LoadFromPath", func() {
 			JobTTL:                           "jobTTL",
 			LogLevel:                         zapcore.DebugLevel,
 			SpaceFinalizerAppDeletionTimeout: tools.PtrTo(int64(42)),
+			BuildCacheMB:                     1024,
 		}))
 	})
 
@@ -110,6 +112,16 @@ var _ = Describe("LoadFromPath", func() {
 
 		It("uses the default", func() {
 			Expect(retConfig.SpaceFinalizerAppDeletionTimeout).To(gstruct.PointTo(Equal(int64(60))))
+		})
+	})
+
+	When("the staging build cache size is not set", func() {
+		BeforeEach(func() {
+			cfg.BuildCacheMB = 0
+		})
+
+		It("uses the default", func() {
+			Expect(retConfig.BuildCacheMB).To(Equal(2048))
 		})
 	})
 })

--- a/helm/korifi/controllers/configmap.yaml
+++ b/helm/korifi/controllers/configmap.yaml
@@ -38,6 +38,7 @@ data:
     builderReadinessTimeout: {{ required "builderReadinessTimeout is required" .Values.kpackImageBuilder.builderReadinessTimeout }}
     containerRepositoryPrefix: {{ .Values.global.containerRepositoryPrefix | quote }}
     builderServiceAccount: kpack-service-account
+    buildCacheMB: {{ .Values.api.lifecycle.stagingRequirements.buildCacheMB }}
     {{- if .Values.global.eksContainerRegistryRoleARN }}
     containerRegistryType: "ECR"
     {{- end }}

--- a/helm/korifi/values.schema.json
+++ b/helm/korifi/values.schema.json
@@ -182,9 +182,13 @@
                 "diskMB": {
                   "description": "Disk in MB for staging.",
                   "type": "integer"
+                },
+                "buildCacheMB": {
+                  "description": "Persistent disk in MB for caching staging artifacts across builds.",
+                  "type": "integer"
                 }
               },
-              "required": ["memoryMB", "diskMB"]
+              "required": ["memoryMB", "diskMB", "buildCacheMB"]
             }
           },
           "required": ["type", "stack", "stagingRequirements"]

--- a/helm/korifi/values.yaml
+++ b/helm/korifi/values.yaml
@@ -46,6 +46,7 @@ api:
     stagingRequirements:
       memoryMB: 1024
       diskMB: 1024
+      buildCacheMB: 2048
 
   builderName: kpack-image-builder
   userCertificateExpirationWarningDuration: 168h

--- a/kpack-image-builder/controllers/buildworkload_controller_test.go
+++ b/kpack-image-builder/controllers/buildworkload_controller_test.go
@@ -22,6 +22,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -160,6 +161,7 @@ var _ = Describe("BuildWorkloadReconciler", func() {
 
 					g.Expect(kpackImage.Spec.Builder.Kind).To(Equal("ClusterBuilder"))
 					g.Expect(kpackImage.Spec.Builder.Name).To(Equal("cf-kpack-builder"))
+					g.Expect(kpackImage.Spec.Cache.Volume.Size.Equal(resource.MustParse("1024Mi"))).To(BeTrue())
 				}).Should(Succeed())
 			})
 

--- a/kpack-image-builder/controllers/suite_test.go
+++ b/kpack-image-builder/controllers/suite_test.go
@@ -124,6 +124,7 @@ var _ = BeforeSuite(func() {
 		ClusterBuilderName:        "cf-kpack-builder",
 		ContainerRepositoryPrefix: "image/registry/tag",
 		BuilderServiceAccount:     "builder-service-account",
+		BuildCacheMB:              1024,
 	}
 
 	imageRepoCreator = new(fake.RepositoryCreator)

--- a/scripts/assets/values-template.yaml
+++ b/scripts/assets/values-template.yaml
@@ -9,6 +9,10 @@ api:
   apiServer:
     url: localhost
   image: cloudfoundry/korifi-api:latest
+  lifecycle:
+    stagingRequirements:
+      buildCacheMB: 1024
+
 
 controllers:
   taskTTL: 5s


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ --> #2634

## What is this change about?
<!-- _Please describe the change here._ -->
- This value is used to set the size of the persistent disk we allocate for image caching when building images with kpack.
- it defaults to 2GiB which is similar to the 2GB default size that kpack allocates.
- The new setting allows customers building large applications to take advantage of caching.

Note: It's a little odd that the staging parameters are in the `api` section of the configuration, but if we want to eventually plumb these through the CFBuild object so that different builds can have different sized caches, then it *kind of* makes sense. I decided that it would be better to put the caching value next to the other staging resources than it would be to put  some of the configuration in the api section and other things in the `controllers` section. Ultimately, we might want to move more things into the top level settings where they make more sense.

 

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ --> #2634

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
