### PR TITLE
Fix failing unit tests

### DIFF
--- a/tools/k8s/reconcile_test.go
+++ b/tools/k8s/reconcile_test.go
@@ -148,7 +148,7 @@ var _ = Describe("Reconcile", func() {
 		})
 
 		It("returns the error", func() {
-			Expect(err).To(MatchError("patch-object-error"))
+			Expect(err).To(MatchError(errors.New("patch-object-error")))
 		})
 	})
 
@@ -166,7 +166,7 @@ var _ = Describe("Reconcile", func() {
 		})
 
 		It("returns the error", func() {
-			Expect(err).To(MatchError("patch-status-error"))
+			Expect(err).To(MatchError(errors.New("patch-status-error")))
 		})
 	})
 


### PR DESCRIPTION


<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->Nope

## What is this change about?
<!-- _Please describe the change here._ -->
The tools/k8s unit tests had a couple of failures. The gomega error matcher can't match on wrapped errors unless the type of the expected object matches the wrapped error type. This commit fixes it.

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->
`ginkgo tools/k8s`

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
