### PR TITLE
Use requestValidator in space/manifest handlers

### DIFF
--- a/api/handlers/app_test.go
+++ b/api/handlers/app_test.go
@@ -147,7 +147,7 @@ var _ = Describe("App", func() {
 					},
 				},
 			}
-			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidateJSONPayloadStub(payload)
+			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidatePayloadStub(payload)
 			appRepo.CreateAppReturns(appRecord, nil)
 			req = createHttpRequest("POST", "/v3/apps", strings.NewReader("the-json-body"))
 		})
@@ -444,7 +444,7 @@ var _ = Describe("App", func() {
 					},
 				},
 			}
-			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidateJSONPayloadStub(payload)
+			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidatePayloadStub(payload)
 
 			appRepo.PatchAppMetadataReturns(appRecord, nil)
 			req = createHttpRequest("PATCH", "/v3/apps/"+appGUID, strings.NewReader("the-json-body"))
@@ -548,7 +548,7 @@ var _ = Describe("App", func() {
 					},
 				},
 			}
-			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidateJSONPayloadStub(payload)
+			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidatePayloadStub(payload)
 
 			req = createHttpRequest("PATCH", "/v3/apps/"+appGUID+"/relationships/current_droplet", strings.NewReader("the-json-body"))
 		})
@@ -1000,7 +1000,7 @@ var _ = Describe("App", func() {
 				MemoryMB:  tools.PtrTo[int64](256),
 				DiskMB:    tools.PtrTo[int64](1024),
 			}
-			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidateJSONPayloadStub(payload)
+			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidatePayloadStub(payload)
 
 			req = createHttpRequest("POST", "/v3/apps/"+appGUID+"/processes/web/actions/scale", strings.NewReader("the-json-body"))
 		})
@@ -1510,7 +1510,7 @@ var _ = Describe("App", func() {
 					"KEY2": "VAL2",
 				},
 			}
-			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidateJSONPayloadStub(payload)
+			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidatePayloadStub(payload)
 
 			req = createHttpRequest("PATCH", "/v3/apps/"+appGUID+"/environment_variables", strings.NewReader("the-json-body"))
 		})

--- a/api/handlers/build_test.go
+++ b/api/handlers/build_test.go
@@ -134,7 +134,7 @@ var _ = Describe("Build", func() {
 		)
 
 		BeforeEach(func() {
-			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidateJSONPayloadStub(&payloads.BuildCreate{
+			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidatePayloadStub(&payloads.BuildCreate{
 				Package: &payloads.RelationshipData{
 					GUID: packageGUID,
 				},

--- a/api/handlers/deployment_test.go
+++ b/api/handlers/deployment_test.go
@@ -61,7 +61,7 @@ var _ = Describe("Deployment", func() {
 			}, nil)
 
 			req = createHttpRequest("POST", "/v3/deployments", strings.NewReader("the-payload"))
-			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidateJSONPayloadStub(&payloads.DeploymentCreate{
+			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidatePayloadStub(&payloads.DeploymentCreate{
 				Droplet: payloads.DropletGUID{
 					Guid: dropletGUID,
 				},

--- a/api/handlers/domain_test.go
+++ b/api/handlers/domain_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Domain", func() {
 					},
 				},
 			}
-			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidateJSONPayloadStub(payload)
+			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidatePayloadStub(payload)
 
 			domainRepo.CreateDomainReturns(repositories.DomainRecord{
 				Name:        "my.domain",
@@ -196,7 +196,7 @@ var _ = Describe("Domain", func() {
 					},
 				},
 			}
-			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidateJSONPayloadStub(payload)
+			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidatePayloadStub(payload)
 
 			domainRepo.UpdateDomainReturns(repositories.DomainRecord{
 				Name:        "my.domain",

--- a/api/handlers/droplet_test.go
+++ b/api/handlers/droplet_test.go
@@ -183,7 +183,7 @@ var _ = Describe("Droplet", func() {
 				},
 			}
 
-			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidateJSONPayloadStub(payload)
+			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidatePayloadStub(payload)
 		})
 
 		It("validates the payload", func() {

--- a/api/handlers/fake/request_validator.go
+++ b/api/handlers/fake/request_validator.go
@@ -9,11 +9,11 @@ import (
 )
 
 type RequestValidator struct {
-	DecodeAndValidateJSONPayloadStub        func(*http.Request, interface{}) error
+	DecodeAndValidateJSONPayloadStub        func(*http.Request, any) error
 	decodeAndValidateJSONPayloadMutex       sync.RWMutex
 	decodeAndValidateJSONPayloadArgsForCall []struct {
 		arg1 *http.Request
-		arg2 interface{}
+		arg2 any
 	}
 	decodeAndValidateJSONPayloadReturns struct {
 		result1 error
@@ -33,16 +33,28 @@ type RequestValidator struct {
 	decodeAndValidateURLValuesReturnsOnCall map[int]struct {
 		result1 error
 	}
+	DecodeAndValidateYAMLPayloadStub        func(*http.Request, any) error
+	decodeAndValidateYAMLPayloadMutex       sync.RWMutex
+	decodeAndValidateYAMLPayloadArgsForCall []struct {
+		arg1 *http.Request
+		arg2 any
+	}
+	decodeAndValidateYAMLPayloadReturns struct {
+		result1 error
+	}
+	decodeAndValidateYAMLPayloadReturnsOnCall map[int]struct {
+		result1 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *RequestValidator) DecodeAndValidateJSONPayload(arg1 *http.Request, arg2 interface{}) error {
+func (fake *RequestValidator) DecodeAndValidateJSONPayload(arg1 *http.Request, arg2 any) error {
 	fake.decodeAndValidateJSONPayloadMutex.Lock()
 	ret, specificReturn := fake.decodeAndValidateJSONPayloadReturnsOnCall[len(fake.decodeAndValidateJSONPayloadArgsForCall)]
 	fake.decodeAndValidateJSONPayloadArgsForCall = append(fake.decodeAndValidateJSONPayloadArgsForCall, struct {
 		arg1 *http.Request
-		arg2 interface{}
+		arg2 any
 	}{arg1, arg2})
 	stub := fake.DecodeAndValidateJSONPayloadStub
 	fakeReturns := fake.decodeAndValidateJSONPayloadReturns
@@ -63,13 +75,13 @@ func (fake *RequestValidator) DecodeAndValidateJSONPayloadCallCount() int {
 	return len(fake.decodeAndValidateJSONPayloadArgsForCall)
 }
 
-func (fake *RequestValidator) DecodeAndValidateJSONPayloadCalls(stub func(*http.Request, interface{}) error) {
+func (fake *RequestValidator) DecodeAndValidateJSONPayloadCalls(stub func(*http.Request, any) error) {
 	fake.decodeAndValidateJSONPayloadMutex.Lock()
 	defer fake.decodeAndValidateJSONPayloadMutex.Unlock()
 	fake.DecodeAndValidateJSONPayloadStub = stub
 }
 
-func (fake *RequestValidator) DecodeAndValidateJSONPayloadArgsForCall(i int) (*http.Request, interface{}) {
+func (fake *RequestValidator) DecodeAndValidateJSONPayloadArgsForCall(i int) (*http.Request, any) {
 	fake.decodeAndValidateJSONPayloadMutex.RLock()
 	defer fake.decodeAndValidateJSONPayloadMutex.RUnlock()
 	argsForCall := fake.decodeAndValidateJSONPayloadArgsForCall[i]
@@ -161,6 +173,68 @@ func (fake *RequestValidator) DecodeAndValidateURLValuesReturnsOnCall(i int, res
 	}{result1}
 }
 
+func (fake *RequestValidator) DecodeAndValidateYAMLPayload(arg1 *http.Request, arg2 any) error {
+	fake.decodeAndValidateYAMLPayloadMutex.Lock()
+	ret, specificReturn := fake.decodeAndValidateYAMLPayloadReturnsOnCall[len(fake.decodeAndValidateYAMLPayloadArgsForCall)]
+	fake.decodeAndValidateYAMLPayloadArgsForCall = append(fake.decodeAndValidateYAMLPayloadArgsForCall, struct {
+		arg1 *http.Request
+		arg2 any
+	}{arg1, arg2})
+	stub := fake.DecodeAndValidateYAMLPayloadStub
+	fakeReturns := fake.decodeAndValidateYAMLPayloadReturns
+	fake.recordInvocation("DecodeAndValidateYAMLPayload", []interface{}{arg1, arg2})
+	fake.decodeAndValidateYAMLPayloadMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *RequestValidator) DecodeAndValidateYAMLPayloadCallCount() int {
+	fake.decodeAndValidateYAMLPayloadMutex.RLock()
+	defer fake.decodeAndValidateYAMLPayloadMutex.RUnlock()
+	return len(fake.decodeAndValidateYAMLPayloadArgsForCall)
+}
+
+func (fake *RequestValidator) DecodeAndValidateYAMLPayloadCalls(stub func(*http.Request, any) error) {
+	fake.decodeAndValidateYAMLPayloadMutex.Lock()
+	defer fake.decodeAndValidateYAMLPayloadMutex.Unlock()
+	fake.DecodeAndValidateYAMLPayloadStub = stub
+}
+
+func (fake *RequestValidator) DecodeAndValidateYAMLPayloadArgsForCall(i int) (*http.Request, any) {
+	fake.decodeAndValidateYAMLPayloadMutex.RLock()
+	defer fake.decodeAndValidateYAMLPayloadMutex.RUnlock()
+	argsForCall := fake.decodeAndValidateYAMLPayloadArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *RequestValidator) DecodeAndValidateYAMLPayloadReturns(result1 error) {
+	fake.decodeAndValidateYAMLPayloadMutex.Lock()
+	defer fake.decodeAndValidateYAMLPayloadMutex.Unlock()
+	fake.DecodeAndValidateYAMLPayloadStub = nil
+	fake.decodeAndValidateYAMLPayloadReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *RequestValidator) DecodeAndValidateYAMLPayloadReturnsOnCall(i int, result1 error) {
+	fake.decodeAndValidateYAMLPayloadMutex.Lock()
+	defer fake.decodeAndValidateYAMLPayloadMutex.Unlock()
+	fake.DecodeAndValidateYAMLPayloadStub = nil
+	if fake.decodeAndValidateYAMLPayloadReturnsOnCall == nil {
+		fake.decodeAndValidateYAMLPayloadReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.decodeAndValidateYAMLPayloadReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *RequestValidator) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -168,6 +242,8 @@ func (fake *RequestValidator) Invocations() map[string][][]interface{} {
 	defer fake.decodeAndValidateJSONPayloadMutex.RUnlock()
 	fake.decodeAndValidateURLValuesMutex.RLock()
 	defer fake.decodeAndValidateURLValuesMutex.RUnlock()
+	fake.decodeAndValidateYAMLPayloadMutex.RLock()
+	defer fake.decodeAndValidateYAMLPayloadMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/api/handlers/fake/request_validator.go
+++ b/api/handlers/fake/request_validator.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"code.cloudfoundry.org/korifi/api/handlers"
+	"code.cloudfoundry.org/korifi/api/payloads/validation"
 )
 
 type RequestValidator struct {
@@ -21,11 +22,11 @@ type RequestValidator struct {
 	decodeAndValidateJSONPayloadReturnsOnCall map[int]struct {
 		result1 error
 	}
-	DecodeAndValidateURLValuesStub        func(*http.Request, handlers.KeyedPayload) error
+	DecodeAndValidateURLValuesStub        func(*http.Request, validation.KeyedPayload) error
 	decodeAndValidateURLValuesMutex       sync.RWMutex
 	decodeAndValidateURLValuesArgsForCall []struct {
 		arg1 *http.Request
-		arg2 handlers.KeyedPayload
+		arg2 validation.KeyedPayload
 	}
 	decodeAndValidateURLValuesReturns struct {
 		result1 error
@@ -111,12 +112,12 @@ func (fake *RequestValidator) DecodeAndValidateJSONPayloadReturnsOnCall(i int, r
 	}{result1}
 }
 
-func (fake *RequestValidator) DecodeAndValidateURLValues(arg1 *http.Request, arg2 handlers.KeyedPayload) error {
+func (fake *RequestValidator) DecodeAndValidateURLValues(arg1 *http.Request, arg2 validation.KeyedPayload) error {
 	fake.decodeAndValidateURLValuesMutex.Lock()
 	ret, specificReturn := fake.decodeAndValidateURLValuesReturnsOnCall[len(fake.decodeAndValidateURLValuesArgsForCall)]
 	fake.decodeAndValidateURLValuesArgsForCall = append(fake.decodeAndValidateURLValuesArgsForCall, struct {
 		arg1 *http.Request
-		arg2 handlers.KeyedPayload
+		arg2 validation.KeyedPayload
 	}{arg1, arg2})
 	stub := fake.DecodeAndValidateURLValuesStub
 	fakeReturns := fake.decodeAndValidateURLValuesReturns
@@ -137,13 +138,13 @@ func (fake *RequestValidator) DecodeAndValidateURLValuesCallCount() int {
 	return len(fake.decodeAndValidateURLValuesArgsForCall)
 }
 
-func (fake *RequestValidator) DecodeAndValidateURLValuesCalls(stub func(*http.Request, handlers.KeyedPayload) error) {
+func (fake *RequestValidator) DecodeAndValidateURLValuesCalls(stub func(*http.Request, validation.KeyedPayload) error) {
 	fake.decodeAndValidateURLValuesMutex.Lock()
 	defer fake.decodeAndValidateURLValuesMutex.Unlock()
 	fake.DecodeAndValidateURLValuesStub = stub
 }
 
-func (fake *RequestValidator) DecodeAndValidateURLValuesArgsForCall(i int) (*http.Request, handlers.KeyedPayload) {
+func (fake *RequestValidator) DecodeAndValidateURLValuesArgsForCall(i int) (*http.Request, validation.KeyedPayload) {
 	fake.decodeAndValidateURLValuesMutex.RLock()
 	defer fake.decodeAndValidateURLValuesMutex.RUnlock()
 	argsForCall := fake.decodeAndValidateURLValuesArgsForCall[i]

--- a/api/handlers/fake/runner_info_repository.go
+++ b/api/handlers/fake/runner_info_repository.go
@@ -8,21 +8,9 @@ import (
 	"code.cloudfoundry.org/korifi/api/authorization"
 	"code.cloudfoundry.org/korifi/api/handlers"
 	"code.cloudfoundry.org/korifi/api/repositories"
-	"code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 )
 
 type RunnerInfoRepository struct {
-	GetCapabilitiesStub        func(repositories.RunnerInfoRecord) v1alpha1.RunnerInfoCapabilities
-	getCapabilitiesMutex       sync.RWMutex
-	getCapabilitiesArgsForCall []struct {
-		arg1 repositories.RunnerInfoRecord
-	}
-	getCapabilitiesReturns struct {
-		result1 v1alpha1.RunnerInfoCapabilities
-	}
-	getCapabilitiesReturnsOnCall map[int]struct {
-		result1 v1alpha1.RunnerInfoCapabilities
-	}
 	GetRunnerInfoStub        func(context.Context, authorization.Info, string) (repositories.RunnerInfoRecord, error)
 	getRunnerInfoMutex       sync.RWMutex
 	getRunnerInfoArgsForCall []struct {
@@ -40,67 +28,6 @@ type RunnerInfoRepository struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
-}
-
-func (fake *RunnerInfoRepository) GetCapabilities(arg1 repositories.RunnerInfoRecord) v1alpha1.RunnerInfoCapabilities {
-	fake.getCapabilitiesMutex.Lock()
-	ret, specificReturn := fake.getCapabilitiesReturnsOnCall[len(fake.getCapabilitiesArgsForCall)]
-	fake.getCapabilitiesArgsForCall = append(fake.getCapabilitiesArgsForCall, struct {
-		arg1 repositories.RunnerInfoRecord
-	}{arg1})
-	stub := fake.GetCapabilitiesStub
-	fakeReturns := fake.getCapabilitiesReturns
-	fake.recordInvocation("GetCapabilities", []interface{}{arg1})
-	fake.getCapabilitiesMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *RunnerInfoRepository) GetCapabilitiesCallCount() int {
-	fake.getCapabilitiesMutex.RLock()
-	defer fake.getCapabilitiesMutex.RUnlock()
-	return len(fake.getCapabilitiesArgsForCall)
-}
-
-func (fake *RunnerInfoRepository) GetCapabilitiesCalls(stub func(repositories.RunnerInfoRecord) v1alpha1.RunnerInfoCapabilities) {
-	fake.getCapabilitiesMutex.Lock()
-	defer fake.getCapabilitiesMutex.Unlock()
-	fake.GetCapabilitiesStub = stub
-}
-
-func (fake *RunnerInfoRepository) GetCapabilitiesArgsForCall(i int) repositories.RunnerInfoRecord {
-	fake.getCapabilitiesMutex.RLock()
-	defer fake.getCapabilitiesMutex.RUnlock()
-	argsForCall := fake.getCapabilitiesArgsForCall[i]
-	return argsForCall.arg1
-}
-
-func (fake *RunnerInfoRepository) GetCapabilitiesReturns(result1 v1alpha1.RunnerInfoCapabilities) {
-	fake.getCapabilitiesMutex.Lock()
-	defer fake.getCapabilitiesMutex.Unlock()
-	fake.GetCapabilitiesStub = nil
-	fake.getCapabilitiesReturns = struct {
-		result1 v1alpha1.RunnerInfoCapabilities
-	}{result1}
-}
-
-func (fake *RunnerInfoRepository) GetCapabilitiesReturnsOnCall(i int, result1 v1alpha1.RunnerInfoCapabilities) {
-	fake.getCapabilitiesMutex.Lock()
-	defer fake.getCapabilitiesMutex.Unlock()
-	fake.GetCapabilitiesStub = nil
-	if fake.getCapabilitiesReturnsOnCall == nil {
-		fake.getCapabilitiesReturnsOnCall = make(map[int]struct {
-			result1 v1alpha1.RunnerInfoCapabilities
-		})
-	}
-	fake.getCapabilitiesReturnsOnCall[i] = struct {
-		result1 v1alpha1.RunnerInfoCapabilities
-	}{result1}
 }
 
 func (fake *RunnerInfoRepository) GetRunnerInfo(arg1 context.Context, arg2 authorization.Info, arg3 string) (repositories.RunnerInfoRecord, error) {
@@ -172,8 +99,6 @@ func (fake *RunnerInfoRepository) GetRunnerInfoReturnsOnCall(i int, result1 repo
 func (fake *RunnerInfoRepository) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.getCapabilitiesMutex.RLock()
-	defer fake.getCapabilitiesMutex.RUnlock()
 	fake.getRunnerInfoMutex.RLock()
 	defer fake.getRunnerInfoMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/api/handlers/handlers_suite_test.go
+++ b/api/handlers/handlers_suite_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"code.cloudfoundry.org/korifi/api/authorization"
-	"code.cloudfoundry.org/korifi/api/handlers"
+	"code.cloudfoundry.org/korifi/api/payloads/validation"
 	"code.cloudfoundry.org/korifi/api/routing"
 	. "code.cloudfoundry.org/korifi/tests/matchers"
 	"github.com/google/uuid"
@@ -126,12 +126,12 @@ func decodeAndValidatePayloadStub[T any](desiredPayload *T) func(_ *http.Request
 }
 
 type keyedPayloadImpl[P any] interface {
-	handlers.KeyedPayload
+	validation.KeyedPayload
 	*P
 }
 
-func decodeAndValidateURLValuesStub[P any, I keyedPayloadImpl[P]](desiredPayload I) func(*http.Request, handlers.KeyedPayload) error {
-	return func(_ *http.Request, output handlers.KeyedPayload) error {
+func decodeAndValidateURLValuesStub[P any, I keyedPayloadImpl[P]](desiredPayload I) func(*http.Request, validation.KeyedPayload) error {
+	return func(_ *http.Request, output validation.KeyedPayload) error {
 		GinkgoHelper()
 
 		outputPtr, ok := output.(I)

--- a/api/handlers/handlers_suite_test.go
+++ b/api/handlers/handlers_suite_test.go
@@ -112,7 +112,7 @@ func generateGUID(prefix string) string {
 	return fmt.Sprintf("%s-%s", prefix, guid[:13])
 }
 
-func decodeAndValidateJSONPayloadStub[T any](desiredPayload *T) func(_ *http.Request, decodedPayload any) error {
+func decodeAndValidatePayloadStub[T any](desiredPayload *T) func(_ *http.Request, decodedPayload any) error {
 	return func(_ *http.Request, decodedPayload any) error {
 		GinkgoHelper()
 

--- a/api/handlers/org_test.go
+++ b/api/handlers/org_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Org", func() {
 
 	Describe("Create Org", func() {
 		BeforeEach(func() {
-			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidateJSONPayloadStub(&payloads.OrgCreate{
+			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidatePayloadStub(&payloads.OrgCreate{
 				Name:      "the-org",
 				Suspended: true,
 				Metadata: payloads.Metadata{
@@ -223,7 +223,7 @@ var _ = Describe("Org", func() {
 
 			requestBody = "the-json-body"
 
-			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidateJSONPayloadStub(&payloads.OrgPatch{
+			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidatePayloadStub(&payloads.OrgPatch{
 				Metadata: payloads.MetadataPatch{
 					Annotations: map[string]*string{
 						"hello":                       tools.PtrTo("there"),

--- a/api/handlers/package_test.go
+++ b/api/handlers/package_test.go
@@ -301,7 +301,7 @@ var _ = Describe("Package", func() {
 		BeforeEach(func() {
 			appUID = "appUID"
 
-			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidateJSONPayloadStub(&payloads.PackageCreate{
+			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidatePayloadStub(&payloads.PackageCreate{
 				Type: "bits",
 				Relationships: &payloads.PackageRelationships{
 					App: &payloads.Relationship{
@@ -445,7 +445,7 @@ var _ = Describe("Package", func() {
 		BeforeEach(func() {
 			packageGUID = generateGUID("package")
 
-			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidateJSONPayloadStub(&payloads.PackageUpdate{
+			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidatePayloadStub(&payloads.PackageUpdate{
 				Metadata: payloads.MetadataPatch{
 					Labels: map[string]*string{
 						"bob": tools.PtrTo("foo"),

--- a/api/handlers/process_test.go
+++ b/api/handlers/process_test.go
@@ -144,7 +144,7 @@ var _ = Describe("Process", func() {
 				GUID: "process-guid",
 			}, nil)
 
-			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidateJSONPayloadStub(&payloads.ProcessScale{
+			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidatePayloadStub(&payloads.ProcessScale{
 				Instances: tools.PtrTo(3),
 				MemoryMB:  tools.PtrTo[int64](512),
 				DiskMB:    tools.PtrTo[int64](256),
@@ -368,7 +368,7 @@ var _ = Describe("Process", func() {
 				GUID: "process-guid",
 			}, nil)
 
-			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidateJSONPayloadStub(&payloads.ProcessPatch{
+			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidatePayloadStub(&payloads.ProcessPatch{
 				Metadata: &payloads.MetadataPatch{
 					Labels: map[string]*string{
 						"foo": tools.PtrTo("value1"),

--- a/api/handlers/role_test.go
+++ b/api/handlers/role_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Role", func() {
 				},
 			}
 
-			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidateJSONPayloadStub(roleCreate)
+			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidatePayloadStub(roleCreate)
 		})
 
 		JustBeforeEach(func() {

--- a/api/handlers/route_test.go
+++ b/api/handlers/route_test.go
@@ -289,7 +289,7 @@ var _ = Describe("Route", func() {
 					Annotations: map[string]string{"annotation-key": "annotation-val"},
 				},
 			}
-			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidateJSONPayloadStub(&payload)
+			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidatePayloadStub(&payload)
 		})
 
 		It("creates the route", func() {
@@ -428,7 +428,7 @@ var _ = Describe("Route", func() {
 					Labels:      map[string]*string{"l": tools.PtrTo("lv")},
 				},
 			}
-			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidateJSONPayloadStub(&payload)
+			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidatePayloadStub(&payload)
 		})
 
 		It("patches the route", func() {
@@ -585,7 +585,7 @@ var _ = Describe("Route", func() {
 					},
 				},
 			}
-			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidateJSONPayloadStub(&payload)
+			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidatePayloadStub(&payload)
 		})
 
 		It("adds the destinations to the route", func() {

--- a/api/handlers/service_binding_test.go
+++ b/api/handlers/service_binding_test.go
@@ -93,7 +93,7 @@ var _ = Describe("ServiceBinding", func() {
 				},
 				Type: "app",
 			}
-			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidateJSONPayloadStub(&payload)
+			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidatePayloadStub(&payload)
 		})
 
 		It("creates a service binding", func() {
@@ -325,7 +325,7 @@ var _ = Describe("ServiceBinding", func() {
 					Annotations: map[string]*string{"bar": tools.PtrTo("baz")},
 				},
 			}
-			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidateJSONPayloadStub(&payload)
+			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidatePayloadStub(&payload)
 		})
 
 		It("updates the service binding", func() {

--- a/api/handlers/service_instance_test.go
+++ b/api/handlers/service_instance_test.go
@@ -61,7 +61,7 @@ var _ = Describe("ServiceInstance", func() {
 		BeforeEach(func() {
 			reqMethod = http.MethodPost
 
-			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidateJSONPayloadStub(&payloads.ServiceInstanceCreate{
+			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidatePayloadStub(&payloads.ServiceInstanceCreate{
 				Name: "service-instance-name",
 				Type: "user-provided",
 				Tags: []string{"foo", "bar"},
@@ -298,7 +298,7 @@ var _ = Describe("ServiceInstance", func() {
 
 	Describe("PATCH /v3/service_instances/:guid", func() {
 		BeforeEach(func() {
-			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidateJSONPayloadStub(&payloads.ServiceInstancePatch{
+			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidatePayloadStub(&payloads.ServiceInstancePatch{
 				Name:        tools.PtrTo("new-name"),
 				Tags:        &[]string{"alice", "bob"},
 				Credentials: &map[string]string{"foo": "bar"},

--- a/api/handlers/space_manifest.go
+++ b/api/handlers/space_manifest.go
@@ -33,7 +33,7 @@ type SpaceManifest struct {
 	serverURL        url.URL
 	manifestApplier  ManifestApplier
 	spaceRepo        CFSpaceRepository
-	decoderValidator DecoderValidator
+	requestValidator RequestValidator
 }
 
 //counterfeiter:generate -o fake -fake-name ManifestApplier . ManifestApplier
@@ -45,13 +45,13 @@ func NewSpaceManifest(
 	serverURL url.URL,
 	manifestApplier ManifestApplier,
 	spaceRepo CFSpaceRepository,
-	decoderValidator DecoderValidator,
+	requestValidator RequestValidator,
 ) *SpaceManifest {
 	return &SpaceManifest{
 		serverURL:        serverURL,
 		manifestApplier:  manifestApplier,
 		spaceRepo:        spaceRepo,
-		decoderValidator: decoderValidator,
+		requestValidator: requestValidator,
 	}
 }
 
@@ -72,7 +72,7 @@ func (h *SpaceManifest) apply(r *http.Request) (*routing.Response, error) {
 
 	spaceGUID := routing.URLParam(r, "spaceGUID")
 	var manifest payloads.Manifest
-	if err := h.decoderValidator.DecodeAndValidateYAMLPayload(r, &manifest); err != nil {
+	if err := h.requestValidator.DecodeAndValidateYAMLPayload(r, &manifest); err != nil {
 		return nil, apierrors.LogAndReturn(logger, err, "failed to decode payload")
 	}
 

--- a/api/handlers/space_manifest_test.go
+++ b/api/handlers/space_manifest_test.go
@@ -3,13 +3,14 @@ package handlers_test
 import (
 	"errors"
 	"net/http"
-	"regexp"
 	"strings"
 
 	apierrors "code.cloudfoundry.org/korifi/api/errors"
 	. "code.cloudfoundry.org/korifi/api/handlers"
 	"code.cloudfoundry.org/korifi/api/handlers/fake"
+	"code.cloudfoundry.org/korifi/api/payloads"
 	"code.cloudfoundry.org/korifi/api/repositories"
+	"code.cloudfoundry.org/korifi/tools"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -18,34 +19,32 @@ import (
 
 var _ = Describe("SpaceManifest", func() {
 	var (
-		manifestApplier *fake.ManifestApplier
-		spaceRepo       *fake.CFSpaceRepository
-		requestMethod   string
-		requestPath     string
-		requestBody     string
+		manifestApplier  *fake.ManifestApplier
+		spaceRepo        *fake.CFSpaceRepository
+		requestValidator *fake.RequestValidator
+		requestMethod    string
+		requestPath      string
 	)
 
 	BeforeEach(func() {
 		requestMethod = "POST"
 		requestPath = ""
-		requestBody = ""
 
 		manifestApplier = new(fake.ManifestApplier)
 		spaceRepo = new(fake.CFSpaceRepository)
-
-		decoderValidator := NewDefaultDecoderValidator()
+		requestValidator = new(fake.RequestValidator)
 
 		apiHandler := NewSpaceManifest(
 			*serverURL,
 			manifestApplier,
 			spaceRepo,
-			decoderValidator,
+			requestValidator,
 		)
 		routerBuilder.LoadRoutes(apiHandler)
 	})
 
 	JustBeforeEach(func() {
-		req, err := http.NewRequestWithContext(ctx, requestMethod, requestPath, strings.NewReader(requestBody))
+		req, err := http.NewRequestWithContext(ctx, requestMethod, requestPath, strings.NewReader("the-yaml-body"))
 		Expect(err).NotTo(HaveOccurred())
 		req.Header.Add("Content-type", "application/x-yaml")
 		routerBuilder.Build().ServeHTTP(rr, req)
@@ -54,28 +53,35 @@ var _ = Describe("SpaceManifest", func() {
 	Describe("POST /v3/spaces/{spaceGUID}/actions/apply_manifest", func() {
 		BeforeEach(func() {
 			requestPath = "/v3/spaces/test-space-guid/actions/apply_manifest"
-			requestBody = `---
-                version: 1
-                applications:
-                - name: app1
-                  default-route: true
-                  memory: 128M
-                  disk_quota: 256M
-                  processes:
-                  - type: web
-                    command: start-web.sh
-                    disk_quota: 512M
-                    health-check-http-endpoint: /healthcheck
-                    health-check-invocation-timeout: 5
-                    health-check-type: http
-                    instances: 1
-                    memory: 256M
-                    timeout: 10`
+			requestValidator.DecodeAndValidateYAMLPayloadStub = decodeAndValidatePayloadStub(&payloads.Manifest{
+				Version: 1,
+				Applications: []payloads.ManifestApplication{{
+					Name:         "app1",
+					DefaultRoute: true,
+					Memory:       tools.PtrTo("128M"),
+					DiskQuota:    tools.PtrTo("256M"),
+					Processes: []payloads.ManifestApplicationProcess{{
+						Type:                         "web",
+						Command:                      tools.PtrTo("start-web.sh"),
+						DiskQuota:                    tools.PtrTo("512M"),
+						HealthCheckHTTPEndpoint:      tools.PtrTo("/healthcheck"),
+						HealthCheckInvocationTimeout: tools.PtrTo[int64](5),
+						HealthCheckType:              tools.PtrTo("http"),
+						Instances:                    tools.PtrTo(1),
+						Memory:                       tools.PtrTo("256M"),
+						Timeout:                      tools.PtrTo[int64](10),
+					}},
+				}},
+			})
 		})
 
 		It("applies the manifest", func() {
 			Expect(rr).To(HaveHTTPStatus(http.StatusAccepted))
 			Expect(rr).To(HaveHTTPHeaderWithValue("Location", ContainSubstring("space.apply_manifest~"+spaceGUID)))
+
+			Expect(requestValidator.DecodeAndValidateYAMLPayloadCallCount()).To(Equal(1))
+			actualReq, _ := requestValidator.DecodeAndValidateYAMLPayloadArgsForCall(0)
+			Expect(bodyString(actualReq)).To(Equal("the-yaml-body"))
 
 			Expect(manifestApplier.ApplyCallCount()).To(Equal(1))
 			_, actualAuthInfo, _, payload := manifestApplier.ApplyArgsForCall(0)
@@ -102,49 +108,11 @@ var _ = Describe("SpaceManifest", func() {
 
 		When("the manifest is invalid", func() {
 			BeforeEach(func() {
-				requestBody = `---
-                version: 1
-                applications:
-                - name: app1
-                  default-route: true
-                  memory: "128"
-                  disk_quota: 256M
-                  processes:
-                  - type: web
-                    command: start-web.sh
-                    disk_quota: 512M
-                    health-check-http-endpoint: /healthcheck
-                    health-check-invocation-timeout: 5
-                    health-check-type: httpppp
-                    instances: 1
-                    memory: 256M
-                    timeout: 1
-                  routes:
-                  - route: "ssh://1.2.3.4"`
+				requestValidator.DecodeAndValidateYAMLPayloadReturns(errors.New("boom"))
 			})
 
-			It("response with an unprocessable entity error listing all the errors", func() {
-				expectUnprocessableEntityError(regexp.QuoteMeta("applications[0].memory must use a supported unit (B, K, KB, M, MB, G, GB, T, or TB), applications[0].processes[0].health-check-type must be a valid value, applications[0].routes[0].route is not a valid route"))
-			})
-		})
-
-		When("the manifest contains unsupported fields", func() {
-			BeforeEach(func() {
-				requestBody = `---
-                version: 1
-                applications:
-                - name: app1
-                  metadata:
-                    annotations:
-                      contact: "bob@example.com jane@example.com"
-                    labels:
-                      sensitive: true`
-			})
-
-			It("calls applyManifestAction and passes it the authInfo from the context", func() {
-				Expect(manifestApplier.ApplyCallCount()).To(Equal(1))
-				_, actualAuthInfo, _, _ := manifestApplier.ApplyArgsForCall(0)
-				Expect(actualAuthInfo).To(Equal(authInfo))
+			It("returns an error", func() {
+				expectUnknownError()
 			})
 		})
 	})
@@ -152,10 +120,6 @@ var _ = Describe("SpaceManifest", func() {
 	Describe("POST /v3/spaces/{spaceGUID}/manifest_diff", func() {
 		BeforeEach(func() {
 			requestPath = "/v3/spaces/test-space-guid/manifest_diff"
-			requestBody = `---
-			version: 1
-			applications:
-				- name: app1`
 		})
 
 		It("returns 202 with an empty diff", func() {

--- a/api/handlers/space_test.go
+++ b/api/handlers/space_test.go
@@ -63,7 +63,7 @@ var _ = Describe("Space", func() {
 				OrganizationGUID: "the-org-guid",
 			}, nil)
 
-			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidateJSONPayloadStub(&payloads.SpaceCreate{
+			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidatePayloadStub(&payloads.SpaceCreate{
 				Name: "the-space",
 				Relationships: &payloads.SpaceRelationships{
 					Org: &payloads.Relationship{
@@ -264,7 +264,7 @@ var _ = Describe("Space", func() {
 				OrganizationGUID: "the-org-guid",
 			}, nil)
 
-			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidateJSONPayloadStub(&payloads.SpacePatch{
+			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidatePayloadStub(&payloads.SpacePatch{
 				Metadata: payloads.MetadataPatch{
 					Annotations: map[string]*string{
 						"hello":                       tools.PtrTo("there"),

--- a/api/handlers/task_test.go
+++ b/api/handlers/task_test.go
@@ -61,7 +61,7 @@ var _ = Describe("Task", func() {
 
 	Describe("POST /v3/apps/:app-guid/tasks", func() {
 		BeforeEach(func() {
-			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidateJSONPayloadStub(&payloads.TaskCreate{
+			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidatePayloadStub(&payloads.TaskCreate{
 				Command: "echo hello",
 				Metadata: payloads.Metadata{
 					Labels:      map[string]string{"env": "production"},
@@ -453,7 +453,7 @@ var _ = Describe("Task", func() {
 
 	Describe("PATCH /v3/tasks/:guid", func() {
 		BeforeEach(func() {
-			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidateJSONPayloadStub(&payloads.TaskUpdate{
+			requestValidator.DecodeAndValidateJSONPayloadStub = decodeAndValidatePayloadStub(&payloads.TaskUpdate{
 				Metadata: payloads.MetadataPatch{
 					Labels: map[string]*string{
 						"env":                           tools.PtrTo("production"),

--- a/api/handlers/validation.go
+++ b/api/handlers/validation.go
@@ -1,0 +1,15 @@
+package handlers
+
+import (
+	"net/http"
+
+	"code.cloudfoundry.org/korifi/api/payloads/validation"
+)
+
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
+
+type RequestValidator interface {
+	DecodeAndValidateJSONPayload(r *http.Request, object any) error
+	DecodeAndValidateURLValues(r *http.Request, payloadObject validation.KeyedPayload) error
+	DecodeAndValidateYAMLPayload(r *http.Request, object any) error
+}

--- a/api/handlers/validator.go
+++ b/api/handlers/validator.go
@@ -21,8 +21,9 @@ import (
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 
 type RequestValidator interface {
-	DecodeAndValidateJSONPayload(r *http.Request, object interface{}) error
+	DecodeAndValidateJSONPayload(r *http.Request, object any) error
 	DecodeAndValidateURLValues(r *http.Request, payloadObject KeyedPayload) error
+	DecodeAndValidateYAMLPayload(r *http.Request, object any) error
 }
 
 type KeyedPayload interface {
@@ -40,7 +41,7 @@ func NewDefaultDecoderValidator() DecoderValidator {
 	return DecoderValidator{}
 }
 
-func (dv DecoderValidator) DecodeAndValidateJSONPayload(r *http.Request, object interface{}) error {
+func (dv DecoderValidator) DecodeAndValidateJSONPayload(r *http.Request, object any) error {
 	decoder := json.NewDecoder(r.Body)
 	defer r.Body.Close()
 	decoder.DisallowUnknownFields()
@@ -62,7 +63,7 @@ func (dv DecoderValidator) DecodeAndValidateJSONPayload(r *http.Request, object 
 	return dv.validatePayload(object)
 }
 
-func (dv DecoderValidator) DecodeAndValidateYAMLPayload(r *http.Request, object interface{}) error {
+func (dv DecoderValidator) DecodeAndValidateYAMLPayload(r *http.Request, object any) error {
 	decoder := yaml.NewDecoder(r.Body)
 	defer r.Body.Close()
 	decoder.KnownFields(false) // TODO: change this to true once we've added all manifest fields to payloads.Manifest
@@ -117,7 +118,7 @@ func isIgnored(payload KeyedPayload, key string) bool {
 	return false
 }
 
-func (dv *DecoderValidator) validatePayload(object interface{}) error {
+func (dv *DecoderValidator) validatePayload(object any) error {
 	t, ok := object.(validation.Validatable)
 	if !ok {
 		return nil

--- a/api/main.go
+++ b/api/main.go
@@ -18,6 +18,7 @@ import (
 	"code.cloudfoundry.org/korifi/api/handlers"
 	"code.cloudfoundry.org/korifi/api/middleware"
 	"code.cloudfoundry.org/korifi/api/payloads"
+	"code.cloudfoundry.org/korifi/api/payloads/validation"
 	"code.cloudfoundry.org/korifi/api/repositories"
 	"code.cloudfoundry.org/korifi/api/repositories/conditions"
 	"code.cloudfoundry.org/korifi/api/routing"
@@ -236,7 +237,7 @@ func main() {
 	)
 	appLogs := actions.NewAppLogs(appRepo, buildRepo, podRepo)
 
-	decoderValidator := handlers.NewDefaultDecoderValidator()
+	requestValidator := validation.NewDefaultDecoderValidator()
 
 	routerBuilder := routing.NewRouterBuilder()
 	routerBuilder.UseMiddleware(
@@ -272,7 +273,7 @@ func main() {
 			domainRepo,
 			spaceRepo,
 			packageRepo,
-			decoderValidator,
+			requestValidator,
 		),
 		handlers.NewRoute(
 			*serverURL,
@@ -280,7 +281,7 @@ func main() {
 			domainRepo,
 			appRepo,
 			spaceRepo,
-			decoderValidator,
+			requestValidator,
 		),
 		handlers.NewServiceRouteBinding(
 			*serverURL,
@@ -291,7 +292,7 @@ func main() {
 			appRepo,
 			dropletRepo,
 			imageRepo,
-			decoderValidator,
+			requestValidator,
 			cfg.PackageRegistrySecretName,
 		),
 		handlers.NewBuild(
@@ -299,27 +300,27 @@ func main() {
 			buildRepo,
 			packageRepo,
 			appRepo,
-			decoderValidator,
+			requestValidator,
 		),
 		handlers.NewDroplet(
 			*serverURL,
 			dropletRepo,
-			decoderValidator,
+			requestValidator,
 		),
 		handlers.NewProcess(
 			*serverURL,
 			processRepo,
 			processStats,
-			decoderValidator,
+			requestValidator,
 		),
 		handlers.NewDomain(
 			*serverURL,
-			decoderValidator,
+			requestValidator,
 			domainRepo,
 		),
 		handlers.NewDeployment(
 			*serverURL,
-			decoderValidator,
+			requestValidator,
 			deploymentRepo,
 			runnerInfoRepo,
 			cfg.RunnerName,
@@ -331,57 +332,57 @@ func main() {
 			appRepo,
 			buildRepo,
 			appLogs,
-			decoderValidator,
+			requestValidator,
 		),
 		handlers.NewOrg(
 			*serverURL,
 			orgRepo,
 			domainRepo,
-			decoderValidator,
+			requestValidator,
 			cfg.GetUserCertificateDuration(),
 			cfg.DefaultDomainName,
 		),
 		handlers.NewSpace(
 			*serverURL,
 			spaceRepo,
-			decoderValidator,
+			requestValidator,
 		),
 		handlers.NewSpaceManifest(
 			*serverURL,
 			manifest,
 			spaceRepo,
-			decoderValidator,
+			requestValidator,
 		),
 		handlers.NewRole(
 			*serverURL,
 			roleRepo,
-			decoderValidator,
+			requestValidator,
 		),
 		handlers.NewWhoAmI(cachingIdentityProvider, *serverURL),
 		handlers.NewUser(*serverURL),
 		handlers.NewBuildpack(
 			*serverURL,
 			buildpackRepo,
-			decoderValidator,
+			requestValidator,
 		),
 		handlers.NewServiceInstance(
 			*serverURL,
 			serviceInstanceRepo,
 			spaceRepo,
-			decoderValidator,
+			requestValidator,
 		),
 		handlers.NewServiceBinding(
 			*serverURL,
 			serviceBindingRepo,
 			appRepo,
 			serviceInstanceRepo,
-			decoderValidator,
+			requestValidator,
 		),
 		handlers.NewTask(
 			*serverURL,
 			appRepo,
 			taskRepo,
-			decoderValidator,
+			requestValidator,
 		),
 		handlers.NewOAuth(
 			*serverURL,

--- a/api/payloads/app_test.go
+++ b/api/payloads/app_test.go
@@ -53,7 +53,7 @@ var _ = Describe("App payload validation", func() {
 		})
 
 		JustBeforeEach(func() {
-			validatorErr = validator.DecodeAndValidateJSONPayload(createRequest(payload), decodedPayload)
+			validatorErr = validator.DecodeAndValidateJSONPayload(createJSONRequest(payload), decodedPayload)
 		})
 
 		It("succeeds", func() {
@@ -138,7 +138,7 @@ var _ = Describe("App payload validation", func() {
 		})
 
 		JustBeforeEach(func() {
-			validatorErr = validator.DecodeAndValidateJSONPayload(createRequest(payload), decodedPayload)
+			validatorErr = validator.DecodeAndValidateJSONPayload(createJSONRequest(payload), decodedPayload)
 		})
 
 		It("succeeds", func() {
@@ -180,7 +180,7 @@ var _ = Describe("App payload validation", func() {
 		})
 
 		JustBeforeEach(func() {
-			validatorErr = validator.DecodeAndValidateJSONPayload(createRequest(payload), decodedPayload)
+			validatorErr = validator.DecodeAndValidateJSONPayload(createJSONRequest(payload), decodedPayload)
 		})
 
 		It("succeeds", func() {
@@ -216,7 +216,7 @@ var _ = Describe("App payload validation", func() {
 		})
 
 		JustBeforeEach(func() {
-			validatorErr = validator.DecodeAndValidateJSONPayload(createRequest(payload), decodedPayload)
+			validatorErr = validator.DecodeAndValidateJSONPayload(createJSONRequest(payload), decodedPayload)
 		})
 
 		It("succeeds", func() {

--- a/api/payloads/build_test.go
+++ b/api/payloads/build_test.go
@@ -26,7 +26,7 @@ var _ = Describe("BuildCreate", func() {
 		})
 
 		JustBeforeEach(func() {
-			validatorErr = validator.DecodeAndValidateJSONPayload(createRequest(createPayload), decodedBuildPayload)
+			validatorErr = validator.DecodeAndValidateJSONPayload(createJSONRequest(createPayload), decodedBuildPayload)
 		})
 
 		It("succeeds", func() {

--- a/api/payloads/deployment_test.go
+++ b/api/payloads/deployment_test.go
@@ -38,7 +38,7 @@ var _ = Describe("DeploymentCreate", func() {
 		})
 
 		JustBeforeEach(func() {
-			validatorErr = validator.DecodeAndValidateJSONPayload(createRequest(createDeployment), decodedDeploymentPayload)
+			validatorErr = validator.DecodeAndValidateJSONPayload(createJSONRequest(createDeployment), decodedDeploymentPayload)
 		})
 
 		It("succeeds", func() {

--- a/api/payloads/domain_test.go
+++ b/api/payloads/domain_test.go
@@ -36,7 +36,7 @@ var _ = Describe("DomainCreate", func() {
 		})
 
 		JustBeforeEach(func() {
-			validatorErr = validator.DecodeAndValidateJSONPayload(createRequest(createPayload), decodedDomainPayload)
+			validatorErr = validator.DecodeAndValidateJSONPayload(createJSONRequest(createPayload), decodedDomainPayload)
 		})
 
 		It("succeeds", func() {
@@ -160,7 +160,7 @@ var _ = Describe("DomainUpdate", func() {
 	})
 
 	JustBeforeEach(func() {
-		validatorErr = validator.DecodeAndValidateJSONPayload(createRequest(updatePayload), decodedUpdatePayload)
+		validatorErr = validator.DecodeAndValidateJSONPayload(createJSONRequest(updatePayload), decodedUpdatePayload)
 	})
 
 	It("succeeds", func() {

--- a/api/payloads/droplet_test.go
+++ b/api/payloads/droplet_test.go
@@ -32,7 +32,7 @@ var _ = Describe("DropletUpdate", func() {
 		})
 
 		JustBeforeEach(func() {
-			validatorErr = validator.DecodeAndValidateJSONPayload(createRequest(updatePayload), decodedDropletPayload)
+			validatorErr = validator.DecodeAndValidateJSONPayload(createJSONRequest(updatePayload), decodedDropletPayload)
 		})
 
 		It("succeeds", func() {

--- a/api/payloads/lifecycle_test.go
+++ b/api/payloads/lifecycle_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Lifecycle", func() {
 	})
 
 	JustBeforeEach(func() {
-		validatorErr = validator.DecodeAndValidateJSONPayload(createRequest(payload), decodedPayload)
+		validatorErr = validator.DecodeAndValidateJSONPayload(createJSONRequest(payload), decodedPayload)
 	})
 
 	It("succeeds", func() {

--- a/api/payloads/metadata_test.go
+++ b/api/payloads/metadata_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Metadata", func() {
 	})
 
 	JustBeforeEach(func() {
-		validatorErr = validator.DecodeAndValidateJSONPayload(createRequest(metadataPayload), decodedMetadataPayload)
+		validatorErr = validator.DecodeAndValidateJSONPayload(createJSONRequest(metadataPayload), decodedMetadataPayload)
 	})
 
 	It("succeeds", func() {
@@ -77,7 +77,7 @@ var _ = Describe("MetadataPatch", func() {
 	})
 
 	JustBeforeEach(func() {
-		validatorErr = validator.DecodeAndValidateJSONPayload(createRequest(metadataPatchPayload), decodedMetadataPatchPayload)
+		validatorErr = validator.DecodeAndValidateJSONPayload(createJSONRequest(metadataPatchPayload), decodedMetadataPatchPayload)
 	})
 
 	It("succeeds", func() {

--- a/api/payloads/org_test.go
+++ b/api/payloads/org_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Org", func() {
 		})
 
 		JustBeforeEach(func() {
-			validatorErr = validator.DecodeAndValidateJSONPayload(createRequest(payload), decodedPayload)
+			validatorErr = validator.DecodeAndValidateJSONPayload(createJSONRequest(payload), decodedPayload)
 		})
 
 		It("succeeds", func() {
@@ -78,7 +78,7 @@ var _ = Describe("Org", func() {
 		})
 
 		JustBeforeEach(func() {
-			validatorErr = validator.DecodeAndValidateJSONPayload(createRequest(payload), decodedPayload)
+			validatorErr = validator.DecodeAndValidateJSONPayload(createJSONRequest(payload), decodedPayload)
 		})
 
 		It("succeeds", func() {

--- a/api/payloads/package_test.go
+++ b/api/payloads/package_test.go
@@ -38,7 +38,7 @@ var _ = Describe("PackageCreate", func() {
 	})
 
 	JustBeforeEach(func() {
-		validatorErr = validator.DecodeAndValidateJSONPayload(createRequest(createPayload), packageCreate)
+		validatorErr = validator.DecodeAndValidateJSONPayload(createJSONRequest(createPayload), packageCreate)
 	})
 
 	It("succeeds", func() {
@@ -136,7 +136,7 @@ var _ = Describe("PackageUpdate", func() {
 
 		JustBeforeEach(func() {
 			decodedPayload = new(payloads.PackageUpdate)
-			validatorErr = validator.DecodeAndValidateJSONPayload(createRequest(payload), decodedPayload)
+			validatorErr = validator.DecodeAndValidateJSONPayload(createJSONRequest(payload), decodedPayload)
 		})
 
 		It("succeeds", func() {

--- a/api/payloads/payloads_suite_test.go
+++ b/api/payloads/payloads_suite_test.go
@@ -8,6 +8,7 @@ import (
 
 	apierrors "code.cloudfoundry.org/korifi/api/errors"
 	"code.cloudfoundry.org/korifi/api/handlers"
+	"gopkg.in/yaml.v2"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -34,10 +35,21 @@ func expectUnprocessableEntityError(err error, detail string) {
 	Expect(err.(apierrors.UnprocessableEntityError).Detail()).To(ContainSubstring(detail))
 }
 
-func createRequest(payload any) *http.Request {
+func createJSONRequest(payload any) *http.Request {
 	GinkgoHelper()
 
 	body, err := json.Marshal(payload)
+	Expect(err).NotTo(HaveOccurred())
+
+	req, err := http.NewRequest("", "", bytes.NewReader(body))
+	Expect(err).NotTo(HaveOccurred())
+	return req
+}
+
+func createYAMLRequest(payload any) *http.Request {
+	GinkgoHelper()
+
+	body, err := yaml.Marshal(payload)
 	Expect(err).NotTo(HaveOccurred())
 
 	req, err := http.NewRequest("", "", bytes.NewReader(body))

--- a/api/payloads/payloads_suite_test.go
+++ b/api/payloads/payloads_suite_test.go
@@ -7,18 +7,18 @@ import (
 	"testing"
 
 	apierrors "code.cloudfoundry.org/korifi/api/errors"
-	"code.cloudfoundry.org/korifi/api/handlers"
+	"code.cloudfoundry.org/korifi/api/payloads/validation"
 	"gopkg.in/yaml.v2"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
-var validator handlers.DecoderValidator
+var validator validation.DecoderValidator
 
 var _ = BeforeEach(func() {
 	var err error
-	validator = handlers.NewDefaultDecoderValidator()
+	validator = validation.NewDefaultDecoderValidator()
 	Expect(err).NotTo(HaveOccurred())
 })
 
@@ -58,7 +58,7 @@ func createYAMLRequest(payload any) *http.Request {
 }
 
 type keyedPayload[T any] interface {
-	handlers.KeyedPayload
+	validation.KeyedPayload
 	*T
 }
 

--- a/api/payloads/process_test.go
+++ b/api/payloads/process_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Process payload validation", func() {
 		})
 
 		JustBeforeEach(func() {
-			validatorErr = validator.DecodeAndValidateJSONPayload(createRequest(payload), decodedPayload)
+			validatorErr = validator.DecodeAndValidateJSONPayload(createJSONRequest(payload), decodedPayload)
 		})
 
 		It("succeeds", func() {

--- a/api/payloads/relationship_test.go
+++ b/api/payloads/relationship_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Relationship", func() {
 	})
 
 	JustBeforeEach(func() {
-		validatorErr = validator.DecodeAndValidateJSONPayload(createRequest(relationshipPayload), decodedRelationshipPayload)
+		validatorErr = validator.DecodeAndValidateJSONPayload(createJSONRequest(relationshipPayload), decodedRelationshipPayload)
 	})
 
 	It("succeeds", func() {

--- a/api/payloads/role_test.go
+++ b/api/payloads/role_test.go
@@ -43,7 +43,7 @@ var _ = Describe("RoleCreate", func() {
 	})
 
 	JustBeforeEach(func() {
-		validatorErr = validator.DecodeAndValidateJSONPayload(createRequest(createPayload), roleCreate)
+		validatorErr = validator.DecodeAndValidateJSONPayload(createJSONRequest(createPayload), roleCreate)
 		apiError, _ = validatorErr.(errors.ApiError)
 	})
 

--- a/api/payloads/route_test.go
+++ b/api/payloads/route_test.go
@@ -86,7 +86,7 @@ var _ = Describe("RouteCreate", func() {
 	})
 
 	JustBeforeEach(func() {
-		validatorErr = validator.DecodeAndValidateJSONPayload(createRequest(createPayload), routeCreate)
+		validatorErr = validator.DecodeAndValidateJSONPayload(createJSONRequest(createPayload), routeCreate)
 		apiError, _ = validatorErr.(errors.ApiError)
 	})
 
@@ -170,7 +170,7 @@ var _ = Describe("RoutePatch", func() {
 	})
 
 	JustBeforeEach(func() {
-		validatorErr = validator.DecodeAndValidateJSONPayload(createRequest(patchPayload), routePatch)
+		validatorErr = validator.DecodeAndValidateJSONPayload(createJSONRequest(patchPayload), routePatch)
 		apiError, _ = validatorErr.(errors.ApiError)
 	})
 
@@ -223,7 +223,7 @@ var _ = Describe("Add destination", func() {
 	})
 
 	JustBeforeEach(func() {
-		validatorErr = validator.DecodeAndValidateJSONPayload(createRequest(addPayload), destinationAdd)
+		validatorErr = validator.DecodeAndValidateJSONPayload(createJSONRequest(addPayload), destinationAdd)
 		apiError, _ = validatorErr.(errors.ApiError)
 	})
 

--- a/api/payloads/service_binding_test.go
+++ b/api/payloads/service_binding_test.go
@@ -57,7 +57,7 @@ var _ = Describe("ServiceBindingCreate", func() {
 	})
 
 	JustBeforeEach(func() {
-		validatorErr = validator.DecodeAndValidateJSONPayload(createRequest(createPayload), serviceBindingCreate)
+		validatorErr = validator.DecodeAndValidateJSONPayload(createJSONRequest(createPayload), serviceBindingCreate)
 		apiError, _ = validatorErr.(errors.ApiError)
 	})
 
@@ -152,7 +152,7 @@ var _ = Describe("ServiceBindingUpdate", func() {
 	})
 
 	JustBeforeEach(func() {
-		validatorErr = validator.DecodeAndValidateJSONPayload(createRequest(patchPayload), serviceBindingPatch)
+		validatorErr = validator.DecodeAndValidateJSONPayload(createJSONRequest(patchPayload), serviceBindingPatch)
 		apiError, _ = validatorErr.(errors.ApiError)
 	})
 

--- a/api/payloads/service_instance_test.go
+++ b/api/payloads/service_instance_test.go
@@ -71,7 +71,7 @@ var _ = Describe("ServiceInstanceCreate", func() {
 	})
 
 	JustBeforeEach(func() {
-		validatorErr = validator.DecodeAndValidateJSONPayload(createRequest(createPayload), serviceInstanceCreate)
+		validatorErr = validator.DecodeAndValidateJSONPayload(createJSONRequest(createPayload), serviceInstanceCreate)
 	})
 
 	It("succeeds", func() {
@@ -240,7 +240,7 @@ var _ = Describe("ServiceInstancePatch", func() {
 	})
 
 	JustBeforeEach(func() {
-		validatorErr = validator.DecodeAndValidateJSONPayload(createRequest(patchPayload), serviceInstancePatch)
+		validatorErr = validator.DecodeAndValidateJSONPayload(createJSONRequest(patchPayload), serviceInstancePatch)
 	})
 
 	It("succeeds", func() {

--- a/api/payloads/space.go
+++ b/api/payloads/space.go
@@ -1,6 +1,9 @@
 package payloads
 
 import (
+	"net/url"
+
+	"code.cloudfoundry.org/korifi/api/payloads/parse"
 	"code.cloudfoundry.org/korifi/api/repositories"
 	"github.com/jellydator/validation"
 )
@@ -55,4 +58,26 @@ func (p SpacePatch) ToMessage(spaceGUID, orgGUID string) repositories.PatchSpace
 			Annotations: p.Metadata.Annotations,
 		},
 	}
+}
+
+type SpaceList struct {
+	Names             string
+	OrganizationGUIDs string
+}
+
+func (l *SpaceList) ToMessage() repositories.ListSpacesMessage {
+	return repositories.ListSpacesMessage{
+		Names:             parse.ArrayParam(l.Names),
+		OrganizationGUIDs: parse.ArrayParam(l.OrganizationGUIDs),
+	}
+}
+
+func (l *SpaceList) SupportedKeys() []string {
+	return []string{"names", "organization_guids", "order_by", "per_page", "page"}
+}
+
+func (l *SpaceList) DecodeFromURLValues(values url.Values) error {
+	l.Names = values.Get("names")
+	l.OrganizationGUIDs = values.Get("organization_guids")
+	return nil
 }

--- a/api/payloads/space_test.go
+++ b/api/payloads/space_test.go
@@ -1,6 +1,8 @@
 package payloads_test
 
 import (
+	"net/http"
+
 	"code.cloudfoundry.org/korifi/api/payloads"
 	"code.cloudfoundry.org/korifi/tools"
 	. "github.com/onsi/ginkgo/v2"
@@ -130,6 +132,32 @@ var _ = Describe("Space", func() {
 					validatorErr,
 					"label/annotation key cannot use the cloudfoundry.org domain",
 				)
+			})
+		})
+	})
+
+	Describe("SpaceList", func() {
+		Describe("decoding from url values", func() {
+			It("gets the names and organization_guids param and allows order_by", func() {
+				spaceList := payloads.SpaceList{}
+				req, err := http.NewRequest("GET", "http://foo.com/bar?names=foo,bar&organization_guids=o1,o2&order_by=name", nil)
+				Expect(err).NotTo(HaveOccurred())
+				err = validator.DecodeAndValidateURLValues(req, &spaceList)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(spaceList.Names).To(Equal("foo,bar"))
+				Expect(spaceList.OrganizationGUIDs).To(Equal("o1,o2"))
+			})
+		})
+
+		Describe("ToMessage", func() {
+			It("splits names to strings", func() {
+				spaceList := payloads.SpaceList{
+					Names:             "foo,bar",
+					OrganizationGUIDs: "org1,org2",
+				}
+				Expect(spaceList.ToMessage().Names).To(ConsistOf("foo", "bar"))
+				Expect(spaceList.ToMessage().OrganizationGUIDs).To(ConsistOf("org1", "org2"))
 			})
 		})
 	})

--- a/api/payloads/space_test.go
+++ b/api/payloads/space_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Space", func() {
 		})
 
 		JustBeforeEach(func() {
-			validatorErr = validator.DecodeAndValidateJSONPayload(createRequest(payload), decodedPayload)
+			validatorErr = validator.DecodeAndValidateJSONPayload(createJSONRequest(payload), decodedPayload)
 		})
 
 		It("succeeds", func() {
@@ -114,7 +114,7 @@ var _ = Describe("Space", func() {
 		})
 
 		JustBeforeEach(func() {
-			validatorErr = validator.DecodeAndValidateJSONPayload(createRequest(payload), decodedPayload)
+			validatorErr = validator.DecodeAndValidateJSONPayload(createJSONRequest(payload), decodedPayload)
 		})
 
 		It("succeeds", func() {

--- a/api/payloads/task_test.go
+++ b/api/payloads/task_test.go
@@ -63,7 +63,7 @@ var _ = Describe("TaskCreate", func() {
 
 		JustBeforeEach(func() {
 			decodedPayload = new(payloads.TaskCreate)
-			validatorErr = validator.DecodeAndValidateJSONPayload(createRequest(payload), decodedPayload)
+			validatorErr = validator.DecodeAndValidateJSONPayload(createJSONRequest(payload), decodedPayload)
 		})
 
 		It("succeeds", func() {
@@ -137,7 +137,7 @@ var _ = Describe("TaskUpdate", func() {
 
 		JustBeforeEach(func() {
 			decodedPayload = new(payloads.TaskUpdate)
-			validatorErr = validator.DecodeAndValidateJSONPayload(createRequest(payload), decodedPayload)
+			validatorErr = validator.DecodeAndValidateJSONPayload(createJSONRequest(payload), decodedPayload)
 		})
 
 		It("succeeds", func() {

--- a/api/payloads/validation/validation_suite_test.go
+++ b/api/payloads/validation/validation_suite_test.go
@@ -1,0 +1,13 @@
+package validation_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestValidation(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Validation Suite")
+}

--- a/api/payloads/validation/validator.go
+++ b/api/payloads/validation/validator.go
@@ -1,4 +1,4 @@
-package handlers
+package validation
 
 import (
 	"encoding/json"
@@ -17,14 +17,6 @@ import (
 	"golang.org/x/text/language"
 	"gopkg.in/yaml.v3"
 )
-
-//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
-
-type RequestValidator interface {
-	DecodeAndValidateJSONPayload(r *http.Request, object any) error
-	DecodeAndValidateURLValues(r *http.Request, payloadObject KeyedPayload) error
-	DecodeAndValidateYAMLPayload(r *http.Request, object any) error
-}
 
 type KeyedPayload interface {
 	SupportedKeys() []string

--- a/api/payloads/validation/validator_test.go
+++ b/api/payloads/validation/validator_test.go
@@ -1,4 +1,4 @@
-package handlers_test
+package validation_test
 
 import (
 	"net/http"
@@ -7,8 +7,8 @@ import (
 	"strconv"
 
 	apierrors "code.cloudfoundry.org/korifi/api/errors"
-	"code.cloudfoundry.org/korifi/api/handlers"
-	"github.com/jellydator/validation"
+	"code.cloudfoundry.org/korifi/api/payloads/validation"
+	jellidation "github.com/jellydator/validation"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -16,14 +16,14 @@ import (
 var _ = Describe("Validator", func() {
 	Describe("DecodeAndValidateURLValues", func() {
 		var (
-			requestValidator handlers.DecoderValidator
+			requestValidator validation.DecoderValidator
 			decoded          DecodeTestPayload
 			decodeErr        error
 			requestUrl       string
 		)
 
 		BeforeEach(func() {
-			requestValidator = handlers.NewDefaultDecoderValidator()
+			requestValidator = validation.NewDefaultDecoderValidator()
 			requestUrl = "http://foo.com?key=3"
 			decoded = DecodeTestPayload{}
 		})
@@ -107,8 +107,8 @@ type DecodeTestPayload struct {
 }
 
 func (p DecodeTestPayload) Validate() error {
-	return validation.ValidateStruct(&p,
-		validation.Field(&p.Key, validation.Min(0)),
+	return jellidation.ValidateStruct(&p,
+		jellidation.Field(&p.Key, jellidation.Min(0)),
 	)
 }
 


### PR DESCRIPTION

<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
#1996
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
- Use the requestValidator in the spaces handler
- Use RequestValidator in handlers.Manifest
- RunnerInfoRepository fake was out of date
- Move decoder/validator to payloads/validation package
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
N/A
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@danail-branekov
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
