### PR TITLE
Build workloads do not own custom kpack builders via ControllerReference

### DIFF
--- a/kpack-image-builder/controllers/buildworkload_controller.go
+++ b/kpack-image-builder/controllers/buildworkload_controller.go
@@ -466,7 +466,7 @@ func (r *BuildWorkloadReconciler) ensureKpackBuilder(ctx context.Context, log lo
 		},
 	}
 	_, err = ctrl.CreateOrUpdate(ctx, r.k8sClient, builder, func() error {
-		if err = controllerutil.SetControllerReference(buildWorkload, builder, r.scheme); err != nil {
+		if err = controllerutil.SetOwnerReference(buildWorkload, builder, r.scheme); err != nil {
 			log.Info("unable to set owner reference on Builder", "reason", err)
 			return err
 		}


### PR DESCRIPTION
## Is there a related GitHub Issue?
#2645
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Custom kpack builders (the ones that are created on the fly for build
workloads with buildpacks specified) are shared by build workloads
that have the same set of buildpacks. Therefore, setting
ControllerReference from the build workload to the builder is incorrect
as the ControllerReference can only be set once.

This PR sets simple owner references to custom kpack builds instead.
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
See bug description
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

