### PR TITLE
Include filemode when zipping source in e2es

### DIFF
--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -1074,7 +1074,12 @@ func zipAsset(src string) string {
 			return err
 		}
 
-		f, err := w.Create(rel)
+		fh := &zip.FileHeader{
+			Name: rel,
+		}
+		fh.SetMode(info.Mode())
+
+		f, err := w.CreateHeader(fh)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
Our mitigation against the GKE/GAR UNKNOWN_BLOB error is to pre-push the apps we push in the e2e tests. However, we ended up with different droplets when using `cf push` to those created in the e2e code.

The difference turned out to be omitting file permissions when we zipped the source in e2es. So this PR sets the file mode while zipping.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
See UNKNOWN_BLOB flakes reduce / stop

## Tag your pair, your PM, and/or team
@gcapizzi
