### PR TITLE
handle non-resizable storage classes for build cache

### DIFF
--- a/helm/korifi/kpack-image-builder/role.yaml
+++ b/helm/korifi/kpack-image-builder/role.yaml
@@ -124,3 +124,10 @@ rules:
   verbs:
   - get
   - patch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - list
+  - watch


### PR DESCRIPTION

<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->#2634

## What is this change about?
<!-- _Please describe the change here._ -->
We set build cache size on kpack `Images`, but if we already have an `Image`, and we try to change the buildCacheMB setting, redeploy Korifi, and then repush an app, the operation will fail if the storage class doesn't support resize, because kpack will try to modify the persistent disk. This change checks the storage class and deletes the `Image` if resizing isn't supported.

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->
#2634

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->
@davewalter 

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
