### PR TITLE
Operator can limit ephemeral disk used during staging

### DIFF
--- a/README.helm.md
+++ b/README.helm.md
@@ -43,7 +43,7 @@ Here are all the values that can be set for the chart:
     - `stack` (_String_): Stack.
     - `stagingRequirements`:
       - `buildCacheMB` (_Integer_): Persistent disk in MB for caching staging artifacts across builds.
-      - `diskMB` (_Integer_): Disk in MB for staging.
+      - `diskMB` (_Integer_): Ephemeral Disk limit in MB for staging apps.
       - `memoryMB` (_Integer_): Memory in MB for staging.
     - `type` (_String_): Lifecycle type (only `buildpack` accepted currently).
   - `replicas` (_Integer_): Number of replicas.

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -60,7 +60,6 @@ type (
 		Type            string `yaml:"type"`
 		Stack           string `yaml:"stack"`
 		StagingMemoryMB int    `yaml:"stagingMemoryMB"`
-		StagingDiskMB   int    `yaml:"stagingDiskMB"`
 	}
 )
 

--- a/api/config/config_test.go
+++ b/api/config/config_test.go
@@ -45,7 +45,6 @@ var _ = Describe("Config", func() {
 				Type:            "lc-type",
 				Stack:           "lc-stack",
 				StagingMemoryMB: 10,
-				StagingDiskMB:   20,
 			},
 		}
 	})
@@ -87,7 +86,6 @@ var _ = Describe("Config", func() {
 			Type:            "lc-type",
 			Stack:           "lc-stack",
 			StagingMemoryMB: 10,
-			StagingDiskMB:   20,
 		}))
 		Expect(cfg.ContainerRegistryType).To(BeEmpty())
 	})

--- a/api/handlers/build_test.go
+++ b/api/handlers/build_test.go
@@ -200,7 +200,6 @@ var _ = Describe("Build", func() {
 			Expect(actualCreate.AppGUID).To(Equal(appGUID))
 			Expect(actualCreate.PackageGUID).To(Equal(packageGUID))
 			Expect(actualCreate.StagingMemoryMB).To(Equal(expectedStagingMem))
-			Expect(actualCreate.StagingDiskMB).To(Equal(expectedStagingDisk))
 			Expect(actualCreate.Lifecycle.Type).To(Equal(expectedLifecycleType))
 			Expect(actualCreate.Lifecycle.Data.Buildpacks).To(Equal(expectedLifecycleBuildpacks))
 			Expect(actualCreate.Lifecycle.Data.Stack).To(Equal(expectedLifecycleStack))

--- a/api/payloads/app.go
+++ b/api/payloads/app.go
@@ -17,7 +17,6 @@ var DefaultLifecycleConfig = config.DefaultLifecycleConfig{
 	Type:            "buildpack",
 	Stack:           "cflinuxfs3",
 	StagingMemoryMB: 1024,
-	StagingDiskMB:   1024,
 }
 
 type AppCreate struct {

--- a/api/payloads/build.go
+++ b/api/payloads/build.go
@@ -27,7 +27,6 @@ func (c *BuildCreate) ToMessage(appRecord repositories.AppRecord) repositories.C
 		PackageGUID:     c.Package.GUID,
 		SpaceGUID:       appRecord.SpaceGUID,
 		StagingMemoryMB: DefaultLifecycleConfig.StagingMemoryMB,
-		StagingDiskMB:   DefaultLifecycleConfig.StagingDiskMB,
 		Lifecycle:       appRecord.Lifecycle,
 		Labels:          c.Metadata.Labels,
 		Annotations:     c.Metadata.Annotations,

--- a/controllers/api/v1alpha1/cfbuild_types.go
+++ b/controllers/api/v1alpha1/cfbuild_types.go
@@ -30,7 +30,7 @@ type CFBuildSpec struct {
 
 	// The memory limit for the pod that will stage the image
 	StagingMemoryMB int `json:"stagingMemoryMB"`
-	// The disk limit for the pod that will stage the image
+	// The ephemeral-disk size request for the pod that will stage the image
 	StagingDiskMB int `json:"stagingDiskMB"`
 
 	// Specifies the buildpacks and stack for the build

--- a/controllers/api/v1alpha1/cfbuild_types.go
+++ b/controllers/api/v1alpha1/cfbuild_types.go
@@ -30,7 +30,7 @@ type CFBuildSpec struct {
 
 	// The memory limit for the pod that will stage the image
 	StagingMemoryMB int `json:"stagingMemoryMB"`
-	// The ephemeral-disk size request for the pod that will stage the image
+	// Unimplemented: StagingDiskMB is the ephemeral-disk size request for the pod that will stage the image
 	StagingDiskMB int `json:"stagingDiskMB"`
 
 	// Specifies the buildpacks and stack for the build

--- a/controllers/config/config.go
+++ b/controllers/config/config.go
@@ -42,6 +42,7 @@ type ControllerConfig struct {
 	ContainerRepositoryPrefix string `yaml:"containerRepositoryPrefix"`
 	ContainerRegistryType     string `yaml:"containerRegistryType"`
 	BuildCacheMB              int    `yaml:"buildCacheMB"`
+	DiskMB                    int    `yaml:"diskMB"`
 }
 
 type CFProcessDefaults struct {

--- a/controllers/config/config_test.go
+++ b/controllers/config/config_test.go
@@ -46,6 +46,7 @@ var _ = Describe("LoadFromPath", func() {
 			LogLevel:                         zapcore.DebugLevel,
 			SpaceFinalizerAppDeletionTimeout: tools.PtrTo(int64(42)),
 			BuildCacheMB:                     1024,
+			DiskMB:                           512,
 		}
 	})
 
@@ -82,6 +83,7 @@ var _ = Describe("LoadFromPath", func() {
 			LogLevel:                         zapcore.DebugLevel,
 			SpaceFinalizerAppDeletionTimeout: tools.PtrTo(int64(42)),
 			BuildCacheMB:                     1024,
+			DiskMB:                           512,
 		}))
 	})
 

--- a/helm/korifi/api/configmap.yaml
+++ b/helm/korifi/api/configmap.yaml
@@ -19,7 +19,6 @@ data:
       type: {{ .Values.api.lifecycle.type }}
       stack: {{ .Values.api.lifecycle.stack }}
       stagingMemoryMB: {{ .Values.api.lifecycle.stagingRequirements.memoryMB }}
-      stagingDiskMB: {{ .Values.api.lifecycle.stagingRequirements.diskMB }}
     containerRepositoryPrefix: {{ .Values.global.containerRepositoryPrefix | quote }}
     {{- if not .Values.global.eksContainerRegistryRoleARN }}
     packageRegistrySecretName: {{ required "global.containerRegistrySecret is required when global.eksContainerRegistryRoleARN is not set" .Values.global.containerRegistrySecret }}

--- a/helm/korifi/controllers/configmap.yaml
+++ b/helm/korifi/controllers/configmap.yaml
@@ -39,6 +39,7 @@ data:
     containerRepositoryPrefix: {{ .Values.global.containerRepositoryPrefix | quote }}
     builderServiceAccount: kpack-service-account
     buildCacheMB: {{ .Values.api.lifecycle.stagingRequirements.buildCacheMB }}
+    diskMB: {{ .Values.api.lifecycle.stagingRequirements.diskMB }}
     {{- if .Values.global.eksContainerRegistryRoleARN }}
     containerRegistryType: "ECR"
     {{- end }}

--- a/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfbuilds.yaml
+++ b/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfbuilds.yaml
@@ -94,8 +94,8 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               stagingDiskMB:
-                description: The ephemeral-disk size request for the pod that will
-                  stage the image
+                description: 'Unimplemented: StagingDiskMB is the ephemeral-disk size
+                  request for the pod that will stage the image'
                 type: integer
               stagingMemoryMB:
                 description: The memory limit for the pod that will stage the image

--- a/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfbuilds.yaml
+++ b/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfbuilds.yaml
@@ -94,7 +94,8 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               stagingDiskMB:
-                description: The disk limit for the pod that will stage the image
+                description: The ephemeral-disk size request for the pod that will
+                  stage the image
                 type: integer
               stagingMemoryMB:
                 description: The memory limit for the pod that will stage the image

--- a/helm/korifi/values.schema.json
+++ b/helm/korifi/values.schema.json
@@ -180,7 +180,7 @@
                   "type": "integer"
                 },
                 "diskMB": {
-                  "description": "Disk in MB for staging.",
+                  "description": "Ephemeral Disk limit in MB for staging apps.",
                   "type": "integer"
                 },
                 "buildCacheMB": {

--- a/kpack-image-builder/controllers/buildworkload_controller.go
+++ b/kpack-image-builder/controllers/buildworkload_controller.go
@@ -702,6 +702,11 @@ func (r *BuildWorkloadReconciler) reconcileKpackImage(
 			Build: &buildv1alpha2.ImageBuild{
 				Services: buildWorkload.Spec.Services,
 				Env:      buildWorkload.Spec.Env,
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceEphemeralStorage: *resource.NewScaledQuantity(int64(r.controllerConfig.DiskMB), resource.Mega),
+					},
+				},
 			},
 			Cache: &buildv1alpha2.ImageCacheConfig{
 				Volume: &buildv1alpha2.ImagePersistentVolumeCache{

--- a/kpack-image-builder/controllers/buildworkload_controller_test.go
+++ b/kpack-image-builder/controllers/buildworkload_controller_test.go
@@ -162,6 +162,7 @@ var _ = Describe("BuildWorkloadReconciler", func() {
 					g.Expect(kpackImage.Spec.Source.Registry.ImagePullSecrets).To(BeEquivalentTo(source.Registry.ImagePullSecrets))
 					g.Expect(kpackImage.Spec.Build.Env).To(Equal(env))
 					g.Expect(kpackImage.Spec.Build.Services).To(BeEquivalentTo(services))
+					g.Expect(kpackImage.Spec.Build.Resources.Limits.StorageEphemeral().String()).To(Equal(fmt.Sprintf("%dM", 2048)))
 
 					g.Expect(kpackImage.Spec.Builder.Kind).To(Equal("ClusterBuilder"))
 					g.Expect(kpackImage.Spec.Builder.Name).To(Equal("cf-kpack-builder"))

--- a/kpack-image-builder/controllers/suite_test.go
+++ b/kpack-image-builder/controllers/suite_test.go
@@ -128,6 +128,7 @@ var _ = BeforeSuite(func() {
 		ContainerRepositoryPrefix: "image/registry/tag",
 		BuilderServiceAccount:     "builder-service-account",
 		BuildCacheMB:              1024,
+		DiskMB:                    2048,
 	}
 
 	imageRepoCreator = new(fake.RepositoryCreator)


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
#2651 

## What is this change about?
<!-- _Please describe the change here._ -->
Allows Operators to limit ephemeral disk used during staging
- these limits are set on the kpack image/build.
- `api.stagingRequirements.diskMB` from helm value is now considered as limits set by the platform operator.
- updates the description of `StagingDiskMB` in the CFBuild CRD to say its a "request" instead of "limit".


## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->
No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->
See #2651 
