### PR TITLE
Make all status.conditions fields optional and annotated with omitempty

### DIFF
--- a/api/repositories/app_repository_test.go
+++ b/api/repositories/app_repository_test.go
@@ -1530,7 +1530,6 @@ func createAppWithGUID(space, guid string) *korifiv1alpha1.CFApp {
 	}
 	Expect(k8sClient.Create(context.Background(), cfApp)).To(Succeed())
 
-	cfApp.Status.Conditions = []metav1.Condition{}
 	Expect(k8sClient.Status().Update(context.Background(), cfApp)).To(Succeed())
 
 	return cfApp

--- a/api/repositories/task_repository_test.go
+++ b/api/repositories/task_repository_test.go
@@ -36,10 +36,6 @@ var _ = Describe("TaskRepository", func() {
 	setStatusAndUpdate := func(task *korifiv1alpha1.CFTask, conditionTypes ...string) {
 		GinkgoHelper()
 
-		if task.Status.Conditions == nil {
-			task.Status.Conditions = []metav1.Condition{}
-		}
-
 		for _, cond := range conditionTypes {
 			meta.SetStatusCondition(&(task.Status.Conditions), metav1.Condition{
 				Type:    cond,

--- a/controllers/api/v1alpha1/appworkload_types.go
+++ b/controllers/api/v1alpha1/appworkload_types.go
@@ -56,8 +56,8 @@ type AppWorkloadSpec struct {
 
 // AppWorkloadStatus defines the observed state of AppWorkload
 type AppWorkloadStatus struct {
-	// Conditions capture the current status of the observed generation of the AppWorkload
-	Conditions []metav1.Condition `json:"conditions"`
+	//+kubebuilder:validation:Optional
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
 	// ObservedGeneration captures the latest generation of the AppWorkload that has been reconciled
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`

--- a/controllers/api/v1alpha1/builderinfo_types.go
+++ b/controllers/api/v1alpha1/builderinfo_types.go
@@ -27,7 +27,8 @@ type BuilderInfoSpec struct{}
 type BuilderInfoStatus struct {
 	Stacks     []BuilderInfoStatusStack     `json:"stacks"`
 	Buildpacks []BuilderInfoStatusBuildpack `json:"buildpacks"`
-	Conditions []metav1.Condition           `json:"conditions"`
+	//+kubebuilder:validation:Optional
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
 	// ObservedGeneration captures the latest generation of the BuilderInfo that has been reconciled
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`

--- a/controllers/api/v1alpha1/buildworkload_types.go
+++ b/controllers/api/v1alpha1/buildworkload_types.go
@@ -49,9 +49,8 @@ type BuildWorkloadSpec struct {
 
 // BuildWorkloadStatus defines the observed state of BuildWorkload
 type BuildWorkloadStatus struct {
-	// Conditions capture the current status of the observed generation of the BuildWorkload
-	// +optional
-	Conditions []metav1.Condition `json:"conditions"`
+	//+kubebuilder:validation:Optional
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
 	Droplet *BuildDropletStatus `json:"droplet,omitempty"`
 

--- a/controllers/api/v1alpha1/cfapp_types.go
+++ b/controllers/api/v1alpha1/cfapp_types.go
@@ -51,8 +51,8 @@ type DesiredState string
 
 // CFAppStatus defines the observed state of CFApp
 type CFAppStatus struct {
-	// Conditions capture the current status of the App
-	Conditions []metav1.Condition `json:"conditions"`
+	//+kubebuilder:validation:Optional
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
 	// Deprecated: No longer used
 	//+kubebuilder:validation:Optional

--- a/controllers/api/v1alpha1/cfbuild_types.go
+++ b/controllers/api/v1alpha1/cfbuild_types.go
@@ -40,8 +40,8 @@ type CFBuildSpec struct {
 // CFBuildStatus defines the observed state of CFBuild
 type CFBuildStatus struct {
 	Droplet *BuildDropletStatus `json:"droplet,omitempty"`
-	// Conditions capture the current status of the Build
-	Conditions []metav1.Condition `json:"conditions"`
+	//+kubebuilder:validation:Optional
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
 	// ObservedGeneration captures the latest generation of the CFBuild that has been reconciled
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`

--- a/controllers/api/v1alpha1/cfdomain_types.go
+++ b/controllers/api/v1alpha1/cfdomain_types.go
@@ -32,7 +32,7 @@ type CFDomainSpec struct {
 
 // CFDomainStatus defines the observed state of CFDomain
 type CFDomainStatus struct {
-	// Conditions capture the current status of the domain
+	//+kubebuilder:validation:Optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
 	// ObservedGeneration captures the latest generation of the CFDomain that has been reconciled

--- a/controllers/api/v1alpha1/cforg_types.go
+++ b/controllers/api/v1alpha1/cforg_types.go
@@ -40,7 +40,8 @@ type CFOrgSpec struct {
 
 // CFOrgStatus defines the observed state of CFOrg
 type CFOrgStatus struct {
-	Conditions []metav1.Condition `json:"conditions"`
+	//+kubebuilder:validation:Optional
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
 	GUID string `json:"guid"`
 

--- a/controllers/api/v1alpha1/cfpackage_types.go
+++ b/controllers/api/v1alpha1/cfpackage_types.go
@@ -48,8 +48,8 @@ type PackageSource struct {
 
 // CFPackageStatus defines the observed state of CFPackage
 type CFPackageStatus struct {
-	// Conditions capture the current status of the Package
-	Conditions []metav1.Condition `json:"conditions"`
+	//+kubebuilder:validation:Optional
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
 	// ObservedGeneration captures the latest generation of the CFPackage that has been reconciled
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`

--- a/controllers/api/v1alpha1/cfprocess_types.go
+++ b/controllers/api/v1alpha1/cfprocess_types.go
@@ -83,8 +83,8 @@ type HealthCheckData struct {
 
 // CFProcessStatus defines the observed state of CFProcess
 type CFProcessStatus struct {
-	// Conditions capture the current status of the Process
-	Conditions []metav1.Condition `json:"conditions"`
+	//+kubebuilder:validation:Optional
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
 	// ObservedGeneration captures the latest generation of the CFProcess that has been reconciled
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`

--- a/controllers/api/v1alpha1/cfroute_types.go
+++ b/controllers/api/v1alpha1/cfroute_types.go
@@ -78,7 +78,7 @@ type CFRouteStatus struct {
 	// The observed state of the destinations. This is mainly used to record the target port of the underlying service
 	Destinations []Destination `json:"destinations,omitempty"`
 
-	// Conditions capture the current status of the route
+	//+kubebuilder:validation:Optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
 	// ObservedGeneration captures the latest generation of the CFRoute that has been reconciled

--- a/controllers/api/v1alpha1/cfservicebinding_types.go
+++ b/controllers/api/v1alpha1/cfservicebinding_types.go
@@ -42,8 +42,8 @@ type CFServiceBindingStatus struct {
 	// +optional
 	Binding v1.LocalObjectReference `json:"binding"`
 
-	// Conditions capture the current status of the CFServiceBinding
-	Conditions []metav1.Condition `json:"conditions"`
+	//+kubebuilder:validation:Optional
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
 	// ObservedGeneration captures the latest generation of the CFServiceBinding that has been reconciled
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`

--- a/controllers/api/v1alpha1/cfserviceinstance_types.go
+++ b/controllers/api/v1alpha1/cfserviceinstance_types.go
@@ -58,8 +58,8 @@ type CFServiceInstanceStatus struct {
 	// +optional
 	Binding corev1.LocalObjectReference `json:"binding"`
 
-	// Conditions capture the current status of the CFServiceInstance
-	Conditions []metav1.Condition `json:"conditions"`
+	//+kubebuilder:validation:Optional
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
 	// ObservedGeneration captures the latest generation of the CFServiceInstance that has been reconciled
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`

--- a/controllers/api/v1alpha1/cfspace_types.go
+++ b/controllers/api/v1alpha1/cfspace_types.go
@@ -39,8 +39,8 @@ type CFSpaceSpec struct {
 
 // CFSpaceStatus defines the observed state of CFSpace
 type CFSpaceStatus struct {
-	// Conditions capture the current status of the CFSpace
-	Conditions []metav1.Condition `json:"conditions"`
+	//+kubebuilder:validation:Optional
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
 	GUID string `json:"guid"`
 

--- a/controllers/api/v1alpha1/cftask_types.go
+++ b/controllers/api/v1alpha1/cftask_types.go
@@ -42,8 +42,8 @@ type CFTaskSpec struct {
 
 // CFTaskStatus defines the observed state of CFTask
 type CFTaskStatus struct {
-	// +optional
-	Conditions []metav1.Condition `json:"conditions"`
+	//+kubebuilder:validation:Optional
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
 	// +optional
 	SequenceID int64 `json:"sequenceId"`

--- a/controllers/api/v1alpha1/runnerinfo_types.go
+++ b/controllers/api/v1alpha1/runnerinfo_types.go
@@ -30,7 +30,7 @@ type RunnerInfoSpec struct {
 // RunnerInfoStatus defines the observed state of RunnerInfo
 type RunnerInfoStatus struct {
 	//+kubebuilder:validation:Optional
-	Conditions []metav1.Condition `json:"conditions"`
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
 	Capabilities RunnerInfoCapabilities `json:"capabilities"`
 

--- a/controllers/api/v1alpha1/taskworkload_types.go
+++ b/controllers/api/v1alpha1/taskworkload_types.go
@@ -41,8 +41,8 @@ type TaskWorkloadSpec struct {
 
 // TaskWorkloadStatus defines the observed state of TaskWorkload
 type TaskWorkloadStatus struct {
-	// +optional
-	Conditions []metav1.Condition `json:"conditions"`
+	//+kubebuilder:validation:Optional
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
 	// ObservedGeneration captures the latest generation of the TaskWorkload that has been reconciled
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`

--- a/controllers/controllers/workloads/cfapp_controller.go
+++ b/controllers/controllers/workloads/cfapp_controller.go
@@ -133,10 +133,6 @@ func (r *CFAppReconciler) ReconcileResource(ctx context.Context, cfApp *korifiv1
 
 	cfApp.Status.VCAPServicesSecretName = secretName
 
-	if cfApp.Status.Conditions == nil {
-		cfApp.Status.Conditions = make([]metav1.Condition, 0)
-	}
-
 	if cfApp.Spec.CurrentDropletRef.Name == "" {
 		meta.SetStatusCondition(&cfApp.Status.Conditions, metav1.Condition{
 			Type:               shared.StatusConditionReady,

--- a/controllers/controllers/workloads/cfapp_controller_test.go
+++ b/controllers/controllers/workloads/cfapp_controller_test.go
@@ -112,7 +112,6 @@ var _ = Describe("CFAppReconciler Integration Tests", func() {
 			}
 			Expect(adminClient.Create(ctx, serviceBinding)).To(Succeed())
 			Expect(k8s.Patch(ctx, adminClient, serviceBinding, func() {
-				serviceBinding.Status.Conditions = []metav1.Condition{}
 				serviceBinding.Status.Binding = corev1.LocalObjectReference{
 					Name: serviceInstanceSecret.Name,
 				}

--- a/controllers/controllers/workloads/env/env_suite_test.go
+++ b/controllers/controllers/workloads/env/env_suite_test.go
@@ -99,7 +99,6 @@ var _ = BeforeEach(func() {
 	ensureCreate(cfOrg)
 	orgNSName := testutils.PrefixedGUID("org")
 	ensurePatch(cfOrg, func(cfOrg *korifiv1alpha1.CFOrg) {
-		cfOrg.Status.Conditions = []metav1.Condition{}
 		cfOrg.Status.GUID = orgNSName
 	})
 	createNamespace(cfOrg.Status.GUID)
@@ -116,7 +115,6 @@ var _ = BeforeEach(func() {
 	ensureCreate(cfSpace)
 	cfNSName := testutils.PrefixedGUID("space")
 	ensurePatch(cfSpace, func(cfSpace *korifiv1alpha1.CFSpace) {
-		cfSpace.Status.Conditions = []metav1.Condition{}
 		cfSpace.Status.GUID = cfNSName
 	})
 	createNamespace(cfSpace.Status.GUID)
@@ -138,7 +136,6 @@ var _ = BeforeEach(func() {
 	ensureCreate(cfApp)
 	ensurePatch(cfApp, func(app *korifiv1alpha1.CFApp) {
 		app.Status = korifiv1alpha1.CFAppStatus{
-			Conditions:                []metav1.Condition{},
 			VCAPServicesSecretName:    "app-guid-vcap-services",
 			VCAPApplicationSecretName: "app-guid-vcap-application",
 		}

--- a/controllers/controllers/workloads/env/vcap_services_builder_test.go
+++ b/controllers/controllers/workloads/env/vcap_services_builder_test.go
@@ -69,7 +69,6 @@ var _ = Describe("Builder", func() {
 		ensureCreate(serviceBinding)
 		ensurePatch(serviceBinding, func(sb *korifiv1alpha1.CFServiceBinding) {
 			sb.Status = korifiv1alpha1.CFServiceBindingStatus{
-				Conditions: []metav1.Condition{},
 				Binding: corev1.LocalObjectReference{
 					Name: "service-binding-secret",
 				},
@@ -118,7 +117,6 @@ var _ = Describe("Builder", func() {
 		ensureCreate(serviceBinding2)
 		ensurePatch(serviceBinding2, func(sb *korifiv1alpha1.CFServiceBinding) {
 			sb.Status = korifiv1alpha1.CFServiceBindingStatus{
-				Conditions: []metav1.Condition{},
 				Binding: corev1.LocalObjectReference{
 					Name: "service-binding-secret-2",
 				},

--- a/controllers/controllers/workloads/suite_test.go
+++ b/controllers/controllers/workloads/suite_test.go
@@ -264,7 +264,6 @@ func createBuildWithDroplet(ctx context.Context, k8sClient client.Client, cfBuil
 		k8sClient.Create(ctx, cfBuild),
 	).To(Succeed())
 	patchedCFBuild := cfBuild.DeepCopy()
-	patchedCFBuild.Status.Conditions = []metav1.Condition{}
 	patchedCFBuild.Status.Droplet = droplet
 	Expect(
 		k8sClient.Status().Patch(ctx, patchedCFBuild, client.MergeFrom(cfBuild)),

--- a/controllers/webhooks/workloads/cftask_defaulter_test.go
+++ b/controllers/webhooks/workloads/cftask_defaulter_test.go
@@ -37,9 +37,7 @@ var _ = Describe("CFTaskMutatingWebhook", func() {
 	JustBeforeEach(func() {
 		Expect(adminClient.Create(context.Background(), cfTask)).To(Succeed())
 		Expect(k8s.Patch(context.Background(), adminClient, cfTask, func() {
-			cfTask.Status = korifiv1alpha1.CFTaskStatus{
-				Conditions: []metav1.Condition{},
-			}
+			cfTask.Status = korifiv1alpha1.CFTaskStatus{}
 		})).To(Succeed())
 	})
 

--- a/controllers/webhooks/workloads/cftask_validator_test.go
+++ b/controllers/webhooks/workloads/cftask_validator_test.go
@@ -88,7 +88,6 @@ var _ = Describe("CFTask Creation", func() {
 
 			originalCfTask := cfTask.DeepCopy()
 			cfTask.Status = korifiv1alpha1.CFTaskStatus{
-				Conditions: []metav1.Condition{},
 				SequenceID: seqId,
 			}
 
@@ -141,9 +140,7 @@ var _ = Describe("CFTask Update", func() {
 		}
 		Expect(adminClient.Create(context.Background(), cfTask)).To(Succeed())
 		Expect(k8s.Patch(context.Background(), adminClient, cfTask, func() {
-			cfTask.Status = korifiv1alpha1.CFTaskStatus{
-				Conditions: []metav1.Condition{},
-			}
+			cfTask.Status = korifiv1alpha1.CFTaskStatus{}
 		})).To(Succeed())
 	})
 

--- a/helm/korifi/controllers/crds/korifi.cloudfoundry.org_appworkloads.yaml
+++ b/helm/korifi/controllers/crds/korifi.cloudfoundry.org_appworkloads.yaml
@@ -678,8 +678,6 @@ spec:
             description: AppWorkloadStatus defines the observed state of AppWorkload
             properties:
               conditions:
-                description: Conditions capture the current status of the observed
-                  generation of the AppWorkload
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
@@ -752,8 +750,6 @@ spec:
                   the AppWorkload that has been reconciled
                 format: int64
                 type: integer
-            required:
-            - conditions
             type: object
         type: object
     served: true

--- a/helm/korifi/controllers/crds/korifi.cloudfoundry.org_builderinfos.yaml
+++ b/helm/korifi/controllers/crds/korifi.cloudfoundry.org_builderinfos.yaml
@@ -162,7 +162,6 @@ spec:
                 type: array
             required:
             - buildpacks
-            - conditions
             - stacks
             type: object
         type: object

--- a/helm/korifi/controllers/crds/korifi.cloudfoundry.org_buildworkloads.yaml
+++ b/helm/korifi/controllers/crds/korifi.cloudfoundry.org_buildworkloads.yaml
@@ -267,8 +267,6 @@ spec:
             description: BuildWorkloadStatus defines the observed state of BuildWorkload
             properties:
               conditions:
-                description: Conditions capture the current status of the observed
-                  generation of the BuildWorkload
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct

--- a/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfapps.yaml
+++ b/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfapps.yaml
@@ -108,7 +108,6 @@ spec:
             description: CFAppStatus defines the observed state of CFApp
             properties:
               conditions:
-                description: Conditions capture the current status of the App
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
@@ -192,8 +191,6 @@ spec:
                 description: VCAPServicesSecretName contains the name of the CFApp's
                   VCAP_SERVICES Secret, which should exist in the same namespace
                 type: string
-            required:
-            - conditions
             type: object
         type: object
     served: true

--- a/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfbuilds.yaml
+++ b/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfbuilds.yaml
@@ -111,7 +111,6 @@ spec:
             description: CFBuildStatus defines the observed state of CFBuild
             properties:
               conditions:
-                description: Conditions capture the current status of the Build
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
@@ -243,8 +242,6 @@ spec:
                   the CFBuild that has been reconciled
                 format: int64
                 type: integer
-            required:
-            - conditions
             type: object
         type: object
     served: true

--- a/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfdomains.yaml
+++ b/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfdomains.yaml
@@ -52,7 +52,6 @@ spec:
             description: CFDomainStatus defines the observed state of CFDomain
             properties:
               conditions:
-                description: Conditions capture the current status of the domain
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct

--- a/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cforgs.yaml
+++ b/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cforgs.yaml
@@ -128,7 +128,6 @@ spec:
                 format: int64
                 type: integer
             required:
-            - conditions
             - guid
             type: object
         type: object

--- a/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfpackages.yaml
+++ b/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfpackages.yaml
@@ -98,7 +98,6 @@ spec:
             description: CFPackageStatus defines the observed state of CFPackage
             properties:
               conditions:
-                description: Conditions capture the current status of the Package
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
@@ -171,8 +170,6 @@ spec:
                   the CFPackage that has been reconciled
                 format: int64
                 type: integer
-            required:
-            - conditions
             type: object
         type: object
     served: true

--- a/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfprocesses.yaml
+++ b/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfprocesses.yaml
@@ -120,7 +120,6 @@ spec:
             description: CFProcessStatus defines the observed state of CFProcess
             properties:
               conditions:
-                description: Conditions capture the current status of the Process
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
@@ -193,8 +192,6 @@ spec:
                   the CFProcess that has been reconciled
                 format: int64
                 type: integer
-            required:
-            - conditions
             type: object
         type: object
     served: true

--- a/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfroutes.yaml
+++ b/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfroutes.yaml
@@ -142,7 +142,6 @@ spec:
             description: CFRouteStatus defines the observed state of CFRoute
             properties:
               conditions:
-                description: Conditions capture the current status of the route
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct

--- a/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfservicebindings.yaml
+++ b/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfservicebindings.yaml
@@ -111,7 +111,6 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               conditions:
-                description: Conditions capture the current status of the CFServiceBinding
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
@@ -184,8 +183,6 @@ spec:
                   the CFServiceBinding that has been reconciled
                 format: int64
                 type: integer
-            required:
-            - conditions
             type: object
         type: object
     served: true

--- a/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfserviceinstances.yaml
+++ b/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfserviceinstances.yaml
@@ -83,7 +83,6 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               conditions:
-                description: Conditions capture the current status of the CFServiceInstance
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
@@ -156,8 +155,6 @@ spec:
                   the CFServiceInstance that has been reconciled
                 format: int64
                 type: integer
-            required:
-            - conditions
             type: object
         type: object
     served: true

--- a/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfspaces.yaml
+++ b/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfspaces.yaml
@@ -53,7 +53,6 @@ spec:
             description: CFSpaceStatus defines the observed state of CFSpace
             properties:
               conditions:
-                description: Conditions capture the current status of the CFSpace
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
@@ -129,7 +128,6 @@ spec:
                 format: int64
                 type: integer
             required:
-            - conditions
             - guid
             type: object
         type: object


### PR DESCRIPTION
## Is there a related GitHub Issue?
#2580

## What is this change about?
Ensure all status.conditions fields are optional and decorated with `omitempty`.

This means we no longer have to initialize them to empty slices before making non-related status changes (mainly in tests). All instances of this have been removed.

## Does this PR introduce a breaking change?
No

## Acceptance Steps


## Tag your pair, your PM, and/or team
@gcapizzi

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
