### PR TITLE
Do not configure staging resources by default

### DIFF
--- a/controllers/config/config.go
+++ b/controllers/config/config.go
@@ -17,21 +17,21 @@ type ControllerConfig struct {
 	IncludeContourRouter     bool `yaml:"includeContourRouter"`
 
 	// core controllers
-	CFProcessDefaults                CFProcessDefaults       `yaml:"cfProcessDefaults"`
-	CFStagingResourceLimits          CFStagingResourceLimits `yaml:"cfStagingResourceLimits"`
-	CFRootNamespace                  string                  `yaml:"cfRootNamespace"`
-	ContainerRegistrySecretNames     []string                `yaml:"containerRegistrySecretNames"`
-	TaskTTL                          string                  `yaml:"taskTTL"`
-	WorkloadsTLSSecretName           string                  `yaml:"workloads_tls_secret_name"`
-	WorkloadsTLSSecretNamespace      string                  `yaml:"workloads_tls_secret_namespace"`
-	BuilderName                      string                  `yaml:"builderName"`
-	RunnerName                       string                  `yaml:"runnerName"`
-	NamespaceLabels                  map[string]string       `yaml:"namespaceLabels"`
-	ExtraVCAPApplicationValues       map[string]any          `yaml:"extraVCAPApplicationValues"`
-	MaxRetainedPackagesPerApp        int                     `yaml:"maxRetainedPackagesPerApp"`
-	MaxRetainedBuildsPerApp          int                     `yaml:"maxRetainedBuildsPerApp"`
-	LogLevel                         zapcore.Level           `yaml:"logLevel"`
-	SpaceFinalizerAppDeletionTimeout *int64                  `yaml:"spaceFinalizerAppDeletionTimeout"`
+	CFProcessDefaults                CFProcessDefaults  `yaml:"cfProcessDefaults"`
+	CFStagingResources               CFStagingResources `yaml:"cfStagingResources"`
+	CFRootNamespace                  string             `yaml:"cfRootNamespace"`
+	ContainerRegistrySecretNames     []string           `yaml:"containerRegistrySecretNames"`
+	TaskTTL                          string             `yaml:"taskTTL"`
+	WorkloadsTLSSecretName           string             `yaml:"workloads_tls_secret_name"`
+	WorkloadsTLSSecretNamespace      string             `yaml:"workloads_tls_secret_namespace"`
+	BuilderName                      string             `yaml:"builderName"`
+	RunnerName                       string             `yaml:"runnerName"`
+	NamespaceLabels                  map[string]string  `yaml:"namespaceLabels"`
+	ExtraVCAPApplicationValues       map[string]any     `yaml:"extraVCAPApplicationValues"`
+	MaxRetainedPackagesPerApp        int                `yaml:"maxRetainedPackagesPerApp"`
+	MaxRetainedBuildsPerApp          int                `yaml:"maxRetainedBuildsPerApp"`
+	LogLevel                         zapcore.Level      `yaml:"logLevel"`
+	SpaceFinalizerAppDeletionTimeout *int64             `yaml:"spaceFinalizerAppDeletionTimeout"`
 
 	// job-task-runner
 	JobTTL string `yaml:"jobTTL"`
@@ -50,7 +50,7 @@ type CFProcessDefaults struct {
 	Timeout     *int64 `yaml:"timeout"`
 }
 
-type CFStagingResourceLimits struct {
+type CFStagingResources struct {
 	BuildCacheMB int64 `yaml:"buildCacheMB"`
 	DiskMB       int64 `yaml:"diskMB"`
 	MemoryMB     int64 `yaml:"memoryMB"`
@@ -78,8 +78,8 @@ func LoadFromPath(path string) (*ControllerConfig, error) {
 		config.SpaceFinalizerAppDeletionTimeout = tools.PtrTo(defaultTimeout)
 	}
 
-	if config.CFStagingResourceLimits.BuildCacheMB == 0 {
-		config.CFStagingResourceLimits.BuildCacheMB = defaultBuildCacheMB
+	if config.CFStagingResources.BuildCacheMB == 0 {
+		config.CFStagingResources.BuildCacheMB = defaultBuildCacheMB
 	}
 
 	return &config, nil

--- a/controllers/config/config_test.go
+++ b/controllers/config/config_test.go
@@ -35,7 +35,7 @@ var _ = Describe("LoadFromPath", func() {
 				DiskQuotaMB: 512,
 				Timeout:     tools.PtrTo(int64(30)),
 			},
-			CFStagingResourceLimits: config.CFStagingResourceLimits{
+			CFStagingResources: config.CFStagingResources{
 				BuildCacheMB: 1024,
 				DiskMB:       512,
 				MemoryMB:     2048,
@@ -73,7 +73,7 @@ var _ = Describe("LoadFromPath", func() {
 				DiskQuotaMB: 512,
 				Timeout:     tools.PtrTo(int64(30)),
 			},
-			CFStagingResourceLimits: config.CFStagingResourceLimits{
+			CFStagingResources: config.CFStagingResources{
 				BuildCacheMB: 1024,
 				DiskMB:       512,
 				MemoryMB:     2048,
@@ -125,11 +125,11 @@ var _ = Describe("LoadFromPath", func() {
 
 	When("the staging build cache size is not set", func() {
 		BeforeEach(func() {
-			cfg.CFStagingResourceLimits.BuildCacheMB = 0
+			cfg.CFStagingResources.BuildCacheMB = 0
 		})
 
 		It("uses the default", func() {
-			Expect(retConfig.CFStagingResourceLimits.BuildCacheMB).To(Equal(int64(2048)))
+			Expect(retConfig.CFStagingResources.BuildCacheMB).To(Equal(int64(2048)))
 		})
 	})
 })

--- a/helm/korifi/controllers/configmap.yaml
+++ b/helm/korifi/controllers/configmap.yaml
@@ -46,7 +46,7 @@ data:
     builderReadinessTimeout: {{ required "builderReadinessTimeout is required" .Values.kpackImageBuilder.builderReadinessTimeout }}
     containerRepositoryPrefix: {{ .Values.global.containerRepositoryPrefix | quote }}
     builderServiceAccount: kpack-service-account
-    cfStagingResourceLimits:
+    cfStagingResources:
       buildCacheMB: {{ .Values.api.lifecycle.stagingRequirements.buildCacheMB }}
       diskMB: {{ .Values.api.lifecycle.stagingRequirements.diskMB }}
       memoryMB: {{ .Values.api.lifecycle.stagingRequirements.memoryMB }}

--- a/helm/korifi/values.schema.json
+++ b/helm/korifi/values.schema.json
@@ -184,11 +184,11 @@
               "type": "object",
               "properties": {
                 "memoryMB": {
-                  "description": "Memory in MB for staging.",
+                  "description": "Memory request in MB for staging.",
                   "type": "integer"
                 },
                 "diskMB": {
-                  "description": "Ephemeral Disk limit in MB for staging apps.",
+                  "description": "Ephemeral Disk request in MB for staging apps.",
                   "type": "integer"
                 },
                 "buildCacheMB": {

--- a/helm/korifi/values.yaml
+++ b/helm/korifi/values.yaml
@@ -45,8 +45,8 @@ api:
     type: buildpack
     stack: cflinuxfs3
     stagingRequirements:
-      memoryMB: 1024
-      diskMB: 1024
+      memoryMB: 0
+      diskMB: 0
       buildCacheMB: 2048
 
   builderName: kpack-image-builder

--- a/kpack-image-builder/controllers/suite_test.go
+++ b/kpack-image-builder/controllers/suite_test.go
@@ -110,7 +110,7 @@ var _ = BeforeSuite(func() {
 		ClusterBuilderName:        "cf-kpack-builder",
 		ContainerRepositoryPrefix: "image/registry/tag",
 		BuilderServiceAccount:     "builder-service-account",
-		CFStagingResourceLimits: config.CFStagingResourceLimits{
+		CFStagingResources: config.CFStagingResources{
 			BuildCacheMB: 1024,
 			DiskMB:       2048,
 			MemoryMB:     1234,


### PR DESCRIPTION
## Is there a related GitHub Issue?
#2682 

## What is this change about?
Revert the changes that set resource limits on the kpack build pods, instead opting to configure requests.

## Does this PR introduce a breaking change?
No, only the internal controller configmap interface is updated.

## Acceptance Steps
See issue.

## Tag your pair, your PM, and/or team
paired w/ @davewalter 

## Open Questions
Added a note to the refactor issue dev notes about the difficulty we had reasoning about the exercising the different configuration options in the controller test suite.
