### PR TITLE
Support listing service instances by guid

### DIFF
--- a/api/handlers/service_instance_test.go
+++ b/api/handlers/service_instance_test.go
@@ -169,7 +169,7 @@ var _ = Describe("ServiceInstance", func() {
 			_, actualAuthInfo, actualListMessage := serviceInstanceRepo.ListServiceInstancesArgsForCall(0)
 			Expect(actualAuthInfo).To(Equal(authInfo))
 			Expect(actualListMessage.Names).To(BeEmpty())
-			Expect(actualListMessage.SpaceGuids).To(BeEmpty())
+			Expect(actualListMessage.SpaceGUIDs).To(BeEmpty())
 
 			Expect(rr).Should(HaveHTTPStatus(http.StatusOK))
 			Expect(rr).To(HaveHTTPHeaderWithValue("Content-Type", "application/json"))
@@ -186,7 +186,8 @@ var _ = Describe("ServiceInstance", func() {
 			BeforeEach(func() {
 				requestValidator.DecodeAndValidateURLValuesStub = decodeAndValidateURLValuesStub(&payloads.ServiceInstanceList{
 					Names:      "sc1,sc2",
-					SpaceGuids: "space1,space2",
+					SpaceGUIDs: "space1,space2",
+					GUIDs:      "g1,g2",
 				})
 			})
 
@@ -195,7 +196,8 @@ var _ = Describe("ServiceInstance", func() {
 				_, _, message := serviceInstanceRepo.ListServiceInstancesArgsForCall(0)
 
 				Expect(message.Names).To(ConsistOf("sc1", "sc2"))
-				Expect(message.SpaceGuids).To(ConsistOf("space1", "space2"))
+				Expect(message.SpaceGUIDs).To(ConsistOf("space1", "space2"))
+				Expect(message.GUIDs).To(ConsistOf("g1", "g2"))
 			})
 
 			It("correctly sets query parameters in response pagination links", func() {

--- a/api/payloads/service_instance.go
+++ b/api/payloads/service_instance.go
@@ -130,7 +130,8 @@ func (p *ServiceInstancePatch) UnmarshalJSON(data []byte) error {
 
 type ServiceInstanceList struct {
 	Names      string
-	SpaceGuids string
+	GUIDs      string
+	SpaceGUIDs string
 	OrderBy    string
 }
 
@@ -143,12 +144,13 @@ func (l ServiceInstanceList) Validate() error {
 func (l *ServiceInstanceList) ToMessage() repositories.ListServiceInstanceMessage {
 	return repositories.ListServiceInstanceMessage{
 		Names:      parse.ArrayParam(l.Names),
-		SpaceGuids: parse.ArrayParam(l.SpaceGuids),
+		SpaceGUIDs: parse.ArrayParam(l.SpaceGUIDs),
+		GUIDs:      parse.ArrayParam(l.GUIDs),
 	}
 }
 
 func (l *ServiceInstanceList) SupportedKeys() []string {
-	return []string{"names", "space_guids", "order_by", "per_page", "page"}
+	return []string{"names", "space_guids", "guids", "order_by", "per_page", "page"}
 }
 
 func (l *ServiceInstanceList) IgnoredKeys() []*regexp.Regexp {
@@ -157,7 +159,8 @@ func (l *ServiceInstanceList) IgnoredKeys() []*regexp.Regexp {
 
 func (l *ServiceInstanceList) DecodeFromURLValues(values url.Values) error {
 	l.Names = values.Get("names")
-	l.SpaceGuids = values.Get("space_guids")
+	l.SpaceGUIDs = values.Get("space_guids")
+	l.GUIDs = values.Get("guids")
 	l.OrderBy = values.Get("order_by")
 	return nil
 }

--- a/api/payloads/service_instance_test.go
+++ b/api/payloads/service_instance_test.go
@@ -20,7 +20,8 @@ var _ = Describe("ServiceInstanceList", func() {
 			Expect(*actualServiceInstanceList).To(Equal(expectedServiceInstanceList))
 		},
 		Entry("names", "names=name", payloads.ServiceInstanceList{Names: "name"}),
-		Entry("space_guids", "space_guids=space_guid", payloads.ServiceInstanceList{SpaceGuids: "space_guid"}),
+		Entry("space_guids", "space_guids=space_guid", payloads.ServiceInstanceList{SpaceGUIDs: "space_guid"}),
+		Entry("guids", "guids=guid", payloads.ServiceInstanceList{GUIDs: "guid"}),
 		Entry("created_at", "order_by=created_at", payloads.ServiceInstanceList{OrderBy: "created_at"}),
 		Entry("-created_at", "order_by=-created_at", payloads.ServiceInstanceList{OrderBy: "-created_at"}),
 		Entry("updated_at", "order_by=updated_at", payloads.ServiceInstanceList{OrderBy: "updated_at"}),

--- a/api/repositories/service_instance_repository.go
+++ b/api/repositories/service_instance_repository.go
@@ -77,7 +77,8 @@ func (p PatchServiceInstanceMessage) Apply(cfServiceInstance *korifiv1alpha1.CFS
 
 type ListServiceInstanceMessage struct {
 	Names      []string
-	SpaceGuids []string
+	SpaceGUIDs []string
+	GUIDs      []string
 }
 
 type DeleteServiceInstanceMessage struct {
@@ -198,9 +199,10 @@ func (r *ServiceInstanceRepo) ListServiceInstances(ctx context.Context, authInfo
 
 	preds := []func(korifiv1alpha1.CFServiceInstance) bool{
 		SetPredicate(message.Names, func(s korifiv1alpha1.CFServiceInstance) string { return s.Spec.DisplayName }),
+		SetPredicate(message.GUIDs, func(s korifiv1alpha1.CFServiceInstance) string { return s.Name }),
 	}
 
-	spaceGUIDSet := NewSet(message.SpaceGuids...)
+	spaceGUIDSet := NewSet(message.SpaceGUIDs...)
 	var filteredServiceInstances []korifiv1alpha1.CFServiceInstance
 	for ns := range nsList {
 		if len(spaceGUIDSet) > 0 && !spaceGUIDSet.Includes(ns) {

--- a/api/repositories/service_instance_repository_test.go
+++ b/api/repositories/service_instance_repository_test.go
@@ -434,7 +434,7 @@ var _ = Describe("ServiceInstanceRepository", func() {
 			When("the spaceGUID filter is set", func() {
 				BeforeEach(func() {
 					filters = repositories.ListServiceInstanceMessage{
-						SpaceGuids: []string{
+						SpaceGUIDs: []string{
 							cfServiceInstance2.Namespace,
 							cfServiceInstance3.Namespace,
 						},
@@ -443,6 +443,20 @@ var _ = Describe("ServiceInstanceRepository", func() {
 				It("returns only records for the ServiceInstances within the matching spaces", func() {
 					Expect(serviceInstanceList).To(ConsistOf(
 						MatchFields(IgnoreExtras, Fields{"GUID": Equal(cfServiceInstance2.Name)}),
+						MatchFields(IgnoreExtras, Fields{"GUID": Equal(cfServiceInstance3.Name)}),
+					))
+				})
+			})
+
+			When("the serviceGUID filter is set", func() {
+				BeforeEach(func() {
+					filters = repositories.ListServiceInstanceMessage{
+						GUIDs: []string{cfServiceInstance1.Name, cfServiceInstance3.Name},
+					}
+				})
+				It("returns only records for the ServiceInstances within the matching spaces", func() {
+					Expect(serviceInstanceList).To(ConsistOf(
+						MatchFields(IgnoreExtras, Fields{"GUID": Equal(cfServiceInstance1.Name)}),
 						MatchFields(IgnoreExtras, Fields{"GUID": Equal(cfServiceInstance3.Name)}),
 					))
 				})


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
#2692
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
This PR makes it possible to filter a list of service instances by their guids
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps

- Create a couple of services
- `cf curl /v3/service_instances?guids=<service-instance-guid1>,<service-instance-guid2>`
- see the result only contains the two service instances with the guids above


## Tag your pair, your PM, and/or team
@kieron-dev
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
