### PR TITLE
Remove redundant retry from job handler

### DIFF
--- a/api/handlers/job_test.go
+++ b/api/handlers/job_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Job", func() {
 	})
 
 	JustBeforeEach(func() {
-		handler = handlers.NewJob(*serverURL, deletionRepos, 0)
+		handler = handlers.NewJob(*serverURL, deletionRepos)
 		routerBuilder.LoadRoutes(handler)
 
 		var err error

--- a/api/main.go
+++ b/api/main.go
@@ -335,7 +335,6 @@ func main() {
 				handlers.DomainDeleteJobType: domainRepo,
 				handlers.RoleDeleteJobType:   roleRepo,
 			},
-			500*time.Millisecond,
 		),
 		handlers.NewLogCache(
 			appRepo,


### PR DESCRIPTION
## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Remove redundant retry logic from the job handler

The purpose of jobs is to report async operation statuses to the cli or
whatever other clients may be polling for these statuses. Therefore
there is no need to retry anything in this handler as the clients
themselves will retry.
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
Green tests
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@gcapizzi
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
