### PR TITLE
Fix line number reporting on an e2e test failure

### DIFF
--- a/tests/e2e/helpers/fail_handler.go
+++ b/tests/e2e/helpers/fail_handler.go
@@ -32,9 +32,9 @@ func E2EFailHandler(correlationId func() string) func(string, ...int) {
 		fmt.Fprintf(ginkgo.GinkgoWriter, "Fail Handler: failure correlation ID: %q\n", correlationId())
 
 		if len(callerSkip) > 0 {
-			callerSkip[0] = callerSkip[0] + 1
+			callerSkip[0] = callerSkip[0] + 2
 		} else {
-			callerSkip = []int{1}
+			callerSkip = []int{2}
 		}
 
 		defer func() {


### PR DESCRIPTION
## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Fix line number reporting on an e2e test failure

Our fail handler wrapper was not skipping enough stack frames
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
N/A
