### PR TITLE
Fix GetDeletedAt for orgs

### DIFF
--- a/api/repositories/org_repository.go
+++ b/api/repositories/org_repository.go
@@ -243,18 +243,11 @@ func (r *OrgRepo) PatchOrgMetadata(ctx context.Context, authInfo authorization.I
 }
 
 func (r *OrgRepo) GetDeletedAt(ctx context.Context, authInfo authorization.Info, orgGUID string) (*time.Time, error) {
-	userClient, err := r.userClientFactory.BuildClient(authInfo)
+	org, err := r.GetOrg(ctx, authInfo, orgGUID)
 	if err != nil {
-		return nil, fmt.Errorf("get-deleted-at failed to build user client: %w", err)
+		return nil, err
 	}
-
-	cfOrg := new(korifiv1alpha1.CFOrg)
-	err = userClient.Get(ctx, client.ObjectKey{Namespace: r.rootNamespace, Name: orgGUID}, cfOrg)
-	if err != nil {
-		return nil, apierrors.FromK8sError(err, OrgResourceType)
-	}
-
-	return cfOrgToOrgRecord(*cfOrg).DeletedAt, nil
+	return org.DeletedAt, nil
 }
 
 func cfOrgToOrgRecord(cfOrg korifiv1alpha1.CFOrg) OrgRecord {


### PR DESCRIPTION
## Is there a related GitHub Issue?
#2605
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
The GetDeletedAt method now delegates to GetOrg. This is important since
orgs are special from rbac point of view since in order to know if we
have permission in an org we have to have role bindings to some role in
that org. This is why GetOrg is implemented via List-ing orgs and
filtering by guid. Not following that pattern results in any user seeing
any orgs.
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
See https://github.com/cloudfoundry/korifi/issues/2605#issuecomment-1636472656
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@gcapizzi
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
