### PR TITLE
Revert "Fix GetDeletedAt for orgs"

### DIFF
--- a/api/repositories/org_repository_test.go
+++ b/api/repositories/org_repository_test.go
@@ -369,35 +369,23 @@ var _ = Describe("OrgRepository", func() {
 			deletionTime, getErr = orgRepo.GetDeletedAt(ctx, authInfo, cfOrg.Name)
 		})
 
-		When("the user has a role binding in the org", func() {
-			BeforeEach(func() {
-				createRoleBinding(ctx, userName, orgUserRole.Name, cfOrg.Name)
-			})
-
-			It("returns nil", func() {
-				Expect(getErr).NotTo(HaveOccurred())
-				Expect(deletionTime).To(BeNil())
-			})
-
-			When("the org is being deleted", func() {
-				BeforeEach(func() {
-					Expect(k8s.PatchResource(ctx, k8sClient, cfOrg, func() {
-						cfOrg.Finalizers = append(cfOrg.Finalizers, "foo")
-					})).To(Succeed())
-
-					Expect(k8sClient.Delete(ctx, cfOrg)).To(Succeed())
-				})
-
-				It("returns the deletion time", func() {
-					Expect(getErr).NotTo(HaveOccurred())
-					Expect(deletionTime).To(PointTo(BeTemporally("~", time.Now(), time.Minute)))
-				})
-			})
+		It("returns nil", func() {
+			Expect(getErr).NotTo(HaveOccurred())
+			Expect(deletionTime).To(BeNil())
 		})
 
-		When("the user does not have a role binding in the org", func() {
-			It("errors", func() {
-				Expect(getErr).To(matchers.WrapErrorAssignableToTypeOf(apierrors.NotFoundError{}))
+		When("the org is being deleted", func() {
+			BeforeEach(func() {
+				Expect(k8s.PatchResource(ctx, k8sClient, cfOrg, func() {
+					cfOrg.Finalizers = append(cfOrg.Finalizers, "foo")
+				})).To(Succeed())
+
+				Expect(k8sClient.Delete(ctx, cfOrg)).To(Succeed())
+			})
+
+			It("returns the deletion time", func() {
+				Expect(getErr).NotTo(HaveOccurred())
+				Expect(deletionTime).To(PointTo(BeTemporally("~", time.Now(), time.Minute)))
 			})
 		})
 


### PR DESCRIPTION
Reverts cloudfoundry/korifi#2700 for #2605 

While this PR's change fixes the org deletion job response for unauthorized users, it also prevents the job endpoint from waiting for the org to actually be deleted. Instead, it returns as soon as the role binding in the org's namespace has been deleted.

The acceptance steps I follow to confirm this:

- Create an org `o` as the admin user
- Use kubectl or k9s to add a finalizer called "nosuchfinalizer" to the `CFOrg` resource created above
- Run `cf delete-org -f o`. The expected response was for it to hang for about a minute and then give an error. Instead, it quickly said the deletion was complete. However, the `CFOrg` still existed on the cluster and was in an indefinite terminating state.