### PR TITLE
Actually wait for the CFOrg to be deleted in job endpoint

### DIFF
--- a/api/repositories/org_repository.go
+++ b/api/repositories/org_repository.go
@@ -243,11 +243,25 @@ func (r *OrgRepo) PatchOrgMetadata(ctx context.Context, authInfo authorization.I
 }
 
 func (r *OrgRepo) GetDeletedAt(ctx context.Context, authInfo authorization.Info, orgGUID string) (*time.Time, error) {
-	org, err := r.GetOrg(ctx, authInfo, orgGUID)
+	userClient, err := r.userClientFactory.BuildClient(authInfo)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("get-deleted-at failed to build user client: %w", err)
 	}
-	return org.DeletedAt, nil
+
+	cfOrg := new(korifiv1alpha1.CFOrg)
+	err = userClient.Get(ctx, client.ObjectKey{Namespace: r.rootNamespace, Name: orgGUID}, cfOrg)
+	if err != nil {
+		return nil, apierrors.FromK8sError(err, OrgResourceType)
+	}
+
+	record := cfOrgToOrgRecord(*cfOrg)
+
+	if record.DeletedAt != nil {
+		return record.DeletedAt, nil
+	}
+
+	_, err = r.GetOrg(ctx, authInfo, orgGUID)
+	return nil, err
 }
 
 func cfOrgToOrgRecord(cfOrg korifiv1alpha1.CFOrg) OrgRecord {


### PR DESCRIPTION


<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->
[#2605]

## What is this change about?
<!-- _Please describe the change here._ -->
Before this change, the job endpoint would say that an org was deleted as soon as the CFOrg finalizer removed their role binding from the Org namespace. We now fetch the CFOrg directly to determine if it's done deleting. If it isn't deleting, then we will use GetOrg to determine if the user has access to the org

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ --> No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ --> Follow AC for the issue

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->
@davewalter @gcapizzi @georgethebeatle 
<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
