### PR TITLE
Make the e2e eventually timeout configurable via env var

### DIFF
--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -314,7 +314,13 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	defaultAppBitsFile = sharedSetup.DefaultAppBitsFile
 	multiProcessAppBitsFile = sharedSetup.MultiProcessAppBitsFile
 
-	SetDefaultEventuallyTimeout(240 * time.Second)
+	eventuallyTimeoutSeconds := 240
+	customEventuallyTimeoutSeconds := os.Getenv("E2E_EVENTUALLY_TIMEOUT_SECONDS")
+	if customEventuallyTimeoutSeconds != "" {
+		eventuallyTimeoutSeconds, err = strconv.Atoi(customEventuallyTimeoutSeconds)
+		Expect(err).NotTo(HaveOccurred())
+	}
+	SetDefaultEventuallyTimeout(time.Duration(eventuallyTimeoutSeconds) * time.Second)
 	SetDefaultEventuallyPollingInterval(2 * time.Second)
 
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ --> No

## What is this change about?
<!-- _Please describe the change here._ --> Allow the user to change the Eventually timeout in e2e tests via env var

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ --> No change to behavior. For environments where Eventually statements frequently time out, setting the env var to a higher value should resolve the problem

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ --> @davewalter 

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
