### PR TITLE
make the image for the jobs configurable

### DIFF
--- a/README.helm.md
+++ b/README.helm.md
@@ -17,6 +17,8 @@ Here are all the values that can be set for the chart:
   - `defaultAppDomainName` (_String_): Base domain name for application URLs.
   - `eksContainerRegistryRoleARN` (_String_): Amazon Resource Name (ARN) of the IAM role to use to access the ECR registry from an EKS deployed Korifi. Required if containerRegistrySecret not set.
   - `generateIngressCertificates` (_Boolean_): Use `cert-manager` to generate self-signed certificates for the API and app endpoints.
+  - `jobs`:
+    - `image` (_String_): The image for the jobs containing kubectl
   - `logLevel` (_String_): Sets level of logging for api and controllers components. Can be 'info' or 'debug'.
   - `reconcilers`:
     - `app` (_String_): ID of the workload runner to set on all `AppWorkload` objects. Defaults to `statefulset-runner`.

--- a/README.helm.md
+++ b/README.helm.md
@@ -17,8 +17,6 @@ Here are all the values that can be set for the chart:
   - `defaultAppDomainName` (_String_): Base domain name for application URLs.
   - `eksContainerRegistryRoleARN` (_String_): Amazon Resource Name (ARN) of the IAM role to use to access the ECR registry from an EKS deployed Korifi. Required if containerRegistrySecret not set.
   - `generateIngressCertificates` (_Boolean_): Use `cert-manager` to generate self-signed certificates for the API and app endpoints.
-  - `jobs`:
-    - `image` (_String_): The image for the jobs containing kubectl
   - `logLevel` (_String_): Sets level of logging for api and controllers components. Can be 'info' or 'debug'.
   - `reconcilers`:
     - `app` (_String_): ID of the workload runner to set on all `AppWorkload` objects. Defaults to `statefulset-runner`.
@@ -79,6 +77,8 @@ Here are all the values that can be set for the chart:
       - `memory` (_String_): Memory request.
   - `taskTTL` (_String_): How long before the `CFTask` object is deleted after the task has completed. See [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration) for details on the format, an additional `d` suffix for days is supported.
   - `workloadsTLSSecret` (_String_): TLS secret used when setting up an app routes.
+- `helm`:
+  - `hooksImage` (_String_): Image for the helm hooks containing kubectl
 - `jobTaskRunner`:
   - `include` (_Boolean_): Deploy the `job-task-runner` component.
   - `jobTTL` (_String_): How long before the `Job` backing up a task is deleted after completion. See [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration) for details on the format, an additional `d` suffix for days is supported.

--- a/helm/korifi/controllers/post-install-app-domain.yaml
+++ b/helm/korifi/controllers/post-install-app-domain.yaml
@@ -28,7 +28,7 @@ spec:
       {{- include "korifi.podSecurityContext" . | indent 6 }}
       containers:
       - name: post-install-create-app-domain
-        image: "alpine/k8s:1.25.2"
+        image: {{ .Values.global.jobs.image }}
         securityContext:
           allowPrivilegeEscalation: false
           runAsNonRoot: true

--- a/helm/korifi/controllers/post-install-app-domain.yaml
+++ b/helm/korifi/controllers/post-install-app-domain.yaml
@@ -28,7 +28,7 @@ spec:
       {{- include "korifi.podSecurityContext" . | indent 6 }}
       containers:
       - name: post-install-create-app-domain
-        image: {{ .Values.global.jobs.image }}
+        image: {{ .Values.helm.hooksImage }}
         securityContext:
           allowPrivilegeEscalation: false
           runAsNonRoot: true

--- a/helm/korifi/kpack-image-builder/post-install-builderinfo.yaml
+++ b/helm/korifi/kpack-image-builder/post-install-builderinfo.yaml
@@ -28,7 +28,7 @@ spec:
       {{- include "korifi.podSecurityContext" . | indent 6 }}
       containers:
       - name: post-install-create-builderinfo
-        image: {{ .Values.global.jobs.image }}
+        image: {{ .Values.helm.hooksImage }}
         securityContext:
           allowPrivilegeEscalation: false
           runAsNonRoot: true

--- a/helm/korifi/kpack-image-builder/post-install-builderinfo.yaml
+++ b/helm/korifi/kpack-image-builder/post-install-builderinfo.yaml
@@ -28,7 +28,7 @@ spec:
       {{- include "korifi.podSecurityContext" . | indent 6 }}
       containers:
       - name: post-install-create-builderinfo
-        image: "alpine/k8s:1.25.2"
+        image: {{ .Values.global.jobs.image }}
         securityContext:
           allowPrivilegeEscalation: false
           runAsNonRoot: true

--- a/helm/korifi/kpack-image-builder/pre-delete-builderinfo.yaml
+++ b/helm/korifi/kpack-image-builder/pre-delete-builderinfo.yaml
@@ -26,7 +26,7 @@ spec:
       {{- include "korifi.podSecurityContext" . | indent 6 }}
       containers:
       - name: pre-delete-builderinfo
-        image: {{ .Values.global.jobs.image }}
+        image: {{ .Values.helm.hooksImage }}
         securityContext:
           allowPrivilegeEscalation: false
           runAsNonRoot: true

--- a/helm/korifi/kpack-image-builder/pre-delete-builderinfo.yaml
+++ b/helm/korifi/kpack-image-builder/pre-delete-builderinfo.yaml
@@ -26,7 +26,7 @@ spec:
       {{- include "korifi.podSecurityContext" . | indent 6 }}
       containers:
       - name: pre-delete-builderinfo
-        image: "alpine/k8s:1.25.2"
+        image: {{ .Values.global.jobs.image }}
         securityContext:
           allowPrivilegeEscalation: false
           runAsNonRoot: true

--- a/helm/korifi/statefulset-runner/post-install-runnerinfo.yaml
+++ b/helm/korifi/statefulset-runner/post-install-runnerinfo.yaml
@@ -28,7 +28,7 @@ spec:
       {{- include "korifi.podSecurityContext" . | indent 6 }}
       containers:
       - name: post-install-create-runnerinfo
-        image: "alpine/k8s:1.25.2"
+        image: {{ .Values.global.jobs.image }}
         securityContext:
           allowPrivilegeEscalation: false
           runAsNonRoot: true

--- a/helm/korifi/statefulset-runner/post-install-runnerinfo.yaml
+++ b/helm/korifi/statefulset-runner/post-install-runnerinfo.yaml
@@ -28,7 +28,7 @@ spec:
       {{- include "korifi.podSecurityContext" . | indent 6 }}
       containers:
       - name: post-install-create-runnerinfo
-        image: {{ .Values.global.jobs.image }}
+        image: {{ .Values.helm.hooksImage }}
         securityContext:
           allowPrivilegeEscalation: false
           runAsNonRoot: true

--- a/helm/korifi/values.schema.json
+++ b/helm/korifi/values.schema.json
@@ -50,6 +50,15 @@
           "description": "Amazon Resource Name (ARN) of the IAM role to use to access the ECR registry from an EKS deployed Korifi. Required if containerRegistrySecret not set.",
           "type": "string"
         },
+        "jobs": {
+          "properties": {
+            "image": {
+              "description": "The image for the jobs containing kubectl",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
         "reconcilers": {
           "type": "object",
           "properties": {

--- a/helm/korifi/values.schema.json
+++ b/helm/korifi/values.schema.json
@@ -50,15 +50,6 @@
           "description": "Amazon Resource Name (ARN) of the IAM role to use to access the ECR registry from an EKS deployed Korifi. Required if containerRegistrySecret not set.",
           "type": "string"
         },
-        "jobs": {
-          "properties": {
-            "image": {
-              "description": "The image for the jobs containing kubectl",
-              "type": "string"
-            }
-          },
-          "type": "object"
-        },
         "reconcilers": {
           "type": "object",
           "properties": {
@@ -511,6 +502,15 @@
         }
       },
       "required": ["include"],
+      "type": "object"
+    },
+    "helm": {
+      "properties": {
+        "hooksImage": {
+          "description": "Image for the helm hooks containing kubectl",
+          "type": "string"
+        }
+      },
       "type": "object"
     }
   },

--- a/helm/korifi/values.yaml
+++ b/helm/korifi/values.yaml
@@ -8,8 +8,6 @@ global:
   - image-registry-credentials
   eksContainerRegistryRoleARN: ""
   containerRegistryCACertSecret:
-  jobs:
-    image: alpine/k8s:1.25.2
 
   reconcilers:
     build: kpack-image-builder
@@ -124,3 +122,6 @@ jobTaskRunner:
 
 contourRouter:
   include: true
+
+helm:
+  hooksImage: alpine/k8s:1.25.2

--- a/helm/korifi/values.yaml
+++ b/helm/korifi/values.yaml
@@ -8,6 +8,8 @@ global:
   - image-registry-credentials
   eksContainerRegistryRoleARN: ""
   containerRegistryCACertSecret:
+  jobs:
+    image: alpine/k8s:1.25.2
 
   reconcilers:
     build: kpack-image-builder


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Currently, Korifi cannot be installed via helm chart in air-gapped environments, as a hard-coded dockerhub  image is used for the helm jobs

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
