### PR TITLE
Fix deploy-on-kind with docker hub as registry

### DIFF
--- a/scripts/deploy-on-kind.sh
+++ b/scripts/deploy-on-kind.sh
@@ -126,9 +126,7 @@ function ensure_local_registry() {
 function install_dependencies() {
   pushd "${ROOT_DIR}" >/dev/null
   {
-    export INSECURE_TLS_METRICS_SERVER=true
-
-    "${SCRIPT_DIR}/install-dependencies.sh"
+    "${SCRIPT_DIR}/install-dependencies.sh" -i
   }
   popd >/dev/null
 }
@@ -192,9 +190,16 @@ EOF
 }
 
 function create_registry_secret() {
+  local docker_server="$DOCKER_SERVER"
+
+  # docker hub is very picky about its server name
+  if [ "$docker_server" == "" ] || [ "$docker_server" == "index.docker.io" ]; then
+    docker_server="https://index.docker.io/v1/"
+  fi
+
   kubectl delete -n cf secret image-registry-credentials --ignore-not-found
   kubectl create secret -n cf docker-registry image-registry-credentials \
-    --docker-server="$DOCKER_SERVER" \
+    --docker-server="$docker_server" \
     --docker-username="$DOCKER_USERNAME" \
     --docker-password="$DOCKER_PASSWORD"
 }


### PR DESCRIPTION
## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
When using deploy-on-kind we default to using the local registry. In
case we want a custom registry we should export the following vars:

DOCKER_SERVER
DOCKER_USERNAME
DOCKER_PASSWORD
REPOSOTORY_PREFIX
KPACK_BUILDER_REPOSITORY

In the INSTALL.kind.md we advise that people use dockerhub as the
registry, but setting DOCKER_SERVER to index.docker.io would result in a
wrong image-registry-credentials secret as the .dockerconfigjson wants
https://index.docker.io/v1/ as the host name. On the other hand
REPOSOTORY_PREFIX should be `index.dpcker.io/username/ and
KPACK_BUILDER_REPOSITORY should be
`index.docker.io/username/kpack-builder`, i.e. they do not have the
https scheme and the /v1 path suffix. The docker hub config json is very
picky about the server name and we need special treatment for this use
case to work
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
Running the following command results in an operational korifi cluster
DOCKER_SERVER=index.docker.io DOCKER_USERNAME=<username> DOCKER_PASSWORD=<password> REPOSITORY_PREFIX=index.docker.io/<username>/ KPACK_BUILDER_REPOSITORY=index.docker.io/<username>/kpack-builder ./scripts/deploy-on-kind.sh korifi


<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
