### PR TITLE
Pass failure message from fail handler to hooks

### DIFF
--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -278,8 +278,8 @@ type cfErr struct {
 }
 
 func TestE2E(t *testing.T) {
-	RegisterFailHandler(fail_handler.New("E2E Tests", map[types.GomegaMatcher]func(*rest.Config){
-		fail_handler.Always: func(config *rest.Config) {
+	RegisterFailHandler(fail_handler.New("E2E Tests", map[types.GomegaMatcher]func(*rest.Config, string){
+		fail_handler.Always: func(config *rest.Config, _ string) {
 			fail_handler.PrintPodsLogs(config, []fail_handler.PodContainerDescriptor{
 				{
 					Namespace:     systemNamespace(),
@@ -296,10 +296,10 @@ func TestE2E(t *testing.T) {
 				},
 			})
 		},
-		ContainSubstring("Droplet not found"): func(config *rest.Config) {
-			printDropletNotFoundDebugInfo(config)
+		ContainSubstring("Droplet not found"): func(config *rest.Config, message string) {
+			printDropletNotFoundDebugInfo(config, message)
 		},
-		ContainSubstring("404"): func(config *rest.Config) {
+		ContainSubstring("404"): func(config *rest.Config, _ string) {
 			printAllRoleBindings(config)
 		},
 	}))
@@ -1112,7 +1112,7 @@ func getCorrelationId() string {
 	return correlationId
 }
 
-func printDropletNotFoundDebugInfo(config *rest.Config) {
+func printDropletNotFoundDebugInfo(config *rest.Config, message string) {
 	fmt.Fprint(GinkgoWriter, "\n\n========== Droplet not found debug log (start) ==========\n")
 
 	fmt.Fprint(GinkgoWriter, "\n========== Kpack logs ==========\n")
@@ -1129,7 +1129,7 @@ func printDropletNotFoundDebugInfo(config *rest.Config) {
 		},
 	})
 
-	dropletGUID, err := getDropletGUID(CurrentSpecReport().FailureMessage())
+	dropletGUID, err := getDropletGUID(message)
 	if err != nil {
 		fmt.Fprintf(GinkgoWriter, "Failed to get droplet GUID from message %v\n", err)
 		return

--- a/tests/helpers/fail_handler/handler.go
+++ b/tests/helpers/fail_handler/handler.go
@@ -12,7 +12,7 @@ import (
 
 var Always types.GomegaMatcher = gomega.ContainSubstring("")
 
-func New(name string, hooks map[types.GomegaMatcher]func(config *rest.Config)) func(message string, callerSkip ...int) {
+func New(name string, hooks map[types.GomegaMatcher]func(config *rest.Config, message string)) func(message string, callerSkip ...int) {
 	config, err := controllerruntime.GetConfig()
 	if err != nil {
 		panic(err)
@@ -40,7 +40,7 @@ func New(name string, hooks map[types.GomegaMatcher]func(config *rest.Config)) f
 			}
 
 			if matchingMessage {
-				hook(config)
+				hook(config, message)
 			}
 		}
 	}

--- a/tests/smoke/smoke_suite_test.go
+++ b/tests/smoke/smoke_suite_test.go
@@ -37,8 +37,8 @@ var (
 )
 
 func TestSmoke(t *testing.T) {
-	RegisterFailHandler(fail_handler.New("Smoke Tests", map[gomegatypes.GomegaMatcher]func(*rest.Config){
-		fail_handler.Always: func(config *rest.Config) {
+	RegisterFailHandler(fail_handler.New("Smoke Tests", map[gomegatypes.GomegaMatcher]func(*rest.Config, string){
+		fail_handler.Always: func(config *rest.Config, _ string) {
 			_, _ = runCfCmd("apps")
 			printCfApp(config)
 			fail_handler.PrintPodsLogs(config, []fail_handler.PodContainerDescriptor{


### PR DESCRIPTION
CurrentSpecReport().FailureMessage() seems to be empty in the context of
a fail handler.

Co-authored-by: Georgi Sabev <georgethebeatle@gmail.com>

<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Pass the correct failure message to the fail handler so that it can parse the droplet guid and print the build logs for debugging
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
When the e2ec suite fails with a droplet not found error, there should be a section quoting the parsed droplet guid and printing related logs
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@georgethebeatle
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
