### PR TITLE
Fix `build-dorifi` to work with golang 1.21.0

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -23,7 +23,7 @@ jobs:
           ${{ runner.os }}-go-
     - uses: actions/setup-go@v4
       with:
-        go-version: 'stable'
+        go-version: '1.20.7'
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
     - name: staticcheck
@@ -48,7 +48,7 @@ jobs:
 
     - uses: actions/setup-go@v4
       with:
-        go-version: 'stable'
+        go-version: '1.20.7'
 
     - name: Run API unit tests
       run: make -C api test
@@ -70,7 +70,7 @@ jobs:
 
     - uses: actions/setup-go@v4
       with:
-        go-version: 'stable'
+        go-version: '1.20.7'
 
     - name: Run Controllers tests
       run: make -C controllers test
@@ -92,7 +92,7 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: 'stable'
+          go-version: '1.20.7'
 
       - name: Run job-task-runner tests
         run: make -C job-task-runner test
@@ -114,7 +114,7 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: 'stable'
+          go-version: '1.20.7'
 
       - name: Run kpack-image-builder tests
         run: make -C kpack-image-builder test
@@ -136,7 +136,7 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: 'stable'
+          go-version: '1.20.7'
 
       - name: Run statefulset-runner tests
         run: make -C statefulset-runner test
@@ -158,7 +158,7 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: 'stable'
+          go-version: '1.20.7'
 
       - name: Run tools tests
         run: make -C tools test

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ test-smoke: build-dorifi
 
 
 build-dorifi:
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ../dorifi/dorifi -C tests/assets/golang .
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -C tests/assets/golang -o ../dorifi/dorifi .
 
 GOFUMPT = $(shell go env GOPATH)/bin/gofumpt
 install-gofumpt:


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

There is a CI build failure though: https://ci.korifi.cf-app.com/teams/main/pipelines/main/jobs/run-e2es-pr/builds/1997
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Fix `build-dorifi` to work with golang 1.21.0: `-C` flag is now required to be the first on the command line
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
Green CI
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

