### PR TITLE
Check kubernetes server version from within the test

### DIFF
--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -50,8 +49,6 @@ var (
 	commonTestOrgGUID       string
 	commonTestOrgName       string
 	assetsTmpDir            string
-	clusterVersionMinor     int
-	clusterVersionMajor     int
 	defaultAppBitsFile      string
 	multiProcessAppBitsFile string
 )
@@ -1029,9 +1026,6 @@ func commonTestSetup() {
 	rootNamespace = helpers.GetRequiredEnvVar("ROOT_NAMESPACE")
 
 	appFQDN = helpers.GetRequiredEnvVar("APP_FQDN")
-
-	clusterVersionMinor, _ = strconv.Atoi(helpers.GetRequiredEnvVar("CLUSTER_VERSION_MINOR"))
-	clusterVersionMajor, _ = strconv.Atoi(helpers.GetRequiredEnvVar("CLUSTER_VERSION_MAJOR"))
 
 	ensureServerIsUp()
 

--- a/tests/e2e/orgs_test.go
+++ b/tests/e2e/orgs_test.go
@@ -106,6 +106,7 @@ var _ = Describe("Orgs", func() {
 		})
 
 		It("doesn't set an HTTP warning header for long certs", func() {
+			clusterVersionMajor, clusterVersionMinor := helpers.GetClusterVersion()
 			if clusterVersionMajor < 1 || (clusterVersionMajor == 1 && clusterVersionMinor < 22) {
 				GinkgoWriter.Printf("Skipping certificate warning test as k8s v%d.%d doesn't support creation of short lived test client certificates\n", clusterVersionMajor, clusterVersionMinor)
 				return

--- a/tests/helpers/cert_auth.go
+++ b/tests/helpers/cert_auth.go
@@ -18,7 +18,6 @@ import (
 	certv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -149,11 +148,6 @@ func generateCSR(k8sClient client.Client, key *rsa.PrivateKey, userName string, 
 func approveCSR(csr *certv1.CertificateSigningRequest) {
 	GinkgoHelper()
 
-	config, err := controllerruntime.GetConfig()
-	Expect(err).NotTo(HaveOccurred())
-	clientSet, err := kubernetes.NewForConfig(config)
-	Expect(err).NotTo(HaveOccurred())
-
 	csr.Status.Conditions = append(csr.Status.Conditions, certv1.CertificateSigningRequestCondition{
 		Type:           certv1.RequestConditionType(certv1.CertificateApproved),
 		Status:         corev1.ConditionTrue,
@@ -162,7 +156,7 @@ func approveCSR(csr *certv1.CertificateSigningRequest) {
 		LastUpdateTime: metav1.Now(),
 	})
 
-	_, err = clientSet.CertificatesV1().CertificateSigningRequests().UpdateApproval(
+	_, err := getClientSet().CertificatesV1().CertificateSigningRequests().UpdateApproval(
 		context.Background(),
 		csr.Name,
 		csr,

--- a/tests/helpers/k8s.go
+++ b/tests/helpers/k8s.go
@@ -1,0 +1,41 @@
+package helpers
+
+import (
+	"fmt"
+	"strconv"
+
+	. "github.com/onsi/ginkgo/v2" //lint:ignore ST1001 this is a test file
+	. "github.com/onsi/gomega"    //lint:ignore ST1001 this is a test file
+	"k8s.io/client-go/kubernetes"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+)
+
+func getClientSet() *kubernetes.Clientset {
+	GinkgoHelper()
+
+	config, err := controllerruntime.GetConfig()
+	Expect(err).NotTo(HaveOccurred())
+	clientSet, err := kubernetes.NewForConfig(config)
+	Expect(err).NotTo(HaveOccurred())
+
+	return clientSet
+}
+
+func GetClusterVersion() (int, int) {
+	GinkgoHelper()
+
+	serverVersion, err := getClientSet().ServerVersion()
+	Expect(err).NotTo(HaveOccurred())
+
+	majorVersion, err := strconv.Atoi(serverVersion.Major)
+	if err != nil {
+		Skip(fmt.Sprintf("cannot determine kubernetes server major version: %v", err))
+	}
+
+	minorVersion, err := strconv.Atoi(serverVersion.Minor)
+	if err != nil {
+		Skip(fmt.Sprintf("cannot determine kubernetes server minor version: %v", err))
+	}
+
+	return majorVersion, minorVersion
+}


### PR DESCRIPTION
## Is there a related GitHub Issue?
#2519
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Check kubernetes server version from within the test

Thus we simplify e2e tests setup
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
E2E tests passing
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@georgethebeatle
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
