### PR TITLE
Configure whether cert authentication is supported

### DIFF
--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -370,8 +370,8 @@ var _ = BeforeEach(func() {
 func makeCertClientForUserName(userName string, validFor time.Duration) *helpers.CorrelatedRestyClient {
 	GinkgoHelper()
 
-	if os.Getenv("CLUSTER_TYPE") == "EKS" {
-		Skip("EKS does not support cert users: https://github.com/aws/containers-roadmap/issues/1604#issuecomment-1072660824")
+	if _, ok := os.LookupEnv("CSR_SIGNING_DISALLOWED"); ok {
+		Skip("CSR singing is not allowed on this environment")
 	}
 
 	return helpers.NewCorrelatedRestyClient(apiServerRoot, getCorrelationId).


### PR DESCRIPTION
## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
When the `CSR_SIGNING_DISALLOWED` env var is set, tests that require
certificate authentication are skipped. Useful when running tests
against clusters where CSR signing is not allowed, such as EKS.
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
* Set the `CSR_SIGNING_DISALLOWED` env var
* Run e2e tests against e.g. EKS
* See tests succeed
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@georgethebeatle
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
