### PR TITLE
Remove redundant cluster version check in e2e tests

### DIFF
--- a/scripts/create-new-user.sh
+++ b/scripts/create-new-user.sh
@@ -17,10 +17,7 @@ createCert() {
     -nodes \
     -subj "/CN=${username}" 2>/dev/null
 
-  # note: we need 'validate=false' here in order to install on k8s clusters with
-  #  version <= 1.21, which don't support expirationSeconds. Those environments will
-  #  end up with long-lived certificates.
-  cat <<EOF | kubectl create --validate=false -f -
+  cat <<EOF | kubectl create -f -
 apiVersion: certificates.k8s.io/v1
 kind: CertificateSigningRequest
 metadata:

--- a/tests/e2e/orgs_test.go
+++ b/tests/e2e/orgs_test.go
@@ -105,12 +105,7 @@ var _ = Describe("Orgs", func() {
 			))
 		})
 
-		It("doesn't set an HTTP warning header for long certs", func() {
-			clusterVersionMajor, clusterVersionMinor := helpers.GetClusterVersion()
-			if clusterVersionMajor < 1 || (clusterVersionMajor == 1 && clusterVersionMinor < 22) {
-				GinkgoWriter.Printf("Skipping certificate warning test as k8s v%d.%d doesn't support creation of short lived test client certificates\n", clusterVersionMajor, clusterVersionMinor)
-				return
-			}
+		It("doesn't set an HTTP warning header for short lived certs", func() {
 			Expect(resp.Header().Get("X-Cf-Warnings")).To(BeEmpty())
 		})
 

--- a/tests/helpers/k8s.go
+++ b/tests/helpers/k8s.go
@@ -1,9 +1,6 @@
 package helpers
 
 import (
-	"fmt"
-	"strconv"
-
 	. "github.com/onsi/ginkgo/v2" //lint:ignore ST1001 this is a test file
 	. "github.com/onsi/gomega"    //lint:ignore ST1001 this is a test file
 	"k8s.io/client-go/kubernetes"
@@ -21,25 +18,6 @@ func getClientSet() *kubernetes.Clientset {
 	Expect(err).NotTo(HaveOccurred())
 
 	return clientSet
-}
-
-func GetClusterVersion() (int, int) {
-	GinkgoHelper()
-
-	serverVersion, err := getClientSet().ServerVersion()
-	Expect(err).NotTo(HaveOccurred())
-
-	majorVersion, err := strconv.Atoi(serverVersion.Major)
-	if err != nil {
-		Skip(fmt.Sprintf("cannot determine kubernetes server major version: %v", err))
-	}
-
-	minorVersion, err := strconv.Atoi(serverVersion.Minor)
-	if err != nil {
-		Skip(fmt.Sprintf("cannot determine kubernetes server minor version: %v", err))
-	}
-
-	return majorVersion, minorVersion
 }
 
 func AddUserToKubeConfig(userName, userToken string) {


### PR DESCRIPTION
## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Remove cluster version check
- Kubernetes 1.22 is already end of life
- Also improve test description
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
N/A
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@georgethebeatle
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
