### PR TITLE
Check the value of CSR_SIGNING_DISALLOWED

### DIFF
--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -17,10 +17,10 @@ import (
 	"testing"
 	"time"
 
-	"code.cloudfoundry.org/go-loggregator/v8/rpc/loggregator_v2"
 	"code.cloudfoundry.org/korifi/tests/helpers"
 	"code.cloudfoundry.org/korifi/tests/helpers/fail_handler"
 
+	"code.cloudfoundry.org/go-loggregator/v8/rpc/loggregator_v2"
 	"github.com/go-resty/resty/v2"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
@@ -370,7 +370,8 @@ var _ = BeforeEach(func() {
 func makeCertClientForUserName(userName string, validFor time.Duration) *helpers.CorrelatedRestyClient {
 	GinkgoHelper()
 
-	if _, ok := os.LookupEnv("CSR_SIGNING_DISALLOWED"); ok {
+	disallowed, found := os.LookupEnv("CSR_SIGNING_DISALLOWED")
+	if found && disallowed == "true" {
 		Skip("CSR singing is not allowed on this environment")
 	}
 


### PR DESCRIPTION
## Is there a related GitHub Issue?
No, but it is related to #2784.

## What is this change about?
This PR updates the E2E tests to check the value of the `CSR_SIGNING_DISALLOWED` env var. Concourse always creates the env var in the running container, so it will always be found, which will always cause the tests to be skipped.

## Does this PR introduce a breaking change?
No.

## Acceptance Steps
Confirm that running the E2E tests with the `CSR_SIGNING_DISALLOWED` env var set to anything except "true" does not skip the certificate authentication tests.

## Tag your pair, your PM, and/or team
@clintyoshimura 