### PR TITLE
Return an error when updating app lifecycle type

### DIFF
--- a/api/handlers/app_test.go
+++ b/api/handlers/app_test.go
@@ -507,6 +507,7 @@ var _ = Describe("App", func() {
 			Expect(msg.Labels).To(HaveKeyWithValue("env", PointTo(Equal("production"))))
 			Expect(msg.Labels).To(HaveKeyWithValue("foo.example.com/my-identifier", PointTo(Equal("aruba"))))
 			Expect(*msg.Lifecycle).To(Equal(repositories.LifecyclePatch{
+				Type: tools.PtrTo("buildpack"),
 				Data: &repositories.LifecycleDataPatch{
 					Buildpacks: &[]string{"my-buildpack"},
 					Stack:      "cflinuxfs3",

--- a/api/payloads/app.go
+++ b/api/payloads/app.go
@@ -189,6 +189,10 @@ func (a *AppPatch) ToMessage(appGUID, spaceGUID string) repositories.PatchAppMes
 	if a.Lifecycle != nil {
 		msg.Lifecycle = &repositories.LifecyclePatch{}
 
+		if a.Lifecycle.Type != "" {
+			msg.Lifecycle.Type = &a.Lifecycle.Type
+		}
+
 		if a.Lifecycle.Data != nil {
 			msg.Lifecycle.Data = &repositories.LifecycleDataPatch{
 				Stack:      a.Lifecycle.Data.Stack,

--- a/api/payloads/app_test.go
+++ b/api/payloads/app_test.go
@@ -340,6 +340,7 @@ var _ = Describe("App payload validation", func() {
 					AppGUID:   "app-guid",
 					SpaceGUID: "space-guid",
 					Lifecycle: &repositories.LifecyclePatch{
+						Type: tools.PtrTo("buildpack"),
 						Data: &repositories.LifecycleDataPatch{
 							Buildpacks: &[]string{"buildpack"},
 							Stack:      "mystack",

--- a/api/repositories/app_repository.go
+++ b/api/repositories/app_repository.go
@@ -92,6 +92,7 @@ type LifecycleData struct {
 }
 
 type LifecyclePatch struct {
+	Type *string
 	Data *LifecycleDataPatch
 }
 
@@ -625,6 +626,10 @@ func (m *PatchAppMessage) Apply(app *korifiv1alpha1.CFApp) {
 	}
 
 	if m.Lifecycle != nil {
+		if m.Lifecycle.Type != nil {
+			app.Spec.Lifecycle.Type = korifiv1alpha1.LifecycleType(*m.Lifecycle.Type)
+		}
+
 		if m.Lifecycle.Data.Buildpacks != nil {
 			app.Spec.Lifecycle.Data.Buildpacks = *m.Lifecycle.Data.Buildpacks
 		}

--- a/api/repositories/app_repository_test.go
+++ b/api/repositories/app_repository_test.go
@@ -616,7 +616,24 @@ var _ = Describe("AppRepository", func() {
 		)
 
 		BeforeEach(func() {
-			appPatchMessage = initializeAppPatchMessage(cfApp.Spec.DisplayName, cfApp.Name, cfSpace.Name)
+			appPatchMessage = PatchAppMessage{
+				Name:      cfApp.Spec.DisplayName,
+				AppGUID:   cfApp.Name,
+				SpaceGUID: cfSpace.Name,
+				Lifecycle: &LifecyclePatch{
+					Type: tools.PtrTo("docker"),
+					Data: &LifecycleDataPatch{
+						Buildpacks: &[]string{
+							"some-buildpack",
+						},
+						Stack: "cflinuxfs3",
+					},
+				},
+				MetadataPatch: MetadataPatch{
+					Labels:      map[string]*string{"l": tools.PtrTo("lv")},
+					Annotations: map[string]*string{"a": tools.PtrTo("av")},
+				},
+			}
 		})
 
 		JustBeforeEach(func() {
@@ -637,7 +654,7 @@ var _ = Describe("AppRepository", func() {
 				Expect(patchedAppRecord.SpaceGUID).To(Equal(cfSpace.Name))
 				Expect(patchedAppRecord.Name).To(Equal(appPatchMessage.Name))
 				Expect(patchedAppRecord.Lifecycle).To(Equal(Lifecycle{
-					Type: string(cfApp.Spec.Lifecycle.Type),
+					Type: "docker",
 					Data: LifecycleData{
 						Buildpacks: []string{"some-buildpack"},
 						Stack:      "cflinuxfs3",
@@ -646,7 +663,7 @@ var _ = Describe("AppRepository", func() {
 
 				Expect(cfApp.Spec.DisplayName).To(Equal(appPatchMessage.Name))
 				Expect(cfApp.Spec.Lifecycle).To(Equal(korifiv1alpha1.Lifecycle{
-					Type: "buildpack",
+					Type: "docker",
 					Data: korifiv1alpha1.LifecycleData{
 						Buildpacks: []string{"some-buildpack"},
 						Stack:      "cflinuxfs3",

--- a/api/repositories/shared_test.go
+++ b/api/repositories/shared_test.go
@@ -238,26 +238,6 @@ func initializeAppCreateMessage(appName string, spaceGUID string) CreateAppMessa
 	}
 }
 
-func initializeAppPatchMessage(appName, appGUID, spaceGUID string) PatchAppMessage {
-	return PatchAppMessage{
-		Name:      appName,
-		AppGUID:   appGUID,
-		SpaceGUID: spaceGUID,
-		Lifecycle: &LifecyclePatch{
-			Data: &LifecycleDataPatch{
-				Buildpacks: &[]string{
-					"some-buildpack",
-				},
-				Stack: "cflinuxfs3",
-			},
-		},
-		MetadataPatch: MetadataPatch{
-			Labels:      map[string]*string{"l": tools.PtrTo("lv")},
-			Annotations: map[string]*string{"a": tools.PtrTo("av")},
-		},
-	}
-}
-
 func generateAppEnvSecretName(appGUID string) string {
 	return appGUID + "-env"
 }

--- a/controllers/webhooks/workloads/cfapp_validator.go
+++ b/controllers/webhooks/workloads/cfapp_validator.go
@@ -67,6 +67,13 @@ func (v *CFAppValidator) ValidateUpdate(ctx context.Context, oldObj, obj runtime
 		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a CFApp but got a %T", oldObj))
 	}
 
+	if app.Spec.Lifecycle.Type != oldApp.Spec.Lifecycle.Type {
+		return nil, webhooks.ValidationError{
+			Type:    "ImmutableFieldError",
+			Message: "CFApp.Spec.Lifecycle.Type is immutable",
+		}.ExportJSONError()
+	}
+
 	return nil, v.duplicateValidator.ValidateUpdate(ctx, cfapplog, app.Namespace, oldApp, app)
 }
 

--- a/controllers/webhooks/workloads/cfapp_validator_test.go
+++ b/controllers/webhooks/workloads/cfapp_validator_test.go
@@ -179,6 +179,16 @@ var _ = Describe("CFAppValidatingWebhook", func() {
 				Expect(updateErr).To(MatchError(ContainSubstring(fmt.Sprintf("App with the name '%s' already exists.", app2Name))))
 			})
 		})
+
+		When("changing the lifecycle type", func() {
+			BeforeEach(func() {
+				app1.Spec.Lifecycle.Type = korifiv1alpha1.LifecycleType("docker")
+			})
+
+			It("should fail", func() {
+				Expect(updateErr).To(MatchError(ContainSubstring("immutable")))
+			})
+		})
 	})
 
 	Describe("Delete", func() {


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
https://github.com/cloudfoundry/korifi/issues/2796
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Return an error when updating app lifecycle type
Thus making the lifecycle type immutable for both cf api and kubectl
users
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
See story
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@georgethebeatle
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
