### PR TITLE
Package type validation

### DIFF
--- a/controllers/api/v1alpha1/cfpackage_webhook_test.go
+++ b/controllers/api/v1alpha1/cfpackage_webhook_test.go
@@ -1,9 +1,13 @@
 package v1alpha1_test
 
 import (
+	"context"
+
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	. "code.cloudfoundry.org/korifi/controllers/controllers/workloads/testutils"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
@@ -18,6 +22,21 @@ var _ = Describe("CFPackageMutatingWebhook", func() {
 
 	BeforeEach(func() {
 		cfAppGUID = GenerateGUID()
+
+		cfApp := &korifiv1alpha1.CFApp{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      cfAppGUID,
+			},
+			Spec: korifiv1alpha1.CFAppSpec{
+				DisplayName: uuid.NewString(),
+				Lifecycle: korifiv1alpha1.Lifecycle{
+					Type: "buildpack",
+				},
+				DesiredState: "STOPPED",
+			},
+		}
+		Expect(client.IgnoreAlreadyExists(adminClient.Create(context.Background(), cfApp))).To(Succeed())
 
 		cfPackage = &korifiv1alpha1.CFPackage{
 			ObjectMeta: metav1.ObjectMeta{

--- a/controllers/api/v1alpha1/webhook_suite_test.go
+++ b/controllers/api/v1alpha1/webhook_suite_test.go
@@ -128,6 +128,7 @@ var _ = BeforeSuite(func() {
 	Expect(workloads.NewCFSpaceValidator(spaceNameDuplicateValidator, spacePlacementValidator).SetupWebhookWithManager(k8sManager)).To(Succeed())
 	version.NewVersionWebhook("some-version").SetupWebhookWithManager(k8sManager)
 	finalizer.NewControllersFinalizerWebhook().SetupWebhookWithManager(k8sManager)
+	Expect(workloads.NewCFPackageValidator().SetupWebhookWithManager(k8sManager)).To(Succeed())
 
 	Expect(adminClient.Create(ctx, &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{

--- a/controllers/controllers/workloads/cfpackage_controller_test.go
+++ b/controllers/controllers/workloads/cfpackage_controller_test.go
@@ -156,6 +156,23 @@ var _ = Describe("CFPackageReconciler Integration Tests", func() {
 
 		When("the package type is docker", func() {
 			BeforeEach(func() {
+				cfAppGUID = GenerateGUID()
+				cfApp = &korifiv1alpha1.CFApp{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      cfAppGUID,
+						Namespace: cfSpace.Status.GUID,
+					},
+					Spec: korifiv1alpha1.CFAppSpec{
+						DisplayName:  "docker-test-app-name",
+						DesiredState: "STOPPED",
+						Lifecycle: korifiv1alpha1.Lifecycle{
+							Type: "docker",
+						},
+					},
+				}
+				Expect(adminClient.Create(context.Background(), cfApp)).To(Succeed())
+
+				cfPackage = BuildCFPackageCRObject(cfPackageGUID, cfSpace.Status.GUID, cfAppGUID, imageRef)
 				cfPackage.Spec.Type = "docker"
 			})
 

--- a/controllers/controllers/workloads/suite_test.go
+++ b/controllers/controllers/workloads/suite_test.go
@@ -261,6 +261,7 @@ var _ = BeforeSuite(func() {
 	Expect(services.NewCFServiceBindingValidator(
 		webhooks.NewDuplicateValidator(coordination.NewNameRegistry(k8sManager.GetClient(), services.ServiceBindingEntityType)),
 	).SetupWebhookWithManager(k8sManager)).To(Succeed())
+	Expect(workloads.NewCFPackageValidator().SetupWebhookWithManager(k8sManager)).To(Succeed())
 
 	stopManager = helpers.StartK8sManager(k8sManager)
 

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -494,6 +494,11 @@ func main() {
 		versionwebhook.NewVersionWebhook(version.Version).SetupWebhookWithManager(mgr)
 		controllersfinalizer.NewControllersFinalizerWebhook().SetupWebhookWithManager(mgr)
 
+		if err = workloads.NewCFPackageValidator().SetupWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "CFPackage")
+			os.Exit(1)
+		}
+
 		if controllerConfig.IncludeStatefulsetRunner {
 			if err = statesetfulrunnerv1.NewSTSPodDefaulter().SetupWebhookWithManager(mgr); err != nil {
 				setupLog.Error(err, "unable to create webhook", "webhook", "Pod")

--- a/controllers/webhooks/finalizer/suite_integration_test.go
+++ b/controllers/webhooks/finalizer/suite_integration_test.go
@@ -102,6 +102,7 @@ var _ = BeforeSuite(func() {
 		rootNamespace,
 		k8sManager.GetClient(),
 	).SetupWebhookWithManager(k8sManager)).To(Succeed())
+	Expect(workloads.NewCFPackageValidator().SetupWebhookWithManager(k8sManager)).To(Succeed())
 
 	stopManager = helpers.StartK8sManager(k8sManager)
 

--- a/controllers/webhooks/version/suite_integration_test.go
+++ b/controllers/webhooks/version/suite_integration_test.go
@@ -111,6 +111,7 @@ var _ = BeforeSuite(func() {
 		webhooks.NewDuplicateValidator(coordination.NewNameRegistry(k8sManager.GetClient(), services.ServiceBindingEntityType)),
 	).SetupWebhookWithManager(k8sManager)).To(Succeed())
 	finalizer.NewControllersFinalizerWebhook().SetupWebhookWithManager(k8sManager)
+	Expect(workloads.NewCFPackageValidator().SetupWebhookWithManager(k8sManager)).To(Succeed())
 
 	stopManager = helpers.StartK8sManager(k8sManager)
 

--- a/controllers/webhooks/version/version_webhook_test.go
+++ b/controllers/webhooks/version/version_webhook_test.go
@@ -24,7 +24,10 @@ const (
 var _ = Describe("Setting the version annotation", func() {
 	Describe("create", func() {
 		var testObjects []client.Object
+
 		createObject := func(obj client.Object) client.Object {
+			GinkgoHelper()
+
 			Expect(adminClient.Create(context.Background(), obj)).To(Succeed())
 			return obj
 		}
@@ -39,6 +42,7 @@ var _ = Describe("Setting the version annotation", func() {
 			})).To(Succeed())
 
 			domainName := uuid.NewString()
+			cfAppGUID := uuid.NewString()
 			testObjects = []client.Object{
 				createObject(&korifiv1alpha1.CFOrg{
 					ObjectMeta: metav1.ObjectMeta{
@@ -85,7 +89,7 @@ var _ = Describe("Setting the version annotation", func() {
 				createObject(&korifiv1alpha1.CFApp{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: orgNamespace,
-						Name:      uuid.NewString(),
+						Name:      cfAppGUID,
 					},
 					Spec: korifiv1alpha1.CFAppSpec{
 						DisplayName:  "cfapp",
@@ -102,6 +106,9 @@ var _ = Describe("Setting the version annotation", func() {
 					},
 					Spec: korifiv1alpha1.CFPackageSpec{
 						Type: "bits",
+						AppRef: corev1.LocalObjectReference{
+							Name: cfAppGUID,
+						},
 					},
 				}),
 				createObject(&korifiv1alpha1.CFTask{

--- a/controllers/webhooks/workloads/cfapp_validator.go
+++ b/controllers/webhooks/workloads/cfapp_validator.go
@@ -70,7 +70,7 @@ func (v *CFAppValidator) ValidateUpdate(ctx context.Context, oldObj, obj runtime
 	if app.Spec.Lifecycle.Type != oldApp.Spec.Lifecycle.Type {
 		return nil, webhooks.ValidationError{
 			Type:    "ImmutableFieldError",
-			Message: "CFApp.Spec.Lifecycle.Type is immutable",
+			Message: fmt.Sprintf("Lifecycle type cannot be changed from %s to %s", oldApp.Spec.Lifecycle.Type, app.Spec.Lifecycle.Type),
 		}.ExportJSONError()
 	}
 

--- a/controllers/webhooks/workloads/cfapp_validator_test.go
+++ b/controllers/webhooks/workloads/cfapp_validator_test.go
@@ -186,7 +186,7 @@ var _ = Describe("CFAppValidatingWebhook", func() {
 			})
 
 			It("should fail", func() {
-				Expect(updateErr).To(MatchError(ContainSubstring("immutable")))
+				Expect(updateErr).To(MatchError(ContainSubstring("cannot be changed from buildpack to docker")))
 			})
 		})
 	})

--- a/controllers/webhooks/workloads/cfpackage_validator.go
+++ b/controllers/webhooks/workloads/cfpackage_validator.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workloads
+
+import (
+	"context"
+	"fmt"
+
+	"code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
+	"code.cloudfoundry.org/korifi/controllers/webhooks"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// log is for logging in this package.
+var (
+	cfpackagelog         = logf.Log.WithName("cftask-resource")
+	appTypeToPackageType = map[v1alpha1.LifecycleType]v1alpha1.PackageType{
+		"buildpack": "bits",
+		"docker":    "docker",
+	}
+)
+
+//+kubebuilder:webhook:path=/validate-korifi-cloudfoundry-org-v1alpha1-cfpackage,mutating=false,failurePolicy=fail,sideEffects=None,groups=korifi.cloudfoundry.org,resources=cfpackages,verbs=create;update,versions=v1alpha1,name=vcfpackage.korifi.cloudfoundry.org,admissionReviewVersions={v1,v1beta1}
+
+type CFPackageValidator struct {
+	client client.Client
+}
+
+var _ webhook.CustomValidator = &CFPackageValidator{}
+
+func NewCFPackageValidator() *CFPackageValidator {
+	return &CFPackageValidator{}
+}
+
+func (v *CFPackageValidator) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	v.client = mgr.GetClient()
+
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(&v1alpha1.CFPackage{}).
+		WithValidator(v).
+		Complete()
+}
+
+var _ webhook.CustomValidator = &CFPackageValidator{}
+
+func (v *CFPackageValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	cfPackage, ok := obj.(*v1alpha1.CFPackage)
+	if !ok {
+		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a CFPackage but got a %T", obj))
+	}
+
+	cfpackagelog.V(1).Info("validate package creation", "namespace", cfPackage.Namespace, "name", cfPackage.Name)
+
+	cfApp := &v1alpha1.CFApp{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: cfPackage.Namespace,
+			Name:      cfPackage.Spec.AppRef.Name,
+		},
+	}
+	err := v.client.Get(ctx, client.ObjectKeyFromObject(cfApp), cfApp)
+	if err != nil {
+		return nil, webhooks.ValidationError{
+			Type:    "ReferencedAppDoesNotExistError",
+			Message: fmt.Sprintf("referenced CFApp %q does not exist", cfPackage.Spec.AppRef.Name),
+		}.ExportJSONError()
+	}
+
+	if cfPackage.Spec.Type != appTypeToPackageType[cfApp.Spec.Lifecycle.Type] {
+		return nil, webhooks.ValidationError{
+			Type:    "InvalidPackageTypeError",
+			Message: fmt.Sprintf("cannot create %s package for a %s app", cfPackage.Spec.Type, cfApp.Spec.Lifecycle.Type),
+		}.ExportJSONError()
+	}
+
+	return nil, nil
+}
+
+func (v *CFPackageValidator) ValidateUpdate(ctx context.Context, oldObj runtime.Object, obj runtime.Object) (admission.Warnings, error) {
+	newCFPackage, ok := obj.(*v1alpha1.CFPackage)
+	if !ok {
+		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a CFPackage but got a %T", obj))
+	}
+
+	if !newCFPackage.GetDeletionTimestamp().IsZero() {
+		return nil, nil
+	}
+
+	cfpackagelog.V(1).Info("validate task update", "namespace", newCFPackage.Namespace, "name", newCFPackage.Name)
+
+	oldCFPackage, ok := oldObj.(*v1alpha1.CFPackage)
+	if !ok {
+		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a CFPackage but got a %T", oldObj))
+	}
+
+	if newCFPackage.Spec.Type != oldCFPackage.Spec.Type {
+		return nil, webhooks.ValidationError{
+			Type:    ImmutableFieldModificationErrorType,
+			Message: fmt.Sprintf("package %s:%s Spec.Type is immutable", newCFPackage.Namespace, newCFPackage.Name),
+		}.ExportJSONError()
+	}
+
+	return nil, nil
+}
+
+func (v *CFPackageValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	return nil, nil
+}

--- a/controllers/webhooks/workloads/cfpackage_validator_test.go
+++ b/controllers/webhooks/workloads/cfpackage_validator_test.go
@@ -1,0 +1,132 @@
+package workloads_test
+
+import (
+	"context"
+
+	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
+	"code.cloudfoundry.org/korifi/controllers/controllers/workloads/testutils"
+	"code.cloudfoundry.org/korifi/tools/k8s"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("CFPackage Validation", func() {
+	var (
+		cfApp     *korifiv1alpha1.CFApp
+		cfPackage *korifiv1alpha1.CFPackage
+	)
+
+	BeforeEach(func() {
+		cfApp = makeCFApp(testutils.PrefixedGUID("cfapp"), rootNamespace, testutils.PrefixedGUID("appName"))
+		cfPackage = &korifiv1alpha1.CFPackage{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: cfApp.Namespace,
+				Name:      testutils.PrefixedGUID("cfpackage"),
+			},
+			Spec: korifiv1alpha1.CFPackageSpec{
+				AppRef: v1.LocalObjectReference{
+					Name: cfApp.Name,
+				},
+			},
+		}
+	})
+
+	Describe("create", func() {
+		var creationErr error
+
+		JustBeforeEach(func() {
+			Expect(adminClient.Create(context.Background(), cfApp)).To(Succeed())
+			creationErr = adminClient.Create(context.Background(), cfPackage)
+		})
+
+		When("the app does not exist", func() {
+			BeforeEach(func() {
+				cfPackage.Spec.Type = korifiv1alpha1.PackageType("bits")
+				cfPackage.Spec.AppRef.Name = "not-existing"
+			})
+
+			It("returns a validation error", func() {
+				Expect(creationErr).To(MatchError(ContainSubstring("does not exist")))
+			})
+		})
+
+		Describe("buildpack apps", func() {
+			BeforeEach(func() {
+				cfApp.Spec.Lifecycle.Type = "buildpack"
+				cfPackage.Spec.Type = korifiv1alpha1.PackageType("bits")
+			})
+
+			It("succeeds", func() {
+				Expect(creationErr).NotTo(HaveOccurred())
+			})
+
+			When("the package type is not bits", func() {
+				BeforeEach(func() {
+					cfPackage.Spec.Type = korifiv1alpha1.PackageType("docker")
+				})
+
+				It("returns a validation error", func() {
+					Expect(creationErr).To(MatchError(ContainSubstring("cannot create docker package for a buildpack app")))
+				})
+			})
+		})
+
+		Describe("docker apps", func() {
+			BeforeEach(func() {
+				cfApp.Spec.Lifecycle.Type = "docker"
+				cfPackage.Spec.Type = korifiv1alpha1.PackageType("docker")
+			})
+
+			It("succeeds", func() {
+				Expect(creationErr).NotTo(HaveOccurred())
+			})
+
+			When("the package type is not docker", func() {
+				BeforeEach(func() {
+					cfPackage.Spec.Type = korifiv1alpha1.PackageType("bits")
+				})
+
+				It("returns a validation error", func() {
+					Expect(creationErr).To(MatchError(ContainSubstring("cannot create bits package for a docker app")))
+				})
+			})
+		})
+	})
+
+	Describe("update", func() {
+		BeforeEach(func() {
+			Expect(adminClient.Create(context.Background(), cfApp)).To(Succeed())
+			cfPackage.Spec.Type = korifiv1alpha1.PackageType("bits")
+			Expect(adminClient.Create(context.Background(), cfPackage)).To(Succeed())
+		})
+
+		Describe("package type", func() {
+			var updateErr error
+
+			JustBeforeEach(func() {
+				updateErr = k8s.Patch(context.Background(), adminClient, cfPackage, func() {
+					cfPackage.Spec.Type = "docker"
+				})
+			})
+
+			It("does not allow changing the package type", func() {
+				Expect(updateErr).To(MatchError(ContainSubstring("immutable")))
+			})
+
+			When("the package is being deleted", func() {
+				BeforeEach(func() {
+					Expect(k8s.Patch(context.Background(), adminClient, cfPackage, func() {
+						cfPackage.Finalizers = append(cfPackage.Finalizers, "dummy")
+					})).To(Succeed())
+					Expect(adminClient.Delete(context.Background(), cfPackage)).To(Succeed())
+				})
+
+				It("allows it", func() {
+					Expect(updateErr).NotTo(HaveOccurred())
+				})
+			})
+		})
+	})
+})

--- a/controllers/webhooks/workloads/suite_integration_test.go
+++ b/controllers/webhooks/workloads/suite_integration_test.go
@@ -98,6 +98,7 @@ var _ = BeforeSuite(func() {
 	Expect(workloads.NewCFTaskValidator().SetupWebhookWithManager(k8sManager)).To(Succeed())
 	version.NewVersionWebhook("some-version").SetupWebhookWithManager(k8sManager)
 	finalizer.NewControllersFinalizerWebhook().SetupWebhookWithManager(k8sManager)
+	Expect(workloads.NewCFPackageValidator().SetupWebhookWithManager(k8sManager)).To(Succeed())
 
 	stopManager = helpers.StartK8sManager(k8sManager)
 

--- a/helm/korifi/controllers/manifests.yaml
+++ b/helm/korifi/controllers/manifests.yaml
@@ -357,6 +357,27 @@ webhooks:
       service:
         name: korifi-controllers-webhook-service
         namespace: '{{ .Release.Namespace }}'
+        path: /validate-korifi-cloudfoundry-org-v1alpha1-cfpackage
+    failurePolicy: Fail
+    name: vcfpackage.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - cfpackages
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-controllers-webhook-service
+        namespace: '{{ .Release.Namespace }}'
         path: /validate-korifi-cloudfoundry-org-v1alpha1-cfspace
     failurePolicy: Fail
     name: vcfspace.korifi.cloudfoundry.org

--- a/tests/e2e/builds_test.go
+++ b/tests/e2e/builds_test.go
@@ -65,6 +65,7 @@ var _ = Describe("Builds", func() {
 
 		When("the package type is docker", func() {
 			BeforeEach(func() {
+				appGUID = createDockerApp(spaceGUID, generateGUID("app"))
 				pkgGUID = createPackage(appGUID, packageResource{
 					typedResource: typedResource{
 						Type: "docker",

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -612,6 +612,20 @@ func createBuildpackApp(spaceGUID, name string) string {
 	})
 }
 
+func createDockerApp(spaceGUID, name string) string {
+	GinkgoHelper()
+
+	return createApp(appResource{
+		Lifecycle: &lifecycle{
+			Type: "docker",
+		},
+		resource: resource{
+			Name:          name,
+			Relationships: relationships{"space": {Data: resource{GUID: spaceGUID}}},
+		},
+	})
+}
+
 func createApp(app appResource) string {
 	GinkgoHelper()
 

--- a/tests/e2e/packages_test.go
+++ b/tests/e2e/packages_test.go
@@ -97,9 +97,19 @@ var _ = Describe("Package", func() {
 
 		When("the package is of type docker", func() {
 			BeforeEach(func() {
-				packageRequest.Type = "docker"
-				packageRequest.Data = &packageData{
-					Image: "eirini/dorini",
+				appGUID = createDockerApp(spaceGUID, generateGUID("app"))
+				packageRequest = packageResource{
+					typedResource: typedResource{
+						Type: "docker",
+						resource: resource{
+							Relationships: relationships{
+								"app": relationship{Data: resource{GUID: appGUID}},
+							},
+						},
+					},
+					Data: &packageData{
+						Image: "eirini/dorini",
+					},
 				}
 			})
 


### PR DESCRIPTION
## Is there a related GitHub Issue?
#2797
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Validate CFPackage type to match the CFApp lifecycle type by introducing a validating webhook that:
* Validates that the package type matches the referenced app lifecycle when the CFPackage is created
* Denies CFPackage type modification
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
Not breaking, but with this PR in order to create a CFPackage, the referenced CFApp must exists. While this is not a problem for API users, it _might_ be a bit awkward for kubectl users who would like to apply an yaml file that describes a CFApp and a CFPAckage. In order to break this dependency we should probably reconsider all Korifi validation by e.g. introducing a `Valid` status condition for all of them and assert on that condition being set to `true`. Sounds related to https://github.com/cloudfoundry/korifi/issues/2098

<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
See story
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

