### PR TITLE
Put app env vars expectations in `Eventually`

### DIFF
--- a/tests/e2e/spaces_test.go
+++ b/tests/e2e/spaces_test.go
@@ -264,20 +264,21 @@ var _ = Describe("Spaces", func() {
 				Expect(app1ServiceBindings[0].Relationships["app"].Data.GUID).To(Equal(app1GUID))
 				Expect(app1ServiceBindings[0].Relationships["service_instance"].Data.GUID).To(Equal(serviceGUID))
 
-				app1Env := getAppEnv(app1GUID)
-				Expect(app1Env).To(
-					HaveKeyWithValue("system_env_json",
-						HaveKeyWithValue("VCAP_SERVICES",
-							HaveKeyWithValue("user-provided",
-								ContainElement(SatisfyAll(
-									HaveKeyWithValue("instance_guid", serviceGUID),
-									HaveKeyWithValue("instance_name", serviceName),
-									HaveKeyWithValue("binding_name", serviceBindingName),
-								)),
+				Eventually(func(g Gomega) {
+					g.Expect(getAppEnv(app1GUID)).To(
+						HaveKeyWithValue("system_env_json",
+							HaveKeyWithValue("VCAP_SERVICES",
+								HaveKeyWithValue("user-provided",
+									ContainElement(SatisfyAll(
+										HaveKeyWithValue("instance_guid", serviceGUID),
+										HaveKeyWithValue("instance_name", serviceName),
+										HaveKeyWithValue("binding_name", serviceBindingName),
+									)),
+								),
 							),
 						),
-					),
-				)
+					)
+				}).Should(Succeed())
 
 				app2GUID := getAppGUIDFromName(app2Name)
 				Expect(getProcess(app2GUID, "web").Instances).To(Equal(1))


### PR DESCRIPTION
## Is there a related GitHub Issue?
https://github.com/cloudfoundry/korifi/issues/2862
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
The `space.apply_manifest` job endpoint is stubbed to always return
`HTTP 200`. As the app env vars secret might not have been created yet,
we put the app env vars expectations in `Eventually` to let the app
controller process the app and create the secret
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
Flake fixed
