### PR TITLE
Package type validation

### DIFF
--- a/controllers/api/v1alpha1/webhook_suite_test.go
+++ b/controllers/api/v1alpha1/webhook_suite_test.go
@@ -128,6 +128,7 @@ var _ = BeforeSuite(func() {
 	Expect(workloads.NewCFSpaceValidator(spaceNameDuplicateValidator, spacePlacementValidator).SetupWebhookWithManager(k8sManager)).To(Succeed())
 	version.NewVersionWebhook("some-version").SetupWebhookWithManager(k8sManager)
 	finalizer.NewControllersFinalizerWebhook().SetupWebhookWithManager(k8sManager)
+	Expect(workloads.NewCFPackageValidator().SetupWebhookWithManager(k8sManager)).To(Succeed())
 
 	Expect(adminClient.Create(ctx, &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{

--- a/controllers/controllers/workloads/suite_test.go
+++ b/controllers/controllers/workloads/suite_test.go
@@ -254,6 +254,7 @@ var _ = BeforeSuite(func() {
 	Expect(services.NewCFServiceBindingValidator(
 		webhooks.NewDuplicateValidator(coordination.NewNameRegistry(k8sManager.GetClient(), services.ServiceBindingEntityType)),
 	).SetupWebhookWithManager(k8sManager)).To(Succeed())
+	Expect(workloads.NewCFPackageValidator().SetupWebhookWithManager(k8sManager)).To(Succeed())
 
 	stopManager = helpers.StartK8sManager(k8sManager)
 

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -492,6 +492,11 @@ func main() {
 		versionwebhook.NewVersionWebhook(version.Version).SetupWebhookWithManager(mgr)
 		controllersfinalizer.NewControllersFinalizerWebhook().SetupWebhookWithManager(mgr)
 
+		if err = workloads.NewCFPackageValidator().SetupWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "CFPackage")
+			os.Exit(1)
+		}
+
 		if controllerConfig.IncludeStatefulsetRunner {
 			if err = statesetfulrunnerv1.NewSTSPodDefaulter().SetupWebhookWithManager(mgr); err != nil {
 				setupLog.Error(err, "unable to create webhook", "webhook", "Pod")

--- a/controllers/webhooks/finalizer/suite_integration_test.go
+++ b/controllers/webhooks/finalizer/suite_integration_test.go
@@ -102,6 +102,7 @@ var _ = BeforeSuite(func() {
 		rootNamespace,
 		k8sManager.GetClient(),
 	).SetupWebhookWithManager(k8sManager)).To(Succeed())
+	Expect(workloads.NewCFPackageValidator().SetupWebhookWithManager(k8sManager)).To(Succeed())
 
 	stopManager = helpers.StartK8sManager(k8sManager)
 

--- a/controllers/webhooks/version/suite_integration_test.go
+++ b/controllers/webhooks/version/suite_integration_test.go
@@ -111,6 +111,7 @@ var _ = BeforeSuite(func() {
 		webhooks.NewDuplicateValidator(coordination.NewNameRegistry(k8sManager.GetClient(), services.ServiceBindingEntityType)),
 	).SetupWebhookWithManager(k8sManager)).To(Succeed())
 	finalizer.NewControllersFinalizerWebhook().SetupWebhookWithManager(k8sManager)
+	Expect(workloads.NewCFPackageValidator().SetupWebhookWithManager(k8sManager)).To(Succeed())
 
 	stopManager = helpers.StartK8sManager(k8sManager)
 

--- a/controllers/webhooks/workloads/cfapp_validator.go
+++ b/controllers/webhooks/workloads/cfapp_validator.go
@@ -70,7 +70,7 @@ func (v *CFAppValidator) ValidateUpdate(ctx context.Context, oldObj, obj runtime
 	if app.Spec.Lifecycle.Type != oldApp.Spec.Lifecycle.Type {
 		return nil, webhooks.ValidationError{
 			Type:    "ImmutableFieldError",
-			Message: "CFApp.Spec.Lifecycle.Type is immutable",
+			Message: fmt.Sprintf("Lifecycle type cannot be changed from %s to %s", oldApp.Spec.Lifecycle.Type, app.Spec.Lifecycle.Type),
 		}.ExportJSONError()
 	}
 

--- a/controllers/webhooks/workloads/cfapp_validator_test.go
+++ b/controllers/webhooks/workloads/cfapp_validator_test.go
@@ -186,7 +186,7 @@ var _ = Describe("CFAppValidatingWebhook", func() {
 			})
 
 			It("should fail", func() {
-				Expect(updateErr).To(MatchError(ContainSubstring("immutable")))
+				Expect(updateErr).To(MatchError(ContainSubstring("cannot be changed from buildpack to docker")))
 			})
 		})
 	})

--- a/controllers/webhooks/workloads/cfpackage_validator.go
+++ b/controllers/webhooks/workloads/cfpackage_validator.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workloads
+
+import (
+	"context"
+	"fmt"
+
+	"code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
+	"code.cloudfoundry.org/korifi/controllers/webhooks"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	runtime "k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// log is for logging in this package.
+var (
+	cfpackagelog = logf.Log.WithName("cftask-resource")
+)
+
+//+kubebuilder:webhook:path=/validate-korifi-cloudfoundry-org-v1alpha1-cfpackage,mutating=false,failurePolicy=fail,sideEffects=None,groups=korifi.cloudfoundry.org,resources=cfpackages,verbs=update,versions=v1alpha1,name=vcfpackage.korifi.cloudfoundry.org,admissionReviewVersions={v1,v1beta1}
+
+type CFPackageValidator struct {
+	client client.Client
+}
+
+var _ webhook.CustomValidator = &CFPackageValidator{}
+
+func NewCFPackageValidator() *CFPackageValidator {
+	return &CFPackageValidator{}
+}
+
+func (v *CFPackageValidator) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	v.client = mgr.GetClient()
+
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(&v1alpha1.CFPackage{}).
+		WithValidator(v).
+		Complete()
+}
+
+var _ webhook.CustomValidator = &CFPackageValidator{}
+
+func (v *CFPackageValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	return nil, nil
+}
+
+func (v *CFPackageValidator) ValidateUpdate(ctx context.Context, oldObj runtime.Object, obj runtime.Object) (admission.Warnings, error) {
+	newCFPackage, ok := obj.(*v1alpha1.CFPackage)
+	if !ok {
+		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a CFPackage but got a %T", obj))
+	}
+
+	if !newCFPackage.GetDeletionTimestamp().IsZero() {
+		return nil, nil
+	}
+
+	cfpackagelog.V(1).Info("validate task update", "namespace", newCFPackage.Namespace, "name", newCFPackage.Name)
+
+	oldCFPackage, ok := oldObj.(*v1alpha1.CFPackage)
+	if !ok {
+		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a CFPackage but got a %T", oldObj))
+	}
+
+	if newCFPackage.Spec.Type != oldCFPackage.Spec.Type {
+		return nil, webhooks.ValidationError{
+			Type:    ImmutableFieldModificationErrorType,
+			Message: fmt.Sprintf("package %s:%s Spec.Type is immutable", newCFPackage.Namespace, newCFPackage.Name),
+		}.ExportJSONError()
+	}
+
+	return nil, nil
+}
+
+func (v *CFPackageValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	return nil, nil
+}

--- a/controllers/webhooks/workloads/cfpackage_validator_test.go
+++ b/controllers/webhooks/workloads/cfpackage_validator_test.go
@@ -1,0 +1,66 @@
+package workloads_test
+
+import (
+	"context"
+
+	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
+	"code.cloudfoundry.org/korifi/controllers/controllers/workloads/testutils"
+	"code.cloudfoundry.org/korifi/tools/k8s"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("CFPackage Validation", func() {
+	var (
+		cfApp     *korifiv1alpha1.CFApp
+		cfPackage *korifiv1alpha1.CFPackage
+	)
+
+	BeforeEach(func() {
+		cfApp = makeCFApp(testutils.PrefixedGUID("cfapp"), rootNamespace, testutils.PrefixedGUID("appName"))
+		Expect(adminClient.Create(context.Background(), cfApp)).To(Succeed())
+
+		cfPackage = &korifiv1alpha1.CFPackage{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: cfApp.Namespace,
+				Name:      testutils.PrefixedGUID("cfpackage"),
+			},
+			Spec: korifiv1alpha1.CFPackageSpec{
+				AppRef: v1.LocalObjectReference{
+					Name: cfApp.Name,
+				},
+				Type: "bits",
+			},
+		}
+		Expect(adminClient.Create(context.Background(), cfPackage)).To(Succeed())
+	})
+
+	Describe("package type immutability", func() {
+		var updateErr error
+
+		JustBeforeEach(func() {
+			updateErr = k8s.Patch(context.Background(), adminClient, cfPackage, func() {
+				cfPackage.Spec.Type = "docker"
+			})
+		})
+
+		It("does not allow changing the package type", func() {
+			Expect(updateErr).To(MatchError(ContainSubstring("immutable")))
+		})
+
+		When("the package is being deleted", func() {
+			BeforeEach(func() {
+				Expect(k8s.Patch(context.Background(), adminClient, cfPackage, func() {
+					cfPackage.Finalizers = append(cfPackage.Finalizers, "dummy")
+				})).To(Succeed())
+				Expect(adminNonSyncClient.Delete(context.Background(), cfPackage)).To(Succeed())
+			})
+
+			It("allows it", func() {
+				Expect(updateErr).NotTo(HaveOccurred())
+			})
+		})
+	})
+})

--- a/controllers/webhooks/workloads/suite_integration_test.go
+++ b/controllers/webhooks/workloads/suite_integration_test.go
@@ -104,6 +104,7 @@ var _ = BeforeSuite(func() {
 	Expect(workloads.NewCFTaskValidator().SetupWebhookWithManager(k8sManager)).To(Succeed())
 	version.NewVersionWebhook("some-version").SetupWebhookWithManager(k8sManager)
 	finalizer.NewControllersFinalizerWebhook().SetupWebhookWithManager(k8sManager)
+	Expect(workloads.NewCFPackageValidator().SetupWebhookWithManager(k8sManager)).To(Succeed())
 
 	stopManager = helpers.StartK8sManager(k8sManager)
 

--- a/helm/korifi/controllers/manifests.yaml
+++ b/helm/korifi/controllers/manifests.yaml
@@ -357,6 +357,26 @@ webhooks:
       service:
         name: korifi-controllers-webhook-service
         namespace: '{{ .Release.Namespace }}'
+        path: /validate-korifi-cloudfoundry-org-v1alpha1-cfpackage
+    failurePolicy: Fail
+    name: vcfpackage.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - UPDATE
+        resources:
+          - cfpackages
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-controllers-webhook-service
+        namespace: '{{ .Release.Namespace }}'
         path: /validate-korifi-cloudfoundry-org-v1alpha1-cfspace
     failurePolicy: Fail
     name: vcfspace.korifi.cloudfoundry.org

--- a/tests/e2e/builds_test.go
+++ b/tests/e2e/builds_test.go
@@ -62,29 +62,6 @@ var _ = Describe("Builds", func() {
 			Expect(resp).To(HaveRestyStatusCode(http.StatusCreated))
 			Expect(result.Package.GUID).To(Equal(pkgGUID))
 		})
-
-		When("the package type is docker", func() {
-			BeforeEach(func() {
-				pkgGUID = createPackage(appGUID, packageResource{
-					typedResource: typedResource{
-						Type: "docker",
-						resource: resource{
-							Relationships: relationships{
-								"app": relationship{Data: resource{GUID: appGUID}},
-							},
-						},
-					},
-					Data: &packageData{
-						Image: "eirini/dorini",
-					},
-				})
-			})
-
-			It("returns the build", func() {
-				Expect(resp).To(HaveRestyStatusCode(http.StatusCreated))
-				Expect(result.Package.GUID).To(Equal(pkgGUID))
-			})
-		})
 	})
 
 	Describe("update", func() {

--- a/tests/e2e/packages_test.go
+++ b/tests/e2e/packages_test.go
@@ -94,22 +94,6 @@ var _ = Describe("Package", func() {
 				Expect(resp).To(HaveRestyStatusCode(http.StatusCreated))
 			})
 		})
-
-		When("the package is of type docker", func() {
-			BeforeEach(func() {
-				packageRequest.Type = "docker"
-				packageRequest.Data = &packageData{
-					Image: "eirini/dorini",
-				}
-			})
-
-			It("succeeds", func() {
-				Expect(resultErr.Errors).To(BeEmpty())
-				Expect(resp).To(HaveRestyStatusCode(http.StatusCreated))
-				Expect(result.GUID).ToNot(BeEmpty())
-				Expect(result.Type).To(Equal("docker"))
-			})
-		})
 	})
 
 	Describe("Update", func() {


### PR DESCRIPTION
## Is there a related GitHub Issue?
#2797
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Error when package type does not match app type

* Check that the package type matches the app type when creating the
  package via the API
* Do not error on package type and app lifecycle type mismatch when
  creating the CFPackage with kubectl. This is to ensure that kubectl
  users can create CFPackages that reference apps that do not yet exist
* Do not allow changing the package type
* Fail the CFBuild if CFPackage type and CFApp lifecycle type mismatch.
  This way kubectl users would in the end get the mismatch error.
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
See story
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@georgethebeatle
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
