### PR TITLE
Cleanup test env vars

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -27,9 +27,9 @@ function deploy_korifi() {
 }
 
 function configure_e2e_tests() {
-  export ROOT_NAMESPACE="${ROOT_NAMESPACE:-cf}"
-  export APP_FQDN="${APP_FQDN:-apps-127-0-0-1.nip.io}"
   export API_SERVER_ROOT="${API_SERVER_ROOT:-https://localhost}"
+  export APP_FQDN="${APP_FQDN:-apps-127-0-0-1.nip.io}"
+  export ROOT_NAMESPACE="${ROOT_NAMESPACE:-cf}"
 
   deploy_korifi
 
@@ -37,20 +37,16 @@ function configure_e2e_tests() {
 }
 
 function configure_crd_tests() {
+  export API_SERVER_ROOT="${API_SERVER_ROOT:-https://localhost}"
   export NO_PARALLEL=true
-  export CRDS_TEST_API_ENDPOINT="${CRDS_TEST_API_ENDPOINT:-https://localhost}"
-  export CRDS_TEST_SKIP_SSL="${CRDS_TEST_SKIP_SSL:-true}"
 
   deploy_korifi
 }
 
 function configure_smoke_tests() {
+  export API_SERVER_ROOT="${API_SERVER_ROOT:-https://localhost}"
+  export APP_FQDN="${APP_FQDN:-apps-127-0-0-1.nip.io}"
   export NO_PARALLEL=true
-  export SMOKE_TEST_USER="${SMOKE_TEST_USER:-cf-admin}"
-  export SMOKE_TEST_APPS_DOMAIN="${SMOKE_TEST_APPS_DOMAIN:-apps-127-0-0-1.nip.io}"
-  export SMOKE_TEST_APP_ROUTE_PROTOCOL="${SMOKE_TEST_APP_ROUTE_PROTOCOL:-https}"
-  export SMOKE_TEST_API_ENDPOINT="${SMOKE_TEST_API_ENDPOINT:-https://localhost}"
-  export SMOKE_TEST_SKIP_SSL="${SMOKE_TEST_SKIP_SSL:-true}"
 
   deploy_korifi
 }
@@ -103,7 +99,6 @@ function run_ginkgo() {
 }
 
 function main() {
-
   if grep -q "tests/e2e" <(echo "$@"); then
     configure_e2e_tests $@
   elif grep -q "tests/crds" <(echo "$@"); then

--- a/tests/crds/crds_suite_test.go
+++ b/tests/crds/crds_suite_test.go
@@ -1,17 +1,13 @@
 package crds_test
 
 import (
-	"fmt"
-	"strings"
 	"testing"
 	"time"
 
 	"code.cloudfoundry.org/korifi/tests/helpers"
-	"github.com/cloudfoundry/cf-test-helpers/cf"
-	"github.com/cloudfoundry/cf-test-helpers/commandreporter"
-	"github.com/cloudfoundry/cf-test-helpers/commandstarter"
-	"github.com/google/uuid"
 
+	"github.com/cloudfoundry/cf-test-helpers/cf"
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
@@ -34,7 +30,7 @@ var _ = BeforeSuite(func() {
 	serviceAccountFactory = helpers.NewServiceAccountFactory(rootNamespace)
 
 	Eventually(
-		kubectl("get", "namespace/"+rootNamespace),
+		helpers.Kubectl("get", "namespace/"+rootNamespace),
 	).Should(Exit(0), "Could not find root namespace called %q", rootNamespace)
 
 	cfUser = uuid.NewString()
@@ -47,34 +43,13 @@ var _ = AfterSuite(func() {
 	helpers.RemoveUserFromKubeConfig(cfUser)
 })
 
-func kubectl(args ...string) *Session {
-	cmdStarter := commandstarter.NewCommandStarter()
-	return kubectlWithCustomReporter(cmdStarter, commandreporter.NewCommandReporter(), args...)
-}
-
-func kubectlApply(stdinText string, sprintfArgs ...any) *Session {
-	cmdStarter := commandstarter.NewCommandStarterWithStdin(
-		strings.NewReader(
-			fmt.Sprintf(stdinText, sprintfArgs...),
-		),
-	)
-	return kubectlWithCustomReporter(cmdStarter, commandreporter.NewCommandReporter(), "apply", "-f=-")
-}
-
-func kubectlWithCustomReporter(cmdStarter *commandstarter.CommandStarter, reporter *commandreporter.CommandReporter, args ...string) *Session {
-	request, err := cmdStarter.Start(reporter, "kubectl", args...)
-	if err != nil {
-		panic(err)
-	}
-
-	return request
-}
-
-func loginAs(apiEndpoint string, skipSSL bool, user string) {
-	apiArguments := []string{"api", apiEndpoint}
-	if skipSSL {
-		apiArguments = append(apiArguments, "--skip-ssl-validation")
+func loginAs(apiEndpoint string, user string) {
+	apiArguments := []string{
+		"api",
+		apiEndpoint,
+		"--skip-ssl-validation",
 	}
 	Eventually(cf.Cf(apiArguments...)).Should(Exit(0))
+
 	Eventually(cf.Cf("auth", user)).Should(Exit(0))
 }

--- a/tests/crds/crds_test.go
+++ b/tests/crds/crds_test.go
@@ -3,6 +3,7 @@ package crds_test
 import (
 	. "code.cloudfoundry.org/korifi/controllers/controllers/workloads/testutils"
 	"code.cloudfoundry.org/korifi/tests/helpers"
+
 	"github.com/cloudfoundry/cf-test-helpers/cf"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
@@ -20,7 +21,6 @@ var _ = Describe("Using the k8s API directly", Ordered, func() {
 		bindingUser           string
 		propagatedBindingName string
 		korifiAPIEndpoint     string
-		skipSSL               string
 	)
 
 	BeforeAll(func() {
@@ -29,8 +29,7 @@ var _ = Describe("Using the k8s API directly", Ordered, func() {
 		spaceGUID = PrefixedGUID("space")
 		spaceDisplayName = PrefixedGUID("Space")
 
-		korifiAPIEndpoint = helpers.GetRequiredEnvVar("CRDS_TEST_API_ENDPOINT")
-		skipSSL = helpers.GetDefaultedEnvVar("CRDS_TEST_SKIP_SSL", "false")
+		korifiAPIEndpoint = helpers.GetRequiredEnvVar("API_SERVER_ROOT")
 
 		bindingName = cfUser + "-root-namespace-user"
 		bindingUser = rootNamespace + ":" + cfUser
@@ -39,15 +38,15 @@ var _ = Describe("Using the k8s API directly", Ordered, func() {
 	})
 
 	AfterAll(func() {
-		deleteOrg := kubectl("delete", "--ignore-not-found=true", "-n="+rootNamespace, "cforg", orgGUID)
-		deleteRoleBinding := kubectl("delete", "--ignore-not-found=true", "-n="+rootNamespace, "rolebinding", bindingName)
+		deleteOrg := helpers.Kubectl("delete", "--ignore-not-found=true", "-n="+rootNamespace, "cforg", orgGUID)
+		deleteRoleBinding := helpers.Kubectl("delete", "--ignore-not-found=true", "-n="+rootNamespace, "rolebinding", bindingName)
 
 		Eventually(deleteOrg, "20s").Should(Exit(0), "deleteOrg")
 		Eventually(deleteRoleBinding, "20s").Should(Exit(0), "deleteRoleBinging")
 	})
 
 	It("can create a CFOrg", func() {
-		applyCFOrg := kubectlApply(`---
+		applyCFOrg := helpers.KubectlApply(`---
             apiVersion: korifi.cloudfoundry.org/v1alpha1
             kind: CFOrg
             metadata:
@@ -59,17 +58,17 @@ var _ = Describe("Using the k8s API directly", Ordered, func() {
 		Eventually(applyCFOrg).Should(Exit(0))
 
 		Eventually(
-			kubectl("wait", "--for=condition=ready", "-n="+rootNamespace, "cforg/"+orgGUID),
+			helpers.Kubectl("wait", "--for=condition=ready", "-n="+rootNamespace, "cforg/"+orgGUID),
 			"20s",
 		).Should(Exit(0))
 
 		Eventually(
-			kubectl("get", "namespace/"+orgGUID),
+			helpers.Kubectl("get", "namespace/"+orgGUID),
 		).Should(Exit(0))
 	})
 
 	It("can create a CFSpace", func() {
-		applyCFSpace := kubectlApply(`---
+		applyCFSpace := helpers.KubectlApply(`---
             apiVersion: korifi.cloudfoundry.org/v1alpha1
             kind: CFSpace
             metadata:
@@ -81,38 +80,38 @@ var _ = Describe("Using the k8s API directly", Ordered, func() {
 		Eventually(applyCFSpace).Should(Exit(0))
 
 		Eventually(
-			kubectl("wait", "--for=condition=ready", "-n="+orgGUID, "cfspace/"+spaceGUID),
+			helpers.Kubectl("wait", "--for=condition=ready", "-n="+orgGUID, "cfspace/"+spaceGUID),
 			"20s",
 		).Should(Exit(0))
 
 		Eventually(
-			kubectl("get", "namespace/"+spaceGUID),
+			helpers.Kubectl("get", "namespace/"+spaceGUID),
 		).Should(Exit(0))
 	})
 
 	It("can grant the necessary roles to push an app via the CLI", func() {
 		Eventually(
-			kubectl("create", "rolebinding", "-n="+rootNamespace, "--serviceaccount="+bindingUser, "--clusterrole=korifi-controllers-root-namespace-user", bindingName),
+			helpers.Kubectl("create", "rolebinding", "-n="+rootNamespace, "--serviceaccount="+bindingUser, "--clusterrole=korifi-controllers-root-namespace-user", bindingName),
 		).Should(Exit(0))
 		Eventually(
-			kubectl("label", "rolebinding", bindingName, "-n="+rootNamespace, "cloudfoundry.org/role-guid="+GenerateGUID()),
+			helpers.Kubectl("label", "rolebinding", bindingName, "-n="+rootNamespace, "cloudfoundry.org/role-guid="+GenerateGUID()),
 		).Should(Exit(0))
 
 		Eventually(
-			kubectl("create", "rolebinding", "-n="+orgGUID, "--serviceaccount="+bindingUser, "--clusterrole=korifi-controllers-organization-user", cfUser+"-org-user"),
+			helpers.Kubectl("create", "rolebinding", "-n="+orgGUID, "--serviceaccount="+bindingUser, "--clusterrole=korifi-controllers-organization-user", cfUser+"-org-user"),
 		).Should(Exit(0))
 		Eventually(
-			kubectl("label", "rolebinding", cfUser+"-org-user", "-n="+orgGUID, "cloudfoundry.org/role-guid="+GenerateGUID()),
+			helpers.Kubectl("label", "rolebinding", cfUser+"-org-user", "-n="+orgGUID, "cloudfoundry.org/role-guid="+GenerateGUID()),
 		).Should(Exit(0))
 
 		Eventually(
-			kubectl("create", "rolebinding", "-n="+spaceGUID, "--serviceaccount="+bindingUser, "--clusterrole=korifi-controllers-space-developer", cfUser+"-space-developer"),
+			helpers.Kubectl("create", "rolebinding", "-n="+spaceGUID, "--serviceaccount="+bindingUser, "--clusterrole=korifi-controllers-space-developer", cfUser+"-space-developer"),
 		).Should(Exit(0))
 		Eventually(
-			kubectl("label", "rolebinding", cfUser+"-space-developer", "-n="+spaceGUID, "cloudfoundry.org/role-guid="+GenerateGUID()),
+			helpers.Kubectl("label", "rolebinding", cfUser+"-space-developer", "-n="+spaceGUID, "cloudfoundry.org/role-guid="+GenerateGUID()),
 		).Should(Exit(0))
 
-		loginAs(korifiAPIEndpoint, skipSSL == "true", cfUser)
+		loginAs(korifiAPIEndpoint, cfUser)
 
 		Eventually(cf.Cf("target", "-o", orgDisplayName, "-s", spaceDisplayName)).Should(Exit(0))
 
@@ -123,7 +122,7 @@ var _ = Describe("Using the k8s API directly", Ordered, func() {
 	})
 
 	It("can create cf-admin rolebinding which propagates to child namespaces", func() {
-		applyCFAdminRoleBinding := kubectlApply(`---
+		applyCFAdminRoleBinding := helpers.KubectlApply(`---
             apiVersion: rbac.authorization.k8s.io/v1
             kind: RoleBinding
             metadata:
@@ -143,40 +142,40 @@ var _ = Describe("Using the k8s API directly", Ordered, func() {
 		Eventually(applyCFAdminRoleBinding).Should(Exit(0))
 
 		Eventually(func() int {
-			return kubectl("get", "rolebinding/"+propagatedBindingName, "-n", rootNamespace).Wait().ExitCode()
+			return helpers.Kubectl("get", "rolebinding/"+propagatedBindingName, "-n", rootNamespace).Wait().ExitCode()
 		}, "20s").Should(BeNumerically("==", 0))
 
 		Eventually(func() int {
-			return kubectl("get", "rolebinding/"+propagatedBindingName, "-n", orgGUID).Wait().ExitCode()
+			return helpers.Kubectl("get", "rolebinding/"+propagatedBindingName, "-n", orgGUID).Wait().ExitCode()
 		}, "20s").Should(BeNumerically("==", 0))
 
 		Eventually(func() int {
-			return kubectl("get", "rolebinding/"+propagatedBindingName, "-n", spaceGUID).Wait().ExitCode()
+			return helpers.Kubectl("get", "rolebinding/"+propagatedBindingName, "-n", spaceGUID).Wait().ExitCode()
 		}, "20s").Should(BeNumerically("==", 0))
 	})
 
 	It("can delete the cf-admin rolebinding", func() {
 		Eventually(
-			kubectl("delete", "--ignore-not-found=true", "-n="+rootNamespace, "rolebinding/"+propagatedBindingName),
+			helpers.Kubectl("delete", "--ignore-not-found=true", "-n="+rootNamespace, "rolebinding/"+propagatedBindingName),
 			"20s",
 		).Should(Exit(0))
 
-		Eventually(kubectl("wait", "--for=delete", "rolebinding/"+propagatedBindingName, "-n", rootNamespace, "--timeout=60s"), "60s").Should(Exit(0))
+		Eventually(helpers.Kubectl("wait", "--for=delete", "rolebinding/"+propagatedBindingName, "-n", rootNamespace, "--timeout=60s"), "60s").Should(Exit(0))
 
-		Eventually(kubectl("wait", "--for=delete", "rolebinding/"+propagatedBindingName, "-n", orgGUID, "--timeout=60s"), "60s").Should(Exit(0))
+		Eventually(helpers.Kubectl("wait", "--for=delete", "rolebinding/"+propagatedBindingName, "-n", orgGUID, "--timeout=60s"), "60s").Should(Exit(0))
 
-		Eventually(kubectl("wait", "--for=delete", "rolebinding/"+propagatedBindingName, "-n", spaceGUID, "--timeout=60s"), "60s").Should(Exit(0))
+		Eventually(helpers.Kubectl("wait", "--for=delete", "rolebinding/"+propagatedBindingName, "-n", spaceGUID, "--timeout=60s"), "60s").Should(Exit(0))
 	})
 
 	It("can delete the space", func() {
-		Eventually(kubectl("delete", "--ignore-not-found=true", "-n="+orgGUID, "cfspace/"+spaceGUID), "120s").Should(Exit(0))
-		Eventually(kubectl("wait", "--for=delete", "namespace/"+spaceGUID)).Should(Exit(0))
+		Eventually(helpers.Kubectl("delete", "--ignore-not-found=true", "-n="+orgGUID, "cfspace/"+spaceGUID), "120s").Should(Exit(0))
+		Eventually(helpers.Kubectl("wait", "--for=delete", "namespace/"+spaceGUID)).Should(Exit(0))
 	})
 
 	It("can delete the org", func() {
-		Eventually(kubectl("delete", "--ignore-not-found=true", "-n="+rootNamespace, "cforgs/"+orgGUID), "120s").Should(Exit(0))
+		Eventually(helpers.Kubectl("delete", "--ignore-not-found=true", "-n="+rootNamespace, "cforgs/"+orgGUID), "120s").Should(Exit(0))
 
-		Eventually(kubectl("wait", "--for=delete", "cforg/"+orgGUID, "-n", rootNamespace)).Should(Exit(0))
-		Eventually(kubectl("wait", "--for=delete", "namespace/"+orgGUID)).Should(Exit(0))
+		Eventually(helpers.Kubectl("wait", "--for=delete", "cforg/"+orgGUID, "-n", rootNamespace)).Should(Exit(0))
+		Eventually(helpers.Kubectl("wait", "--for=delete", "namespace/"+orgGUID)).Should(Exit(0))
 	})
 })

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -1,13 +1,13 @@
 package smoke_test
 
 import (
-	"bytes"
 	"crypto/tls"
 	"fmt"
 	"net/http"
 	"strings"
 
 	. "code.cloudfoundry.org/korifi/tests/matchers"
+
 	"github.com/cloudfoundry/cf-test-helpers/cf"
 	"github.com/cloudfoundry/cf-test-helpers/generator"
 	. "github.com/onsi/ginkgo/v2"
@@ -88,14 +88,6 @@ func printAppReportBanner(announcement string) {
 	fmt.Fprintf(GinkgoWriter, "\n\n%s\n%s\n%s\n", sequence, announcement, sequence)
 }
 
-func loginAs(user string) {
-	// Stdin contains username followed by 2 return carriages. Firtst one
-	// enters the username and second one skips the org selection prompt that
-	// is presented if there is more than one org
-	loginSession := cf.CfWithStdin(bytes.NewBufferString(user+"\n\n"), "login")
-	Eventually(loginSession).Should(Exit(0))
-}
-
 func appResponseShould(appName, requestPath string, matchExpectations types.GomegaMatcher) {
 	var httpClient http.Client
 	httpClient.Transport = &http.Transport{
@@ -103,7 +95,7 @@ func appResponseShould(appName, requestPath string, matchExpectations types.Gome
 	}
 
 	Eventually(func(g Gomega) {
-		resp, err := httpClient.Get(fmt.Sprintf("%s://%s.%s%s", appRouteProtocol, appName, appsDomain, requestPath))
+		resp, err := httpClient.Get(fmt.Sprintf("https://%s.%s%s", appName, appsDomain, requestPath))
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(resp).To(matchExpectations)
 	}).Should(Succeed())


### PR DESCRIPTION
## Is there a related GitHub Issue?
#2788

## What is this change about?
This PR cleans up the test env vars:

- Smoke tests now create an admin service account when required.
- Standardise on API_SERVER_ROOT for the API address.
- Standardise on APP_FQDN for the app domain.
- Always skip SSL validation.
- Always use https.

## Does this PR introduce a breaking change?
Only in tests.

## Acceptance Steps
All the tests pass.

## Tag your pair, your PM, and/or team
