### PR TITLE
Korifi installer for kind clusters

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -19,7 +19,7 @@ This document was tested on:
 
 -   [EKS](https://aws.amazon.com/eks/), using AWS' [Elastic Container Registry (ECR)](https://aws.amazon.com/ecr/) (see [_Install Korifi on EKS_](./INSTALL.EKS.md));
 -   [GKE](https://cloud.google.com/kubernetes-engine), using GCP's [Artifact Registry](https://cloud.google.com/artifact-registry);
--   [kind](https://kind.sigs.k8s.io/), using [DockerHub](https://hub.docker.com/) (see [_Install Korifi on kind_](./INSTALL.kind.md)).
+-   [kind](https://kind.sigs.k8s.io/): see [_Install Korifi on kind_](./INSTALL.kind.md).
 
 ## Initial setup
 

--- a/scripts/installer/Dockerfile
+++ b/scripts/installer/Dockerfile
@@ -1,0 +1,34 @@
+FROM ubuntu
+
+ARG HELM_CHART_SOURCE
+
+COPY scripts/install-dependencies.sh scripts/install-dependencies.sh
+COPY scripts/create-new-user.sh scripts/create-new-user.sh
+COPY tests/dependencies tests/dependencies
+COPY tests/vendor tests/vendor
+COPY ${HELM_CHART_SOURCE} helm/korifi
+
+RUN apt-get update \
+  && apt-get install --yes \
+       --no-install-recommends \
+       apt-transport-https \
+       ca-certificates \
+       conntrack \
+       gnupg2 \
+       curl \
+       git \
+       sudo \
+  && rm -rf /var/lib/apt/lists/*
+
+# helm
+RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" >/etc/apt/sources.list.d/helm-stable-debian.list \
+  && curl -fsSL https://baltocdn.com/helm/signing.asc | gpg --dearmor >/usr/share/keyrings/helm.gpg
+
+RUN apt-get update \
+  && apt-get install --yes \
+       helm \
+  && rm -rf /var/lib/apt/lists/*
+
+# kubectl
+RUN curl -fsSLo /usr/bin/kubectl "https://dl.k8s.io/release/$(curl -fsSL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" \
+  && chmod +x /usr/bin/kubectl

--- a/scripts/installer/install-korifi-kind.yaml
+++ b/scripts/installer/install-korifi-kind.yaml
@@ -1,0 +1,113 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: korifi-installer
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cf
+  labels:
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/enforce: restricted
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: korifi
+  labels:
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/enforce: restricted
+
+---
+apiVersion: v1
+data:
+  .dockerconfigjson: eyJhdXRocyI6eyJsb2NhbHJlZ2lzdHJ5LWRvY2tlci1yZWdpc3RyeS5kZWZhdWx0LnN2Yy5jbHVzdGVyLmxvY2FsOjMwMDUwIjp7InVzZXJuYW1lIjoidXNlciIsInBhc3N3b3JkIjoicGFzc3dvcmQiLCJhdXRoIjoiZFhObGNqcHdZWE56ZDI5eVpBPT0ifX19
+kind: Secret
+metadata:
+  name: image-registry-credentials
+  namespace: cf
+type: kubernetes.io/dockerconfigjson
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: korifi-installer
+  namespace: korifi-installer
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: korifi-installer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: korifi-installer
+  namespace: korifi-installer
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: install-korifi
+  namespace: korifi-installer
+spec:
+  template:
+    metadata:
+      name: install-korifi
+    spec:
+      serviceAccountName: korifi-installer
+      restartPolicy: Never
+      containers:
+      - name: install-korifi
+        image: cloudfoundry/korifi-installer
+        command:
+        - bash
+        - -c
+        - |
+          scripts/install-dependencies.sh --insecure-tls-metrics-server
+
+          helm repo add twuni https://helm.twun.io
+          # the htpasswd value below is username: user, password: password encoded using `htpasswd` binary
+          # e.g. `docker run --entrypoint htpasswd httpd:2 -Bbn user password`
+          #
+          helm upgrade --install localregistry twuni/docker-registry \
+            --namespace default \
+            --set service.type=NodePort,service.nodePort=30050,service.port=30050 \
+            --set persistence.enabled=true \
+            --set persistence.deleteEnabled=true \
+            --set secrets.htpasswd='user:$2y$05$Ue5dboOfmqk6Say31Sin9uVbHWTl8J1Sgq9QyAEmFQRnq1TPfP1n2'
+
+          registry_status_code=""
+          while [[ "$registry_status_code" != "200" ]]; do
+            echo Waiting for the local docker registry to start...
+            registry_status_code=$(curl -o /dev/null -w "%{http_code}" --user user:password http://localregistry-docker-registry.default.svc.cluster.local:30050/v2/_catalog 2>/dev/null)
+            sleep 1
+          done
+
+          helm upgrade --install korifi helm/korifi \
+            --namespace korifi \
+            --set=adminUserName="kubernetes-admin" \
+            --set=defaultAppDomainName="apps-127-0-0-1.nip.io" \
+            --set=generateIngressCertificates="true" \
+            --set=logLevel="debug" \
+            --set=debug="false" \
+            --set=stagingRequirements.buildCacheMB="1024" \
+            --set=api.apiServer.url="localhost" \
+            --set=controllers.taskTTL="5s" \
+            --set=jobTaskRunner.jobTTL="5s" \
+            --set=containerRepositoryPrefix="localregistry-docker-registry.default.svc.cluster.local:30050/" \
+            --set=kpackImageBuilder.clusterStackBuildImage="paketobuildpacks/build-jammy-base" \
+            --set=kpackImageBuilder.clusterStackRunImage="paketobuildpacks/run-jammy-base" \
+            --set=kpackImageBuilder.builderRepository="localregistry-docker-registry.default.svc.cluster.local:30050/kpack-builder" \
+            --wait
+
+          kubectl wait --for=condition=ready clusterbuilder --all=true --timeout=15m


### PR DESCRIPTION
## Is there a related GitHub Issue?
https://github.com/cloudfoundry/korifi/issues/2895
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Introduce a k8s job definition that when run on a kind cluster would install Korifi dependencies and latest Korifi release. This also involves a Dockerfile for the job image.

<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
Install Korifi on kind following INSTALL.kind.md
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@cloudfoundry/wg-cf-on-k8s
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
