### PR TITLE
Introduce a systemImagePullSecrets helm value

### DIFF
--- a/README.helm.md
+++ b/README.helm.md
@@ -115,3 +115,4 @@ Here are all the values that can be set for the chart:
     - `requests`: Resource requests.
       - `cpu` (_String_): CPU request.
       - `memory` (_String_): Memory request.
+- `systemImagePullSecrets` (_Array_): List of `Secret` names to be used when pulling Korifi system images from private registries

--- a/helm/korifi/api/rbac.yaml
+++ b/helm/korifi/api/rbac.yaml
@@ -7,6 +7,10 @@ metadata:
   annotations:
     eks.amazonaws.com/role-arn: {{ .Values.eksContainerRegistryRoleARN }}
   {{- end }}
+imagePullSecrets:
+{{- range .Values.systemImagePullSecrets }}
+- name: {{ . | quote }}
+{{- end }}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/korifi/controllers/rbac.yaml
+++ b/helm/korifi/controllers/rbac.yaml
@@ -7,6 +7,10 @@ metadata:
   annotations:
     eks.amazonaws.com/role-arn: {{ .Values.eksContainerRegistryRoleARN }}
   {{- end }}
+imagePullSecrets:
+{{- range .Values.systemImagePullSecrets }}
+- name: {{ . | quote }}
+{{- end }}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/korifi/values.schema.json
+++ b/helm/korifi/values.schema.json
@@ -43,6 +43,13 @@
         "type": "string"
       }
     },
+    "systemImagePullSecrets": {
+      "description": "List of `Secret` names to be used when pulling Korifi system images from private registries",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
     "eksContainerRegistryRoleARN": {
       "description": "Amazon Resource Name (ARN) of the IAM role to use to access the ECR registry from an EKS deployed Korifi. Required if containerRegistrySecret not set.",
       "type": "string"

--- a/helm/korifi/values.yaml
+++ b/helm/korifi/values.yaml
@@ -8,6 +8,7 @@ containerRegistrySecrets:
 - image-registry-credentials
 eksContainerRegistryRoleARN: ""
 containerRegistryCACertSecret:
+systemImagePullSecrets: []
 
 reconcilers:
   build: kpack-image-builder


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
This value would allow the korifi api and controller images to be pulled from a
private registry. This can be useful in corporate environments if an internal
mirror registry is being used as well as in environments with no internet.

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
N/A

## Tag your pair, your PM, and/or team
@cloudfoundry/wg-cf-on-k8s
