### PR TITLE
Extend korifi diff CF docs with container lifecycle

### DIFF
--- a/docs/known-differences-with-cf-for-vms.md
+++ b/docs/known-differences-with-cf-for-vms.md
@@ -12,4 +12,9 @@ the API shim, we filter the org list to show only the orgs the user has a role-b
 
 ### Org User
 When interacting directly through `kubectl`, users with CF managed [cf_org_user](https://github.com/cloudfoundry/korifi/blob/main/controllers/config/cf_roles/cf_org_user.yaml) roles will have permissions to view and list all orgs and all spaces. But when listed through
-the API shim, the user would only be able to list and view spaces which have role-binding corresponding to the user. 
+the API shim, the user would only be able to list and view spaces which have role-binding corresponding to the user.
+
+## Container Lifecycle
+
+### Rolling Updates
+In Kofiri `--strategy=rolling` is implemented using k8S rolling update capabilities of the scheduler. At the moment korifi uses statefulsets to run the app workloads. Rolling update for statefulsets stops the old instance before starting the new one, for ordering reasons. If the app has only one instance the udpate will cause a downtime. Apps with more than one instance won't experience any downtime, but they will have one instance less up and running during the update.


### PR DESCRIPTION
## Is there a related GitHub Issue?
https://github.com/cloudfoundry/korifi/issues/2913


## What is this change about?
As discussed in https://github.com/cloudfoundry/korifi/issues/2913 there is a difference in the Korifi behaviour during a rolling update compared to CF on VMs. That is why, I think that it makes sense to document this at the moment.


## Does this PR introduce a breaking change?
No

## Acceptance Steps
Docs change

