### PR TITLE
Configure eventually timeouts in e2e tests

### DIFF
--- a/tests/crds/crds_suite_test.go
+++ b/tests/crds/crds_suite_test.go
@@ -2,11 +2,9 @@ package crds_test
 
 import (
 	"testing"
-	"time"
 
 	"code.cloudfoundry.org/korifi/tests/helpers"
 
-	"github.com/cloudfoundry/cf-test-helpers/cf"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -15,7 +13,8 @@ import (
 
 func TestCrds(t *testing.T) {
 	RegisterFailHandler(Fail)
-	SetDefaultEventuallyTimeout(10 * time.Second)
+	SetDefaultEventuallyTimeout(helpers.EventuallyTimeout())
+	SetDefaultEventuallyPollingInterval(helpers.EventuallyPollingInterval())
 	RunSpecs(t, "CRDs Suite")
 }
 
@@ -29,9 +28,9 @@ var _ = BeforeSuite(func() {
 	rootNamespace = helpers.GetDefaultedEnvVar("ROOT_NAMESPACE", "cf")
 	serviceAccountFactory = helpers.NewServiceAccountFactory(rootNamespace)
 
-	Eventually(
+	Expect(
 		helpers.Kubectl("get", "namespace/"+rootNamespace),
-	).Should(Exit(0), "Could not find root namespace called %q", rootNamespace)
+	).To(Exit(0), "Could not find root namespace called %q", rootNamespace)
 
 	cfUser = uuid.NewString()
 	cfUserToken := serviceAccountFactory.CreateServiceAccount(cfUser)
@@ -42,14 +41,3 @@ var _ = AfterSuite(func() {
 	serviceAccountFactory.DeleteServiceAccount(cfUser)
 	helpers.RemoveUserFromKubeConfig(cfUser)
 })
-
-func loginAs(apiEndpoint string, user string) {
-	apiArguments := []string{
-		"api",
-		apiEndpoint,
-		"--skip-ssl-validation",
-	}
-	Eventually(cf.Cf(apiArguments...)).Should(Exit(0))
-
-	Eventually(cf.Cf("auth", user)).Should(Exit(0))
-}

--- a/tests/crds/crds_test.go
+++ b/tests/crds/crds_test.go
@@ -1,10 +1,11 @@
 package crds_test
 
 import (
+	"fmt"
+
 	. "code.cloudfoundry.org/korifi/controllers/controllers/workloads/testutils"
 	"code.cloudfoundry.org/korifi/tests/helpers"
 
-	"github.com/cloudfoundry/cf-test-helpers/cf"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -38,15 +39,16 @@ var _ = Describe("Using the k8s API directly", Ordered, func() {
 	})
 
 	AfterAll(func() {
-		deleteOrg := helpers.Kubectl("delete", "--ignore-not-found=true", "-n="+rootNamespace, "cforg", orgGUID)
-		deleteRoleBinding := helpers.Kubectl("delete", "--ignore-not-found=true", "-n="+rootNamespace, "rolebinding", bindingName)
-
-		Eventually(deleteOrg, "60s").Should(Exit(0), "deleteOrg")
-		Eventually(deleteRoleBinding, "20s").Should(Exit(0), "deleteRoleBinging")
+		Expect(
+			helpers.Kubectl("delete", "--ignore-not-found=true", "-n="+rootNamespace, "cforg", orgGUID),
+		).To(Exit(0))
+		Expect(
+			helpers.Kubectl("delete", "--ignore-not-found=true", "-n="+rootNamespace, "rolebinding", bindingName),
+		).To(Exit(0))
 	})
 
 	It("can create a CFOrg", func() {
-		applyCFOrg := helpers.KubectlApply(`---
+		Expect(helpers.KubectlApply(`---
             apiVersion: korifi.cloudfoundry.org/v1alpha1
             kind: CFOrg
             metadata:
@@ -54,21 +56,20 @@ var _ = Describe("Using the k8s API directly", Ordered, func() {
                 name: %s
             spec:
                 displayName: %s
-            `, rootNamespace, orgGUID, orgDisplayName)
-		Eventually(applyCFOrg).Should(Exit(0))
+            `, rootNamespace, orgGUID, orgDisplayName),
+		).To(Exit(0))
 
-		Eventually(
-			helpers.Kubectl("wait", "--for=condition=ready", "-n="+rootNamespace, "cforg/"+orgGUID),
-			"20s",
-		).Should(Exit(0))
+		Expect(
+			helpers.Kubectl("wait", "--for=condition=ready", "-n="+rootNamespace, "cforg/"+orgGUID, fmt.Sprintf("--timeout=%s", helpers.EventuallyTimeout())),
+		).To(Exit(0))
 
-		Eventually(
+		Expect(
 			helpers.Kubectl("get", "namespace/"+orgGUID),
-		).Should(Exit(0))
+		).To(Exit(0))
 	})
 
 	It("can create a CFSpace", func() {
-		applyCFSpace := helpers.KubectlApply(`---
+		Expect(helpers.KubectlApply(`---
             apiVersion: korifi.cloudfoundry.org/v1alpha1
             kind: CFSpace
             metadata:
@@ -76,53 +77,51 @@ var _ = Describe("Using the k8s API directly", Ordered, func() {
                 name: %s
             spec:
                 displayName: %s
-            `, orgGUID, spaceGUID, spaceDisplayName)
-		Eventually(applyCFSpace).Should(Exit(0))
+            `, orgGUID, spaceGUID, spaceDisplayName),
+		).To(Exit(0))
 
-		Eventually(
-			helpers.Kubectl("wait", "--for=condition=ready", "-n="+orgGUID, "cfspace/"+spaceGUID),
-			"20s",
-		).Should(Exit(0))
+		Expect(
+			helpers.Kubectl("wait", "--for=condition=ready", "-n="+orgGUID, "cfspace/"+spaceGUID, fmt.Sprintf("--timeout=%s", helpers.EventuallyTimeout())),
+		).To(Exit(0))
 
-		Eventually(
+		Expect(
 			helpers.Kubectl("get", "namespace/"+spaceGUID),
-		).Should(Exit(0))
+		).To(Exit(0))
 	})
 
 	It("can grant the necessary roles to push an app via the CLI", func() {
-		Eventually(
+		Expect(
 			helpers.Kubectl("create", "rolebinding", "-n="+rootNamespace, "--serviceaccount="+bindingUser, "--clusterrole=korifi-controllers-root-namespace-user", bindingName),
-		).Should(Exit(0))
-		Eventually(
+		).To(Exit(0))
+		Expect(
 			helpers.Kubectl("label", "rolebinding", bindingName, "-n="+rootNamespace, "cloudfoundry.org/role-guid="+GenerateGUID()),
-		).Should(Exit(0))
+		).To(Exit(0))
 
-		Eventually(
+		Expect(
 			helpers.Kubectl("create", "rolebinding", "-n="+orgGUID, "--serviceaccount="+bindingUser, "--clusterrole=korifi-controllers-organization-user", cfUser+"-org-user"),
-		).Should(Exit(0))
-		Eventually(
+		).To(Exit(0))
+		Expect(
 			helpers.Kubectl("label", "rolebinding", cfUser+"-org-user", "-n="+orgGUID, "cloudfoundry.org/role-guid="+GenerateGUID()),
-		).Should(Exit(0))
+		).To(Exit(0))
 
-		Eventually(
+		Expect(
 			helpers.Kubectl("create", "rolebinding", "-n="+spaceGUID, "--serviceaccount="+bindingUser, "--clusterrole=korifi-controllers-space-developer", cfUser+"-space-developer"),
-		).Should(Exit(0))
-		Eventually(
+		).To(Exit(0))
+		Expect(
 			helpers.Kubectl("label", "rolebinding", cfUser+"-space-developer", "-n="+spaceGUID, "cloudfoundry.org/role-guid="+GenerateGUID()),
-		).Should(Exit(0))
+		).To(Exit(0))
 
-		loginAs(korifiAPIEndpoint, cfUser)
+		Expect(helpers.Cf("api", korifiAPIEndpoint, "--skip-ssl-validation")).To(Exit(0))
+		Expect(helpers.Cf("auth", cfUser)).To(Exit(0))
+		Expect(helpers.Cf("target", "-o", orgDisplayName, "-s", spaceDisplayName)).To(Exit(0))
 
-		Eventually(cf.Cf("target", "-o", orgDisplayName, "-s", spaceDisplayName)).Should(Exit(0))
-
-		Eventually(
-			cf.Cf("push", PrefixedGUID("crds-test-app"), "-p", "../assets/dorifi", "--no-start"), // This could be any app
-			"20s",
-		).Should(Exit(0))
+		Expect(
+			helpers.Cf("push", PrefixedGUID("crds-test-app"), "-p", "../assets/dorifi", "--no-start"), // This could be any app
+		).To(Exit(0))
 	})
 
 	It("can create cf-admin rolebinding which propagates to child namespaces", func() {
-		applyCFAdminRoleBinding := helpers.KubectlApply(`---
+		Expect(helpers.KubectlApply(`---
             apiVersion: rbac.authorization.k8s.io/v1
             kind: RoleBinding
             metadata:
@@ -138,44 +137,53 @@ var _ = Describe("Using the k8s API directly", Ordered, func() {
               - kind: ServiceAccount
                 name: %s
                 namespace: %s
-            `, rootNamespace, propagatedBindingName, cfUser, rootNamespace)
-		Eventually(applyCFAdminRoleBinding).Should(Exit(0))
+            `, rootNamespace, propagatedBindingName, cfUser, rootNamespace),
+		).To(Exit(0))
 
-		Eventually(func() int {
-			return helpers.Kubectl("get", "rolebinding/"+propagatedBindingName, "-n", rootNamespace).Wait().ExitCode()
-		}, "20s").Should(BeNumerically("==", 0))
+		Eventually(func(g Gomega) {
+			g.Expect(helpers.Kubectl("get", "rolebinding/"+propagatedBindingName, "-n", rootNamespace)).To(Exit(0))
+		}).Should(Succeed())
 
-		Eventually(func() int {
-			return helpers.Kubectl("get", "rolebinding/"+propagatedBindingName, "-n", orgGUID).Wait().ExitCode()
-		}, "20s").Should(BeNumerically("==", 0))
+		Eventually(func(g Gomega) {
+			g.Expect(helpers.Kubectl("get", "rolebinding/"+propagatedBindingName, "-n", orgGUID)).To(Exit(0))
+		}).Should(Succeed())
 
-		Eventually(func() int {
-			return helpers.Kubectl("get", "rolebinding/"+propagatedBindingName, "-n", spaceGUID).Wait().ExitCode()
-		}, "20s").Should(BeNumerically("==", 0))
+		Eventually(func(g Gomega) {
+			g.Expect(helpers.Kubectl("get", "rolebinding/"+propagatedBindingName, "-n", orgGUID)).To(Exit(0))
+		}).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			g.Expect(helpers.Kubectl("get", "rolebinding/"+propagatedBindingName, "-n", spaceGUID)).To(Exit(0))
+		}).Should(Succeed())
 	})
 
 	It("can delete the cf-admin rolebinding", func() {
-		Eventually(
+		Expect(
 			helpers.Kubectl("delete", "--ignore-not-found=true", "-n="+rootNamespace, "rolebinding/"+propagatedBindingName),
-			"20s",
-		).Should(Exit(0))
+		).To(Exit(0))
 
-		Eventually(helpers.Kubectl("wait", "--for=delete", "rolebinding/"+propagatedBindingName, "-n", rootNamespace, "--timeout=60s"), "60s").Should(Exit(0))
+		Expect(
+			helpers.Kubectl("wait", "--for=delete", "rolebinding/"+propagatedBindingName, "-n", rootNamespace, fmt.Sprintf("--timeout=%s", helpers.EventuallyTimeout())),
+		).To(Exit(0))
 
-		Eventually(helpers.Kubectl("wait", "--for=delete", "rolebinding/"+propagatedBindingName, "-n", orgGUID, "--timeout=60s"), "60s").Should(Exit(0))
+		Expect(
+			helpers.Kubectl("wait", "--for=delete", "rolebinding/"+propagatedBindingName, "-n", orgGUID, fmt.Sprintf("--timeout=%s", helpers.EventuallyTimeout())),
+		).To(Exit(0))
 
-		Eventually(helpers.Kubectl("wait", "--for=delete", "rolebinding/"+propagatedBindingName, "-n", spaceGUID, "--timeout=60s"), "60s").Should(Exit(0))
+		Expect(
+			helpers.Kubectl("wait", "--for=delete", "rolebinding/"+propagatedBindingName, "-n", spaceGUID, fmt.Sprintf("--timeout=%s", helpers.EventuallyTimeout())),
+		).To(Exit(0))
 	})
 
 	It("can delete the space", func() {
-		Eventually(helpers.Kubectl("delete", "--ignore-not-found=true", "-n="+orgGUID, "cfspace/"+spaceGUID), "120s").Should(Exit(0))
-		Eventually(helpers.Kubectl("wait", "--for=delete", "namespace/"+spaceGUID)).Should(Exit(0))
+		Expect(helpers.Kubectl("delete", "--ignore-not-found=true", "-n="+orgGUID, "cfspace/"+spaceGUID)).To(Exit(0))
+		Expect(helpers.Kubectl("wait", "--for=delete", "namespace/"+spaceGUID)).To(Exit(0))
 	})
 
 	It("can delete the org", func() {
-		Eventually(helpers.Kubectl("delete", "--ignore-not-found=true", "-n="+rootNamespace, "cforgs/"+orgGUID), "120s").Should(Exit(0))
+		Expect(helpers.Kubectl("delete", "--ignore-not-found=true", "-n="+rootNamespace, "cforgs/"+orgGUID)).To(Exit(0))
 
-		Eventually(helpers.Kubectl("wait", "--for=delete", "cforg/"+orgGUID, "-n", rootNamespace)).Should(Exit(0))
-		Eventually(helpers.Kubectl("wait", "--for=delete", "namespace/"+orgGUID)).Should(Exit(0))
+		Expect(helpers.Kubectl("wait", "--for=delete", "cforg/"+orgGUID, "-n", rootNamespace)).To(Exit(0))
+		Expect(helpers.Kubectl("wait", "--for=delete", "namespace/"+orgGUID)).To(Exit(0))
 	})
 })

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -366,7 +366,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	adminClient = makeTokenClient(sharedSetup.AdminServiceAccountToken)
 
 	SetDefaultEventuallyTimeout(helpers.EventuallyTimeout())
-	SetDefaultEventuallyPollingInterval(2 * time.Second)
+	SetDefaultEventuallyPollingInterval(helpers.EventuallyPollingInterval())
 
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 })

--- a/tests/helpers/cf.go
+++ b/tests/helpers/cf.go
@@ -1,0 +1,13 @@
+package helpers
+
+import (
+	"github.com/cloudfoundry/cf-test-helpers/cf"
+	. "github.com/onsi/ginkgo/v2" //lint:ignore ST1001 this is a test file
+	"github.com/onsi/gomega/gexec"
+)
+
+func Cf(args ...string) *gexec.Session {
+	GinkgoHelper()
+
+	return cf.Cf(args...).Wait()
+}

--- a/tests/helpers/eventually.go
+++ b/tests/helpers/eventually.go
@@ -5,23 +5,39 @@ import (
 	"strconv"
 	"time"
 
-	. "github.com/onsi/gomega" //lint:ignore ST1001 this is a test file
+	. "github.com/onsi/ginkgo/v2" //lint:ignore ST1001 this is a test file
+	. "github.com/onsi/gomega"    //lint:ignore ST1001 this is a test file
 )
 
 func EventuallyShouldHold(condition func(g Gomega)) {
+	GinkgoHelper()
+
 	Eventually(condition).WithTimeout(EventuallyTimeout()).Should(Succeed())
 	Consistently(condition).Should(Succeed())
 }
 
 func EventuallyTimeout() time.Duration {
-	eventuallyTimeout := 4 * time.Minute
-	eventuallyTimeoutSecondsString := os.Getenv("E2E_EVENTUALLY_TIMEOUT_SECONDS")
+	GinkgoHelper()
 
-	if eventuallyTimeoutSecondsString != "" {
-		eventuallyTimeoutSeconds, err := strconv.Atoi(eventuallyTimeoutSecondsString)
+	return getDuration("E2E_EVENTUALLY_TIMEOUT_SECONDS", 4*60)
+}
+
+func EventuallyPollingInterval() time.Duration {
+	GinkgoHelper()
+
+	return getDuration("E2E_EVENTUALLY_POLLING_INTERVAL_SECONDS", 2)
+}
+
+func getDuration(envName string, defaultDurationSeconds int) time.Duration {
+	GinkgoHelper()
+
+	durationSecondsString := os.Getenv(envName)
+
+	if durationSecondsString != "" {
+		durationSeconds, err := strconv.Atoi(durationSecondsString)
 		Expect(err).NotTo(HaveOccurred())
-		eventuallyTimeout = time.Duration(eventuallyTimeoutSeconds) * time.Second
+		return time.Duration(durationSeconds) * time.Second
 	}
 
-	return eventuallyTimeout
+	return time.Duration(defaultDurationSeconds) * time.Second
 }

--- a/tests/helpers/k8s.go
+++ b/tests/helpers/k8s.go
@@ -51,7 +51,7 @@ func RemoveUserFromKubeConfig(userName string) {
 
 func Kubectl(args ...string) *Session {
 	cmdStarter := commandstarter.NewCommandStarter()
-	return KubectlWithCustomReporter(cmdStarter, commandreporter.NewCommandReporter(), args...)
+	return kubectlWithCustomReporter(cmdStarter, commandreporter.NewCommandReporter(), args...)
 }
 
 func KubectlApply(stdinText string, sprintfArgs ...any) *Session {
@@ -60,14 +60,14 @@ func KubectlApply(stdinText string, sprintfArgs ...any) *Session {
 			fmt.Sprintf(stdinText, sprintfArgs...),
 		),
 	)
-	return KubectlWithCustomReporter(cmdStarter, commandreporter.NewCommandReporter(), "apply", "-f=-")
+	return kubectlWithCustomReporter(cmdStarter, commandreporter.NewCommandReporter(), "apply", "-f=-")
 }
 
-func KubectlWithCustomReporter(cmdStarter *commandstarter.CommandStarter, reporter *commandreporter.CommandReporter, args ...string) *Session {
+func kubectlWithCustomReporter(cmdStarter *commandstarter.CommandStarter, reporter *commandreporter.CommandReporter, args ...string) *Session {
 	request, err := cmdStarter.Start(reporter, "kubectl", args...)
 	if err != nil {
 		panic(err)
 	}
 
-	return request
+	return request.Wait()
 }

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -6,9 +6,9 @@ import (
 	"net/http"
 	"strings"
 
+	"code.cloudfoundry.org/korifi/tests/helpers"
 	. "code.cloudfoundry.org/korifi/tests/matchers"
 
-	"github.com/cloudfoundry/cf-test-helpers/cf"
 	"github.com/cloudfoundry/cf-test-helpers/generator"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -36,13 +36,13 @@ var _ = Describe("Smoke Tests", func() {
 
 	Describe("cf logs", func() {
 		It("prints app logs", func() {
-			Eventually(cf.Cf("logs", buildpackAppName, "--recent")).Should(gbytes.Say("Listening on port 8080"))
+			Eventually(helpers.Cf("logs", buildpackAppName, "--recent")).Should(gbytes.Say("Listening on port 8080"))
 		})
 	})
 
 	Describe("cf run-task", func() {
 		It("succeeds", func() {
-			Eventually(cf.Cf("run-task", buildpackAppName, "-c", `echo "Hello from the task"`)).Should(Exit(0))
+			Eventually(helpers.Cf("run-task", buildpackAppName, "-c", `echo "Hello from the task"`)).Should(Exit(0))
 		})
 	})
 
@@ -50,12 +50,12 @@ var _ = Describe("Smoke Tests", func() {
 		BeforeEach(func() {
 			serviceName := generator.PrefixedRandomName(NamePrefix, "svc")
 
-			Eventually(
-				cf.Cf("create-user-provided-service", serviceName, "-p", `{"key1":"value1","key2":"value2"}`),
-			).Should(Exit(0))
+			Expect(
+				helpers.Cf("create-user-provided-service", serviceName, "-p", `{"key1":"value1","key2":"value2"}`),
+			).To(Exit(0))
 
-			Eventually(cf.Cf("bind-service", buildpackAppName, serviceName)).Should(Exit(0))
-			Eventually(cf.Cf("restart", buildpackAppName)).Should(Exit(0))
+			Expect(helpers.Cf("bind-service", buildpackAppName, serviceName)).To(Exit(0))
+			Expect(helpers.Cf("restart", buildpackAppName)).To(Exit(0))
 		})
 
 		It("binds the service to the app", func() {
@@ -78,8 +78,8 @@ func printAppReport(appName string) {
 	}
 
 	printAppReportBanner(fmt.Sprintf("***** APP REPORT: %s *****", appName))
-	Eventually(cf.Cf("app", appName, "--guid")).Should(Exit())
-	Eventually(cf.Cf("logs", "--recent", appName)).Should(Exit())
+	Expect(helpers.Cf("app", appName, "--guid")).To(Exit())
+	Expect(helpers.Cf("logs", "--recent", appName)).To(Exit())
 	printAppReportBanner(fmt.Sprintf("*** END APP REPORT: %s ***", appName))
 }
 


### PR DESCRIPTION

<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Instead of specifying cutom timeouts in `Eventually`, configure the
default eventually timeout and polling interval consistently across
e2e suites.
<!-- _Please describe the change here._ -->

## Tag your pair, your PM, and/or team
@danail-branekov
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
