### PR TITLE
Allow ready status to equal false when builder not ready

### DIFF
--- a/controllers/controllers/workloads/env/vcap_services_builder.go
+++ b/controllers/controllers/workloads/env/vcap_services_builder.go
@@ -66,7 +66,7 @@ func (b *VCAPServicesEnvValueBuilder) BuildEnvValue(ctx context.Context, cfApp *
 
 func buildSingleServiceEnv(ctx context.Context, k8sClient client.Client, serviceBinding korifiv1alpha1.CFServiceBinding) (ServiceDetails, string, error) {
 	if serviceBinding.Status.Binding.Name == "" {
-		return ServiceDetails{}, "", fmt.Errorf("service binding secret name is empty")
+		return ServiceDetails{}, "", fmt.Errorf("secret name not set for service binding %q", serviceBinding.Name)
 	}
 
 	serviceLabel := UserProvided

--- a/kpack-image-builder/controllers/buildworkload_controller.go
+++ b/kpack-image-builder/controllers/buildworkload_controller.go
@@ -211,7 +211,8 @@ func (r *BuildWorkloadReconciler) ReconcileResource(ctx context.Context, buildWo
 
 	if builderReadyCondition.IsFalse() {
 		if time.Since(builderReadyCondition.LastTransitionTime.Inner.Time) < r.builderReadinessTimeout {
-			return ctrl.Result{}, errors.New("waiting for builder to be ready")
+			log.Info("waiting for builder to be ready")
+			return ctrl.Result{RequeueAfter: time.Second}, nil
 		}
 
 		log.Info("failing build as builder not ready")

--- a/kpack-image-builder/controllers/buildworkload_controller_test.go
+++ b/kpack-image-builder/controllers/buildworkload_controller_test.go
@@ -767,14 +767,11 @@ var _ = Describe("BuildWorkloadReconciler", func() {
 			BeforeEach(func() {
 				Consistently(func(g Gomega) {
 					g.Expect(adminClient.Get(ctx, client.ObjectKeyFromObject(buildWorkload), buildWorkload)).To(Succeed())
-					g.Expect(meta.FindStatusCondition(buildWorkload.Status.Conditions, korifiv1alpha1.SucceededConditionType)).To(
-						SatisfyAny(
-							BeNil(),
-							PointTo(MatchFields(
-								IgnoreExtras,
-								Fields{"Status": Equal(metav1.ConditionUnknown)},
-							)),
-						),
+					g.Expect(meta.FindStatusCondition(buildWorkload.Status.Conditions, korifiv1alpha1.SucceededConditionType)).NotTo(
+						PointTo(MatchFields(
+							IgnoreExtras,
+							Fields{"Status": Equal(metav1.ConditionTrue)},
+						)),
 					)
 				}, "2s").Should(Succeed())
 


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
This test awaits for the build workload reconciler to notice that the
builder is not ready:

* if the builder status is unknown, the build workload status is also
  set to unknown
* if the builder is not ready, the workload redy status is set to false

In either case, test should assert that the build worklod consistently
does not become ready (i.e. its redy status is either nil, or false)
before making the builder ready.

<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
The test does not flake
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@georgethebeatle
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
