### PR TITLE
Use `builderReadyCondition.IsTrue()` to check readiness

### DIFF
--- a/kpack-image-builder/controllers/buildworkload_controller.go
+++ b/kpack-image-builder/controllers/buildworkload_controller.go
@@ -209,8 +209,8 @@ func (r *BuildWorkloadReconciler) ReconcileResource(ctx context.Context, buildWo
 		return ctrl.Result{}, ignoreDoNotRetryError(fmt.Errorf("failed getting builder readiness condition"))
 	}
 
-	if builderReadyCondition.IsFalse() {
-		if time.Since(builderReadyCondition.LastTransitionTime.Inner.Time) < r.builderReadinessTimeout {
+	if !builderReadyCondition.IsTrue() {
+		if time.Since(buildWorkload.CreationTimestamp.Time) < r.builderReadinessTimeout {
 			log.Info("waiting for builder to be ready")
 			return ctrl.Result{RequeueAfter: time.Second}, nil
 		}


### PR DESCRIPTION
## Is there a related GitHub Issue?
https://ci.korifi.cf-app.com/teams/main/pipelines/main/jobs/run-tests-periodic/builds/12802
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Previously we used `builderReadyCondition.IsFalse()` to check whether
the builder is ready. However, `IsFalse` returns `false` when the
condition is `nil` which is not what we want - when the ready condition
is `nil` we should consider that the builder is not ready.

Instead, we now use `builderReadyCondition.IsTrue()` which only returns
`true` if the ready condition is set, and its status is `True`.

We also change the way we check for builder ready timeout - we base the
check on the build workload creation time instead of the builder ready
status condition transition time as the condition itself might be nil.
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
Passing kpack image builder
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@georgethebeatle
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
