### PR TITLE
Auth provider server accepts unhandler requests

### DIFF
--- a/api/authorization/testhelpers/auth_provider.go
+++ b/api/authorization/testhelpers/auth_provider.go
@@ -119,7 +119,7 @@ func configureServer(server *ghttp.Server, signingKey *rsa.PrivateKey) {
 	applicationJSONHeader := http.Header{}
 	applicationJSONHeader.Add("Content-Type", "application/json")
 
-	server.SetAllowUnhandledRequests(false)
+	server.SetAllowUnhandledRequests(true)
 
 	server.RouteToHandler(
 		http.MethodGet,


### PR DESCRIPTION
## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
We have observed the following flakes:
```
+-------+----------------------------------+-----------------------------------------------------
| Ended | Job                              | Url
+-------+----------------------------------+-----------------------------------------------------
| 2h    | main/run-tests-periodic          | https://ci.korifi.cf-app.com/teams/main/pipelines/main/jobs/run-tests-periodic/builds/13087
| 134d  | main/run-tests-periodic          | https://ci.korifi.cf-app.com/teams/main/pipelines/main/jobs/run-tests-periodic/builds/9873
| 275d  | main/run-tests-periodic          | https://ci.korifi.cf-app.com/teams/main/pipelines/main/jobs/run-tests-periodic/builds/6213
| 287d  | main/run-tests-periodic          | https://ci.korifi.cf-app.com/teams/main/pipelines/main/jobs/run-tests-periodic/builds/5890
| 317d  | main/run-tests-periodic          | https://ci.korifi.cf-app.com/teams/main/pipelines/main/jobs/run-tests-periodic/builds/5045
| 451d  | main/run-tests-periodic          | https://ci.korifi.cf-app.com/teams/main/pipelines/main/jobs/run-tests-periodic/builds/1404
| 490d  | main/run-tests-main              | https://ci.korifi.cf-app.com/teams/main/pipelines/main/jobs/run-tests-main/builds/88
| 493d  | main/run-tests-periodic          | https://ci.korifi.cf-app.com/teams/main/pipelines/main/jobs/run-tests-periodic/builds/259
```
Something is trying to call /healthz on the oidc provider which fails
because unhandled requests are not allowed. We hope that by allowing
them (dafault response will be 500) we could find out more about what is
calling the endpoint.
<!-- _Please describe the change here._ -->

