### PR TITLE
Set the ginkgo output-interceptor-mode to none

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -95,7 +95,7 @@ function run_ginkgo() {
     extra_args+=("-p")
   fi
 
-  go run github.com/onsi/ginkgo/v2/ginkgo --randomize-all --randomize-suites "${extra_args[@]}" $@
+  go run github.com/onsi/ginkgo/v2/ginkgo --output-interceptor-mode=none --randomize-all --randomize-suites "${extra_args[@]}" $@
 }
 
 function main() {


### PR DESCRIPTION
## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
This is needed so that we can see the thread dump when we SIGQUIT long
running tests (some tests are currently timing out after 40+ minutes)
<!-- _Please describe the change here._ -->

