### PR TITLE
Print api logs on smoke test failures

### DIFF
--- a/tests/smoke/smoke_suite_test.go
+++ b/tests/smoke/smoke_suite_test.go
@@ -48,6 +48,12 @@ func TestSmoke(t *testing.T) {
 				{
 					Namespace:  "korifi",
 					LabelKey:   "app",
+					LabelValue: "korifi-api",
+					Container:  "korifi-api",
+				},
+				{
+					Namespace:  "korifi",
+					LabelKey:   "app",
 					LabelValue: "korifi-controllers",
 					Container:  "manager",
 				},


### PR DESCRIPTION
## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Print api logs on smoke test failures

