### PR TITLE
Delete domain test waits for the deletion job

### DIFF
--- a/tests/e2e/domains_test.go
+++ b/tests/e2e/domains_test.go
@@ -158,9 +158,7 @@ var _ = Describe("Domain", func() {
 			resp, err = adminClient.R().
 				Delete("/v3/domains/" + domainGUID)
 			Expect(err).NotTo(HaveOccurred())
-		})
 
-		It("succeeds with a job redirect", func() {
 			Expect(resp).To(SatisfyAll(
 				HaveRestyStatusCode(http.StatusAccepted),
 				HaveRestyHeaderWithValue("Location", HaveSuffix("/v3/jobs/domain.delete~"+domainGUID)),
@@ -173,7 +171,9 @@ var _ = Describe("Domain", func() {
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(string(resp.Body())).To(ContainSubstring("COMPLETE"))
 			}).Should(Succeed())
+		})
 
+		It("deletes the domain", func() {
 			getDomainResp, err := adminClient.R().Get("/v3/domains/" + domainGUID)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(getDomainResp).To(HaveRestyStatusCode(http.StatusNotFound))
@@ -204,15 +204,13 @@ var _ = Describe("Domain", func() {
 			})
 
 			It("deletes the domain routes", func() {
-				Eventually(func(g Gomega) {
-					var routes resourceList[responseResource]
-					listRoutesResp, err := adminClient.R().
-						SetResult(&routes).
-						Get("/v3/routes?space_guids=" + spaceGUID)
-					g.Expect(err).NotTo(HaveOccurred())
-					g.Expect(listRoutesResp).To(HaveRestyStatusCode(http.StatusOK))
-					g.Expect(routes.Resources).To(BeEmpty())
-				}).Should(Succeed())
+				var routes resourceList[responseResource]
+				listRoutesResp, err := adminClient.R().
+					SetResult(&routes).
+					Get("/v3/routes?space_guids=" + spaceGUID)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(listRoutesResp).To(HaveRestyStatusCode(http.StatusOK))
+				Expect(routes.Resources).To(BeEmpty())
 			})
 		})
 	})


### PR DESCRIPTION
## Is there a related GitHub Issue?
https://ci.korifi.cf-app.com/teams/main/pipelines/main/jobs/run-e2es-eks-periodic/builds/5518
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Delete domain test waits for the deletion job

It is incorrect to perform checks on domain routes while the domain is
being deleted.

<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

