### PR TITLE
Fix for issue #2749 - trailing slash request handling

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -29,6 +29,7 @@ import (
 	toolsregistry "code.cloudfoundry.org/korifi/tools/registry"
 	"code.cloudfoundry.org/korifi/version"
 
+	chiMiddlewares "github.com/go-chi/chi/middleware"
 	buildv1alpha2 "github.com/pivotal/kpack/pkg/apis/build/v1alpha2"
 	"k8s.io/apimachinery/pkg/util/cache"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -243,6 +244,7 @@ func main() {
 		middleware.Correlation(ctrl.Log),
 		middleware.CFCliVersion,
 		middleware.HTTPLogging,
+		chiMiddlewares.StripSlashes,
 	)
 
 	authInfoParser := authorization.NewInfoParser()

--- a/api/routing/router_test.go
+++ b/api/routing/router_test.go
@@ -164,6 +164,7 @@ var _ = Describe("Router", func() {
 			Expect(res).To(HaveHTTPBody(MatchJSON(`{"not":"allowed"}`)))
 		})
 	})
+
 })
 
 func mkReq(handler http.Handler, method, url string) (*http.Response, error) {

--- a/tests/e2e/root_v3_test.go
+++ b/tests/e2e/root_v3_test.go
@@ -1,0 +1,47 @@
+package e2e_test
+
+import (
+	"net/http"
+
+	"github.com/go-resty/resty/v2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+type RootV3Resource struct {
+	Links struct {
+		Self struct {
+			Href string `json:"href"`
+		} `json:"self"`
+	} `json:"links"`
+}
+
+var _ = Describe("RootV3", func() {
+	var (
+		httpResp    *resty.Response
+		requestPath string
+	)
+
+	BeforeEach(func() {
+		requestPath = "/v3"
+	})
+	JustBeforeEach(func() {
+		var err error
+		httpResp, err = adminClient.R().
+			Get(requestPath)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("succeeds", func() {
+		Expect(httpResp).To(HaveRestyStatusCode(http.StatusOK))
+	})
+
+	When("Request ends with a trailing slash", func() {
+		BeforeEach(func() {
+			requestPath = "/v3/"
+		})
+		It("succeeds", func() {
+			Expect(httpResp).To(HaveRestyStatusCode(http.StatusOK))
+		})
+	})
+})


### PR DESCRIPTION


## Is there a related GitHub Issue?
[Related Issue](https://github.com/cloudfoundry/korifi/issues/2749)

## What is this change about?
Handling the requests with trailing slash in Korifi 

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Test can be found under api/routing/router_test.go
Request to **/hello/world** and **/hello/world/** should behave identical.

## Tag your pair, your PM, and/or team
@danail-branekov 

<!--
## Things to remember
Standard chi middleware has been used for removing the trailing slashes from requests as discussed [here.](https://github.com/cloudfoundry/korifi/issues/2749)
