### PR TITLE
Consider a container crashed when in CrashLoopBackOff

### DIFF
--- a/api/actions/process_stats.go
+++ b/api/actions/process_stats.go
@@ -213,16 +213,16 @@ func getPodState(pod corev1.Pod) string {
 		return stateDown
 	}
 
-	if podHasTerminatedContainer(pod) {
+	if podHasCrashedContainer(pod) {
 		return stateCrashed
 	}
 
 	return stateStarting
 }
 
-func podHasTerminatedContainer(pod corev1.Pod) bool {
+func podHasCrashedContainer(pod corev1.Pod) bool {
 	for _, cond := range pod.Status.ContainerStatuses {
-		if cond.State.Terminated != nil {
+		if cond.State.Waiting != nil && cond.State.Waiting.Reason == "CrashLoopBackOff" {
 			return true
 		}
 	}

--- a/tests/assets/golang/main.go
+++ b/tests/assets/golang/main.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 )
 
@@ -16,6 +17,7 @@ func main() {
 	http.HandleFunc("/env.json", envJsonHandler)
 	http.HandleFunc("/servicebindingroot", serviceBindingRootHandler)
 	http.HandleFunc("/servicebindings", serviceBindingsHandler)
+	http.HandleFunc("/exit", exitHandler)
 
 	port := os.Getenv("PORT")
 	if port == "" {
@@ -23,6 +25,29 @@ func main() {
 	}
 	fmt.Printf("Listening on port %s\n", port)
 	http.ListenAndServe(fmt.Sprintf(":%s", port), nil)
+}
+
+func exitHandler(w http.ResponseWriter, r *http.Request) {
+	err := r.ParseForm()
+	if err != nil {
+		fmt.Fprintf(w, "Failed to parse form: %v", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	code := r.Form.Get("code")
+	if code == "" {
+		code = "0"
+	}
+
+	exitCode, err := strconv.Atoi(code)
+	if err != nil {
+		fmt.Fprintf(w, "Failed to parse exit code: %s: %v", code, err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	os.Exit(exitCode)
 }
 
 func helloWorldHandler(w http.ResponseWriter, _ *http.Request) {


### PR DESCRIPTION
## Is there a related GitHub Issue?
https://github.com/cloudfoundry/korifi/issues/3082
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Looking at the terminated state of a container is not reliable as this
state does not last very long. Once a workload container exits
(regardless of the exit code) consistently, k8s puts the container into
`Waiting` state with reason `CrashLoopBackOff` until the scheduler
starts it again. As this is an exponential backoff, this state tends to
last longer and longer if the app keeps crashing.

With the previous implementation of looking at the `Terminated` state we
could never see the instance as `crashed` in the `cf app` output when we
intentionally kept crashing it.

<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
See story
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@danail-branekov
