### PR TITLE
Support manifest services without name

### DIFF
--- a/api/payloads/manifest.go
+++ b/api/payloads/manifest.go
@@ -2,12 +2,14 @@ package payloads
 
 import (
 	"errors"
+	"fmt"
 	"regexp"
 
 	"code.cloudfoundry.org/korifi/api/repositories"
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"code.cloudfoundry.org/korifi/tools"
 	"github.com/jellydator/validation"
+	"gopkg.in/yaml.v3"
 
 	"code.cloudfoundry.org/bytefmt"
 )
@@ -68,6 +70,21 @@ type ManifestApplicationProcess struct {
 type ManifestApplicationService struct {
 	Name        string  `json:"name" yaml:"name"`
 	BindingName *string `json:"binding_name" yaml:"binding_name"`
+}
+
+func (s *ManifestApplicationService) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind == yaml.ScalarNode && value.Tag == "!!str" {
+		s.Name = value.Value
+		return nil
+	}
+
+	type manifestApplicationService ManifestApplicationService
+	err := value.Decode((*manifestApplicationService)(s))
+	if err != nil {
+		return fmt.Errorf("invalid service: line %d, column %d: %w", value.Line, value.Column, err)
+	}
+
+	return nil
 }
 
 type ManifestRoute struct {


### PR DESCRIPTION

Co-authored-by: Danail Branekov <danailster@gmail.com>

<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
#3050
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Both manifest service formats are now supported:

```
services:
  - my_service
  - name: your_service
```
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
See story
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@danail-branekov
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
