### PR TITLE
Fix hardcoded namespace

### DIFF
--- a/helm/korifi/templates/gateway.yaml
+++ b/helm/korifi/templates/gateway.yaml
@@ -12,7 +12,7 @@ spec:
   from:
   - group: gateway.networking.k8s.io
     kind: Gateway
-    namespace: korifi-gateway
+    namespace: {{ .Release.Namespace }}-gateway
   to:
   - group: ""
     kind: Secret


### PR DESCRIPTION


<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->
No.

## What is this change about?
We had a single reference to `korifi-gateway` not helm templated.

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->
No.

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->
- install with a namespace specified. 
- Observe that we have a broken reference to the non-existent `korifi-gateway` namespace.
## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->
@davewalter @Birdrock 
<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
