### PR TITLE
Add "guids" as a valid package list filter

### DIFF
--- a/api/handlers/package_test.go
+++ b/api/handlers/package_test.go
@@ -16,12 +16,11 @@ import (
 	"code.cloudfoundry.org/korifi/api/handlers/fake"
 	"code.cloudfoundry.org/korifi/api/payloads"
 	"code.cloudfoundry.org/korifi/api/repositories"
+	. "code.cloudfoundry.org/korifi/tests/matchers"
 	"code.cloudfoundry.org/korifi/tools"
 
-	. "code.cloudfoundry.org/korifi/tests/matchers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -192,6 +191,7 @@ var _ = Describe("Package", func() {
 			It("calls the package repository with expected arguments", func() {
 				_, _, message := packageRepo.ListPackagesArgsForCall(0)
 				Expect(message).To(Equal(repositories.ListPackagesMessage{
+					GUIDs:    []string{},
 					AppGUIDs: []string{appGUID},
 					States:   []string{},
 				}))
@@ -252,6 +252,7 @@ var _ = Describe("Package", func() {
 			It("calls repository ListPackage with the correct message object", func() {
 				_, _, message := packageRepo.ListPackagesArgsForCall(0)
 				Expect(message).To(Equal(repositories.ListPackagesMessage{
+					GUIDs:    []string{},
 					AppGUIDs: []string{},
 					States:   []string{"READY", "AWAITING_UPLOAD"},
 				}))

--- a/api/payloads/package.go
+++ b/api/payloads/package.go
@@ -6,6 +6,7 @@ import (
 	"code.cloudfoundry.org/korifi/api/payloads/parse"
 	"code.cloudfoundry.org/korifi/api/payloads/validation"
 	"code.cloudfoundry.org/korifi/api/repositories"
+
 	jellidation "github.com/jellydator/validation"
 )
 
@@ -89,6 +90,7 @@ func (u *PackageUpdate) ToMessage(packageGUID string) repositories.UpdatePackage
 }
 
 type PackageList struct {
+	GUIDs    string
 	AppGUIDs string
 	States   string
 	OrderBy  string
@@ -96,16 +98,18 @@ type PackageList struct {
 
 func (p *PackageList) ToMessage() repositories.ListPackagesMessage {
 	return repositories.ListPackagesMessage{
+		GUIDs:    parse.ArrayParam(p.GUIDs),
 		AppGUIDs: parse.ArrayParam(p.AppGUIDs),
 		States:   parse.ArrayParam(p.States),
 	}
 }
 
 func (p *PackageList) SupportedKeys() []string {
-	return []string{"app_guids", "states", "order_by", "per_page", "page"}
+	return []string{"guids", "app_guids", "states", "order_by", "per_page", "page"}
 }
 
 func (p *PackageList) DecodeFromURLValues(values url.Values) error {
+	p.GUIDs = values.Get("guids")
 	p.AppGUIDs = values.Get("app_guids")
 	p.States = values.Get("states")
 	p.OrderBy = values.Get("order_by")

--- a/api/repositories/package_repository.go
+++ b/api/repositories/package_repository.go
@@ -12,9 +12,9 @@ import (
 	"code.cloudfoundry.org/korifi/controllers/controllers/workloads"
 	"code.cloudfoundry.org/korifi/tools/dockercfg"
 	"code.cloudfoundry.org/korifi/tools/k8s"
+
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/uuid"
-
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -81,6 +81,7 @@ type PackageRecord struct {
 }
 
 type ListPackagesMessage struct {
+	GUIDs    []string
 	AppGUIDs []string
 	States   []string
 }
@@ -298,6 +299,7 @@ func (r *PackageRepo) ListPackages(ctx context.Context, authInfo authorization.I
 	}
 
 	preds := []func(korifiv1alpha1.CFPackage) bool{
+		SetPredicate(message.GUIDs, func(s korifiv1alpha1.CFPackage) string { return s.Name }),
 		SetPredicate(message.AppGUIDs, func(s korifiv1alpha1.CFPackage) string { return s.Spec.AppRef.Name }),
 	}
 	if len(message.States) > 0 {

--- a/api/repositories/package_repository_test.go
+++ b/api/repositories/package_repository_test.go
@@ -13,7 +13,6 @@ import (
 	"code.cloudfoundry.org/korifi/tests/matchers"
 	"code.cloudfoundry.org/korifi/tools"
 	"code.cloudfoundry.org/korifi/tools/k8s"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
@@ -23,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("PackageRepository", func() {
@@ -553,7 +553,22 @@ var _ = Describe("PackageRepository", func() {
 					))
 				})
 
-				When("app_guids filter is provided", func() {
+				When("the guids filter is provided", func() {
+					BeforeEach(func() {
+						listMessage = repositories.ListPackagesMessage{GUIDs: []string{package1GUID}}
+					})
+
+					It("fetches the specified package", func() {
+						Expect(packageList).To(ConsistOf(
+							MatchFields(IgnoreExtras, Fields{
+								"GUID":    Equal(package1GUID),
+								"AppGUID": Equal(appGUID),
+							}),
+						))
+					})
+				})
+
+				When("the app_guids filter is provided", func() {
 					BeforeEach(func() {
 						listMessage = repositories.ListPackagesMessage{AppGUIDs: []string{appGUID}}
 					})
@@ -569,7 +584,7 @@ var _ = Describe("PackageRepository", func() {
 					})
 				})
 
-				When("State filter is provided", func() {
+				When("the state filter is provided", func() {
 					When("filtering by State=READY", func() {
 						BeforeEach(func() {
 							listMessage = repositories.ListPackagesMessage{States: []string{"READY"}}


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
The latest version of the CF CLI (v8.7.8) introduced a change where the 'StagePackage' function now uses the "guids" query parameter when listing packages for an app. Korifi did not support this parameter, even though it claimed to support API v3.117.0.

This call is made by the CLI when an application is pushed with the `--no-start` option and then started with `cf start`.

## Does this PR introduce a breaking change?
No. It fixes a compatibility issue with CF CLI v8.7.8.

## Acceptance Steps
Install CF CLI v8.7.8 and attempt to `cf push` an application.

## Tag your pair, your PM, and/or team
@acosta11 
