### PR TITLE
Add a seccompProfile to the pod

### DIFF
--- a/job-task-runner/controllers/integration/taskworkload_controller_test.go
+++ b/job-task-runner/controllers/integration/taskworkload_controller_test.go
@@ -77,6 +77,9 @@ var _ = Describe("Job TaskWorkload Controller Integration Test", func() {
 		Expect(podSpec.RestartPolicy).To(Equal(corev1.RestartPolicyNever))
 		Expect(podSpec.SecurityContext).To(Equal(&corev1.PodSecurityContext{
 			RunAsNonRoot: tools.PtrTo(true),
+			SeccompProfile: &corev1.SeccompProfile{
+				Type: corev1.SeccompProfileTypeRuntimeDefault,
+			},
 		}))
 		Expect(podSpec.AutomountServiceAccountToken).To(Equal(tools.PtrTo(false)))
 		Expect(podSpec.ImagePullSecrets).To(ConsistOf(corev1.LocalObjectReference{Name: "my-image-secret"}))

--- a/job-task-runner/controllers/taskworkload_controller.go
+++ b/job-task-runner/controllers/taskworkload_controller.go
@@ -167,6 +167,9 @@ func (r *TaskWorkloadReconciler) workloadToJob(taskWorkload *korifiv1alpha1.Task
 					RestartPolicy: corev1.RestartPolicyNever,
 					SecurityContext: &corev1.PodSecurityContext{
 						RunAsNonRoot: tools.PtrTo(true),
+						SeccompProfile: &corev1.SeccompProfile{
+							Type: corev1.SeccompProfileTypeRuntimeDefault,
+						},
 					},
 					AutomountServiceAccountToken: tools.PtrTo(false),
 					ImagePullSecrets:             taskWorkload.Spec.ImagePullSecrets,

--- a/statefulset-runner/controllers/appworkload_to_stset.go
+++ b/statefulset-runner/controllers/appworkload_to_stset.go
@@ -136,6 +136,9 @@ func (r *AppWorkloadToStatefulsetConverter) Convert(appWorkload *korifiv1alpha1.
 					ImagePullSecrets: appWorkload.Spec.ImagePullSecrets,
 					SecurityContext: &corev1.PodSecurityContext{
 						RunAsNonRoot: tools.PtrTo(true),
+						SeccompProfile: &corev1.SeccompProfile{
+							Type: corev1.SeccompProfileTypeRuntimeDefault,
+						},
 					},
 					ServiceAccountName: ServiceAccountName,
 				},

--- a/statefulset-runner/controllers/appworkload_to_stset_test.go
+++ b/statefulset-runner/controllers/appworkload_to_stset_test.go
@@ -115,7 +115,7 @@ var _ = Describe("AppWorkload to StatefulSet Converter", func() {
 		}))
 	})
 
-	It("should set the seccomp profile", func() {
+	It("should set the seccomp profile on the container", func() {
 		Expect(statefulSet.Spec.Template.Spec.Containers[0].SecurityContext.SeccompProfile).NotTo(BeNil())
 		Expect(*statefulSet.Spec.Template.Spec.Containers[0].SecurityContext.SeccompProfile).To(Equal(corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault}))
 	})
@@ -210,6 +210,11 @@ var _ = Describe("AppWorkload to StatefulSet Converter", func() {
 		Expect(statefulSet.Spec.Template.Spec.SecurityContext).NotTo(BeNil())
 		Expect(statefulSet.Spec.Template.Spec.SecurityContext.RunAsNonRoot).NotTo(BeNil())
 		Expect(*statefulSet.Spec.Template.Spec.SecurityContext.RunAsNonRoot).To(BeTrue())
+	})
+
+	It("should set the seccomp profile on the pod", func() {
+		Expect(statefulSet.Spec.Template.Spec.SecurityContext.SeccompProfile).NotTo(BeNil())
+		Expect(*statefulSet.Spec.Template.Spec.SecurityContext.SeccompProfile).To(Equal(corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault}))
 	})
 
 	It("should set soft inter-pod anti-affinity", func() {


### PR DESCRIPTION
## Is there a related GitHub Issue?
N/A

## What is this change about?
Presently Korifi places a seccompProfile on the container, while this works for the container when you want to layer in a service mesh such as Istio you run into a few issues. During the Korifi installation, if you follow the install guide as described it has you place a `pod-security.kubernetes.io/enforce=restricted` on the root namespace, then this cascades to created organization and space namespaces. When this happens, for a space that desires to enable the Istio service mesh, the `istio-init` and `istio-validation` sidecar containers are started with the default seccompProfile which results in the entire pod being unable to be scheduled due to two containers wanting additional privileges. Istio has support for it's own custom, chained CNI which removes the need for the additional privileges in these more secure environments, but during it's mutation it strictly observes a seccompProfile placed upon the pod itself.

## Does this PR introduce a breaking change?
No breaking changes.

## Acceptance Steps
Bring up a Korifi environment utilizing Istio with `pod-security.kubernetes.io/enforce=restricted` on the space namespaces and the API Gateway integration.
_profile.yaml_
```
apiVersion: install.istio.io/v1alpha1
kind: IstioOperator
spec:
  profile: minimal
  components:
    cni:
      enabled: true
  meshConfig:
    accessLogFile: /dev/stdout
    outboundTrafficPolicy:
      mode: ALLOW_ANY
  values:
    cni:
      excludeNamespaces:
        - istio-system
        - kube-system
        - kpack
      logLevel: debug
    pilot:
      env:
        PILOT_ENABLE_ALPHA_GATEWAY_API: true
```

```
istioctl install --file profile.yaml
```

## Tag your pair, your PM, and/or team
N/A

## Additional Information
I found the reference to putting the seccompProfile on the pod in the Istio project's issue comments. You can find the specific comment here: https://github.com/istio/istio/issues/35894#issuecomment-1511634924. I've also verified upstream that kpack is already placing a seccompProfile on both the pod and the build container.