### PR TITLE
Credentials in VCAP_SERVICES are objects

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -25,6 +25,7 @@ COPY controllers/api controllers/api
 COPY controllers/config controllers/config
 COPY controllers/controllers/shared controllers/controllers/shared
 COPY controllers/controllers/workloads controllers/controllers/workloads
+COPY controllers/controllers/services/credentials controllers/controllers/services/credentials
 COPY controllers/webhooks controllers/webhooks
 COPY tools tools
 COPY version version

--- a/api/repositories/app_repository_test.go
+++ b/api/repositories/app_repository_test.go
@@ -1597,7 +1597,7 @@ func generateVcapServiceSecretDataByte() (map[string][]byte, error) {
 		InstanceName: "myupsi",
 		BindingGUID:  "73f68d28-4602-47a3-8110-74ca991d5032",
 		BindingName:  nil,
-		Credentials: map[string]string{
+		Credentials: map[string]any{
 			"foo": "bar",
 		},
 		SyslogDrainURL: nil,

--- a/controllers/api/v1alpha1/cfservicebinding_types.go
+++ b/controllers/api/v1alpha1/cfservicebinding_types.go
@@ -37,10 +37,18 @@ type CFServiceBindingSpec struct {
 
 // CFServiceBindingStatus defines the observed state of CFServiceBinding
 type CFServiceBindingStatus struct {
-	// A reference to the Secret containing the credentials.
-	// This is required to conform to the Kubernetes Service Bindings spec
+	// A reference to the Secret containing the binding Credentials in
+	// servicebinding.io format. In order to conform to that spec the resource
+	// should have a "duck type" field called `binding`. From more info see the
+	// servicebinding.io [spec](https://servicebinding.io/spec/core/1.0.0-rc3/#Duck%20Type)
 	// +optional
 	Binding v1.LocalObjectReference `json:"binding"`
+
+	// A reference to the Secret containing the binding Credentials object. For
+	// bindings to user-provided services this refers to the credentials secret
+	// from the service instance
+	// +optional
+	Credentials v1.LocalObjectReference `json:"credentials"`
 
 	//+kubebuilder:validation:Optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`

--- a/controllers/api/v1alpha1/zz_generated.deepcopy.go
+++ b/controllers/api/v1alpha1/zz_generated.deepcopy.go
@@ -1261,6 +1261,7 @@ func (in *CFServiceBindingSpec) DeepCopy() *CFServiceBindingSpec {
 func (in *CFServiceBindingStatus) DeepCopyInto(out *CFServiceBindingStatus) {
 	*out = *in
 	out.Binding = in.Binding
+	out.Credentials = in.Credentials
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
 		*out = make([]metav1.Condition, len(*in))

--- a/controllers/controllers/services/cfservicebinding_controller.go
+++ b/controllers/controllers/services/cfservicebinding_controller.go
@@ -191,6 +191,8 @@ func (r *CFServiceBindingReconciler) ReconcileResource(ctx context.Context, cfSe
 }
 
 func (r *CFServiceBindingReconciler) reconcileCredentials(ctx context.Context, cfServiceInstance *korifiv1alpha1.CFServiceInstance, cfServiceBinding *korifiv1alpha1.CFServiceBinding) (*corev1.Secret, error) {
+	cfServiceBinding.Status.Credentials.Name = cfServiceInstance.Status.Credentials.Name
+
 	if isLegacyServiceBinding(cfServiceBinding, cfServiceInstance) {
 		bindingSecret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -232,7 +234,7 @@ func (r *CFServiceBindingReconciler) reconcileCredentials(ctx context.Context, c
 		if err != nil {
 			return err
 		}
-		bindingSecret.Data, err = credentials.GetBindingSecretData(credentialsSecret)
+		bindingSecret.Data, err = credentials.GetServiceBindingIOSecretData(credentialsSecret)
 		if err != nil {
 			return err
 		}

--- a/controllers/controllers/services/cfservicebinding_controller_test.go
+++ b/controllers/controllers/services/cfservicebinding_controller_test.go
@@ -153,7 +153,12 @@ var _ = Describe("CFServiceBinding", func() {
 			Eventually(func(g Gomega) {
 				g.Expect(adminClient.Get(ctx, client.ObjectKeyFromObject(cfServiceBinding), cfServiceBinding)).To(Succeed())
 				g.Expect(meta.IsStatusConditionTrue(cfServiceBinding.Status.Conditions, services.BindingSecretAvailableCondition)).To(BeTrue())
+
+				g.Expect(adminClient.Get(ctx, client.ObjectKeyFromObject(cfServiceInstance), cfServiceInstance)).To(Succeed())
+				g.Expect(cfServiceInstance.Status.Credentials.Name).NotTo(BeEmpty())
 			}).Should(Succeed())
+
+			Expect(cfServiceBinding.Status.Credentials.Name).To(Equal(cfServiceInstance.Status.Credentials.Name))
 
 			Expect(cfServiceBinding.Status.Binding.Name).NotTo(BeEmpty())
 

--- a/controllers/controllers/services/credentials/credentials.go
+++ b/controllers/controllers/services/credentials/credentials.go
@@ -11,7 +11,7 @@ import (
 const ServiceBindingSecretTypePrefix = "servicebinding.io/"
 
 func GetBindingSecretType(credentialsSecret *corev1.Secret) (corev1.SecretType, error) {
-	credentials, err := getCredentials(credentialsSecret)
+	credentials, err := GetCredentials(credentialsSecret)
 	if err != nil {
 		return "", err
 	}
@@ -24,8 +24,8 @@ func GetBindingSecretType(credentialsSecret *corev1.Secret) (corev1.SecretType, 
 	return corev1.SecretType(ServiceBindingSecretTypePrefix + korifiv1alpha1.UserProvidedType), nil
 }
 
-func GetBindingSecretData(credentialsSecret *corev1.Secret) (map[string][]byte, error) {
-	credentials, err := getCredentials(credentialsSecret)
+func GetServiceBindingIOSecretData(credentialsSecret *corev1.Secret) (map[string][]byte, error) {
+	credentials, err := GetCredentials(credentialsSecret)
 	if err != nil {
 		return nil, err
 	}
@@ -49,7 +49,7 @@ func toBytes(value any) ([]byte, error) {
 	return json.Marshal(value)
 }
 
-func getCredentials(credentialsSecret *corev1.Secret) (map[string]any, error) {
+func GetCredentials(credentialsSecret *corev1.Secret) (map[string]any, error) {
 	credentials, ok := credentialsSecret.Data[korifiv1alpha1.CredentialsSecretKey]
 	if !ok {
 		return nil, fmt.Errorf(

--- a/controllers/controllers/workloads/cfapp_controller_test.go
+++ b/controllers/controllers/workloads/cfapp_controller_test.go
@@ -76,8 +76,8 @@ var _ = Describe("CFAppReconciler Integration Tests", func() {
 					Name:      PrefixedGUID("service-instance-secret"),
 					Namespace: cfSpace.Status.GUID,
 				},
-				StringData: map[string]string{
-					"foo": "bar",
+				Data: map[string][]byte{
+					korifiv1alpha1.CredentialsSecretKey: []byte(`{"foo": "bar"}`),
 				},
 			}
 			Expect(adminClient.Create(context.Background(), serviceInstanceSecret)).To(Succeed())
@@ -111,7 +111,7 @@ var _ = Describe("CFAppReconciler Integration Tests", func() {
 			}
 			Expect(adminClient.Create(ctx, serviceBinding)).To(Succeed())
 			Expect(k8s.Patch(ctx, adminClient, serviceBinding, func() {
-				serviceBinding.Status.Binding = corev1.LocalObjectReference{
+				serviceBinding.Status.Credentials = corev1.LocalObjectReference{
 					Name: serviceInstanceSecret.Name,
 				}
 			})).To(Succeed())

--- a/controllers/controllers/workloads/env/builder.go
+++ b/controllers/controllers/workloads/env/builder.go
@@ -14,16 +14,16 @@ import (
 type VCAPServices map[string][]ServiceDetails
 
 type ServiceDetails struct {
-	Label          string            `json:"label"`
-	Name           string            `json:"name"`
-	Tags           []string          `json:"tags"`
-	InstanceGUID   string            `json:"instance_guid"`
-	InstanceName   string            `json:"instance_name"`
-	BindingGUID    string            `json:"binding_guid"`
-	BindingName    *string           `json:"binding_name"`
-	Credentials    map[string]string `json:"credentials"`
-	SyslogDrainURL *string           `json:"syslog_drain_url"`
-	VolumeMounts   []string          `json:"volume_mounts"`
+	Label          string         `json:"label"`
+	Name           string         `json:"name"`
+	Tags           []string       `json:"tags"`
+	InstanceGUID   string         `json:"instance_guid"`
+	InstanceName   string         `json:"instance_name"`
+	BindingGUID    string         `json:"binding_guid"`
+	BindingName    *string        `json:"binding_name"`
+	Credentials    map[string]any `json:"credentials"`
+	SyslogDrainURL *string        `json:"syslog_drain_url"`
+	VolumeMounts   []string       `json:"volume_mounts"`
 }
 
 type WorkloadEnvBuilder struct {

--- a/docs/architecture-decisions/0016-user-provided-service-credentils.md
+++ b/docs/architecture-decisions/0016-user-provided-service-credentils.md
@@ -33,16 +33,25 @@ data:
 ```
 
 ### Service Binding
-The service binding controller derives the secret to put in the `.status.binding` duck type of the `CFServiceBinding` from the `.status.credentials` field of the `CFServiceInstance`. The binding secret is in the [format](https://servicebinding.io/spec/core/1.0.0/#example-secret) specified by servicebinding.io and is named after the service binding. According to that spec the secret has type `servicebinding.io/<type>` and its data is a flat collection of key value pairs. For example:
+The service binding credentials need to be stored in two different formats at the same time:
+- As bytes on the filesystem (i.e. in marshalled form) as specified by the servicebinding.io [spec](https://servicebinding.io/spec/core/1.0.0/#workload-projection)
+- As a json object  (i.e. in unmarhalled form) as specified by the cf [docs](https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES)
 
-```
-apiVersion: v1
-kind: Secret
-type: servicebinding.io/database
-data:
-  type: database
-  user: '{"name":"alice", "password": "bob"}'
-```
+In order to support both specs the service binding controller holds references to two secrets, one for each format representation:
+  - The `.status.binding` secret: The service binding controller derives the secret to put in the `.status.binding` duck type of the `CFServiceBinding` from the `.status.credentials` field of the `CFServiceInstance`. The binding secret is in the [format](https://servicebinding.io/spec/core/1.0.0/#example-secret) specified by servicebinding.io and is named after the service binding. According to that spec the secret has type `servicebinding.io/<type>` and its data is a flat collection of key value pairs. For example:
+
+  ```
+  apiVersion: v1
+  kind: Secret
+  type: servicebinding.io/database
+  data:
+    type: database
+    user: '{"name":"alice", "password": "bob"}'
+  ```
+  This secret is later on projected in the app workload by servicebinding.io
+
+
+  - The `.status.credentials` secret: The service binding controller sets's the `.status.credentials` to refer to the secred referred to by the `.status.credentials` of the `CFServiceInstance`. This secret is later on used to calculate the value of the `VCAP_SERVICES` env variable.
 
 ### Backwards Compatibility
 The servicebinding.io contoller monitors the value of the `.status.binding` duck type of the `CFServiceBinding` and updates the spec of the workload statefulset to reflect any changes. The statefulset controller reacts to that change and rolls the statefulset out, causing an app restart. In order to avoid undesired restarting of apps during Korifi upgrade we make sure not to modify the value of the duck type of any pre-existing `CFServiceBinding`s.

--- a/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfservicebindings.yaml
+++ b/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfservicebindings.yaml
@@ -116,8 +116,10 @@ spec:
             properties:
               binding:
                 description: |-
-                  A reference to the Secret containing the credentials.
-                  This is required to conform to the Kubernetes Service Bindings spec
+                  A reference to the Secret containing the binding Credentials in
+                  servicebinding.io format. In order to conform to that spec the resource
+                  should have a "duck type" field called `binding`. From more info see the
+                  servicebinding.io [spec](https://servicebinding.io/spec/core/1.0.0-rc3/#Duck%20Type)
                 properties:
                   name:
                     description: |-
@@ -196,6 +198,20 @@ spec:
                   - type
                   type: object
                 type: array
+              credentials:
+                description: |-
+                  A reference to the Secret containing the binding Credentials object. For
+                  bindings to user-provided services this refers to the credentials secret
+                  from the service instance
+                properties:
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
               observedGeneration:
                 description: ObservedGeneration captures the latest generation of
                   the CFServiceBinding that has been reconciled


### PR DESCRIPTION
## Is there a related GitHub Issue?
#2900
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Fix VCAP_SERVICES env var format: service binding credentials are objects, not string key value pairs
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

