### PR TITLE
Configure whether to set workload pod seccompProfile

### DIFF
--- a/README.helm.md
+++ b/README.helm.md
@@ -77,6 +77,7 @@ Here are all the values that can be set for the chart:
     - `requests`: Resource requests.
       - `cpu` (_String_): CPU request.
       - `memory` (_String_): Memory request.
+  - `temporarySetPodSeccompProfile` (_Boolean_): Sets the pod .spec.securityContext.seccompProfile to RuntimeDefault. Setting this flag to true will cause a restart of all previously running pods.
 - `kpackImageBuilder`:
   - `builderReadinessTimeout` (_String_): The time that the kpack Builder will be waited for if not in ready state, berfore the build workload fails. See [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration) for details on the format, an additional `d` suffix for days is supported.
   - `builderRepository` (_String_): Container image repository to store the `ClusterBuilder` image. Required when `clusterBuilderName` is not provided.
@@ -114,4 +115,5 @@ Here are all the values that can be set for the chart:
     - `requests`: Resource requests.
       - `cpu` (_String_): CPU request.
       - `memory` (_String_): Memory request.
+  - `temporarySetPodSeccompProfile` (_Boolean_): Sets the pod .spec.securityContext.seccompProfile to RuntimeDefault. Setting this flag to true will cause a restart of all previously running pods.
 - `systemImagePullSecrets` (_Array_): List of `Secret` names to be used when pulling Korifi system images from private registries

--- a/controllers/config/config.go
+++ b/controllers/config/config.go
@@ -30,7 +30,11 @@ type ControllerConfig struct {
 	SpaceFinalizerAppDeletionTimeout *int64             `yaml:"spaceFinalizerAppDeletionTimeout"`
 
 	// job-task-runner
-	JobTTL string `yaml:"jobTTL"`
+	JobTTL                                     string `yaml:"jobTTL"`
+	JobTaskRunnerTemporarySetPodSeccompProfile bool   `yaml:"jobTaskRunnerTemporarySetPodSeccompProfile"`
+
+	// statefulset-runner
+	StatefulsetRunnerTemporarySetPodSeccompProfile bool `yaml:"statefulsetRunnerTemporarySetPodSeccompProfile"`
 
 	// kpack-image-builder
 	ClusterBuilderName        string     `yaml:"clusterBuilderName"`

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -349,6 +349,7 @@ func main() {
 				mgr.GetScheme(),
 				jobtaskrunnercontrollers.NewStatusGetter(logger, mgr.GetClient()),
 				jobTTL,
+				controllerConfig.JobTaskRunnerTemporarySetPodSeccompProfile,
 			)
 			if err = taskWorkloadReconciler.SetupWithManager(mgr); err != nil {
 				setupLog.Error(err, "unable to create controller", "controller", "TaskWorkload")
@@ -361,7 +362,10 @@ func main() {
 			if err = statefulsetcontrollers.NewAppWorkloadReconciler(
 				mgr.GetClient(),
 				mgr.GetScheme(),
-				statefulsetcontrollers.NewAppWorkloadToStatefulsetConverter(mgr.GetScheme()),
+				statefulsetcontrollers.NewAppWorkloadToStatefulsetConverter(
+					mgr.GetScheme(),
+					controllerConfig.StatefulsetRunnerTemporarySetPodSeccompProfile,
+				),
 				statefulsetcontrollers.NewPDBUpdater(mgr.GetClient()),
 				logger,
 			).SetupWithManager(mgr); err != nil {

--- a/helm/korifi/controllers/configmap.yaml
+++ b/helm/korifi/controllers/configmap.yaml
@@ -53,6 +53,10 @@ data:
     {{- end }}
     {{- if .Values.jobTaskRunner.include }}
     jobTTL: {{ required "jobTTL is required" .Values.jobTaskRunner.jobTTL }}
+    jobTaskRunnerTemporarySetPodSeccompProfile: {{ .Values.jobTaskRunner.temporarySetPodSeccompProfile }}
+    {{- end }}
+    {{- if .Values.statefulsetRunner.include }}
+    statefulsetRunnerTemporarySetPodSeccompProfile: {{ .Values.statefulsetRunner.temporarySetPodSeccompProfile }}
     {{- end }}
     networking:
       gatewayNamespace: {{ .Release.Namespace }}-gateway

--- a/helm/korifi/values.schema.json
+++ b/helm/korifi/values.schema.json
@@ -392,6 +392,10 @@
           "description": "Number of replicas.",
           "type": "integer"
         },
+        "temporarySetPodSeccompProfile": {
+          "description": "Sets the pod .spec.securityContext.seccompProfile to RuntimeDefault. Setting this flag to true will cause a restart of all previously running pods.",
+          "type": "boolean"
+        },
         "resources": {
           "description": "[`ResourceRequirements`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#resourcerequirements-v1-core) for the API.",
           "type": "object",
@@ -439,6 +443,10 @@
         "replicas": {
           "description": "Number of replicas.",
           "type": "integer"
+        },
+        "temporarySetPodSeccompProfile": {
+          "description": "Sets the pod .spec.securityContext.seccompProfile to RuntimeDefault. Setting this flag to true will cause a restart of all previously running pods.",
+          "type": "boolean"
         },
         "resources": {
           "description": "[`ResourceRequirements`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#resourcerequirements-v1-core) for the API.",

--- a/helm/korifi/values.yaml
+++ b/helm/korifi/values.yaml
@@ -98,6 +98,7 @@ kpackImageBuilder:
 statefulsetRunner:
   include: true
   replicas: 1
+  temporarySetPodSeccompProfile: false
   resources:
     limits:
       cpu: 500m
@@ -109,6 +110,7 @@ statefulsetRunner:
 jobTaskRunner:
   include: true
   replicas: 1
+  temporarySetPodSeccompProfile: false
   resources:
     limits:
       cpu: 500m

--- a/job-task-runner/controllers/integration/suite_test.go
+++ b/job-task-runner/controllers/integration/suite_test.go
@@ -82,6 +82,7 @@ var _ = BeforeSuite(func() {
 		k8sManager.GetScheme(),
 		controllers.NewStatusGetter(logger, k8sManager.GetClient()),
 		time.Minute,
+		false,
 	)
 	err = taskWorkloadReconciler.SetupWithManager(k8sManager)
 	Expect(err).NotTo(HaveOccurred())

--- a/job-task-runner/controllers/integration/taskworkload_controller_test.go
+++ b/job-task-runner/controllers/integration/taskworkload_controller_test.go
@@ -77,9 +77,6 @@ var _ = Describe("Job TaskWorkload Controller Integration Test", func() {
 		Expect(podSpec.RestartPolicy).To(Equal(corev1.RestartPolicyNever))
 		Expect(podSpec.SecurityContext).To(Equal(&corev1.PodSecurityContext{
 			RunAsNonRoot: tools.PtrTo(true),
-			SeccompProfile: &corev1.SeccompProfile{
-				Type: corev1.SeccompProfileTypeRuntimeDefault,
-			},
 		}))
 		Expect(podSpec.AutomountServiceAccountToken).To(Equal(tools.PtrTo(false)))
 		Expect(podSpec.ImagePullSecrets).To(ConsistOf(corev1.LocalObjectReference{Name: "my-image-secret"}))

--- a/job-task-runner/controllers/taskworkload_controller_test.go
+++ b/job-task-runner/controllers/taskworkload_controller_test.go
@@ -8,10 +8,10 @@ import (
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"code.cloudfoundry.org/korifi/job-task-runner/controllers"
 	"code.cloudfoundry.org/korifi/job-task-runner/controllers/fake"
-	"code.cloudfoundry.org/korifi/tools/k8s"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,16 +27,16 @@ var _ = Describe("TaskworkloadController", func() {
 	var (
 		statusGetter *fake.TaskStatusGetter
 
-		reconciler           *k8s.PatchingReconciler[korifiv1alpha1.TaskWorkload, *korifiv1alpha1.TaskWorkload]
-		reconcileResult      ctrl.Result
-		reconcileErr         error
-		req                  ctrl.Request
-		taskWorkload         *korifiv1alpha1.TaskWorkload
-		getTaskWorkloadError error
-		createdJob           *batchv1.Job
-		existingJob          *batchv1.Job
-		getExistingJobError  error
-		createJobError       error
+		reconcileResult                            ctrl.Result
+		reconcileErr                               error
+		req                                        ctrl.Request
+		taskWorkload                               *korifiv1alpha1.TaskWorkload
+		getTaskWorkloadError                       error
+		createdJob                                 *batchv1.Job
+		existingJob                                *batchv1.Job
+		getExistingJobError                        error
+		createJobError                             error
+		jobTaskRunnerTemporarySetPodSeccompProfile bool
 	)
 
 	BeforeEach(func() {
@@ -98,12 +98,13 @@ var _ = Describe("TaskworkloadController", func() {
 			Reason:             "something",
 		}}, nil)
 
-		reconciler = controllers.NewTaskWorkloadReconciler(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)), fakeClient, scheme.Scheme, statusGetter, time.Hour)
+		jobTaskRunnerTemporarySetPodSeccompProfile = false
 
 		req = ctrl.Request{NamespacedName: client.ObjectKeyFromObject(taskWorkload)}
 	})
 
 	JustBeforeEach(func() {
+		reconciler := controllers.NewTaskWorkloadReconciler(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)), fakeClient, scheme.Scheme, statusGetter, time.Hour, jobTaskRunnerTemporarySetPodSeccompProfile)
 		reconcileResult, reconcileErr = reconciler.Reconcile(context.Background(), req)
 	})
 
@@ -222,6 +223,35 @@ var _ = Describe("TaskworkloadController", func() {
 
 		It("returns the error", func() {
 			Expect(reconcileErr).To(MatchError(ContainSubstring("get-conditions-error")))
+		})
+	})
+
+	Describe("jobTaskRunnerTemporarySetPodSeccompProfile", func() {
+		var (
+			job                                        *batchv1.Job
+			jobTaskRunnerTemporarySetPodSeccompProfile bool
+		)
+
+		BeforeEach(func() {
+			jobTaskRunnerTemporarySetPodSeccompProfile = false
+		})
+
+		JustBeforeEach(func() {
+			job = controllers.WorkloadToJob(taskWorkload, 123, jobTaskRunnerTemporarySetPodSeccompProfile)
+		})
+
+		It("does not set spec.securityContext.seccompProfile", func() {
+			Expect(job.Spec.Template.Spec.SecurityContext.SeccompProfile).To(BeNil())
+		})
+
+		When("jobTaskRunnerTemporarySetPodSeccompProfile is set to true", func() {
+			BeforeEach(func() {
+				jobTaskRunnerTemporarySetPodSeccompProfile = true
+			})
+
+			It("sets spec.securityContext.seccompProfile to RuntimeDefault", func() {
+				Expect(job.Spec.Template.Spec.SecurityContext.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
+			})
 		})
 	})
 })

--- a/statefulset-runner/controllers/appworkload_to_stset.go
+++ b/statefulset-runner/controllers/appworkload_to_stset.go
@@ -18,12 +18,17 @@ import (
 )
 
 type AppWorkloadToStatefulsetConverter struct {
-	scheme *runtime.Scheme
+	scheme                                         *runtime.Scheme
+	statefulsetRunnerTemporarySetPodSeccompProfile bool
 }
 
-func NewAppWorkloadToStatefulsetConverter(scheme *runtime.Scheme) *AppWorkloadToStatefulsetConverter {
+func NewAppWorkloadToStatefulsetConverter(
+	scheme *runtime.Scheme,
+	statefulsetRunnerTemporarySetPodSeccompProfile bool,
+) *AppWorkloadToStatefulsetConverter {
 	return &AppWorkloadToStatefulsetConverter{
 		scheme: scheme,
+		statefulsetRunnerTemporarySetPodSeccompProfile: statefulsetRunnerTemporarySetPodSeccompProfile,
 	}
 }
 
@@ -136,14 +141,17 @@ func (r *AppWorkloadToStatefulsetConverter) Convert(appWorkload *korifiv1alpha1.
 					ImagePullSecrets: appWorkload.Spec.ImagePullSecrets,
 					SecurityContext: &corev1.PodSecurityContext{
 						RunAsNonRoot: tools.PtrTo(true),
-						SeccompProfile: &corev1.SeccompProfile{
-							Type: corev1.SeccompProfileTypeRuntimeDefault,
-						},
 					},
 					ServiceAccountName: ServiceAccountName,
 				},
 			},
 		},
+	}
+
+	if r.statefulsetRunnerTemporarySetPodSeccompProfile {
+		statefulSet.Spec.Template.Spec.SecurityContext.SeccompProfile = &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		}
 	}
 
 	statefulSet.Spec.Template.Spec.AutomountServiceAccountToken = tools.PtrTo(false)

--- a/statefulset-runner/controllers/integration/suite_test.go
+++ b/statefulset-runner/controllers/integration/suite_test.go
@@ -77,7 +77,7 @@ var _ = BeforeSuite(func() {
 	appWorkloadReconciler := NewAppWorkloadReconciler(
 		k8sManager.GetClient(),
 		k8sManager.GetScheme(),
-		NewAppWorkloadToStatefulsetConverter(k8sManager.GetScheme()),
+		NewAppWorkloadToStatefulsetConverter(k8sManager.GetScheme(), false),
 		NewPDBUpdater(k8sManager.GetClient()),
 		logger,
 	)


### PR DESCRIPTION
## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
PR https://github.com/cloudfoundry/korifi/pull/3156 changes the
definition of statefulset/job by setting the seccomp profile on the
statefulset/job template spec. This causes all workload pods to get
automatically restarted when upgrading from previous Korifi releases.

We introduce new `statefulsetRunnerTemporarySetPodSeccompProfile` and
`jobTaskRunnerTemporarySetPodSeccompProfile` helm values whose default
value would prevent altering existing statefulsets and jobs.

Those will be probably removed in future releases.
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No, it fixes a breaking change
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
No restart of workload pods on Korifi upgrade
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@shanman190
