### PR TITLE
Print org namespaces on smoke test failure

### DIFF
--- a/tests/smoke/smoke_suite_test.go
+++ b/tests/smoke/smoke_suite_test.go
@@ -60,9 +60,8 @@ func TestSmoke(t *testing.T) {
 					Container:  "manager",
 				},
 			})
-		},
-		ContainSubstring("Org deletion timed out"): func(config *rest.Config, _ string) {
-			printOrgNamespaces(config)
+			printPrefixedNamespaces(config, repositories.OrgPrefix)
+			printPrefixedNamespaces(config, repositories.SpacePrefix)
 		},
 	}))
 	SetDefaultEventuallyTimeout(helpers.EventuallyTimeout())
@@ -123,7 +122,7 @@ func sessionOutput(session *Session) (string, error) {
 	return strings.TrimSpace(string(session.Out.Contents())), nil
 }
 
-func printOrgNamespaces(config *rest.Config) {
+func printPrefixedNamespaces(config *rest.Config, prefix string) {
 	utilruntime.Must(korifiv1alpha1.AddToScheme(scheme.Scheme))
 	k8sClient, err := client.New(config, client.Options{Scheme: scheme.Scheme})
 	if err != nil {
@@ -137,12 +136,12 @@ func printOrgNamespaces(config *rest.Config) {
 		return
 	}
 
+	fmt.Fprintf(GinkgoWriter, "\nPrinting namespaces with %q prefix:\n", prefix)
 	for _, namespace := range namespaces.Items {
-		if !strings.Contains(namespace.Name, repositories.OrgPrefix) {
+		if !strings.Contains(namespace.Name, prefix) {
 			continue
 		}
 
-		fmt.Fprintln(GinkgoWriter, "CFOrg deletion timed out! Printing all Org namespaces:")
 		if err := printObject(k8sClient, &namespace); err != nil {
 			fmt.Fprintf(GinkgoWriter, "failed printing namespace: %v\n", err)
 			return


### PR DESCRIPTION
## Is there a related GitHub Issue?
#3061
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Pring debug info for a flaky test
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
N/A
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@danail-branekov
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
