### PR TITLE
Ignore org deletion exit code in AfterSuite

### DIFF
--- a/api/routing/router_test.go
+++ b/api/routing/router_test.go
@@ -164,7 +164,6 @@ var _ = Describe("Router", func() {
 			Expect(res).To(HaveHTTPBody(MatchJSON(`{"not":"allowed"}`)))
 		})
 	})
-
 })
 
 func mkReq(handler http.Handler, method, url string) (*http.Response, error) {

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -4,7 +4,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
-	"strings"
 
 	"code.cloudfoundry.org/korifi/tests/helpers"
 	. "code.cloudfoundry.org/korifi/tests/matchers"
@@ -71,22 +70,6 @@ var _ = Describe("Smoke Tests", func() {
 		})
 	})
 })
-
-func printAppReport(appName string) {
-	if appName == "" {
-		return
-	}
-
-	printAppReportBanner(fmt.Sprintf("***** APP REPORT: %s *****", appName))
-	Expect(helpers.Cf("app", appName, "--guid")).To(Exit())
-	Expect(helpers.Cf("logs", "--recent", appName)).To(Exit())
-	printAppReportBanner(fmt.Sprintf("*** END APP REPORT: %s ***", appName))
-}
-
-func printAppReportBanner(announcement string) {
-	sequence := strings.Repeat("*", len(announcement))
-	fmt.Fprintf(GinkgoWriter, "\n\n%s\n%s\n%s\n", sequence, announcement, sequence)
-}
 
 func appResponseShould(appName, requestPath string, matchExpectations types.GomegaMatcher) {
 	var httpClient http.Client


### PR DESCRIPTION
## Is there a related GitHub Issue?
#3061
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Smoke tests have been failing frequently because org deletion times out.
Previous debug output showed that the timeout is caused by org namespace
being not deleted because of app pods do not disappear and remaining
pods are in phase `Pending` (e.g. see
https://ci.korifi.cf-app.com/teams/main/pipelines/main/jobs/deploy-korifi-acceptance/builds/802)

We have found a [k8s bug
report](https://github.com/kubernetes/kubernetes/issues/121435) that
pending pods cannot be deleted. We suspect that in those cases the
cluster is just being slow.

In order to workaround that bug, we simply ignore the org deletion exit
code as org deletion is not really in the focus of the smoke tests. Org
deletion is covered in details by e2e tests.

Also, delete the related debug logs as they are not needed anymore.
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
Smoke tests do not fail
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@danail-branekov
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
