### PR TITLE
adding MEMORY_LIMIT environment variable to CFAppWorkload in cfprocess controller

### DIFF
--- a/controllers/controllers/workloads/cfprocess_controller.go
+++ b/controllers/controllers/workloads/cfprocess_controller.go
@@ -312,7 +312,7 @@ func (r *CFProcessReconciler) generateAppWorkload(actualAppWorkload *korifiv1alp
 		desiredAppWorkload.Spec.Instances = int32(*cfProcess.Spec.DesiredInstances)
 	}
 
-	desiredAppWorkload.Spec.Env = generateEnvVars(appPorts, envVars)
+	desiredAppWorkload.Spec.Env = generateEnvVars(appPorts, envVars, cfProcess.Spec.MemoryMB)
 
 	desiredAppWorkload.Spec.StartupProbe = startupProbe(cfProcess, appPorts)
 	desiredAppWorkload.Spec.LivenessProbe = livenessProbe(cfProcess, appPorts)
@@ -389,7 +389,7 @@ func (r *CFProcessReconciler) getPorts(ctx context.Context, processType string, 
 	return ports, nil
 }
 
-func generateEnvVars(ports []int32, commonEnv []corev1.EnvVar) []corev1.EnvVar {
+func generateEnvVars(ports []int32, commonEnv []corev1.EnvVar, memoryMB int64) []corev1.EnvVar {
 	result := []corev1.EnvVar{
 		{Name: "VCAP_APP_HOST", Value: "0.0.0.0"},
 	}
@@ -402,6 +402,10 @@ func generateEnvVars(ports []int32, commonEnv []corev1.EnvVar) []corev1.EnvVar {
 			corev1.EnvVar{Name: "PORT", Value: portString},
 		)
 	}
+
+	result = append(result,
+		corev1.EnvVar{Name: "MEMORY_LIMIT", Value: fmt.Sprintf("%dM", memoryMB)},
+	)
 
 	// Sort env vars to guarantee idempotency
 	sort.SliceStable(result, func(i, j int) bool {

--- a/controllers/controllers/workloads/cfprocess_controller_test.go
+++ b/controllers/controllers/workloads/cfprocess_controller_test.go
@@ -200,6 +200,7 @@ var _ = Describe("CFProcessReconciler Integration Tests", func() {
 				// We expect this test will still continue to pass and failures will not be considered flakes, but may
 				// exhibit false positives should the required sort code be removed.
 				g.Expect(appWorkload.Spec.Env).To(HaveExactElements(
+					Equal(corev1.EnvVar{Name: "MEMORY_LIMIT", Value: "1024M"}),
 					Equal(corev1.EnvVar{Name: "PORT", Value: "8080"}),
 					MatchFields(IgnoreExtras, Fields{
 						"Name": Equal("VCAP_APPLICATION"),


### PR DESCRIPTION
## Is there a related GitHub Issue?
https://github.com/cloudfoundry/korifi/issues/3081

## What is this change about?
Adding MEMORY_LIMIT environment variable into cfprocess generation to ensure compatibility with classic CF behavior

## Does this PR introduce a breaking change?
no, should not.

## Acceptance Steps
kubectl get appworkload -n -o yaml
Check, that spec.env has a variable with Name: "MEMORY_LIMIT"

## Tag your pair, your PM, and/or team
@danail-branekov 

