### PR TITLE
added fake getAppFeature in apps handler and related tests for issue-2357

### DIFF
--- a/api/handlers/app.go
+++ b/api/handlers/app.go
@@ -34,6 +34,7 @@ const (
 	AppRestartPath                    = "/v3/apps/{guid}/actions/restart"
 	AppEnvVarsPath                    = "/v3/apps/{guid}/environment_variables"
 	AppEnvPath                        = "/v3/apps/{guid}/env"
+	AppFeaturePath                    = "/v3/apps/{guid}/features/{name}"
 	AppPackagesPath                   = "/v3/apps/{guid}/packages"
 	AppSSHEnabledPath                 = "/v3/apps/{guid}/ssh_enabled"
 	invalidDropletMsg                 = "Unable to assign current droplet. Ensure the droplet exists and belongs to this app."
@@ -606,6 +607,26 @@ func (h *App) getSSHEnabled(r *http.Request) (*routing.Response, error) {
 	}), nil
 }
 
+func (h *App) getAppFeature(r *http.Request) (*routing.Response, error) {
+	featureName := routing.URLParam(r, "name")
+	switch featureName {
+	case "ssh":
+		return routing.NewResponse(http.StatusOK).WithBody(map[string]any{
+			"name":        "ssh",
+			"description": "Enable SSHing into the app.",
+			"enabled":     false,
+		}), nil
+	case "revisions":
+		return routing.NewResponse(http.StatusOK).WithBody(map[string]any{
+			"name":        "revisions",
+			"description": "Enable versioning of an application",
+			"enabled":     false,
+		}), nil
+	default:
+		return nil, apierrors.NewNotFoundError(nil, "Feature")
+	}
+}
+
 func (h *App) UnauthenticatedRoutes() []routing.Route {
 	return nil
 }
@@ -628,6 +649,7 @@ func (h *App) AuthenticatedRoutes() []routing.Route {
 		{Method: "PATCH", Pattern: AppEnvVarsPath, Handler: h.updateEnvVars},
 		{Method: "GET", Pattern: AppEnvPath, Handler: h.getEnvironment},
 		{Method: "GET", Pattern: AppPackagesPath, Handler: h.getPackages},
+		{Method: "GET", Pattern: AppFeaturePath, Handler: h.getAppFeature},
 		{Method: "PATCH", Pattern: AppPath, Handler: h.update},
 		{Method: "GET", Pattern: AppSSHEnabledPath, Handler: h.getSSHEnabled},
 	}

--- a/api/handlers/app_test.go
+++ b/api/handlers/app_test.go
@@ -1653,6 +1653,55 @@ var _ = Describe("App", func() {
 			)))
 		})
 	})
+
+	Describe("GET /v3/apps/GUID/features", func() {
+		When("feature ssh is called", func() {
+			BeforeEach(func() {
+				req = createHttpRequest("GET", "/v3/apps/"+appGUID+"/features/ssh", nil)
+			})
+
+			It("returns ssh enabled false", func() {
+				Expect(rr).To(HaveHTTPStatus(http.StatusOK))
+				Expect(rr).To(HaveHTTPHeaderWithValue("Content-Type", "application/json"))
+				Expect(rr).To(HaveHTTPBody(SatisfyAll(
+					MatchJSONPath("$.name", Equal("ssh")),
+					MatchJSONPath("$.description", Equal("Enable SSHing into the app.")),
+					MatchJSONPath("$.enabled", BeFalse()),
+				)))
+			})
+		})
+		When("feature revisions is called", func() {
+			BeforeEach(func() {
+				req = createHttpRequest("GET", "/v3/apps/"+appGUID+"/features/revisions", nil)
+			})
+
+			It("returns revisions enabled false", func() {
+				Expect(rr).To(HaveHTTPStatus(http.StatusOK))
+				Expect(rr).To(HaveHTTPHeaderWithValue("Content-Type", "application/json"))
+				Expect(rr).To(HaveHTTPBody(SatisfyAll(
+					MatchJSONPath("$.name", Equal("revisions")),
+					MatchJSONPath("$.description", Equal("Enable versioning of an application")),
+					MatchJSONPath("$.enabled", BeFalse()),
+				)))
+			})
+		})
+		When("anything else is called", func() {
+			BeforeEach(func() {
+				req = createHttpRequest("GET", "/v3/apps/"+appGUID+"/features/anything-else", nil)
+			})
+
+			It("returns feature not found", func() {
+				Expect(rr).To(HaveHTTPStatus(http.StatusNotFound))
+				Expect(rr).To(HaveHTTPHeaderWithValue("Content-Type", "application/json"))
+				Expect(rr).To(HaveHTTPBody(SatisfyAll(
+					MatchJSONPath("$.errors", HaveLen(1)),
+					MatchJSONPath("$.errors[0].detail", Equal("Feature not found. Ensure it exists and you have access to it.")),
+					MatchJSONPath("$.errors[0].title", Equal("CF-ResourceNotFound")),
+					MatchJSONPath("$.errors[0].code", BeEquivalentTo(10010)),
+				)))
+			})
+		})
+	})
 })
 
 func createHttpRequest(method string, url string, body io.Reader) *http.Request {


### PR DESCRIPTION
## Is there a related GitHub Issue?
https://github.com/cloudfoundry/korifi/issues/2357

## What is this change about?
I'm adding a new API endpoint that will reply the requested feature and show it as not enabled. This is for consistency with classical CF. See more details in https://github.com/cloudfoundry/korifi/issues/2357

## Does this PR introduce a breaking change?
Not as far as I can see. 

## Acceptance Steps
GIVEN I have pushed an app to korifi
WHEN I GET /v3/apps/:guid/features/:name
THEN I see the following response
```
HTTP/1.1 200 OK
Content-Type: application/json

{
  "name": "feature-name",
  "description": "fature description",
  "enabled": false
}
```

## Tag your pair, your PM, and/or team
@danail-branekov @georgethebeatle 
<!--
## Things to remember
I stole most of this from our internal fork but changed the "PATCH" there into "GET" as requested in the Issue.
