### PR TITLE
added fix to allow usage of uppercase letters

### DIFF
--- a/controllers/controllers/networking/cfroute_controller.go
+++ b/controllers/controllers/networking/cfroute_controller.go
@@ -449,7 +449,7 @@ func generateServiceName(destination korifiv1alpha1.Destination) string {
 }
 
 func buildFQDN(cfRoute *korifiv1alpha1.CFRoute, cfDomain *korifiv1alpha1.CFDomain) string {
-	return fmt.Sprintf("%s.%s", cfRoute.Spec.Host, cfDomain.Spec.Name)
+	return fmt.Sprintf("%s.%s", strings.ToLower(cfRoute.Spec.Host), cfDomain.Spec.Name)
 }
 
 func toBackendRefs(destinations []korifiv1alpha1.Destination) []gatewayv1beta1.HTTPBackendRef {

--- a/controllers/controllers/networking/cfroute_controller_test.go
+++ b/controllers/controllers/networking/cfroute_controller_test.go
@@ -215,6 +215,19 @@ var _ = Describe("CFRouteReconciler Integration Tests", func() {
 			})
 		})
 
+		When("the route's host contains upper case characters", func() {
+			BeforeEach(func() {
+				cfRoute.Spec.Host = "Test-Route"
+			})
+
+			It("uses the lowercased host in the httproute name and path match prefix", func() {
+				httpRoute := getHTTPRoute()
+				Expect(httpRoute.Spec.Hostnames).To(HaveLen(1))
+				Expect(httpRoute.Spec.Hostnames).To(HaveCap(1))
+				Expect(httpRoute.Spec.Hostnames[0]).To(Equal(gatewayv1beta1.Hostname("test-route.") + gatewayv1.Hostname(cfDomain.Spec.Name)))
+			})
+		})
+
 		It("creates a service for the destination", func() {
 			serviceName := fmt.Sprintf("s-%s", cfRoute.Spec.Destinations[0].GUID)
 			Eventually(func(g Gomega) {

--- a/controllers/webhooks/networking/cfroute_validator.go
+++ b/controllers/webhooks/networking/cfroute_validator.go
@@ -212,6 +212,7 @@ func validateFQDN(host, domain string) error {
 		}.ExportJSONError()
 	}
 
+	host = strings.ToLower(host)
 	err := validateHost(host)
 	if err != nil {
 		return webhooks.ValidationError{

--- a/controllers/webhooks/networking/cfroute_validator_test.go
+++ b/controllers/webhooks/networking/cfroute_validator_test.go
@@ -152,13 +152,13 @@ var _ = Describe("CFRouteValidator", func() {
 
 		When("the host is invalid", func() {
 			BeforeEach(func() {
-				cfRoute.Spec.Host = "inVAlidnAme"
+				cfRoute.Spec.Host = "inVAl!dnAme?"
 			})
 
 			It("denies the request", func() {
 				Expect(retErr).To(matchers.BeValidationError(
 					networking.RouteHostNameValidationErrorType,
-					ContainSubstring("Host \"inVAlidnAme\" is not valid"),
+					ContainSubstring("Host \"inval!dname?\" is not valid"),
 				))
 			})
 		})


### PR DESCRIPTION
## Is there a related GitHub Issue?
https://github.com/cloudfoundry/korifi/issues/3210

## What is this change about?
We want to allow users to define CF Routes with uppercase letters and still have them Work. This is required for CATS compatibility.

## Does this PR introduce a breaking change?
not that I have seen or that it would be expected.

## Acceptance Steps
cf create-route apps-127-0-0-1.nip.io --hostname TEST123 
should work and create a valid HTTPRoute like: test123.apps-127-0-0-1.nip.io 

## Tag your pair, your PM, and/or team
@danail-branekov @georgethebeatle 

