### PR TITLE
Fix a flake in CRDs tests

### DIFF
--- a/tests/crds/crds_suite_test.go
+++ b/tests/crds/crds_suite_test.go
@@ -8,9 +8,11 @@ import (
 	"time"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
+	"code.cloudfoundry.org/korifi/controllers/controllers/shared"
 	"code.cloudfoundry.org/korifi/tests/helpers"
 	"code.cloudfoundry.org/korifi/tests/helpers/fail_handler"
 	"code.cloudfoundry.org/korifi/tools"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	k8sclient "k8s.io/client-go/kubernetes"
@@ -126,7 +128,7 @@ var _ = BeforeEach(func() {
 	Expect(k8sClient.Create(ctx, testOrg)).To(Succeed())
 	Eventually(func(g Gomega) {
 		g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(testOrg), testOrg)).To(Succeed())
-		g.Expect(testOrg.Status.GUID).NotTo(BeEmpty())
+		g.Expect(meta.IsStatusConditionTrue(testOrg.StatusConditions(), shared.StatusConditionReady)).To(BeTrue())
 	}).Should(Succeed())
 
 	testSpace = &korifiv1alpha1.CFSpace{
@@ -142,7 +144,7 @@ var _ = BeforeEach(func() {
 	Expect(k8sClient.Create(ctx, testSpace)).To(Succeed())
 	Eventually(func(g Gomega) {
 		g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(testSpace), testSpace)).To(Succeed())
-		g.Expect(testSpace.Status.GUID).NotTo(BeEmpty())
+		g.Expect(meta.IsStatusConditionTrue(testSpace.StatusConditions(), shared.StatusConditionReady)).To(BeTrue())
 	}).Should(Succeed())
 })
 


### PR DESCRIPTION
## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Whenever the test setup is creating an org/space, it should wait for the
ready condition, rather than expecting a non empty status guid
<!-- _Please describe the change here._ -->

