### PR TITLE
Improve fail handlers in e2e tests

### DIFF
--- a/tests/crds/apps_test.go
+++ b/tests/crds/apps_test.go
@@ -139,7 +139,7 @@ func pushApp() *korifiv1alpha1.CFApp {
 
 	failHandler.RegisterFailHandler(fail_handler.Hook{
 		Matcher: fail_handler.Always,
-		Hook: func(config *rest.Config, message string) {
+		Hook: func(config *rest.Config, _ fail_handler.TestFailure) {
 			fail_handler.PrintBuildLogs(config, build.Name)
 		},
 	})

--- a/tests/crds/crds_suite_test.go
+++ b/tests/crds/crds_suite_test.go
@@ -33,8 +33,9 @@ func init() {
 func TestCrds(t *testing.T) {
 	failHandler = fail_handler.New("CRDs Tests", fail_handler.Hook{
 		Matcher: fail_handler.Always,
-		Hook: func(config *rest.Config, message string) {
-			fail_handler.PrintKorifiLogs(config, "")
+		Hook: func(config *rest.Config, failure fail_handler.TestFailure) {
+			fail_handler.PrintKorifiLogs(config, "", failure.StartTime)
+			printBuildLogs(config)
 		},
 	})
 	RegisterFailHandler(failHandler.Fail)
@@ -58,6 +59,18 @@ var (
 	testOrg   *korifiv1alpha1.CFOrg
 	testSpace *korifiv1alpha1.CFSpace
 )
+
+func printBuildLogs(config *rest.Config) {
+	if testSpace == nil {
+		return
+	}
+
+	if testSpace.Status.GUID == "" {
+		return
+	}
+
+	fail_handler.PrintAllBuildLogs(config, testSpace.Status.GUID)
+}
 
 type sharedSetupData struct {
 	DefaultAppBitsFile string

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -281,19 +281,19 @@ func TestE2E(t *testing.T) {
 	RegisterFailHandler(fail_handler.New("E2E Tests",
 		fail_handler.Hook{
 			Matcher: fail_handler.Always,
-			Hook: func(config *rest.Config, _ string) {
-				fail_handler.PrintKorifiLogs(config, correlationId)
+			Hook: func(config *rest.Config, failure fail_handler.TestFailure) {
+				fail_handler.PrintKorifiLogs(config, correlationId, failure.StartTime)
 			},
 		},
 		fail_handler.Hook{
 			Matcher: ContainSubstring("Droplet not found"),
-			Hook: func(config *rest.Config, message string) {
-				printDropletNotFoundDebugInfo(config, message)
+			Hook: func(config *rest.Config, failure fail_handler.TestFailure) {
+				printDropletNotFoundDebugInfo(config, failure.Message)
 			},
 		},
 		fail_handler.Hook{
 			Matcher: ContainSubstring("404"),
-			Hook: func(config *rest.Config, message string) {
+			Hook: func(config *rest.Config, _ fail_handler.TestFailure) {
 				printAllRoleBindings(config)
 			},
 		},

--- a/tests/smoke/smoke_suite_test.go
+++ b/tests/smoke/smoke_suite_test.go
@@ -42,9 +42,10 @@ func TestSmoke(t *testing.T) {
 	RegisterFailHandler(fail_handler.New("Smoke Tests",
 		fail_handler.Hook{
 			Matcher: fail_handler.Always,
-			Hook: func(config *rest.Config, message string) {
+			Hook: func(config *rest.Config, failure fail_handler.TestFailure) {
 				printCfApp(config)
-				fail_handler.PrintKorifiLogs(config, "")
+				fail_handler.PrintKorifiLogs(config, "", failure.StartTime)
+				printBuildLogs(config, spaceName)
 			},
 		}).Fail)
 
@@ -141,4 +142,13 @@ func printObject(k8sClient client.Client, obj client.Object) error {
 	}
 	fmt.Fprintln(GinkgoWriter, string(objBytes))
 	return nil
+}
+
+func printBuildLogs(config *rest.Config, spaceName string) {
+	spaceGUID, err := sessionOutput(helpers.Cf("space", spaceName, "--guid").Wait())
+	if err != nil {
+		fmt.Fprintf(GinkgoWriter, "failed to get space guid: %v\n", err)
+		return
+	}
+	fail_handler.PrintAllBuildLogs(config, spaceGUID)
 }


### PR DESCRIPTION
## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
- Print pod logs since the start of the test run. It is not sufficient
  to print logs since the current spec start time, because this way we
  are missing logs emitted during the test setup
- Print the logs of all builds in the space under test. There should
  generally be one build per test space, so we do not expect this to go
  out of hand.
- We are doing this in order to address the following flake:
  https://ci.korifi.cf-app.com/teams/main/pipelines/main/jobs/run-e2es-eks/builds/677
  The test is failing to get the latest kpack build with empty name. We
  suspect that the name is empty because the build failed and kpack did
  not update the Image resource. We hope that with this improvement we
  will be able to see what is causing the build failure next time this
  test flakes.
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Tag your pair, your PM, and/or team
@danail-branekov
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
