### PR TITLE
Avoid data pollution on tear-down

### DIFF
--- a/tests/crds/crds_suite_test.go
+++ b/tests/crds/crds_suite_test.go
@@ -162,7 +162,7 @@ var _ = BeforeEach(func() {
 })
 
 var _ = AfterEach(func() {
-	Expect(k8sClient.Delete(ctx, testOrg, &client.DeleteOptions{
+	Expect(k8sClient.Delete(ctx, testOrg.DeepCopy(), &client.DeleteOptions{
 		PropagationPolicy: tools.PtrTo(metav1.DeletePropagationBackground),
 	})).To(Succeed())
 })


### PR DESCRIPTION


<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
https://ci.korifi.cf-app.com/teams/main/pipelines/main/jobs/run-e2es-eks-periodic/builds/7693
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
We are deleting the test org in background. By deleting a copy of the
org we ensure that the shared `testOrg` variable is not modified once
deletion is done. Not doing that would mess up subsequent `It`s
<!-- _Please describe the change here._ -->

