### PR TITLE
added environment variable CF_INSTANCE_PORTS

### DIFF
--- a/controllers/controllers/workloads/cfprocess_controller_test.go
+++ b/controllers/controllers/workloads/cfprocess_controller_test.go
@@ -181,6 +181,7 @@ var _ = Describe("CFProcessReconciler Integration Tests", func() {
 					MatchFields(IgnoreExtras, Fields{"Name": Equal("VCAP_APP_PORT")}),
 					MatchFields(IgnoreExtras, Fields{"Name": Equal("VCAP_SERVICES")}),
 					MatchFields(IgnoreExtras, Fields{"Name": Equal("env-key")}),
+					MatchFields(IgnoreExtras, Fields{"Name": Equal("CF_INSTANCE_PORTS")}),
 				))
 			})
 		})

--- a/controllers/controllers/workloads/env/builder.go
+++ b/controllers/controllers/workloads/env/builder.go
@@ -138,9 +138,11 @@ func (b *ProcessEnvBuilder) buildPortEnv(ctx context.Context, cfApp *korifiv1alp
 	processPorts := ports.FromRoutes(cfRoutesForProcess.Items, cfApp.Name, cfProcess.Spec.ProcessType)
 	if len(processPorts) > 0 {
 		portString := strconv.FormatInt(int64(processPorts[0]), 10)
+		cfInstancePorts := fmt.Sprintf("[{\"internal\":%s}]", portString)
 		return []corev1.EnvVar{
 			{Name: "VCAP_APP_PORT", Value: portString},
 			{Name: "PORT", Value: portString},
+			{Name: "CF_INSTANCE_PORTS", Value: cfInstancePorts},
 		}, nil
 	}
 

--- a/controllers/controllers/workloads/env/builder_test.go
+++ b/controllers/controllers/workloads/env/builder_test.go
@@ -350,9 +350,12 @@ var _ = Describe("EnvBuilder", func() {
 						"Name":  Equal("PORT"),
 						"Value": Equal("1234"),
 					}),
+					MatchFields(IgnoreExtras, Fields{
+						"Name":  Equal("CF_INSTANCE_PORTS"),
+						"Value": MatchJSON("[{\"internal\":1234}]"),
+					}),
 				))
 			})
-
 			When("the route does not have destinations", func() {
 				BeforeEach(func() {
 					ensurePatch(cfRoute, func(cfRoute *korifiv1alpha1.CFRoute) {


### PR DESCRIPTION
## Is there a related GitHub Issue?
https://github.com/cloudfoundry/korifi/issues/3229

## What is this change about?
Adding environment variable `CF_INSTANCE_PORTS` to workloads

## Does this PR introduce a breaking change?
not, that i expect it

## Acceptance Steps
- deploy an app, that prints the environment variable CF_INSTANCE_PORTS
- check that the app actually has the environment variable

## Tag your pair, your PM, and/or team
@danail-branekov @georgethebeatle 
## Additional info
I've seen strange errors when executing `go test -v`: 12:04:37.313765   45784 reflector.go:462] pkg/mod/k8s.io/client-go@v0.29.3/tools/cache/reflector.go:229: watch of *v1.Secret ended with: an error on the server ("unable to decode an event from the watch stream: context canceled") has prevented the request from succeeding - i hope that this is some local issue...