### PR TITLE
adapted regex to also allow small letter m, mb, t, tb, g and gb.

### DIFF
--- a/api/payloads/manifest.go
+++ b/api/payloads/manifest.go
@@ -264,7 +264,7 @@ func (s ManifestApplicationService) Validate() error {
 	return validation.ValidateStruct(&s, validation.Field(&s.Name, validation.Required))
 }
 
-var unitAmount = regexp.MustCompile(`^\d+(?:B|K|KB|M|MB|G|GB|T|TB)$`)
+var unitAmount = regexp.MustCompile(`^\d+(?:B|K|KB|M|m|MB|mb|G|g|GB|gb|T|t|TB|tb)$`)
 
 func validateAmountWithUnit(value any) error {
 	v, isNil := validation.Indirect(value)
@@ -273,7 +273,7 @@ func validateAmountWithUnit(value any) error {
 	}
 
 	if !unitAmount.MatchString(v.(string)) {
-		return errors.New("must use a supported unit (B, K, KB, M, MB, G, GB, T, or TB)")
+		return errors.New("must use a supported unit (B, K, KB, M, m, MB, mb, G, g, GB, gb, T, t, TB or tb)")
 	}
 
 	mbs, err := bytefmt.ToMegabytes(v.(string))

--- a/api/payloads/manifest_test.go
+++ b/api/payloads/manifest_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Manifest payload", func() {
 				})
 
 				It("returns a validation error", func() {
-					expectUnprocessableEntityError(validateErr, "applications[0].memory must use a supported unit (B, K, KB, M, MB, G, GB, T, or TB)")
+					expectUnprocessableEntityError(validateErr, "applications[0].memory must use a supported unit (B, K, KB, M, m, MB, mb, G, g, GB, gb, T, t, TB or tb)")
 				})
 
 				When("there is more than one error", func() {
@@ -53,8 +53,8 @@ var _ = Describe("Manifest payload", func() {
 					})
 
 					It("returns both errors", func() {
-						expectUnprocessableEntityError(validateErr, "applications[0].disk_quota must use a supported unit (B, K, KB, M, MB, G, GB, T, or TB)")
-						expectUnprocessableEntityError(validateErr, "applications[0].memory must use a supported unit (B, K, KB, M, MB, G, GB, T, or TB)")
+						expectUnprocessableEntityError(validateErr, "applications[0].disk_quota must use a supported unit (B, K, KB, M, m, MB, mb, G, g, GB, gb, T, t, TB or tb)")
+						expectUnprocessableEntityError(validateErr, "applications[0].memory must use a supported unit (B, K, KB, M, m, MB, mb, G, g, GB, gb, T, t, TB or tb)")
 					})
 				})
 			})
@@ -109,7 +109,7 @@ var _ = Describe("Manifest payload", func() {
 				})
 
 				It("returns a validation error", func() {
-					expectUnprocessableEntityError(validateErr, "disk_quota must use a supported unit (B, K, KB, M, MB, G, GB, T, or TB)")
+					expectUnprocessableEntityError(validateErr, "disk_quota must use a supported unit (B, K, KB, M, m, MB, mb, G, g, GB, gb, T, t, TB or tb)")
 				})
 			})
 
@@ -129,7 +129,7 @@ var _ = Describe("Manifest payload", func() {
 				})
 
 				It("returns a validation error", func() {
-					expectUnprocessableEntityError(validateErr, "disk-quota must use a supported unit (B, K, KB, M, MB, G, GB, T, or TB)")
+					expectUnprocessableEntityError(validateErr, "disk-quota must use a supported unit (B, K, KB, M, m, MB, mb, G, g, GB, gb, T, t, TB or tb)")
 				})
 			})
 
@@ -190,7 +190,7 @@ var _ = Describe("Manifest payload", func() {
 				})
 
 				It("returns a validation error", func() {
-					expectUnprocessableEntityError(validateErr, "memory must use a supported unit (B, K, KB, M, MB, G, GB, T, or TB)")
+					expectUnprocessableEntityError(validateErr, "memory must use a supported unit (B, K, KB, M, m, MB, mb, G, g, GB, gb, T, t, TB or tb)")
 				})
 			})
 
@@ -422,7 +422,7 @@ var _ = Describe("Manifest payload", func() {
 				})
 
 				It("returns a validation error", func() {
-					expectUnprocessableEntityError(validateErr, "disk_quota must use a supported unit (B, K, KB, M, MB, G, GB, T, or TB)")
+					expectUnprocessableEntityError(validateErr, "disk_quota must use a supported unit (B, K, KB, M, m, MB, mb, G, g, GB, gb, T, t, TB or tb)")
 				})
 			})
 
@@ -442,7 +442,7 @@ var _ = Describe("Manifest payload", func() {
 				})
 
 				It("returns a validation error", func() {
-					expectUnprocessableEntityError(validateErr, "disk-quota must use a supported unit (B, K, KB, M, MB, G, GB, T, or TB)")
+					expectUnprocessableEntityError(validateErr, "disk-quota must use a supported unit (B, K, KB, M, m, MB, mb, G, g, GB, gb, T, t, TB or tb)")
 				})
 			})
 
@@ -503,7 +503,7 @@ var _ = Describe("Manifest payload", func() {
 				})
 
 				It("returns a validation error", func() {
-					expectUnprocessableEntityError(validateErr, "memory must use a supported unit (B, K, KB, M, MB, G, GB, T, or TB)")
+					expectUnprocessableEntityError(validateErr, "memory must use a supported unit (B, K, KB, M, m, MB, mb, G, g, GB, gb, T, t, TB or tb)")
 				})
 			})
 


### PR DESCRIPTION
## Is there a related GitHub Issue?
https://github.com/cloudfoundry/korifi/issues/3231

## What is this change about?
support small letters in memory definition, analog to original CF [spec](https://v3-apidocs.cloudfoundry.org/version/3.156.0/index.html#the-manifest-schema) 

## Does this PR introduce a breaking change?
not that i'm aware of.

## Acceptance Steps
push an app, with memory values like:
128m
128mb
128g
128gb
128t
128tb

## Tag your pair, your PM, and/or team
@danail-branekov  @georgethebeatle 
