### PR TITLE
Introduce `Ready` status condition for CFServiceBinding

### DIFF
--- a/api/repositories/app_repository.go
+++ b/api/repositories/app_repository.go
@@ -11,7 +11,6 @@ import (
 	"code.cloudfoundry.org/korifi/api/authorization"
 	apierrors "code.cloudfoundry.org/korifi/api/errors"
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
-	"code.cloudfoundry.org/korifi/controllers/controllers/shared"
 	"code.cloudfoundry.org/korifi/controllers/controllers/workloads/env"
 	"code.cloudfoundry.org/korifi/controllers/webhooks"
 	"code.cloudfoundry.org/korifi/tools/k8s"
@@ -431,7 +430,7 @@ func (f *AppRepo) SetCurrentDroplet(ctx context.Context, authInfo authorization.
 		return CurrentDropletRecord{}, fmt.Errorf("failed to set app droplet: %w", apierrors.FromK8sError(err, AppResourceType))
 	}
 
-	_, err = f.appAwaiter.AwaitCondition(ctx, userClient, cfApp, shared.StatusConditionReady)
+	_, err = f.appAwaiter.AwaitCondition(ctx, userClient, cfApp, korifiv1alpha1.StatusConditionReady)
 	if err != nil {
 		return CurrentDropletRecord{}, fmt.Errorf("failed to await the app staged condition: %w", apierrors.FromK8sError(err, AppResourceType))
 	}
@@ -674,7 +673,7 @@ func cfAppToAppRecord(cfApp korifiv1alpha1.CFApp) AppRecord {
 		CreatedAt:             cfApp.CreationTimestamp.Time,
 		UpdatedAt:             getLastUpdatedTime(&cfApp),
 		DeletedAt:             golangTime(cfApp.DeletionTimestamp),
-		IsStaged:              meta.IsStatusConditionTrue(cfApp.Status.Conditions, shared.StatusConditionReady),
+		IsStaged:              meta.IsStatusConditionTrue(cfApp.Status.Conditions, korifiv1alpha1.StatusConditionReady),
 		envSecretName:         cfApp.Spec.EnvSecretName,
 		vcapServiceSecretName: cfApp.Status.VCAPServicesSecretName,
 		vcapAppSecretName:     cfApp.Status.VCAPApplicationSecretName,

--- a/api/repositories/app_repository_test.go
+++ b/api/repositories/app_repository_test.go
@@ -13,7 +13,6 @@ import (
 	. "code.cloudfoundry.org/korifi/api/repositories"
 	"code.cloudfoundry.org/korifi/api/repositories/fakeawaiter"
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
-	"code.cloudfoundry.org/korifi/controllers/controllers/shared"
 	"code.cloudfoundry.org/korifi/controllers/controllers/workloads/env"
 	"code.cloudfoundry.org/korifi/controllers/controllers/workloads/testutils"
 	"code.cloudfoundry.org/korifi/tests/matchers"
@@ -108,7 +107,7 @@ var _ = Describe("AppRepository", func() {
 			When("the app has staged condition true", func() {
 				BeforeEach(func() {
 					cfApp.Status.Conditions = []metav1.Condition{{
-						Type:               shared.StatusConditionReady,
+						Type:               korifiv1alpha1.StatusConditionReady,
 						Status:             metav1.ConditionTrue,
 						LastTransitionTime: metav1.Now(),
 						Reason:             "staged",
@@ -131,7 +130,7 @@ var _ = Describe("AppRepository", func() {
 			When("the app has staged condition false", func() {
 				BeforeEach(func() {
 					meta.SetStatusCondition(&cfApp.Status.Conditions, metav1.Condition{
-						Type:    shared.StatusConditionReady,
+						Type:    korifiv1alpha1.StatusConditionReady,
 						Status:  metav1.ConditionFalse,
 						Reason:  "appStaged",
 						Message: "",
@@ -140,7 +139,7 @@ var _ = Describe("AppRepository", func() {
 					Eventually(func(g Gomega) {
 						app := korifiv1alpha1.CFApp{}
 						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cfApp), &app)).To(Succeed())
-						g.Expect(meta.IsStatusConditionFalse(app.Status.Conditions, shared.StatusConditionReady)).To(BeTrue())
+						g.Expect(meta.IsStatusConditionFalse(app.Status.Conditions, korifiv1alpha1.StatusConditionReady)).To(BeTrue())
 					}).Should(Succeed())
 				})
 
@@ -1120,7 +1119,7 @@ var _ = Describe("AppRepository", func() {
 				obj, conditionType := appAwaiter.AwaitConditionArgsForCall(0)
 				Expect(obj.GetName()).To(Equal(appGUID))
 				Expect(obj.GetNamespace()).To(Equal(cfSpace.Name))
-				Expect(conditionType).To(Equal(shared.StatusConditionReady))
+				Expect(conditionType).To(Equal(korifiv1alpha1.StatusConditionReady))
 			})
 
 			It("returns a CurrentDroplet record", func() {

--- a/api/repositories/buildpack_repository.go
+++ b/api/repositories/buildpack_repository.go
@@ -7,7 +7,7 @@ import (
 
 	"code.cloudfoundry.org/korifi/api/authorization"
 	apierrors "code.cloudfoundry.org/korifi/api/errors"
-	"code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
+	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/types"
@@ -41,7 +41,7 @@ func NewBuildpackRepository(builderName string, userClientFactory authorization.
 }
 
 func (r *BuildpackRepository) ListBuildpacks(ctx context.Context, authInfo authorization.Info) ([]BuildpackRecord, error) {
-	var builderInfo v1alpha1.BuilderInfo
+	var builderInfo korifiv1alpha1.BuilderInfo
 
 	userClient, err := r.userClientFactory.BuildClient(authInfo)
 	if err != nil {
@@ -64,10 +64,10 @@ func (r *BuildpackRepository) ListBuildpacks(ctx context.Context, authInfo autho
 		return nil, apierrors.FromK8sError(err, BuildpackResourceType)
 	}
 
-	if !meta.IsStatusConditionTrue(builderInfo.Status.Conditions, StatusConditionReady) {
+	if !meta.IsStatusConditionTrue(builderInfo.Status.Conditions, korifiv1alpha1.StatusConditionReady) {
 		var conditionNotReadyMessage string
 
-		readyCondition := meta.FindStatusCondition(builderInfo.Status.Conditions, StatusConditionReady)
+		readyCondition := meta.FindStatusCondition(builderInfo.Status.Conditions, korifiv1alpha1.StatusConditionReady)
 		if readyCondition != nil {
 			conditionNotReadyMessage = readyCondition.Message
 		}
@@ -82,7 +82,7 @@ func (r *BuildpackRepository) ListBuildpacks(ctx context.Context, authInfo autho
 	return builderInfoToBuildpackRecords(builderInfo), nil
 }
 
-func builderInfoToBuildpackRecords(info v1alpha1.BuilderInfo) []BuildpackRecord {
+func builderInfoToBuildpackRecords(info korifiv1alpha1.BuilderInfo) []BuildpackRecord {
 	buildpackRecords := make([]BuildpackRecord, 0, len(info.Status.Buildpacks))
 
 	for i := range info.Status.Buildpacks {

--- a/api/repositories/deployment_repository.go
+++ b/api/repositories/deployment_repository.go
@@ -9,7 +9,6 @@ import (
 	"code.cloudfoundry.org/korifi/api/authorization"
 	apierrors "code.cloudfoundry.org/korifi/api/errors"
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
-	"code.cloudfoundry.org/korifi/controllers/controllers/shared"
 	"code.cloudfoundry.org/korifi/tools/k8s"
 	"code.cloudfoundry.org/korifi/version"
 	"github.com/go-logr/logr"
@@ -155,7 +154,7 @@ func appToDeploymentRecord(cfApp *korifiv1alpha1.CFApp) DeploymentRecord {
 		},
 	}
 
-	if meta.IsStatusConditionTrue(cfApp.Status.Conditions, shared.StatusConditionReady) {
+	if meta.IsStatusConditionTrue(cfApp.Status.Conditions, korifiv1alpha1.StatusConditionReady) {
 		deploymentRecord.Status = DeploymentStatus{
 			Value:  DeploymentStatusValueFinalized,
 			Reason: DeploymentStatusReasonDeployed,

--- a/api/repositories/deployment_repository_test.go
+++ b/api/repositories/deployment_repository_test.go
@@ -6,7 +6,6 @@ import (
 	apierrors "code.cloudfoundry.org/korifi/api/errors"
 	"code.cloudfoundry.org/korifi/api/repositories"
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
-	"code.cloudfoundry.org/korifi/controllers/controllers/shared"
 	"code.cloudfoundry.org/korifi/tests/matchers"
 	"code.cloudfoundry.org/korifi/tools/k8s"
 	"code.cloudfoundry.org/korifi/version"
@@ -88,7 +87,7 @@ var _ = Describe("DeploymentRepository", func() {
 				BeforeEach(func() {
 					Expect(k8s.Patch(ctx, k8sClient, cfApp, func() {
 						meta.SetStatusCondition(&cfApp.Status.Conditions, metav1.Condition{
-							Type:   shared.StatusConditionReady,
+							Type:   korifiv1alpha1.StatusConditionReady,
 							Status: metav1.ConditionTrue,
 							Reason: "ready",
 						})
@@ -179,7 +178,7 @@ var _ = Describe("DeploymentRepository", func() {
 				BeforeEach(func() {
 					Expect(k8s.Patch(ctx, k8sClient, cfApp, func() {
 						meta.SetStatusCondition(&cfApp.Status.Conditions, metav1.Condition{
-							Type:   shared.StatusConditionReady,
+							Type:   korifiv1alpha1.StatusConditionReady,
 							Status: metav1.ConditionTrue,
 							Reason: "ready",
 						})

--- a/api/repositories/org_repository.go
+++ b/api/repositories/org_repository.go
@@ -100,7 +100,7 @@ func (r *OrgRepo) CreateOrg(ctx context.Context, info authorization.Info, messag
 		return OrgRecord{}, fmt.Errorf("failed to create cf org: %w", apierrors.FromK8sError(err, OrgResourceType))
 	}
 
-	cfOrg, err = r.conditionAwaiter.AwaitCondition(ctx, userClient, cfOrg, StatusConditionReady)
+	cfOrg, err = r.conditionAwaiter.AwaitCondition(ctx, userClient, cfOrg, korifiv1alpha1.StatusConditionReady)
 	if err != nil {
 		return OrgRecord{}, apierrors.FromK8sError(err, OrgResourceType)
 	}
@@ -130,7 +130,7 @@ func (r *OrgRepo) ListOrgs(ctx context.Context, info authorization.Info, filter 
 			return authorizedNamespaces[o.Name]
 		},
 		func(o korifiv1alpha1.CFOrg) bool {
-			return meta.IsStatusConditionTrue(o.Status.Conditions, StatusConditionReady)
+			return meta.IsStatusConditionTrue(o.Status.Conditions, korifiv1alpha1.StatusConditionReady)
 		},
 		SetPredicate(filter.GUIDs, func(s korifiv1alpha1.CFOrg) string { return s.Name }),
 		SetPredicate(filter.Names, func(s korifiv1alpha1.CFOrg) string { return s.Spec.DisplayName }),

--- a/api/repositories/org_repository_test.go
+++ b/api/repositories/org_repository_test.go
@@ -10,7 +10,6 @@ import (
 	"code.cloudfoundry.org/korifi/api/repositories"
 	"code.cloudfoundry.org/korifi/api/repositories/fakeawaiter"
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
-	"code.cloudfoundry.org/korifi/controllers/controllers/shared"
 	"code.cloudfoundry.org/korifi/tests/matchers"
 	"code.cloudfoundry.org/korifi/tools"
 	"code.cloudfoundry.org/korifi/tools/k8s"
@@ -137,7 +136,7 @@ var _ = Describe("OrgRepository", func() {
 				obj, conditionType := conditionAwaiter.AwaitConditionArgsForCall(0)
 				Expect(obj.GetName()).To(Equal(cfOrg.Name))
 				Expect(obj.GetNamespace()).To(Equal(rootNamespace))
-				Expect(conditionType).To(Equal(shared.StatusConditionReady))
+				Expect(conditionType).To(Equal(korifiv1alpha1.StatusConditionReady))
 			})
 
 			When("the org does not become ready", func() {

--- a/api/repositories/package_repository.go
+++ b/api/repositories/package_repository.go
@@ -8,7 +8,6 @@ import (
 	"code.cloudfoundry.org/korifi/api/authorization"
 	apierrors "code.cloudfoundry.org/korifi/api/errors"
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
-	"code.cloudfoundry.org/korifi/controllers/controllers/shared"
 	"code.cloudfoundry.org/korifi/controllers/controllers/workloads"
 	"code.cloudfoundry.org/korifi/tools/dockercfg"
 	"code.cloudfoundry.org/korifi/tools/k8s"
@@ -305,8 +304,8 @@ func (r *PackageRepo) ListPackages(ctx context.Context, authInfo authorization.I
 	if len(message.States) > 0 {
 		stateSet := NewSet(message.States...)
 		preds = append(preds, func(p korifiv1alpha1.CFPackage) bool {
-			return (stateSet.Includes(PackageStateReady) && meta.IsStatusConditionTrue(p.Status.Conditions, shared.StatusConditionReady)) ||
-				(stateSet.Includes(PackageStateAwaitingUpload) && !meta.IsStatusConditionTrue(p.Status.Conditions, shared.StatusConditionReady))
+			return (stateSet.Includes(PackageStateReady) && meta.IsStatusConditionTrue(p.Status.Conditions, korifiv1alpha1.StatusConditionReady)) ||
+				(stateSet.Includes(PackageStateAwaitingUpload) && !meta.IsStatusConditionTrue(p.Status.Conditions, korifiv1alpha1.StatusConditionReady))
 		})
 	}
 
@@ -347,7 +346,7 @@ func (r *PackageRepo) UpdatePackageSource(ctx context.Context, authInfo authoriz
 		return PackageRecord{}, fmt.Errorf("failed to update package source: %w", apierrors.FromK8sError(err, PackageResourceType))
 	}
 
-	cfPackage, err = r.awaiter.AwaitCondition(ctx, userClient, cfPackage, shared.StatusConditionReady)
+	cfPackage, err = r.awaiter.AwaitCondition(ctx, userClient, cfPackage, korifiv1alpha1.StatusConditionReady)
 	if err != nil {
 		return PackageRecord{}, fmt.Errorf("failed awaiting Ready status condition: %w", err)
 	}
@@ -358,7 +357,7 @@ func (r *PackageRepo) UpdatePackageSource(ctx context.Context, authInfo authoriz
 
 func (r *PackageRepo) cfPackageToPackageRecord(cfPackage *korifiv1alpha1.CFPackage) PackageRecord {
 	state := PackageStateAwaitingUpload
-	if meta.IsStatusConditionTrue(cfPackage.Status.Conditions, shared.StatusConditionReady) {
+	if meta.IsStatusConditionTrue(cfPackage.Status.Conditions, korifiv1alpha1.StatusConditionReady) {
 		state = PackageStateReady
 	}
 	return PackageRecord{

--- a/api/repositories/service_binding_repository.go
+++ b/api/repositories/service_binding_repository.go
@@ -144,7 +144,7 @@ func (r *ServiceBindingRepo) CreateServiceBinding(ctx context.Context, authInfo 
 		return ServiceBindingRecord{}, apierrors.FromK8sError(err, ServiceBindingResourceType)
 	}
 
-	cfServiceBinding, err = r.bindingConditionAwaiter.AwaitCondition(ctx, userClient, cfServiceBinding, VCAPServicesSecretAvailableCondition)
+	cfServiceBinding, err = r.bindingConditionAwaiter.AwaitCondition(ctx, userClient, cfServiceBinding, korifiv1alpha1.StatusConditionReady)
 	if err != nil {
 		return ServiceBindingRecord{}, err
 	}

--- a/api/repositories/service_binding_repository_test.go
+++ b/api/repositories/service_binding_repository_test.go
@@ -89,7 +89,7 @@ var _ = Describe("ServiceBindingRepo", func() {
 				Expect(k8s.Patch(ctx, k8sClient, cfServiceBinding, func() {
 					cfServiceBinding.Status.Binding.Name = "service-secret-name"
 					meta.SetStatusCondition(&cfServiceBinding.Status.Conditions, metav1.Condition{
-						Type:    repositories.VCAPServicesSecretAvailableCondition,
+						Type:    korifiv1alpha1.StatusConditionReady,
 						Status:  metav1.ConditionTrue,
 						Reason:  "blah",
 						Message: "blah",
@@ -169,7 +169,7 @@ var _ = Describe("ServiceBindingRepo", func() {
 				obj, conditionType := conditionAwaiter.AwaitConditionArgsForCall(0)
 				Expect(obj.GetName()).To(Equal(cfServiceBinding.Name))
 				Expect(obj.GetNamespace()).To(Equal(space.Name))
-				Expect(conditionType).To(Equal(repositories.VCAPServicesSecretAvailableCondition))
+				Expect(conditionType).To(Equal(korifiv1alpha1.StatusConditionReady))
 			})
 
 			When("the vcap services secret available condition is never met", func() {

--- a/api/repositories/shared.go
+++ b/api/repositories/shared.go
@@ -10,11 +10,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const (
-	StatusConditionReady                 = "Ready"
-	VCAPServicesSecretAvailableCondition = "VCAPServicesSecretAvailable"
-)
-
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 
 //counterfeiter:generate -o fake -fake-name RepositoryCreator . RepositoryCreator

--- a/api/repositories/space_repository.go
+++ b/api/repositories/space_repository.go
@@ -104,7 +104,7 @@ func (r *SpaceRepo) CreateSpace(ctx context.Context, info authorization.Info, me
 		return SpaceRecord{}, apierrors.FromK8sError(err, SpaceResourceType)
 	}
 
-	cfSpace, err = r.conditionAwaiter.AwaitCondition(ctx, userClient, cfSpace, StatusConditionReady)
+	cfSpace, err = r.conditionAwaiter.AwaitCondition(ctx, userClient, cfSpace, korifiv1alpha1.StatusConditionReady)
 	if err != nil {
 		return SpaceRecord{}, apierrors.FromK8sError(err, SpaceResourceType)
 	}
@@ -133,7 +133,7 @@ func (r *SpaceRepo) ListSpaces(ctx context.Context, info authorization.Info, mes
 	preds := []func(korifiv1alpha1.CFSpace) bool{
 		func(s korifiv1alpha1.CFSpace) bool { return authorizedSpaceNamespaces[s.Name] },
 		func(s korifiv1alpha1.CFSpace) bool {
-			return meta.IsStatusConditionTrue(s.Status.Conditions, StatusConditionReady)
+			return meta.IsStatusConditionTrue(s.Status.Conditions, korifiv1alpha1.StatusConditionReady)
 		},
 		SetPredicate(message.GUIDs, func(s korifiv1alpha1.CFSpace) string { return s.Name }),
 		SetPredicate(message.Names, func(s korifiv1alpha1.CFSpace) string { return s.Spec.DisplayName }),

--- a/api/repositories/space_repository_test.go
+++ b/api/repositories/space_repository_test.go
@@ -9,7 +9,6 @@ import (
 	"code.cloudfoundry.org/korifi/api/repositories"
 	"code.cloudfoundry.org/korifi/api/repositories/fakeawaiter"
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
-	"code.cloudfoundry.org/korifi/controllers/controllers/shared"
 	"code.cloudfoundry.org/korifi/tests/matchers"
 	"code.cloudfoundry.org/korifi/tools"
 	"code.cloudfoundry.org/korifi/tools/k8s"
@@ -124,7 +123,7 @@ var _ = Describe("SpaceRepository", func() {
 				obj, conditionType := conditionAwaiter.AwaitConditionArgsForCall(0)
 				Expect(obj.GetName()).To(Equal(cfSpace.Name))
 				Expect(obj.GetNamespace()).To(Equal(orgGUID))
-				Expect(conditionType).To(Equal(shared.StatusConditionReady))
+				Expect(conditionType).To(Equal(korifiv1alpha1.StatusConditionReady))
 			})
 
 			It("creates a CFSpace resource in the org namespace", func() {

--- a/controllers/api/v1alpha1/constants.go
+++ b/controllers/api/v1alpha1/constants.go
@@ -10,4 +10,6 @@ const (
 	HTTPHealthCheckType    HealthCheckType = "http"
 	PortHealthCheckType    HealthCheckType = "port"
 	ProcessHealthCheckType HealthCheckType = "process"
+
+	StatusConditionReady = "Ready"
 )

--- a/controllers/cleanup/package_cleaner.go
+++ b/controllers/cleanup/package_cleaner.go
@@ -5,7 +5,6 @@ import (
 	"sort"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
-	"code.cloudfoundry.org/korifi/controllers/controllers/shared"
 	"code.cloudfoundry.org/korifi/statefulset-runner/controllers"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -58,7 +57,7 @@ func (c PackageCleaner) Clean(ctx context.Context, app types.NamespacedName) err
 		if cfPackage.Name == currentPackage {
 			continue
 		}
-		if !meta.IsStatusConditionTrue(cfPackage.Status.Conditions, shared.StatusConditionReady) {
+		if !meta.IsStatusConditionTrue(cfPackage.Status.Conditions, korifiv1alpha1.StatusConditionReady) {
 			continue
 		}
 		deletablePackages = append(deletablePackages, cfPackage)

--- a/controllers/cleanup/package_cleaner_test.go
+++ b/controllers/cleanup/package_cleaner_test.go
@@ -5,7 +5,6 @@ import (
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"code.cloudfoundry.org/korifi/controllers/cleanup"
-	"code.cloudfoundry.org/korifi/controllers/controllers/shared"
 	. "code.cloudfoundry.org/korifi/controllers/controllers/workloads/testutils"
 	"code.cloudfoundry.org/korifi/statefulset-runner/controllers"
 
@@ -132,7 +131,7 @@ func createPackage(namespace, appGUID, name string) *korifiv1alpha1.CFPackage {
 func createReadyPackage(namespace, appGUID, name string) *korifiv1alpha1.CFPackage {
 	pkg := createPackage(namespace, appGUID, name)
 	meta.SetStatusCondition(&pkg.Status.Conditions, metav1.Condition{
-		Type:   shared.StatusConditionReady,
+		Type:   korifiv1alpha1.StatusConditionReady,
 		Status: metav1.ConditionTrue,
 		Reason: "SourceImageSet",
 	})

--- a/controllers/controllers/services/bindings/suite_test.go
+++ b/controllers/controllers/services/bindings/suite_test.go
@@ -47,7 +47,7 @@ var (
 )
 
 func TestAPIs(t *testing.T) {
-	SetDefaultEventuallyTimeout(30 * time.Second)
+	SetDefaultEventuallyTimeout(10 * time.Second)
 	SetDefaultEventuallyPollingInterval(250 * time.Millisecond)
 
 	RegisterFailHandler(Fail)

--- a/controllers/controllers/shared/index.go
+++ b/controllers/controllers/shared/index.go
@@ -22,8 +22,6 @@ const (
 	IndexAppTasks                             = "appTasks"
 	IndexSpaceNamespaceName                   = "spaceNamespace"
 	IndexOrgNamespaceName                     = "orgNamespace"
-
-	StatusConditionReady = "Ready"
 )
 
 func SetupIndexWithManager(mgr manager.Manager) error {

--- a/controllers/controllers/workloads/cforg_controller.go
+++ b/controllers/controllers/workloads/cforg_controller.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
-	"code.cloudfoundry.org/korifi/controllers/controllers/shared"
 	"code.cloudfoundry.org/korifi/controllers/controllers/workloads/k8sns"
 	"code.cloudfoundry.org/korifi/controllers/controllers/workloads/labels"
 	"code.cloudfoundry.org/korifi/tools/k8s"
@@ -129,9 +128,9 @@ func (r *CFOrgReconciler) ReconcileResource(ctx context.Context, cfOrg *korifiv1
 	}
 
 	meta.SetStatusCondition(&cfOrg.Status.Conditions, metav1.Condition{
-		Type:               shared.StatusConditionReady,
+		Type:               korifiv1alpha1.StatusConditionReady,
 		Status:             metav1.ConditionTrue,
-		Reason:             shared.StatusConditionReady,
+		Reason:             korifiv1alpha1.StatusConditionReady,
 		ObservedGeneration: cfOrg.Generation,
 	})
 

--- a/controllers/controllers/workloads/cfpackage_controller.go
+++ b/controllers/controllers/workloads/cfpackage_controller.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
-	"code.cloudfoundry.org/korifi/controllers/controllers/shared"
 	"code.cloudfoundry.org/korifi/tools/image"
 	"code.cloudfoundry.org/korifi/tools/k8s"
 
@@ -125,7 +124,7 @@ func (r *CFPackageReconciler) ReconcileResource(ctx context.Context, cfPackage *
 		readyReason = "SourceImageSet"
 	}
 	meta.SetStatusCondition(&cfPackage.Status.Conditions, metav1.Condition{
-		Type:               shared.StatusConditionReady,
+		Type:               korifiv1alpha1.StatusConditionReady,
 		Status:             readyCondition,
 		Reason:             readyReason,
 		ObservedGeneration: cfPackage.Generation,

--- a/controllers/controllers/workloads/cfpackage_controller_test.go
+++ b/controllers/controllers/workloads/cfpackage_controller_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
-	"code.cloudfoundry.org/korifi/controllers/controllers/shared"
 	"code.cloudfoundry.org/korifi/controllers/controllers/workloads"
 	. "code.cloudfoundry.org/korifi/controllers/controllers/workloads/testutils"
 	"code.cloudfoundry.org/korifi/tools"
@@ -59,8 +58,8 @@ var _ = Describe("CFPackageReconciler Integration Tests", func() {
 
 			Expect(meta.FindStatusCondition(createdCFPackage.Status.Conditions, workloads.InitializedConditionType).ObservedGeneration).To(Equal(createdCFPackage.Generation))
 
-			Expect(meta.IsStatusConditionFalse(createdCFPackage.Status.Conditions, shared.StatusConditionReady)).To(BeTrue())
-			Expect(meta.FindStatusCondition(createdCFPackage.Status.Conditions, shared.StatusConditionReady).ObservedGeneration).To(Equal(createdCFPackage.Generation))
+			Expect(meta.IsStatusConditionFalse(createdCFPackage.Status.Conditions, korifiv1alpha1.StatusConditionReady)).To(BeTrue())
+			Expect(meta.FindStatusCondition(createdCFPackage.Status.Conditions, korifiv1alpha1.StatusConditionReady).ObservedGeneration).To(Equal(createdCFPackage.Generation))
 
 			Expect(createdCFPackage.GetOwnerReferences()).To(ConsistOf(metav1.OwnerReference{
 				APIVersion:         korifiv1alpha1.GroupVersion.Identifier(),
@@ -112,7 +111,7 @@ var _ = Describe("CFPackageReconciler Integration Tests", func() {
 			It("sets the ready condition to true", func() {
 				Eventually(func(g Gomega) {
 					g.Expect(adminClient.Get(context.Background(), client.ObjectKeyFromObject(cfPackage), &createdCFPackage)).To(Succeed())
-					g.Expect(meta.IsStatusConditionTrue(createdCFPackage.Status.Conditions, shared.StatusConditionReady)).To(BeTrue())
+					g.Expect(meta.IsStatusConditionTrue(createdCFPackage.Status.Conditions, korifiv1alpha1.StatusConditionReady)).To(BeTrue())
 				}).Should(Succeed())
 			})
 		})

--- a/controllers/controllers/workloads/cfprocess_controller.go
+++ b/controllers/controllers/workloads/cfprocess_controller.go
@@ -168,9 +168,9 @@ func (r *CFProcessReconciler) ReconcileResource(ctx context.Context, cfProcess *
 	}
 
 	meta.SetStatusCondition(&cfProcess.Status.Conditions, metav1.Condition{
-		Type:               shared.StatusConditionReady,
+		Type:               korifiv1alpha1.StatusConditionReady,
 		Status:             metav1.ConditionTrue,
-		Reason:             shared.StatusConditionReady,
+		Reason:             korifiv1alpha1.StatusConditionReady,
 		ObservedGeneration: cfProcess.Generation,
 	})
 

--- a/controllers/controllers/workloads/cfspace_controller.go
+++ b/controllers/controllers/workloads/cfspace_controller.go
@@ -152,7 +152,7 @@ func (r *CFSpaceReconciler) ReconcileResource(ctx context.Context, cfSpace *kori
 		log.Info("not ready yet", "reason", "error propagating service accounts", "error", err)
 
 		meta.SetStatusCondition(&cfSpace.Status.Conditions, metav1.Condition{
-			Type:               shared.StatusConditionReady,
+			Type:               korifiv1alpha1.StatusConditionReady,
 			Status:             metav1.ConditionFalse,
 			Reason:             "ServiceAccountPropagation",
 			Message:            err.Error(),
@@ -163,9 +163,9 @@ func (r *CFSpaceReconciler) ReconcileResource(ctx context.Context, cfSpace *kori
 	}
 
 	meta.SetStatusCondition(&cfSpace.Status.Conditions, metav1.Condition{
-		Type:               shared.StatusConditionReady,
+		Type:               korifiv1alpha1.StatusConditionReady,
 		Status:             metav1.ConditionTrue,
-		Reason:             shared.StatusConditionReady,
+		Reason:             korifiv1alpha1.StatusConditionReady,
 		ObservedGeneration: cfSpace.Generation,
 	})
 

--- a/controllers/controllers/workloads/cftask_controller.go
+++ b/controllers/controllers/workloads/cftask_controller.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
-	"code.cloudfoundry.org/korifi/controllers/controllers/shared"
 	"code.cloudfoundry.org/korifi/tools/k8s"
 
 	"github.com/go-logr/logr"
@@ -184,7 +183,7 @@ func (r *CFTaskReconciler) getApp(ctx context.Context, cfTask *korifiv1alpha1.CF
 		return nil, err
 	}
 
-	if !meta.IsStatusConditionTrue(cfApp.Status.Conditions, shared.StatusConditionReady) {
+	if !meta.IsStatusConditionTrue(cfApp.Status.Conditions, korifiv1alpha1.StatusConditionReady) {
 		log.Info("CFApp not staged", "appNamespace", cfApp.Namespace, "appName", cfApp.Name)
 		r.recorder.Eventf(cfTask, "Warning", "AppNotStaged", "App %s:%s is not staged", cfApp.Namespace, cfApp.Name)
 		return nil, errors.New("app not staged")

--- a/controllers/controllers/workloads/k8sns/reconciler.go
+++ b/controllers/controllers/workloads/k8sns/reconciler.go
@@ -143,7 +143,7 @@ func (r *Reconciler[T, NS]) setNotReady(log logr.Logger, obj NS, err error, reas
 	log.Info("not ready yet", "reason", reason, "error", err)
 
 	meta.SetStatusCondition(obj.GetStatus().GetConditions(), metav1.Condition{
-		Type:               shared.StatusConditionReady,
+		Type:               korifiv1alpha1.StatusConditionReady,
 		Status:             metav1.ConditionFalse,
 		Reason:             reason,
 		Message:            err.Error(),

--- a/controllers/controllers/workloads/suite_test.go
+++ b/controllers/controllers/workloads/suite_test.go
@@ -357,7 +357,7 @@ func createOrg(rootNamespace string) *korifiv1alpha1.CFOrg {
 	Expect(adminClient.Create(ctx, org)).To(Succeed())
 	Eventually(func(g Gomega) {
 		g.Expect(adminClient.Get(ctx, client.ObjectKeyFromObject(org), org)).To(Succeed())
-		g.Expect(meta.IsStatusConditionTrue(org.Status.Conditions, shared.StatusConditionReady)).To(BeTrue())
+		g.Expect(meta.IsStatusConditionTrue(org.Status.Conditions, korifiv1alpha1.StatusConditionReady)).To(BeTrue())
 	}).Should(Succeed())
 	return org
 }
@@ -375,7 +375,7 @@ func createSpace(org *korifiv1alpha1.CFOrg) *korifiv1alpha1.CFSpace {
 	Expect(adminClient.Create(ctx, cfSpace)).To(Succeed())
 	Eventually(func(g Gomega) {
 		g.Expect(adminClient.Get(ctx, client.ObjectKeyFromObject(cfSpace), cfSpace)).To(Succeed())
-		g.Expect(meta.IsStatusConditionTrue(cfSpace.Status.Conditions, shared.StatusConditionReady)).To(BeTrue())
+		g.Expect(meta.IsStatusConditionTrue(cfSpace.Status.Conditions, korifiv1alpha1.StatusConditionReady)).To(BeTrue())
 	}).Should(Succeed())
 	return cfSpace
 }

--- a/statefulset-runner/controllers/appworkload_controller.go
+++ b/statefulset-runner/controllers/appworkload_controller.go
@@ -206,9 +206,9 @@ func (r *AppWorkloadReconciler) ReconcileResource(ctx context.Context, appWorklo
 
 	appWorkload.Status.ActualInstances = updatedStatefulSet.Status.Replicas
 	meta.SetStatusCondition(&appWorkload.Status.Conditions, metav1.Condition{
-		Type:               shared.StatusConditionReady,
+		Type:               korifiv1alpha1.StatusConditionReady,
 		Status:             metav1.ConditionTrue,
-		Reason:             shared.StatusConditionReady,
+		Reason:             korifiv1alpha1.StatusConditionReady,
 		ObservedGeneration: appWorkload.Generation,
 	})
 

--- a/tests/crds/crds_suite_test.go
+++ b/tests/crds/crds_suite_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
-	"code.cloudfoundry.org/korifi/controllers/controllers/shared"
 	"code.cloudfoundry.org/korifi/tests/helpers"
 	"code.cloudfoundry.org/korifi/tests/helpers/fail_handler"
 	"code.cloudfoundry.org/korifi/tools"
@@ -141,7 +140,7 @@ var _ = BeforeEach(func() {
 	Expect(k8sClient.Create(ctx, testOrg)).To(Succeed())
 	Eventually(func(g Gomega) {
 		g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(testOrg), testOrg)).To(Succeed())
-		g.Expect(meta.IsStatusConditionTrue(testOrg.StatusConditions(), shared.StatusConditionReady)).To(BeTrue())
+		g.Expect(meta.IsStatusConditionTrue(testOrg.StatusConditions(), korifiv1alpha1.StatusConditionReady)).To(BeTrue())
 	}).Should(Succeed())
 
 	testSpace = &korifiv1alpha1.CFSpace{
@@ -157,7 +156,7 @@ var _ = BeforeEach(func() {
 	Expect(k8sClient.Create(ctx, testSpace)).To(Succeed())
 	Eventually(func(g Gomega) {
 		g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(testSpace), testSpace)).To(Succeed())
-		g.Expect(meta.IsStatusConditionTrue(testSpace.StatusConditions(), shared.StatusConditionReady)).To(BeTrue())
+		g.Expect(meta.IsStatusConditionTrue(testSpace.StatusConditions(), korifiv1alpha1.StatusConditionReady)).To(BeTrue())
 	}).Should(Succeed())
 })
 

--- a/tools/k8s/condition_builder.go
+++ b/tools/k8s/condition_builder.go
@@ -1,0 +1,63 @@
+package k8s
+
+import (
+	"time"
+
+	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type ReadyConditionBuilder struct {
+	status             metav1.ConditionStatus
+	observedGeneration int64
+	reason             string
+	message            string
+}
+
+func NewReadyConditionBuilder(obj client.Object) *ReadyConditionBuilder {
+	return &ReadyConditionBuilder{
+		status:             metav1.ConditionFalse,
+		observedGeneration: obj.GetGeneration(),
+		reason:             "Unknown",
+	}
+}
+
+func (b *ReadyConditionBuilder) WithStatus(status metav1.ConditionStatus) *ReadyConditionBuilder {
+	b.status = status
+	return b
+}
+
+func (b *ReadyConditionBuilder) WithReason(reason string) *ReadyConditionBuilder {
+	b.reason = reason
+	return b
+}
+
+func (b *ReadyConditionBuilder) WithMessage(message string) *ReadyConditionBuilder {
+	b.message = message
+	return b
+}
+
+func (b *ReadyConditionBuilder) WithError(err error) *ReadyConditionBuilder {
+	if err == nil {
+		return b
+	}
+
+	b.message = err.Error()
+	return b
+}
+
+func (b *ReadyConditionBuilder) Ready() *ReadyConditionBuilder {
+	return b.WithStatus(metav1.ConditionTrue).WithReason("Ready")
+}
+
+func (b *ReadyConditionBuilder) Build() metav1.Condition {
+	return metav1.Condition{
+		Type:               korifiv1alpha1.StatusConditionReady,
+		Status:             b.status,
+		ObservedGeneration: b.observedGeneration,
+		LastTransitionTime: metav1.NewTime(time.Now()),
+		Reason:             b.reason,
+		Message:            b.message,
+	}
+}

--- a/tools/k8s/condition_builder_test.go
+++ b/tools/k8s/condition_builder_test.go
@@ -1,0 +1,102 @@
+package k8s_test
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
+	"code.cloudfoundry.org/korifi/tools/k8s"
+)
+
+var _ = Describe("ReadyConditionBuilder", func() {
+	var (
+		builder   *k8s.ReadyConditionBuilder
+		condition metav1.Condition
+	)
+
+	BeforeEach(func() {
+		builder = k8s.NewReadyConditionBuilder(&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Generation: 4,
+			},
+		})
+	})
+
+	JustBeforeEach(func() {
+		condition = builder.Build()
+	})
+
+	It("creates a default condition", func() {
+		Expect(condition.Type).To(Equal(korifiv1alpha1.StatusConditionReady))
+		Expect(condition.Status).To(Equal(metav1.ConditionFalse))
+		Expect(condition.ObservedGeneration).To(BeEquivalentTo(4))
+		Expect(condition.LastTransitionTime).NotTo(BeZero())
+		Expect(condition.Reason).To(Equal("Unknown"))
+		Expect(condition.Message).To(BeEmpty())
+	})
+
+	When("the status is set to true", func() {
+		BeforeEach(func() {
+			builder.WithStatus(metav1.ConditionTrue)
+		})
+
+		It("sets condition status to true", func() {
+			Expect(condition.Status).To(Equal(metav1.ConditionTrue))
+		})
+	})
+
+	When("the reason is set", func() {
+		BeforeEach(func() {
+			builder.WithReason("SomeReason")
+		})
+
+		It("sets the reason", func() {
+			Expect(condition.Reason).To(Equal("SomeReason"))
+		})
+	})
+
+	When("the message is set", func() {
+		BeforeEach(func() {
+			builder.WithMessage("Some Message")
+		})
+
+		It("sets the reason", func() {
+			Expect(condition.Message).To(Equal("Some Message"))
+		})
+	})
+
+	When("the error is set", func() {
+		BeforeEach(func() {
+			builder.WithError(errors.New("some-error"))
+		})
+
+		It("sets the reason", func() {
+			Expect(condition.Message).To(Equal("some-error"))
+		})
+	})
+
+	When("nil error is set", func() {
+		BeforeEach(func() {
+			builder.WithError(nil)
+		})
+
+		It("sets the reason", func() {
+			Expect(condition.Message).To(BeEmpty())
+		})
+	})
+
+	When("ready is set", func() {
+		BeforeEach(func() {
+			builder.Ready()
+		})
+
+		It("sets ready status and reason", func() {
+			Expect(condition.Status).To(Equal(metav1.ConditionTrue))
+			Expect(condition.Reason).To(Equal("Ready"))
+		})
+	})
+})


### PR DESCRIPTION
## Is there a related GitHub Issue?
#3217
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
* The CFServiceBinding becomes ready when the underlying
  servicebinding.io bindings become ready
* The rest of the CFServiceBinding status conditions have been removed
  (as other controllers and API should only care whether the binding is
  ready or not)
* Introduce a reusable `ReadyConditionBuilder` utility used to set the
  object status
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
Green tests
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@danail-branekov
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
