### PR TITLE
Add initial /v3/info endpoint

### DIFF
--- a/api/handlers/info_v3.go
+++ b/api/handlers/info_v3.go
@@ -1,0 +1,37 @@
+package handlers
+
+import (
+	"net/http"
+	"net/url"
+
+	"code.cloudfoundry.org/korifi/api/presenter"
+	"code.cloudfoundry.org/korifi/api/routing"
+)
+
+const (
+	InfoV3Path = "/v3/info"
+)
+
+type InfoV3 struct {
+	baseURL url.URL
+}
+
+func NewInfoV3(baseURL url.URL) *InfoV3 {
+	return &InfoV3{
+		baseURL: baseURL,
+	}
+}
+
+func (h *InfoV3) get(r *http.Request) (*routing.Response, error) {
+	return routing.NewResponse(http.StatusOK).WithBody(presenter.ForInfoV3(h.baseURL)), nil
+}
+
+func (h *InfoV3) UnauthenticatedRoutes() []routing.Route {
+	return []routing.Route{
+		{Method: "GET", Pattern: InfoV3Path, Handler: h.get},
+	}
+}
+
+func (h *InfoV3) AuthenticatedRoutes() []routing.Route {
+	return nil
+}

--- a/api/handlers/info_v3_test.go
+++ b/api/handlers/info_v3_test.go
@@ -1,0 +1,40 @@
+package handlers_test
+
+import (
+	"net/http"
+
+	"code.cloudfoundry.org/korifi/api/handlers"
+	. "code.cloudfoundry.org/korifi/tests/matchers"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("InfoV3", func() {
+	var req *http.Request
+
+	BeforeEach(func() {
+		apiHandler := handlers.NewInfoV3(*serverURL)
+		routerBuilder.LoadRoutes(apiHandler)
+	})
+
+	JustBeforeEach(func() {
+		routerBuilder.Build().ServeHTTP(rr, req)
+	})
+
+	Describe("the GET /v3/info endpoint", func() {
+		BeforeEach(func() {
+			var err error
+			req, err = http.NewRequest("GET", "/v3/info", nil)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("returns the expected response", func() {
+			Expect(rr).To(HaveHTTPStatus(http.StatusOK))
+			Expect(rr).To(HaveHTTPHeaderWithValue("Content-Type", "application/json"))
+
+			Expect(rr).To(HaveHTTPBody(SatisfyAll(
+				MatchJSONPath("$.links.self.href", "https://api.example.org/v3/info"),
+			)))
+		})
+	})
+})

--- a/api/main.go
+++ b/api/main.go
@@ -264,6 +264,7 @@ func main() {
 	apiHandlers := []routing.Routable{
 		handlers.NewRootV3(*serverURL),
 		handlers.NewRoot(*serverURL),
+		handlers.NewInfoV3(*serverURL),
 		handlers.NewResourceMatches(),
 		handlers.NewApp(
 			*serverURL,

--- a/api/presenter/info.go
+++ b/api/presenter/info.go
@@ -1,0 +1,33 @@
+package presenter
+
+import "net/url"
+
+type InfoV3Response struct {
+	Build       string                 `json:"build"`
+	CLIVersion  InfoCLIVersion         `json:"cli_version"`
+	Description string                 `json:"description"`
+	Name        string                 `json:"name"`
+	Version     int                    `json:"version"`
+	Custom      map[string]interface{} `json:"custom"`
+
+	Links map[string]Link `json:"links"`
+}
+
+type InfoCLIVersion struct {
+	Minimum     string `json:"minimum"`
+	Recommended string `json:"recommended"`
+}
+
+func ForInfoV3(baseURL url.URL) InfoV3Response {
+	return InfoV3Response{
+		Custom: make(map[string]interface{}),
+		Links: map[string]Link{
+			"self": {
+				HRef: buildURL(baseURL).appendPath("v3/info").build(),
+			},
+			"support": {
+				HRef: "https://www.cloudfoundry.org/technology/korifi/",
+			},
+		},
+	}
+}

--- a/api/presenter/info_test.go
+++ b/api/presenter/info_test.go
@@ -1,0 +1,55 @@
+package presenter_test
+
+import (
+	"encoding/json"
+	"net/url"
+
+	"code.cloudfoundry.org/korifi/api/presenter"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Info endpoints", func() {
+	var (
+		baseURL *url.URL
+		output  []byte
+	)
+
+	BeforeEach(func() {
+		var err error
+		baseURL, err = url.Parse("https://api.example.org")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	Context("/v3/info", func() {
+		JustBeforeEach(func() {
+			response := presenter.ForInfoV3(*baseURL)
+			var err error
+			output, err = json.Marshal(response)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("produces expected info v3 json", func() {
+			Expect(output).To(MatchJSON(`{
+				"build": "",
+				"cli_version": {
+				  "minimum": "",
+					"recommended": ""
+				},
+				"description": "",
+				"name": "",
+				"version": 0,
+				"custom": {},
+				"links": {
+					"self": {
+							"href": "https://api.example.org/v3/info"
+					},
+					"support": {
+							"href": "https://www.cloudfoundry.org/technology/korifi/"
+					}
+				}
+			}`))
+		})
+	})
+})

--- a/tests/e2e/info_v3_test.go
+++ b/tests/e2e/info_v3_test.go
@@ -1,0 +1,30 @@
+package e2e_test
+
+import (
+	"net/http"
+
+	"github.com/go-resty/resty/v2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("InfoV3", func() {
+	var (
+		httpResp    *resty.Response
+		requestPath string
+	)
+
+	BeforeEach(func() {
+		requestPath = "/v3/info"
+	})
+	JustBeforeEach(func() {
+		var err error
+		httpResp, err = adminClient.R().
+			Get(requestPath)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("succeeds", func() {
+		Expect(httpResp).To(HaveRestyStatusCode(http.StatusOK))
+	})
+})


### PR DESCRIPTION
## Is there a related GitHub Issue?

https://github.com/cloudfoundry/korifi/issues/2914

## What is this change about?

Add initial `v3/info` endpoint that presents the fields as implmented in
https://github.com/cloudfoundry/cloud_controller_ng/blob/main/app/controllers/v3/info_controller.rb
and
https://github.com/cloudfoundry/cloud_controller_ng/blob/main/app/presenters/v3/info_presenter.rb
with some static default values for the time being.

This change is the first step in getting a working `v3/info` endpoint implementation.
The next step would be to extend Korifi via configuration to provide some dynamic content (For example the `description` field and others) to be returned by the endpoint `v3/info`.

## Does this PR introduce a breaking change?

No, it adds a new endpoint not available before.

## Acceptance Steps

- Switch to the Git branch.
- Setup local dev environment, `./scripts/deploy-on-kind.sh korifi`
- cf api https://localhost --skip-ssl-validation
- cf login
- Run `cf curl v3/info` and see the following static content (except for the base url):

```
{"build":"","cli_version":{"minimum":"","recommended":""},"description":"","name":"","version":0,"custom":{},"links":{"self":{"href":"https://localhost/v3/info"},"support":{"href":"https://www.cloudfoundry.org/technology/korifi/"}}}
```

## Tag your pair, your PM, and/or team

None