### PR TITLE
Introduce Ready condition for cfServiceInstances

### DIFF
--- a/api/repositories/app_repository.go
+++ b/api/repositories/app_repository.go
@@ -461,7 +461,7 @@ func (f *AppRepo) SetAppDesiredState(ctx context.Context, authInfo authorization
 		return AppRecord{}, fmt.Errorf("failed to set app desired state: %w", apierrors.FromK8sError(err, AppResourceType))
 	}
 
-	if _, err := f.appAwaiter.AwaitCondition(ctx, userClient, cfApp, korifiv1alpha1.ReadyConditionType); err != nil {
+	if _, err := f.appAwaiter.AwaitCondition(ctx, userClient, cfApp, korifiv1alpha1.StatusConditionReady); err != nil {
 		return AppRecord{}, apierrors.FromK8sError(err, AppResourceType)
 	}
 

--- a/api/repositories/app_repository_test.go
+++ b/api/repositories/app_repository_test.go
@@ -1223,7 +1223,7 @@ var _ = Describe("AppRepository", func() {
 					actualCFApp, actualCondition := appAwaiter.AwaitConditionArgsForCall(0)
 					Expect(actualCFApp.GetName()).To(Equal(cfApp.Name))
 					Expect(actualCFApp.GetNamespace()).To(Equal(cfApp.Namespace))
-					Expect(actualCondition).To(Equal(korifiv1alpha1.ReadyConditionType))
+					Expect(actualCondition).To(Equal(korifiv1alpha1.StatusConditionReady))
 				})
 
 				It("changes the desired state of the App", func() {
@@ -1248,7 +1248,7 @@ var _ = Describe("AppRepository", func() {
 					actualCFApp, actualCondition := appAwaiter.AwaitConditionArgsForCall(0)
 					Expect(actualCFApp.GetName()).To(Equal(cfApp.Name))
 					Expect(actualCFApp.GetNamespace()).To(Equal(cfApp.Namespace))
-					Expect(actualCondition).To(Equal(korifiv1alpha1.ReadyConditionType))
+					Expect(actualCondition).To(Equal(korifiv1alpha1.StatusConditionReady))
 				})
 
 				It("changes the desired state of the App", func() {

--- a/api/repositories/conditions/await_test.go
+++ b/api/repositories/conditions/await_test.go
@@ -57,18 +57,18 @@ var _ = Describe("ConditionAwaiter", func() {
 	})
 
 	JustBeforeEach(func() {
-		awaitedTask, awaitErr = awaiter.AwaitCondition(ctx, k8sClient, task, korifiv1alpha1.TaskInitializedConditionType)
+		awaitedTask, awaitErr = awaiter.AwaitCondition(ctx, k8sClient, task, korifiv1alpha1.StatusConditionReady)
 	})
 
 	It("returns an error", func() {
-		Expect(awaitErr).To(MatchError(ContainSubstring("condition Initialized not set yet")))
+		Expect(awaitErr).To(MatchError(ContainSubstring("condition Ready not set yet")))
 	})
 
 	When("the condition becomes false", func() {
 		BeforeEach(func() {
 			asyncPatchTask(func(cfTask *korifiv1alpha1.CFTask) {
 				meta.SetStatusCondition(&cfTask.Status.Conditions, metav1.Condition{
-					Type:               korifiv1alpha1.TaskInitializedConditionType,
+					Type:               korifiv1alpha1.StatusConditionReady,
 					Status:             metav1.ConditionFalse,
 					Reason:             "initialized",
 					ObservedGeneration: task.Generation,
@@ -77,7 +77,7 @@ var _ = Describe("ConditionAwaiter", func() {
 		})
 
 		It("returns an error", func() {
-			Expect(awaitErr).To(MatchError(ContainSubstring("expected the Initialized condition to be true")))
+			Expect(awaitErr).To(MatchError(ContainSubstring("expected the Ready condition to be true")))
 		})
 	})
 
@@ -85,7 +85,7 @@ var _ = Describe("ConditionAwaiter", func() {
 		BeforeEach(func() {
 			asyncPatchTask(func(cfTask *korifiv1alpha1.CFTask) {
 				meta.SetStatusCondition(&cfTask.Status.Conditions, metav1.Condition{
-					Type:               korifiv1alpha1.TaskInitializedConditionType,
+					Type:               korifiv1alpha1.StatusConditionReady,
 					Status:             metav1.ConditionTrue,
 					Reason:             "initialized",
 					ObservedGeneration: task.Generation,
@@ -98,7 +98,7 @@ var _ = Describe("ConditionAwaiter", func() {
 			Expect(awaitedTask).NotTo(BeNil())
 
 			Expect(awaitedTask.Name).To(Equal(task.Name))
-			Expect(meta.IsStatusConditionTrue(awaitedTask.Status.Conditions, korifiv1alpha1.TaskInitializedConditionType)).To(BeTrue())
+			Expect(meta.IsStatusConditionTrue(awaitedTask.Status.Conditions, korifiv1alpha1.StatusConditionReady)).To(BeTrue())
 		})
 	})
 
@@ -107,7 +107,7 @@ var _ = Describe("ConditionAwaiter", func() {
 			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(task), task)).To(Succeed())
 			asyncPatchTask(func(cfTask *korifiv1alpha1.CFTask) {
 				meta.SetStatusCondition(&cfTask.Status.Conditions, metav1.Condition{
-					Type:               korifiv1alpha1.TaskInitializedConditionType,
+					Type:               korifiv1alpha1.StatusConditionReady,
 					Status:             metav1.ConditionTrue,
 					Reason:             "initialized",
 					ObservedGeneration: task.Generation - 1,
@@ -116,7 +116,7 @@ var _ = Describe("ConditionAwaiter", func() {
 		})
 
 		It("returns an error", func() {
-			Expect(awaitErr).To(MatchError(ContainSubstring("condition Initialized is outdated")))
+			Expect(awaitErr).To(MatchError(ContainSubstring("condition Ready is outdated")))
 		})
 	})
 })

--- a/api/repositories/service_instance_repository.go
+++ b/api/repositories/service_instance_repository.go
@@ -23,9 +23,8 @@ import (
 )
 
 const (
-	CFServiceInstanceGUIDLabel          = "korifi.cloudfoundry.org/service-instance-guid"
-	ServiceInstanceResourceType         = "Service Instance"
-	CredentialsSecretAvailableCondition = "CredentialSecretAvailable"
+	CFServiceInstanceGUIDLabel  = "korifi.cloudfoundry.org/service-instance-guid"
+	ServiceInstanceResourceType = "Service Instance"
 )
 
 type NamespaceGetter interface {
@@ -163,7 +162,7 @@ func (r *ServiceInstanceRepo) PatchServiceInstance(ctx context.Context, authInfo
 }
 
 func (r *ServiceInstanceRepo) migrateLegacyCredentials(ctx context.Context, userClient client.WithWatch, cfServiceInstance *korifiv1alpha1.CFServiceInstance) (*korifiv1alpha1.CFServiceInstance, error) {
-	cfServiceInstance, err := r.awaiter.AwaitCondition(ctx, userClient, cfServiceInstance, CredentialsSecretAvailableCondition)
+	cfServiceInstance, err := r.awaiter.AwaitCondition(ctx, userClient, cfServiceInstance, korifiv1alpha1.StatusConditionReady)
 	if err != nil {
 		return nil, err
 	}

--- a/api/repositories/service_instance_repository_test.go
+++ b/api/repositories/service_instance_repository_test.go
@@ -257,7 +257,7 @@ var _ = Describe("ServiceInstanceRepository", func() {
 					obj, conditionType := conditionAwaiter.AwaitConditionArgsForCall(0)
 					Expect(obj.GetName()).To(Equal(cfServiceInstance.Name))
 					Expect(obj.GetNamespace()).To(Equal(cfServiceInstance.Namespace))
-					Expect(conditionType).To(Equal(repositories.CredentialsSecretAvailableCondition))
+					Expect(conditionType).To(Equal(korifiv1alpha1.StatusConditionReady))
 				})
 
 				It("updates the creds", func() {

--- a/controllers/api/v1alpha1/shared_types.go
+++ b/controllers/api/v1alpha1/shared_types.go
@@ -18,7 +18,6 @@ const (
 	CFTaskGUIDLabelKey       = "korifi.cloudfoundry.org/task-guid"
 
 	StagingConditionType   = "Staging"
-	ReadyConditionType     = "Ready"
 	SucceededConditionType = "Succeeded"
 
 	PropagateRoleBindingAnnotation    = "cloudfoundry.org/propagate-cf-role"

--- a/controllers/controllers/services/instances/controller_test.go
+++ b/controllers/controllers/services/instances/controller_test.go
@@ -8,7 +8,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
-	"code.cloudfoundry.org/korifi/controllers/controllers/services/instances"
 	. "code.cloudfoundry.org/korifi/tests/matchers"
 	"code.cloudfoundry.org/korifi/tools/k8s"
 	. "github.com/onsi/ginkgo/v2"
@@ -56,7 +55,7 @@ var _ = Describe("CFServiceInstance", func() {
 		Eventually(func(g Gomega) {
 			g.Expect(adminClient.Get(ctx, client.ObjectKeyFromObject(instance), instance)).To(Succeed())
 			g.Expect(instance.Status.Conditions).To(ContainElement(SatisfyAll(
-				HasType(Equal(instances.CredentialsSecretAvailableCondition)),
+				HasType(Equal(korifiv1alpha1.StatusConditionReady)),
 				HasStatus(Equal(metav1.ConditionFalse)),
 				HasReason(Equal("CredentialsSecretNotAvailable")),
 			)))
@@ -87,7 +86,7 @@ var _ = Describe("CFServiceInstance", func() {
 			Eventually(func(g Gomega) {
 				g.Expect(adminClient.Get(ctx, client.ObjectKeyFromObject(instance), instance)).To(Succeed())
 				g.Expect(instance.Status.Conditions).To(ContainElement(SatisfyAll(
-					HasType(Equal(instances.CredentialsSecretAvailableCondition)),
+					HasType(Equal(korifiv1alpha1.StatusConditionReady)),
 					HasStatus(Equal(metav1.ConditionTrue)),
 				)))
 			}).Should(Succeed())
@@ -112,7 +111,7 @@ var _ = Describe("CFServiceInstance", func() {
 				Eventually(func(g Gomega) {
 					g.Expect(adminClient.Get(ctx, client.ObjectKeyFromObject(instance), instance)).To(Succeed())
 					g.Expect(instance.Status.Conditions).To(ContainElement(SatisfyAll(
-						HasType(Equal(instances.CredentialsSecretAvailableCondition)),
+						HasType(Equal(korifiv1alpha1.StatusConditionReady)),
 						HasStatus(Equal(metav1.ConditionFalse)),
 						HasReason(Equal("SecretInvalid")),
 					)))
@@ -127,7 +126,7 @@ var _ = Describe("CFServiceInstance", func() {
 				Eventually(func(g Gomega) {
 					g.Expect(adminClient.Get(ctx, client.ObjectKeyFromObject(instance), instance)).To(Succeed())
 					g.Expect(instance.Status.Conditions).To(ContainElement(SatisfyAll(
-						HasType(Equal(instances.CredentialsSecretAvailableCondition)),
+						HasType(Equal(korifiv1alpha1.StatusConditionReady)),
 						HasStatus(Equal(metav1.ConditionTrue)),
 					)))
 					secretVersion = instance.Status.CredentialsObservedVersion
@@ -153,7 +152,7 @@ var _ = Describe("CFServiceInstance", func() {
 				Eventually(func(g Gomega) {
 					g.Expect(adminClient.Get(ctx, client.ObjectKeyFromObject(instance), instance)).To(Succeed())
 					g.Expect(instance.Status.Conditions).To(ContainElement(SatisfyAll(
-						HasType(Equal(instances.CredentialsSecretAvailableCondition)),
+						HasType(Equal(korifiv1alpha1.StatusConditionReady)),
 						HasStatus(Equal(metav1.ConditionTrue)),
 					)))
 					lastObservedVersion = instance.Status.CredentialsObservedVersion
@@ -269,7 +268,7 @@ var _ = Describe("CFServiceInstance", func() {
 				Eventually(func(g Gomega) {
 					g.Expect(adminClient.Get(ctx, client.ObjectKeyFromObject(instance), instance)).To(Succeed())
 					g.Expect(instance.Status.Conditions).To(ContainElement(SatisfyAll(
-						HasType(Equal(instances.CredentialsSecretAvailableCondition)),
+						HasType(Equal(korifiv1alpha1.StatusConditionReady)),
 						HasStatus(Equal(metav1.ConditionFalse)),
 						HasReason(Equal("FailedReconcilingCredentialsSecret")),
 					)))

--- a/controllers/controllers/workloads/cfprocess_controller.go
+++ b/controllers/controllers/workloads/cfprocess_controller.go
@@ -131,7 +131,7 @@ func (r *CFProcessReconciler) ReconcileResource(ctx context.Context, cfProcess *
 	cfProcess.Status.ObservedGeneration = cfProcess.Generation
 	log.V(1).Info("set observed generation", "generation", cfProcess.Status.ObservedGeneration)
 
-	shared.GetConditionOrSetAsUnknown(&cfProcess.Status.Conditions, korifiv1alpha1.ReadyConditionType, cfProcess.Generation)
+	shared.GetConditionOrSetAsUnknown(&cfProcess.Status.Conditions, korifiv1alpha1.StatusConditionReady, cfProcess.Generation)
 
 	cfApp := new(korifiv1alpha1.CFApp)
 	err := r.k8sClient.Get(ctx, types.NamespacedName{Name: cfProcess.Spec.AppRef.Name, Namespace: cfProcess.Namespace}, cfApp)

--- a/controllers/controllers/workloads/k8sns/reconciler.go
+++ b/controllers/controllers/workloads/k8sns/reconciler.go
@@ -80,7 +80,7 @@ func (r *Reconciler[T, NS]) ReconcileResource(ctx context.Context, obj NS) (ctrl
 		return r.finalizer.Finalize(ctx, obj)
 	}
 
-	shared.GetConditionOrSetAsUnknown(obj.GetStatus().GetConditions(), korifiv1alpha1.ReadyConditionType, obj.GetGeneration())
+	shared.GetConditionOrSetAsUnknown(obj.GetStatus().GetConditions(), korifiv1alpha1.StatusConditionReady, obj.GetGeneration())
 
 	obj.GetStatus().SetGUID(obj.GetName())
 

--- a/statefulset-runner/controllers/appworkload_controller.go
+++ b/statefulset-runner/controllers/appworkload_controller.go
@@ -159,7 +159,7 @@ func (r *AppWorkloadReconciler) ReconcileResource(ctx context.Context, appWorklo
 	appWorkload.Status.ObservedGeneration = appWorkload.Generation
 	log.V(1).Info("set observed generation", "generation", appWorkload.Status.ObservedGeneration)
 
-	shared.GetConditionOrSetAsUnknown(&appWorkload.Status.Conditions, korifiv1alpha1.ReadyConditionType, appWorkload.Generation)
+	shared.GetConditionOrSetAsUnknown(&appWorkload.Status.Conditions, korifiv1alpha1.StatusConditionReady, appWorkload.Generation)
 
 	statefulSet, err := r.workloadsToStSet.Convert(appWorkload)
 	// Not clear what errors this would produce, but we may use it later

--- a/tools/k8s/condition_builder.go
+++ b/tools/k8s/condition_builder.go
@@ -48,11 +48,11 @@ func (b *ReadyConditionBuilder) WithError(err error) *ReadyConditionBuilder {
 }
 
 func (b *ReadyConditionBuilder) Ready() *ReadyConditionBuilder {
-	return b.WithStatus(metav1.ConditionTrue).WithReason("Ready")
+	return b.WithStatus(metav1.ConditionTrue)
 }
 
 func (b *ReadyConditionBuilder) Build() metav1.Condition {
-	return metav1.Condition{
+	result := metav1.Condition{
 		Type:               korifiv1alpha1.StatusConditionReady,
 		Status:             b.status,
 		ObservedGeneration: b.observedGeneration,
@@ -60,4 +60,11 @@ func (b *ReadyConditionBuilder) Build() metav1.Condition {
 		Reason:             b.reason,
 		Message:            b.message,
 	}
+
+	if b.status == metav1.ConditionTrue {
+		result.Reason = "Ready"
+		result.Message = "Ready"
+	}
+
+	return result
 }

--- a/tools/k8s/condition_builder_test.go
+++ b/tools/k8s/condition_builder_test.go
@@ -97,6 +97,19 @@ var _ = Describe("ReadyConditionBuilder", func() {
 		It("sets ready status and reason", func() {
 			Expect(condition.Status).To(Equal(metav1.ConditionTrue))
 			Expect(condition.Reason).To(Equal("Ready"))
+			Expect(condition.Message).To(Equal("Ready"))
+		})
+
+		When("error is set", func() {
+			BeforeEach(func() {
+				builder.WithError(errors.New("foo"))
+			})
+
+			It("ignores the error and returns ready condition", func() {
+				Expect(condition.Status).To(Equal(metav1.ConditionTrue))
+				Expect(condition.Reason).To(Equal("Ready"))
+				Expect(condition.Message).To(Equal("Ready"))
+			})
 		})
 	})
 })


### PR DESCRIPTION
## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
- Replace the existing CredentialSecretAvailable condition with Ready in
  controller and repository
- Remove one of the two constants for the Ready condition
- The awaiter test now works with Ready condition (unimportant, but this
  way we can better understand what resources are not yet using the
  Ready condtion
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
Green tests
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@danail-branekov
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
