### PR TITLE
Do not use explicit timeout when creating the service account

### DIFF
--- a/tests/helpers/service_account.go
+++ b/tests/helpers/service_account.go
@@ -3,7 +3,6 @@ package helpers
 import (
 	"context"
 	"fmt"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -103,7 +102,7 @@ func (f *ServiceAccountFactory) createServiceAccount(name string) (*corev1.Servi
 			serviceAccountSecret,
 		)).To(Succeed())
 		g.Expect(serviceAccountSecret.Data).To(HaveKey(corev1.ServiceAccountTokenKey))
-	}).WithTimeout(10 * time.Second).Should(Succeed())
+	}).Should(Succeed())
 
 	return serviceAccount, string(serviceAccountSecret.Data[corev1.ServiceAccountTokenKey])
 }


### PR DESCRIPTION
## Is there a related GitHub Issue?
https://ci.korifi.cf-app.com/teams/main/pipelines/main/jobs/run-e2es-eks/builds/690
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Instead of waiting for 10 seconds the serrvice account secret to get
populated, use the default one. Test suites set it to 4 minutes by
default.

