### PR TITLE
Allow pre-release cli versions

### DIFF
--- a/api/middleware/cli_version.go
+++ b/api/middleware/cli_version.go
@@ -11,7 +11,7 @@ import (
 	"github.com/mileusna/useragent"
 )
 
-const minSupportedVersion = ">= 8.5.0"
+const minSupportedVersion = ">= 8.5.0-0"
 
 func CFCliVersion(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/api/middleware/cli_version_test.go
+++ b/api/middleware/cli_version_test.go
@@ -72,6 +72,16 @@ var _ = Describe("CliVersionMiddleware", func() {
 			})
 		})
 
+		When("the cf cli version is a valid pre-release", func() {
+			BeforeEach(func() {
+				requestHeaders["User-Agent"] = []string{"cf/9.0.0-beta+334489f01.2024-05-14 (go1.22.2; arm64 darwin)"}
+			})
+
+			It("delegates to the next handler", func() {
+				Expect(rr).To(HaveHTTPStatus(http.StatusTeapot))
+			})
+		})
+
 		When("there are  multiple UserAgent header values", func() {
 			BeforeEach(func() {
 				requestHeaders["User-Agent"] = []string{


### PR DESCRIPTION
## Is there a related GitHub Issue?

No.

## What is this change about?

Allow to use most recent CF CLI pre-release versions with Korifi.

## Does this PR introduce a breaking change?

No.

## Acceptance Steps

Run `./scripts/deploy-on-kind.sh korifi`, use a recent pre-release version of cf cli, try to use Korifi with the pre-release cf cli and it should work with this PR.
