### PR TITLE
Update `api.md` to reflect v3/info addition

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -111,6 +111,12 @@ No query parameters are supported.
 
 Updating `image` is not supported.
 
+## [Info](https://v3-apidocs.cloudfoundry.org/#info)
+
+### [Get platform info](https://v3-apidocs.cloudfoundry.org/#get-platform-info)
+
+This endpoint is fully supported.
+
 ## [Jobs](https://v3-apidocs.cloudfoundry.org/#jobs)
 
 ### [Get a job](https://v3-apidocs.cloudfoundry.org/#get-a-job)


### PR DESCRIPTION
## Is there a related GitHub Issue?
No.

## What is this change about?
Document in the [Korifi API Documentation](https://github.com/cloudfoundry/korifi/blob/main/docs/api.md#korifi-api-documentation) support for the v3/info endpoint.

## Does this PR introduce a breaking change?
No.