### PR TITLE
Wait for app to become staged after droplet is set

### DIFF
--- a/api/repositories/app_repository_test.go
+++ b/api/repositories/app_repository_test.go
@@ -1218,12 +1218,26 @@ var _ = Describe("AppRepository", func() {
 					Expect(returnedAppRecord.SpaceGUID).To(Equal(cfSpace.Name))
 				})
 
-				It("waits for the app ready condition", func() {
-					Expect(appAwaiter.AwaitConditionCallCount()).To(Equal(1))
-					actualCFApp, actualCondition := appAwaiter.AwaitConditionArgsForCall(0)
+				It("waits for the started app state", func() {
+					Expect(appAwaiter.AwaitStateCallCount()).To(Equal(1))
+					Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cfApp), cfApp)).To(Succeed())
+
+					actualCFApp, actualStateCheck := appAwaiter.AwaitStateArgsForCall(0)
 					Expect(actualCFApp.GetName()).To(Equal(cfApp.Name))
 					Expect(actualCFApp.GetNamespace()).To(Equal(cfApp.Namespace))
-					Expect(actualCondition).To(Equal(korifiv1alpha1.StatusConditionReady))
+					Expect(actualStateCheck(&korifiv1alpha1.CFApp{
+						Spec: korifiv1alpha1.CFAppSpec{
+							DesiredState: korifiv1alpha1.AppState(desiredAppState),
+						},
+						Status: korifiv1alpha1.CFAppStatus{
+							Conditions: []metav1.Condition{{
+								Type:               korifiv1alpha1.StatusConditionReady,
+								Status:             metav1.ConditionTrue,
+								ObservedGeneration: cfApp.Generation,
+							}},
+							ActualState: korifiv1alpha1.AppState(desiredAppState),
+						},
+					})).To(Succeed())
 				})
 
 				It("changes the desired state of the App", func() {
@@ -1243,12 +1257,26 @@ var _ = Describe("AppRepository", func() {
 					Expect(returnedErr).ToNot(HaveOccurred())
 				})
 
-				It("waits for the app ready condition", func() {
-					Expect(appAwaiter.AwaitConditionCallCount()).To(Equal(1))
-					actualCFApp, actualCondition := appAwaiter.AwaitConditionArgsForCall(0)
+				It("waits for the stopped app state", func() {
+					Expect(appAwaiter.AwaitStateCallCount()).To(Equal(1))
+					Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cfApp), cfApp)).To(Succeed())
+
+					actualCFApp, actualStateCheck := appAwaiter.AwaitStateArgsForCall(0)
 					Expect(actualCFApp.GetName()).To(Equal(cfApp.Name))
 					Expect(actualCFApp.GetNamespace()).To(Equal(cfApp.Namespace))
-					Expect(actualCondition).To(Equal(korifiv1alpha1.StatusConditionReady))
+					Expect(actualStateCheck(&korifiv1alpha1.CFApp{
+						Spec: korifiv1alpha1.CFAppSpec{
+							DesiredState: korifiv1alpha1.AppState(desiredAppState),
+						},
+						Status: korifiv1alpha1.CFAppStatus{
+							Conditions: []metav1.Condition{{
+								Type:               korifiv1alpha1.StatusConditionReady,
+								Status:             metav1.ConditionTrue,
+								ObservedGeneration: cfApp.Generation,
+							}},
+							ActualState: korifiv1alpha1.AppState(desiredAppState),
+						},
+					})).To(Succeed())
 				})
 
 				It("changes the desired state of the App", func() {

--- a/api/repositories/fakeawaiter/await.go
+++ b/api/repositories/fakeawaiter/await.go
@@ -13,6 +13,11 @@ type FakeAwaiter[T conditions.RuntimeObjectWithStatusConditions, L any, PL condi
 		conditionType string
 	}
 	AwaitConditionStub func(context.Context, client.WithWatch, client.Object, string) (T, error)
+	AwaitStateStub     func(context.Context, client.WithWatch, client.Object, func(T) error) (T, error)
+	awaitStateCalls    []struct {
+		obj        client.Object
+		checkState func(T) error
+	}
 }
 
 func (a *FakeAwaiter[T, L, PL]) AwaitCondition(ctx context.Context, k8sClient client.WithWatch, object client.Object, conditionType string) (T, error) {
@@ -43,4 +48,34 @@ func (a *FakeAwaiter[T, L, PL]) AwaitConditionCallCount() int {
 
 func (a *FakeAwaiter[T, L, PL]) AwaitConditionArgsForCall(i int) (client.Object, string) {
 	return a.awaitConditionCalls[i].obj, a.awaitConditionCalls[i].conditionType
+}
+
+func (a *FakeAwaiter[T, L, PL]) AwaitState(ctx context.Context, k8sClient client.WithWatch, object client.Object, checkState func(T) error) (T, error) {
+	a.awaitStateCalls = append(a.awaitStateCalls, struct {
+		obj        client.Object
+		checkState func(T) error
+	}{
+		object,
+		checkState,
+	})
+
+	if a.AwaitStateStub == nil {
+		return object.(T), nil
+	}
+
+	return a.AwaitStateStub(ctx, k8sClient, object, checkState)
+}
+
+func (a *FakeAwaiter[T, L, PL]) AwaitStateReturns(object T, err error) {
+	a.AwaitStateStub = func(ctx context.Context, k8sClient client.WithWatch, object client.Object, _ func(T) error) (T, error) {
+		return object.(T), err
+	}
+}
+
+func (a *FakeAwaiter[T, L, PL]) AwaitStateCallCount() int {
+	return len(a.awaitStateCalls)
+}
+
+func (a *FakeAwaiter[T, L, PL]) AwaitStateArgsForCall(i int) (client.Object, func(T) error) {
+	return a.awaitStateCalls[i].obj, a.awaitStateCalls[i].checkState
 }

--- a/api/repositories/shared.go
+++ b/api/repositories/shared.go
@@ -19,6 +19,7 @@ type RepositoryCreator interface {
 
 type Awaiter[T runtime.Object] interface {
 	AwaitCondition(context.Context, client.WithWatch, client.Object, string) (T, error)
+	AwaitState(context.Context, client.WithWatch, client.Object, func(T) error) (T, error)
 }
 
 func getLastUpdatedTime(obj client.Object) *time.Time {


### PR DESCRIPTION
## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
This is an attempt to fix test flakes like this one:

https://ci.korifi.cf-app.com/teams/main/pipelines/main/jobs/run-e2es-eks-periodic/builds/8092#L66377a10:1977

In this test we are pusing an app and then immediately trygin to create
a task for the pushed app. The problem is that the app may take some
time to become properly STAGED and STARTED and the test is not waiting
for the app

Having said that it is not trivial to wait for the app to become
STARTED, because of the nature of the cf v3 api: According to the
[docs](https://v3-apidocs.cloudfoundry.org/version/3.159.0/index.html#the-app-object)
the `state` field in the app response is representing the app desired
state (not the actual state). Luckily there is an endpoint for getting
the current app droplet, namely

```
GET /v3/apps/{appGUID}/droplets/current
```

By waiting for the droplet to appear we are making sure that no test
would proceed before the app is at least STAGED

Analyzing the logs of the failed test it looks like the test is too
quick to attempt to start a task for the app, before the app has its
droplet set. Therefore waiting for the app to be STAGED should fix this
flake.
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
Green Tests
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@danail-branekov
