### PR TITLE
Use the ready condition builder in relevant controllers

### DIFF
--- a/api/repositories/buildpack_repository_test.go
+++ b/api/repositories/buildpack_repository_test.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 
 	. "code.cloudfoundry.org/korifi/api/repositories"
-	"code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
+	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -83,7 +83,7 @@ var _ = Describe("BuildpackRepository", func() {
 		})
 
 		When("the BuilderInfo resource with the configured BuilderName is not ready", func() {
-			var builderInfo *v1alpha1.BuilderInfo
+			var builderInfo *korifiv1alpha1.BuilderInfo
 
 			BeforeEach(func() {
 				builderInfo = createBuilderInfoWithCleanup(ctx, builderName, "io.buildpacks.stacks.bionic", []buildpackInfo{
@@ -96,7 +96,7 @@ var _ = Describe("BuildpackRepository", func() {
 			When("there is a ready condition with a message", func() {
 				BeforeEach(func() {
 					meta.SetStatusCondition(&builderInfo.Status.Conditions, metav1.Condition{
-						Type:    "Ready",
+						Type:    korifiv1alpha1.StatusConditionReady,
 						Status:  metav1.ConditionFalse,
 						Reason:  "testing",
 						Message: "this is a test",
@@ -113,7 +113,7 @@ var _ = Describe("BuildpackRepository", func() {
 			When("there is a ready condition with an empty message", func() {
 				BeforeEach(func() {
 					meta.SetStatusCondition(&builderInfo.Status.Conditions, metav1.Condition{
-						Type:    "Ready",
+						Type:    korifiv1alpha1.StatusConditionReady,
 						Status:  metav1.ConditionFalse,
 						Reason:  "testing",
 						Message: "",
@@ -135,8 +135,8 @@ type buildpackInfo struct {
 	version string
 }
 
-func createBuilderInfoWithCleanup(ctx context.Context, name, stack string, buildpacks []buildpackInfo) *v1alpha1.BuilderInfo {
-	builderInfo := &v1alpha1.BuilderInfo{
+func createBuilderInfoWithCleanup(ctx context.Context, name, stack string, buildpacks []buildpackInfo) *korifiv1alpha1.BuilderInfo {
+	builderInfo := &korifiv1alpha1.BuilderInfo{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: rootNamespace,
@@ -150,7 +150,7 @@ func createBuilderInfoWithCleanup(ctx context.Context, name, stack string, build
 	creationTimestamp := metav1.Time{Time: time.Now().Add(-24 * time.Hour)}
 	updatedTimestamp := metav1.Time{Time: time.Now().Add(-30 * time.Second)}
 
-	builderInfo.Status.Stacks = []v1alpha1.BuilderInfoStatusStack{
+	builderInfo.Status.Stacks = []korifiv1alpha1.BuilderInfoStatusStack{
 		{
 			Name:              stack,
 			CreationTimestamp: metav1.Time{Time: time.Now()},
@@ -158,7 +158,7 @@ func createBuilderInfoWithCleanup(ctx context.Context, name, stack string, build
 		},
 	}
 	for _, b := range buildpacks {
-		builderInfo.Status.Buildpacks = append(builderInfo.Status.Buildpacks, v1alpha1.BuilderInfoStatusBuildpack{
+		builderInfo.Status.Buildpacks = append(builderInfo.Status.Buildpacks, korifiv1alpha1.BuilderInfoStatusBuildpack{
 			Name:              b.name,
 			Version:           b.version,
 			Stack:             stack,
@@ -168,7 +168,7 @@ func createBuilderInfoWithCleanup(ctx context.Context, name, stack string, build
 	}
 
 	meta.SetStatusCondition(&builderInfo.Status.Conditions, metav1.Condition{
-		Type:   "Ready",
+		Type:   korifiv1alpha1.StatusConditionReady,
 		Status: metav1.ConditionTrue,
 		Reason: "testing",
 	})

--- a/api/repositories/org_repository_test.go
+++ b/api/repositories/org_repository_test.go
@@ -67,7 +67,7 @@ var _ = Describe("OrgRepository", func() {
 				Expect(k8s.Patch(ctx, k8sClient, cfOrg, func() {
 					cfOrg.Status.GUID = cfOrg.Name
 					meta.SetStatusCondition(&cfOrg.Status.Conditions, metav1.Condition{
-						Type:    "Ready",
+						Type:    korifiv1alpha1.StatusConditionReady,
 						Status:  conditionStatus,
 						Reason:  "blah",
 						Message: conditionMessage,
@@ -199,7 +199,7 @@ var _ = Describe("OrgRepository", func() {
 		When("the org is not ready", func() {
 			BeforeEach(func() {
 				meta.SetStatusCondition(&(cfOrg1.Status.Conditions), metav1.Condition{
-					Type:    "Ready",
+					Type:    korifiv1alpha1.StatusConditionReady,
 					Status:  metav1.ConditionFalse,
 					Reason:  "because",
 					Message: "because",
@@ -207,7 +207,7 @@ var _ = Describe("OrgRepository", func() {
 				Expect(k8sClient.Status().Update(ctx, cfOrg1)).To(Succeed())
 
 				meta.SetStatusCondition(&(cfOrg2.Status.Conditions), metav1.Condition{
-					Type:    "Ready",
+					Type:    korifiv1alpha1.StatusConditionReady,
 					Status:  metav1.ConditionUnknown,
 					Reason:  "because",
 					Message: "because",

--- a/api/repositories/package_repository_test.go
+++ b/api/repositories/package_repository_test.go
@@ -396,8 +396,8 @@ var _ = Describe("PackageRepository", func() {
 					BeforeEach(func() {
 						Expect(k8s.Patch(ctx, k8sClient, cfPackage, func() {
 							meta.SetStatusCondition(&cfPackage.Status.Conditions, metav1.Condition{
-								Type:               "Ready",
-								Status:             "True",
+								Type:               korifiv1alpha1.StatusConditionReady,
+								Status:             metav1.ConditionTrue,
 								Reason:             "Ready",
 								ObservedGeneration: cfPackage.Generation,
 							})
@@ -507,8 +507,8 @@ var _ = Describe("PackageRepository", func() {
 				Expect(k8sClient.Create(ctx, cfPackage)).To(Succeed())
 				Expect(k8s.Patch(ctx, k8sClient, cfPackage, func() {
 					meta.SetStatusCondition(&cfPackage.Status.Conditions, metav1.Condition{
-						Type:               "Ready",
-						Status:             "True",
+						Type:               korifiv1alpha1.StatusConditionReady,
+						Status:             metav1.ConditionTrue,
 						Reason:             "Ready",
 						ObservedGeneration: cfPackage.Generation,
 					})

--- a/api/repositories/repositories_suite_test.go
+++ b/api/repositories/repositories_suite_test.go
@@ -151,7 +151,7 @@ func createOrgWithCleanup(ctx context.Context, displayName string) *korifiv1alph
 	Expect(k8sClient.Create(ctx, cfOrg)).To(Succeed())
 
 	meta.SetStatusCondition(&(cfOrg.Status.Conditions), metav1.Condition{
-		Type:    "Ready",
+		Type:    korifiv1alpha1.StatusConditionReady,
 		Status:  metav1.ConditionTrue,
 		Reason:  "cus",
 		Message: "cus",
@@ -191,7 +191,7 @@ func createSpaceWithCleanup(ctx context.Context, orgGUID, name string) *korifiv1
 
 	cfSpace.Status.GUID = cfSpace.Name
 	meta.SetStatusCondition(&(cfSpace.Status.Conditions), metav1.Condition{
-		Type:    "Ready",
+		Type:    korifiv1alpha1.StatusConditionReady,
 		Status:  metav1.ConditionTrue,
 		Reason:  "cus",
 		Message: "cus",

--- a/api/repositories/space_repository_test.go
+++ b/api/repositories/space_repository_test.go
@@ -74,7 +74,7 @@ var _ = Describe("SpaceRepository", func() {
 				Expect(k8s.Patch(ctx, k8sClient, cfSpace, func() {
 					cfSpace.Status.GUID = cfSpace.Name
 					meta.SetStatusCondition(&cfSpace.Status.Conditions, metav1.Condition{
-						Type:    "Ready",
+						Type:    korifiv1alpha1.StatusConditionReady,
 						Status:  conditionStatus,
 						Reason:  "blah",
 						Message: conditionMessage,
@@ -227,7 +227,7 @@ var _ = Describe("SpaceRepository", func() {
 		When("the space anchor is not ready", func() {
 			BeforeEach(func() {
 				meta.SetStatusCondition(&(space11.Status.Conditions), metav1.Condition{
-					Type:    "Ready",
+					Type:    korifiv1alpha1.StatusConditionReady,
 					Status:  metav1.ConditionFalse,
 					Reason:  "cus",
 					Message: "cus",

--- a/controllers/controllers/workloads/cftask_controller_test.go
+++ b/controllers/controllers/workloads/cftask_controller_test.go
@@ -158,12 +158,8 @@ var _ = Describe("CFTaskReconciler Integration Tests", func() {
 		BeforeEach(func() {
 			task = &korifiv1alpha1.CFTask{}
 			Eventually(func(g Gomega) {
-				app := new(korifiv1alpha1.CFApp)
-				g.Expect(adminClient.Get(ctx, types.NamespacedName{Namespace: cfSpace.Status.GUID, Name: cfApp.Name}, app)).To(Succeed())
-
-				readyCondition := meta.FindStatusCondition(app.Status.Conditions, "Ready")
-				g.Expect(readyCondition).NotTo(BeNil())
-				g.Expect(readyCondition.Status).To(Equal(metav1.ConditionTrue), "App is not staged")
+				g.Expect(adminClient.Get(ctx, client.ObjectKeyFromObject(cfApp), cfApp)).To(Succeed())
+				g.Expect(meta.IsStatusConditionTrue(cfApp.Status.Conditions, korifiv1alpha1.StatusConditionReady)).To(BeTrue())
 			}).Should(Succeed())
 
 			eventCallCount = eventRecorder.EventfCallCount()

--- a/controllers/controllers/workloads/env/env_suite_test.go
+++ b/controllers/controllers/workloads/env/env_suite_test.go
@@ -140,7 +140,7 @@ var _ = BeforeEach(func() {
 			VCAPApplicationSecretName: "app-guid-vcap-application",
 		}
 		meta.SetStatusCondition(&app.Status.Conditions, metav1.Condition{
-			Type:               "Ready",
+			Type:               korifiv1alpha1.StatusConditionReady,
 			Status:             metav1.ConditionTrue,
 			Reason:             "testing",
 			LastTransitionTime: metav1.Date(2023, 2, 15, 12, 0, 0, 0, time.FixedZone("", 0)),

--- a/controllers/controllers/workloads/k8sns/reconciler_test.go
+++ b/controllers/controllers/workloads/k8sns/reconciler_test.go
@@ -178,10 +178,9 @@ var _ = Describe("K8S NS Reconciler Integration Tests", func() {
 			It("sets the NSObj's Ready condition to 'False'", func() {
 				Expect(reconcileErr).To(MatchError(ContainSubstring("error fetching secret")))
 
-				Expect(meta.IsStatusConditionTrue(nsObj.Status.Conditions, "Ready")).To(BeFalse())
-
-				readyCondition := meta.FindStatusCondition(nsObj.Status.Conditions, "Ready")
+				readyCondition := meta.FindStatusCondition(nsObj.Status.Conditions, korifiv1alpha1.StatusConditionReady)
 				Expect(readyCondition).NotTo(BeNil())
+				Expect(readyCondition.Status).To(Equal(metav1.ConditionFalse))
 				Expect(readyCondition.Message).To(ContainSubstring(fmt.Sprintf(
 					"error fetching secret %q from namespace %q",
 					"i-do-not-exist",

--- a/statefulset-runner/controllers/appworkload_controller.go
+++ b/statefulset-runner/controllers/appworkload_controller.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -152,9 +151,11 @@ func filterAppWorkloads(object client.Object) bool {
 func (r *AppWorkloadReconciler) ReconcileResource(ctx context.Context, appWorkload *korifiv1alpha1.AppWorkload) (ctrl.Result, error) {
 	log := logr.FromContextOrDiscard(ctx)
 
-	if appWorkload.Spec.RunnerName != AppWorkloadReconcilerName {
-		return ctrl.Result{}, nil
-	}
+	var err error
+	readyConditionBuilder := k8s.NewReadyConditionBuilder(appWorkload)
+	defer func() {
+		meta.SetStatusCondition(&appWorkload.Status.Conditions, readyConditionBuilder.WithError(err).Build())
+	}()
 
 	appWorkload.Status.ObservedGeneration = appWorkload.Generation
 	log.V(1).Info("set observed generation", "generation", appWorkload.Status.ObservedGeneration)
@@ -168,17 +169,17 @@ func (r *AppWorkloadReconciler) ReconcileResource(ctx context.Context, appWorklo
 		return ctrl.Result{}, err
 	}
 
-	orig := &appsv1.StatefulSet{
+	createdStSet := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      statefulSet.Name,
 			Namespace: statefulSet.Namespace,
 		},
 	}
-	_, err = controllerutil.CreateOrPatch(ctx, r.k8sClient, orig, func() error {
-		orig.Labels = statefulSet.Labels
-		orig.Annotations = statefulSet.Annotations
-		orig.OwnerReferences = statefulSet.OwnerReferences
-		orig.Spec = statefulSet.Spec
+	_, err = controllerutil.CreateOrPatch(ctx, r.k8sClient, createdStSet, func() error {
+		createdStSet.Labels = statefulSet.Labels
+		createdStSet.Annotations = statefulSet.Annotations
+		createdStSet.OwnerReferences = statefulSet.OwnerReferences
+		createdStSet.Spec = statefulSet.Spec
 
 		return nil
 	})
@@ -187,30 +188,14 @@ func (r *AppWorkloadReconciler) ReconcileResource(ctx context.Context, appWorklo
 		return ctrl.Result{}, err
 	}
 
-	updatedStatefulSet := &appsv1.StatefulSet{}
-	err = r.k8sClient.Get(ctx, client.ObjectKeyFromObject(statefulSet), updatedStatefulSet)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return ctrl.Result{}, nil
-		} else {
-			log.Info("error when fetching StatefulSet", "StatefulSet.Name", statefulSet.Name, "StatefulSet.Namespace", statefulSet.Namespace, "reason", err)
-			return ctrl.Result{}, err
-		}
-	}
-
-	err = r.pdb.Update(ctx, updatedStatefulSet)
+	err = r.pdb.Update(ctx, createdStSet)
 	if err != nil {
 		log.Info("error when creating or patching pod disruption budget", "reason", err)
 		return ctrl.Result{}, err
 	}
 
-	appWorkload.Status.ActualInstances = updatedStatefulSet.Status.Replicas
-	meta.SetStatusCondition(&appWorkload.Status.Conditions, metav1.Condition{
-		Type:               korifiv1alpha1.StatusConditionReady,
-		Status:             metav1.ConditionTrue,
-		Reason:             korifiv1alpha1.StatusConditionReady,
-		ObservedGeneration: appWorkload.Generation,
-	})
+	appWorkload.Status.ActualInstances = createdStSet.Status.Replicas
 
+	readyConditionBuilder.Ready()
 	return ctrl.Result{}, nil
 }

--- a/statefulset-runner/controllers/appworkload_to_stset_test.go
+++ b/statefulset-runner/controllers/appworkload_to_stset_test.go
@@ -13,6 +13,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/scheme"
 )
 
@@ -26,7 +27,64 @@ var _ = Describe("AppWorkload to StatefulSet Converter", func() {
 
 	BeforeEach(func() {
 		Expect(korifiv1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
-		appWorkload = createAppWorkload("some-namespace", "guid_1234")
+		appWorkload = &korifiv1alpha1.AppWorkload{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "guid_1234",
+				Namespace:  "some-namespace",
+				Generation: 1,
+				Annotations: map[string]string{
+					korifiv1alpha1.CFAppLastStopRevisionKey: "lastStopAppRev",
+				},
+			},
+			Spec: korifiv1alpha1.AppWorkloadSpec{
+				AppGUID:          "premium_app_guid_1234",
+				GUID:             "guid_1234",
+				Version:          "version_1234",
+				Image:            "gcr.io/foo/bar",
+				ImagePullSecrets: []corev1.LocalObjectReference{{Name: "some-secret-name"}},
+				Command: []string{
+					"/bin/sh",
+					"-c",
+					"while true; do echo hello; sleep 10;done",
+				},
+				ProcessType: "worker",
+				Env:         []corev1.EnvVar{},
+				StartupProbe: &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path: "/healthz",
+							Port: intstr.IntOrString{Type: intstr.Int, IntVal: int32(8080)},
+						},
+					},
+					FailureThreshold: 30,
+					PeriodSeconds:    2,
+				},
+				LivenessProbe: &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path: "/healthz",
+							Port: intstr.IntOrString{Type: intstr.Int, IntVal: int32(8080)},
+						},
+					},
+					PeriodSeconds:    30,
+					FailureThreshold: 1,
+				},
+				Ports:      []int32{8888, 9999},
+				Instances:  1,
+				RunnerName: "statefulset-runner",
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceEphemeralStorage: resource.MustParse("2048Mi"),
+						corev1.ResourceMemory:           resource.MustParse("1024Mi"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("5m"),
+						corev1.ResourceMemory: resource.MustParse("1024Mi"),
+					},
+				},
+			},
+		}
+
 		statefulsetRunnerTemporarySetPodSeccompProfile = false
 	})
 

--- a/statefulset-runner/controllers/integration/runnerinfo_controller_test.go
+++ b/statefulset-runner/controllers/integration/runnerinfo_controller_test.go
@@ -5,8 +5,10 @@ import (
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	//+kubebuilder:scaffold:imports
@@ -25,9 +27,13 @@ var _ = Describe("RunnerInfosController", func() {
 
 		BeforeEach(func() {
 			ctx = context.Background()
-			namespaceName = prefixedGUID("ns")
 			runnerInfoName = "statefulset-runner"
-			createNamespace(ctx, k8sClient, namespaceName)
+			namespaceName = uuid.NewString()
+			Expect(k8sClient.Create(ctx, &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: namespaceName,
+				},
+			})).To(Succeed())
 
 			runnerInfo = &korifiv1alpha1.RunnerInfo{
 				ObjectMeta: metav1.ObjectMeta{
@@ -64,9 +70,13 @@ var _ = Describe("RunnerInfosController", func() {
 
 		BeforeEach(func() {
 			ctx = context.Background()
-			namespaceName = prefixedGUID("ns")
 			runnerInfoName = "foobrizzle-runner"
-			createNamespace(ctx, k8sClient, namespaceName)
+			namespaceName = uuid.NewString()
+			Expect(k8sClient.Create(ctx, &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: namespaceName,
+				},
+			})).To(Succeed())
 
 			runnerInfo = &korifiv1alpha1.RunnerInfo{
 				ObjectMeta: metav1.ObjectMeta{

--- a/statefulset-runner/controllers/runnerinfo_controller_test.go
+++ b/statefulset-runner/controllers/runnerinfo_controller_test.go
@@ -7,6 +7,7 @@ import (
 	"code.cloudfoundry.org/korifi/statefulset-runner/controllers"
 	"code.cloudfoundry.org/korifi/tools/k8s"
 
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -14,10 +15,6 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-)
-
-const (
-	testNamespace = "test-ns"
 )
 
 var _ = Describe("RunnerInfo Reconcile", func() {
@@ -37,7 +34,7 @@ var _ = Describe("RunnerInfo Reconcile", func() {
 		runnerInfo = &korifiv1alpha1.RunnerInfo{
 			ObjectMeta: v1.ObjectMeta{
 				Name:      runnerName,
-				Namespace: testNamespace,
+				Namespace: uuid.NewString(),
 			},
 			Spec: korifiv1alpha1.RunnerInfoSpec{
 				RunnerName: runnerName,

--- a/statefulset-runner/controllers/suite_test.go
+++ b/statefulset-runner/controllers/suite_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"go.uber.org/zap/zapcore"
-	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
@@ -12,9 +12,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -33,67 +30,9 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = BeforeEach(func() {
+	Expect(korifiv1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
+
 	fakeClient = new(fake.Client)
 	fakeStatusWriter = &fake.StatusWriter{}
 	fakeClient.StatusReturns(fakeStatusWriter)
 })
-
-func createAppWorkload(namespace, name string) *korifiv1alpha1.AppWorkload {
-	return &korifiv1alpha1.AppWorkload{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       name,
-			Namespace:  namespace,
-			Generation: 1,
-			Annotations: map[string]string{
-				korifiv1alpha1.CFAppLastStopRevisionKey: "lastStopAppRev",
-			},
-		},
-		Spec: korifiv1alpha1.AppWorkloadSpec{
-			AppGUID:          "premium_app_guid_1234",
-			GUID:             "guid_1234",
-			Version:          "version_1234",
-			Image:            "gcr.io/foo/bar",
-			ImagePullSecrets: []corev1.LocalObjectReference{{Name: "some-secret-name"}},
-			Command: []string{
-				"/bin/sh",
-				"-c",
-				"while true; do echo hello; sleep 10;done",
-			},
-			ProcessType: "worker",
-			Env:         []corev1.EnvVar{},
-			StartupProbe: &corev1.Probe{
-				ProbeHandler: corev1.ProbeHandler{
-					HTTPGet: &corev1.HTTPGetAction{
-						Path: "/healthz",
-						Port: intstr.IntOrString{Type: intstr.Int, IntVal: int32(8080)},
-					},
-				},
-				FailureThreshold: 30,
-				PeriodSeconds:    2,
-			},
-			LivenessProbe: &corev1.Probe{
-				ProbeHandler: corev1.ProbeHandler{
-					HTTPGet: &corev1.HTTPGetAction{
-						Path: "/healthz",
-						Port: intstr.IntOrString{Type: intstr.Int, IntVal: int32(8080)},
-					},
-				},
-				PeriodSeconds:    30,
-				FailureThreshold: 1,
-			},
-			Ports:      []int32{8888, 9999},
-			Instances:  1,
-			RunnerName: "statefulset-runner",
-			Resources: corev1.ResourceRequirements{
-				Limits: corev1.ResourceList{
-					corev1.ResourceEphemeralStorage: resource.MustParse("2048Mi"),
-					corev1.ResourceMemory:           resource.MustParse("1024Mi"),
-				},
-				Requests: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("5m"),
-					corev1.ResourceMemory: resource.MustParse("1024Mi"),
-				},
-			},
-		},
-	}
-}


### PR DESCRIPTION
## Is there a related GitHub Issue?
#3237
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Korifi custom resources that have their `Ready` condition set by
controllers now utilise the ready condition builder pattern we recently
came up with. The afffected resources are:

* CFPackage
* CFOrg
* CFSpace
* CFProcess
* AppWorkload

While being here,
* take the opportunity to slightly improve their tests
* use the `korifiv1alpha1.StatusConditionReady` constant wherever it
  makes sense

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
No functional change
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@cloudfoundry/wg-cf-on-k8s
