### PR TITLE
Fix unbound variable error in bash

### DIFF
--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -8,7 +8,7 @@ DEP_DIR="$TEST_DIR/dependencies"
 VENDOR_DIR="$TEST_DIR/vendor"
 
 TEMP_FILES=()
-trap 'for file in ${TEMP_FILES[@]}; do rm -rf $file; done' EXIT
+trap 'for file in ${TEMP_FILES[@]-}; do rm -rf $file; done' EXIT
 
 function usage_text() {
   cat <<EOF


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?

6eb3943b6395d8645a4716eefe7b184e059f419f introduced a bash issue when running `./scripts/deploy-on-kind.sh korifi` more than once (on macOS Sonoma). If you run the script more than once, `TEMP_FILES` variable might be empty. With the option `set -u` an empty `TEMP_FILES` will throw an unbound error.

```bash
bash-3.2$ set -u
bash-3.2$ arr=()
bash-3.2$ echo "${arr[@]}"
bash: arr[@]: unbound variable
bash-3.2$ echo "${arr[@]-}"

bash-3.2$ exit
```


## Does this PR introduce a breaking change?
No.

## Acceptance Steps

To reproduce the issue, run the command `./scripts/deploy-on-kind.sh korifi` more than once.
It should exit the script with the following error:

`.../github.com/cloudfoundry/korifi/scripts/install-dependencies.sh: line 108: TEMP_FILES[@]: unbound variable`

## Tag your pair, your PM, and/or team
None