### PR TITLE
Add initial GET /v3/apps/:guid/processes/:type/stats endpoint

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -274,6 +274,7 @@ func main() {
 			appRepo,
 			dropletRepo,
 			processRepo,
+			processStats,
 			routeRepo,
 			domainRepo,
 			spaceRepo,


### PR DESCRIPTION
## Is there a related GitHub Issue?

#2340 

## What is this change about?

It adds the endpoint `GET /v3/apps/:guid/processes/:type/stats` and returns the stats that are already available in the [ProcessStats](https://github.com/cloudfoundry/korifi/blob/c5ee87da875c96a9da6e58c4e01d6c554821d2c4/api/presenter/process_stats.go#L53-L65).

## Does this PR introduce a breaking change?
No

## Acceptance Steps

cf push an app and try to access the stats endpoint.
It should deliver the same result as `cf curl /v3/processes/:guid/stats`

## Tag your pair, your PM, and/or team

None