### PR TITLE
Introduce `experimental.managedServices.include` helm value

### DIFF
--- a/README.helm.md
+++ b/README.helm.md
@@ -74,6 +74,9 @@ Here are all the values that can be set for the chart:
 - `debug` (_Boolean_): Enables remote debugging with [Delve](https://github.com/go-delve/delve).
 - `defaultAppDomainName` (_String_): Base domain name for application URLs.
 - `eksContainerRegistryRoleARN` (_String_): Amazon Resource Name (ARN) of the IAM role to use to access the ECR registry from an EKS deployed Korifi. Required if containerRegistrySecret not set.
+- `experimental`: Experimental features. Make sure you do not enable those on production. No guarantee provided! Backwards incompatible changes in future are quite probable!
+  - `managedServices`:
+    - `include` (_Boolean_): Enable managed services support
 - `generateIngressCertificates` (_Boolean_): Use `cert-manager` to generate self-signed certificates for the API and app endpoints.
 - `helm`:
   - `hooksImage` (_String_): Image for the helm hooks containing kubectl

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -47,6 +47,8 @@ type (
 		AuthProxyHost   string        `yaml:"authProxyHost"`
 		AuthProxyCACert string        `yaml:"authProxyCACert"`
 		LogLevel        zapcore.Level `yaml:"logLevel"`
+
+		ExperimentalManagedServicesEnabled bool `yaml:"experimentalManagedServicesEnabled"`
 	}
 
 	RoleLevel string

--- a/api/config/config_test.go
+++ b/api/config/config_test.go
@@ -46,6 +46,7 @@ var _ = Describe("Config", func() {
 				Stack:           "lc-stack",
 				StagingMemoryMB: 10,
 			},
+			"experimentalManagedServicesEnabled": true,
 		}
 	})
 
@@ -88,6 +89,7 @@ var _ = Describe("Config", func() {
 			StagingMemoryMB: 10,
 		}))
 		Expect(cfg.ContainerRegistryType).To(BeEmpty())
+		Expect(cfg.ExperimentalManagedServicesEnabled).To(BeTrue())
 	})
 
 	When("the FQDN is not specified", func() {

--- a/controllers/config/config.go
+++ b/controllers/config/config.go
@@ -43,6 +43,8 @@ type ControllerConfig struct {
 	ContainerRepositoryPrefix string     `yaml:"containerRepositoryPrefix"`
 	ContainerRegistryType     string     `yaml:"containerRegistryType"`
 	Networking                Networking `yaml:"networking"`
+
+	ExperimentalManagedServicesEnabled bool `yaml:"experimentalManagedServicesEnabled"`
 }
 
 type CFProcessDefaults struct {

--- a/controllers/config/config_test.go
+++ b/controllers/config/config_test.go
@@ -52,6 +52,7 @@ var _ = Describe("LoadFromPath", func() {
 				GatewayName:      "gw-name",
 				GatewayNamespace: "gw-ns",
 			},
+			ExperimentalManagedServicesEnabled: true,
 		}
 	})
 
@@ -94,6 +95,7 @@ var _ = Describe("LoadFromPath", func() {
 				GatewayName:      "gw-name",
 				GatewayNamespace: "gw-ns",
 			},
+			ExperimentalManagedServicesEnabled: true,
 		}))
 	})
 

--- a/helm/korifi/api/configmap.yaml
+++ b/helm/korifi/api/configmap.yaml
@@ -53,6 +53,7 @@ data:
     {{- if .Values.eksContainerRegistryRoleARN }}
     containerRegistryType: "ECR"
     {{- end }}
+    experimentalManagedServicesEnabled: {{ .Values.experimental.managedServices.include }}
   role_mappings_config.yaml: |
     roleMappings:
       admin:

--- a/helm/korifi/controllers/configmap.yaml
+++ b/helm/korifi/controllers/configmap.yaml
@@ -61,4 +61,5 @@ data:
     networking:
       gatewayNamespace: {{ .Release.Namespace }}-gateway
       gatewayName: korifi
+    experimentalManagedServicesEnabled: {{ .Values.experimental.managedServices.include }}
 

--- a/helm/korifi/values.schema.json
+++ b/helm/korifi/values.schema.json
@@ -224,7 +224,14 @@
               "type": "string"
             }
           },
-          "required": ["description", "name", "minCLIVersion", "recommendedCLIVersion", "custom", "supportAddress"]
+          "required": [
+            "description",
+            "name",
+            "minCLIVersion",
+            "recommendedCLIVersion",
+            "custom",
+            "supportAddress"
+          ]
         },
         "lifecycle": {
           "type": "object",
@@ -578,6 +585,21 @@
           "type": "string"
         }
       },
+      "type": "object"
+    },
+    "experimental": {
+      "properties": {
+        "managedServices": {
+          "properties": {
+            "include": {
+              "description": "Enable managed services support",
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "description": "Experimental features. Make sure you do not enable those on production. No guarantee provided! Backwards incompatible changes in future are quite probable!",
       "type": "object"
     }
   },

--- a/helm/korifi/values.yaml
+++ b/helm/korifi/values.yaml
@@ -10,6 +10,8 @@ eksContainerRegistryRoleARN: ""
 containerRegistryCACertSecret:
 systemImagePullSecrets: []
 
+experimentalManagedServicesEnabled: false
+
 reconcilers:
   build: kpack-image-builder
   run: statefulset-runner
@@ -23,7 +25,7 @@ api:
   include: true
 
   image: cloudfoundry/korifi-api:latest
-  
+
   nodeSelector: {}
   tolerations: []
   replicas: 1
@@ -66,7 +68,7 @@ api:
 
 controllers:
   image: cloudfoundry/korifi-controllers:latest
-  
+
   nodeSelector: {}
   tolerations: []
   replicas: 1
@@ -138,3 +140,7 @@ helm:
 
 networking:
   gatewayClass:
+
+experimental:
+  managedServices:
+    include: false

--- a/scripts/deploy-on-kind.sh
+++ b/scripts/deploy-on-kind.sh
@@ -211,6 +211,7 @@ function deploy_korifi() {
       --set=kpackImageBuilder.clusterStackRunImage="paketobuildpacks/run-jammy-base" \
       --set=kpackImageBuilder.builderRepository="$KPACK_BUILDER_REPOSITORY" \
       --set=networking.gatewayClass="contour" \
+      --set=experimental.managedServices.include="true" \
       --wait
   }
   popd >/dev/null

--- a/scripts/installer/install-korifi-kind.yaml
+++ b/scripts/installer/install-korifi-kind.yaml
@@ -111,6 +111,7 @@ spec:
             --set=kpackImageBuilder.clusterStackRunImage="paketobuildpacks/run-jammy-base" \
             --set=kpackImageBuilder.builderRepository="localregistry-docker-registry.default.svc.cluster.local:30050/kpack-builder" \
             --set=networking.gatewayClass="contour" \
+            --set=experimental.managedServices.include="true" \
             --wait
 
           kubectl wait --for=condition=ready clusterbuilder --all=true --timeout=15m


### PR DESCRIPTION
## Is there a related GitHub Issue?
#3262
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
The upcoming managed services support would be initially disabled by
setting the helm value to `false` (the default)

Operators should deliberately enable the flag should they want to give
the feature a try.

This change simply introduces the flag in the helm chart, there is no
implementation that uses it yet. The `deploy-on-kind` script sets it to
`true` as it is meant to be run for development purposes.

The kind installer sets it to `true` as well - whoever is installing
Korifi on kind probably just wants to play with it, therefore enabling
the experimental support does make sense.
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
See story
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@cloudfoundry/wg-cf-on-k8s
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
