### PR TITLE
Temporarily pin java buildpack to 15.0.0 and ruby buildpack to 0.46.1

### DIFF
--- a/helm/korifi/kpack-image-builder/cluster-builder.yaml
+++ b/helm/korifi/kpack-image-builder/cluster-builder.yaml
@@ -5,9 +5,9 @@ metadata:
   name: cf-default-buildpacks
 spec:
   sources:
-  - image: gcr.io/paketo-buildpacks/java
+  - image: gcr.io/paketo-buildpacks/java:15.0.0
   - image: gcr.io/paketo-buildpacks/nodejs
-  - image: gcr.io/paketo-buildpacks/ruby
+  - image: gcr.io/paketo-buildpacks/ruby:0.46.1
   - image: gcr.io/paketo-buildpacks/procfile
   - image: gcr.io/paketo-buildpacks/go
 


### PR DESCRIPTION
## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Latest java buildpack (15.1.0) brings `ca-certificates` buildpack 3.8.2
which reports that the jammy stack is not supported. Thus the cluster
builder never becomes ready

see https://github.com/paketo-buildpacks/ca-certificates/issues/235
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
Cluster builder becomes ready
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@georgethebeatle
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
