### PR TITLE
Group all gomod dependency bumps into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
   directory: "/"
   schedule:
     interval: "daily"
+  groups:
+    gomod:
+      patterns:
+        - "*"
 
 - package-ecosystem: "docker"
   directory: "/api"


### PR DESCRIPTION
## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Group all dependabot gomod bumps into one PR. This will significantly reducde the effort of merging dependabot dependencies

