### PR TITLE
Do not return forbidden error on get domain failure

### DIFF
--- a/api/repositories/domain_repository.go
+++ b/api/repositories/domain_repository.go
@@ -78,7 +78,7 @@ func (r *DomainRepo) GetDomain(ctx context.Context, authInfo authorization.Info,
 	domain := &korifiv1alpha1.CFDomain{}
 	err = userClient.Get(ctx, client.ObjectKey{Namespace: ns, Name: domainGUID}, domain)
 	if err != nil {
-		return DomainRecord{}, apierrors.NewForbiddenError(err, DomainResourceType)
+		return DomainRecord{}, fmt.Errorf("get-domain failed: %w", apierrors.FromK8sError(err, DomainResourceType))
 	}
 
 	return cfDomainToDomainRecord(domain), nil


### PR DESCRIPTION
## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Returning a forbidden error upon any failure when getting the CFDomain
from the repository is simply wrong, especially in situations where
handlers are masking forbidden errors as not found.

Potentially this should give use more information to ivestigate the
flake below should it occur again

https://ci.korifi.cf-app.com/teams/main/pipelines/main/jobs/run-e2es-periodic/builds/16159
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Tag your pair, your PM, and/or team
@georgethebeatle
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
