### PR TITLE
Upgrade go-functional to v2

### DIFF
--- a/api/actions/manifest/applier.go
+++ b/api/actions/manifest/applier.go
@@ -3,6 +3,8 @@ package manifest
 import (
 	"context"
 	"fmt"
+	"maps"
+	"slices"
 	"strings"
 
 	"code.cloudfoundry.org/korifi/api/actions/shared"
@@ -12,7 +14,6 @@ import (
 	"code.cloudfoundry.org/korifi/api/repositories"
 	"code.cloudfoundry.org/korifi/api/tools/singleton"
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
-	"golang.org/x/exp/maps"
 )
 
 type Applier struct {
@@ -218,7 +219,7 @@ func (a *Applier) applyServices(ctx context.Context, authInfo authorization.Info
 	}
 
 	serviceInstances, err := a.serviceInstanceRepo.ListServiceInstances(ctx, authInfo, repositories.ListServiceInstanceMessage{
-		Names: maps.Keys(desiredServiceNames),
+		Names: slices.Collect(maps.Keys(desiredServiceNames)),
 	})
 	if err != nil {
 		return err

--- a/api/actions/manifest/state_collector.go
+++ b/api/actions/manifest/state_collector.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"path"
+	"slices"
 
 	"code.cloudfoundry.org/korifi/api/actions/shared"
 	"code.cloudfoundry.org/korifi/api/authorization"
 	apierrors "code.cloudfoundry.org/korifi/api/errors"
 	"code.cloudfoundry.org/korifi/api/repositories"
 	"code.cloudfoundry.org/korifi/api/tools/singleton"
-	"golang.org/x/exp/maps"
 )
 
 type StateCollector struct {
@@ -131,7 +132,7 @@ func (s StateCollector) collectServiceBindings(ctx context.Context, authInfo aut
 		serviceInstanceGUIDSet[sb.ServiceInstanceGUID] = true
 	}
 
-	services, err := s.serviceInstanceRepo.ListServiceInstances(ctx, authInfo, repositories.ListServiceInstanceMessage{GUIDs: maps.Keys(serviceInstanceGUIDSet)})
+	services, err := s.serviceInstanceRepo.ListServiceInstances(ctx, authInfo, repositories.ListServiceInstanceMessage{GUIDs: slices.Collect(maps.Keys(serviceInstanceGUIDSet))})
 	if err != nil {
 		return nil, err
 	}

--- a/api/handlers/include/resolver.go
+++ b/api/handlers/include/resolver.go
@@ -2,12 +2,14 @@ package include
 
 import (
 	"context"
+	"slices"
 
 	"code.cloudfoundry.org/korifi/api/authorization"
 	"code.cloudfoundry.org/korifi/api/payloads/params"
 	"code.cloudfoundry.org/korifi/api/repositories/relationships"
 	"code.cloudfoundry.org/korifi/model"
-	"github.com/BooleanCat/go-functional/iter"
+	"github.com/BooleanCat/go-functional/v2/it"
+	"github.com/BooleanCat/go-functional/v2/it/itx"
 )
 
 //counterfeiter:generate -o fake -fake-name ResourceRelationshipRepository . ResourceRelationshipRepository
@@ -35,9 +37,9 @@ func (h *IncludeResolver[S, E]) ResolveIncludes(
 ) ([]model.IncludedResource, error) {
 	includes := []model.IncludedResource{}
 
-	repoResources := iter.Map(iter.Lift(resources), func(e E) relationships.Resource {
+	repoResources := slices.Collect(it.Map(itx.FromSlice(resources), func(e E) relationships.Resource {
 		return e
-	}).Collect()
+	}))
 
 	for _, includeResourceRule := range includeResourceRules {
 		includedResources, err := h.resolveInclude(ctx, authInfo, repoResources, includeResourceRule.RelationshipPath)
@@ -71,12 +73,12 @@ func (h *IncludeResolver[S, E]) resolveInclude(
 			return nil, err
 		}
 
-		includedResources = iter.Map(iter.Lift(resources), func(r relationships.Resource) model.IncludedResource {
+		includedResources = slices.Collect(it.Map(itx.FromSlice(resources), func(r relationships.Resource) model.IncludedResource {
 			return model.IncludedResource{
 				Type:     plural(relatedResourceType),
 				Resource: r,
 			}
-		}).Collect()
+		}))
 	}
 
 	return includedResources, nil

--- a/api/handlers/service_offering.go
+++ b/api/handlers/service_offering.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"net/http"
 	"net/url"
+	"slices"
 
 	"code.cloudfoundry.org/korifi/api/authorization"
 	apierrors "code.cloudfoundry.org/korifi/api/errors"
@@ -14,7 +15,8 @@ import (
 	"code.cloudfoundry.org/korifi/api/routing"
 	"code.cloudfoundry.org/korifi/model"
 	"code.cloudfoundry.org/korifi/tools"
-	"github.com/BooleanCat/go-functional/iter"
+	"github.com/BooleanCat/go-functional/v2/it"
+	"github.com/BooleanCat/go-functional/v2/it/itx"
 	"github.com/go-logr/logr"
 )
 
@@ -75,9 +77,9 @@ func (h *ServiceOffering) listBrokersForOfferings(
 	authInfo authorization.Info,
 	serviceOfferings []repositories.ServiceOfferingRecord,
 ) ([]repositories.ServiceBrokerRecord, error) {
-	brokerGUIDs := iter.Map(iter.Lift(serviceOfferings), func(o repositories.ServiceOfferingRecord) string {
+	brokerGUIDs := slices.Collect(it.Map(itx.FromSlice(serviceOfferings), func(o repositories.ServiceOfferingRecord) string {
 		return o.ServiceBrokerGUID
-	}).Collect()
+	}))
 
 	return h.serviceBrokerRepo.ListServiceBrokers(ctx, authInfo, repositories.ListServiceBrokerMessage{
 		GUIDs: tools.Uniq(brokerGUIDs),
@@ -100,12 +102,12 @@ func (h *ServiceOffering) getBrokerIncludes(
 		return nil, err
 	}
 
-	brokerIncludes := iter.Map(iter.Lift(brokers), func(b repositories.ServiceBrokerRecord) model.IncludedResource {
+	brokerIncludes := slices.Collect(it.Map(itx.FromSlice(brokers), func(b repositories.ServiceBrokerRecord) model.IncludedResource {
 		return model.IncludedResource{
 			Type:     "service_brokers",
 			Resource: presenter.ForServiceBroker(b, baseURL),
 		}
-	}).Collect()
+	}))
 
 	brokerIncludesFielded := []model.IncludedResource{}
 	for _, brokerInclude := range brokerIncludes {

--- a/api/handlers/service_plan_test.go
+++ b/api/handlers/service_plan_test.go
@@ -253,9 +253,8 @@ var _ = Describe("ServicePlan", func() {
 			_, actualAuthInfo, actualMessage := servicePlanRepo.ApplyPlanVisibilityArgsForCall(0)
 			Expect(actualAuthInfo).To(Equal(authInfo))
 			Expect(actualMessage).To(Equal(repositories.ApplyServicePlanVisibilityMessage{
-				PlanGUID:      "my-service-plan",
-				Type:          korifiv1alpha1.PublicServicePlanVisibilityType,
-				Organizations: []string{},
+				PlanGUID: "my-service-plan",
+				Type:     korifiv1alpha1.PublicServicePlanVisibilityType,
 			}))
 
 			Expect(rr).To(HaveHTTPStatus(http.StatusOK))
@@ -318,9 +317,8 @@ var _ = Describe("ServicePlan", func() {
 			_, actualAuthInfo, actualMessage := servicePlanRepo.UpdatePlanVisibilityArgsForCall(0)
 			Expect(actualAuthInfo).To(Equal(authInfo))
 			Expect(actualMessage).To(Equal(repositories.UpdateServicePlanVisibilityMessage{
-				PlanGUID:      "my-service-plan",
-				Type:          korifiv1alpha1.PublicServicePlanVisibilityType,
-				Organizations: []string{},
+				PlanGUID: "my-service-plan",
+				Type:     korifiv1alpha1.PublicServicePlanVisibilityType,
 			}))
 
 			Expect(rr).To(HaveHTTPStatus(http.StatusOK))

--- a/api/payloads/service_plan.go
+++ b/api/payloads/service_plan.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"regexp"
 	"strconv"
+	"slices"
 
 	"code.cloudfoundry.org/korifi/api/payloads/params"
 	"code.cloudfoundry.org/korifi/api/payloads/parse"
@@ -13,7 +14,7 @@ import (
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"code.cloudfoundry.org/korifi/model/services"
 	"code.cloudfoundry.org/korifi/tools"
-	"github.com/BooleanCat/go-functional/iter"
+	"github.com/BooleanCat/go-functional/v2/it"
 	jellidation "github.com/jellydator/validation"
 )
 
@@ -109,9 +110,9 @@ func (p *ServicePlanVisibility) ToApplyMessage(planGUID string) repositories.App
 	return repositories.ApplyServicePlanVisibilityMessage{
 		PlanGUID: planGUID,
 		Type:     p.Type,
-		Organizations: iter.Map(iter.Lift(p.Organizations), func(v services.VisibilityOrganization) string {
+		Organizations: slices.Collect(it.Map(slices.Values(p.Organizations), func(v services.VisibilityOrganization) string {
 			return v.GUID
-		}).Collect(),
+		})),
 	}
 }
 
@@ -119,8 +120,8 @@ func (p *ServicePlanVisibility) ToUpdateMessage(planGUID string) repositories.Up
 	return repositories.UpdateServicePlanVisibilityMessage{
 		PlanGUID: planGUID,
 		Type:     p.Type,
-		Organizations: iter.Map(iter.Lift(p.Organizations), func(v services.VisibilityOrganization) string {
+		Organizations: slices.Collect(it.Map(slices.Values(p.Organizations), func(v services.VisibilityOrganization) string {
 			return v.GUID
-		}).Collect(),
+		})),
 	}
 }

--- a/api/payloads/service_plan.go
+++ b/api/payloads/service_plan.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"net/url"
 	"regexp"
-	"strconv"
 	"slices"
+	"strconv"
 
 	"code.cloudfoundry.org/korifi/api/payloads/params"
 	"code.cloudfoundry.org/korifi/api/payloads/parse"

--- a/api/presenter/service_binding.go
+++ b/api/presenter/service_binding.go
@@ -2,10 +2,12 @@ package presenter
 
 import (
 	"net/url"
+	"slices"
 
 	"code.cloudfoundry.org/korifi/api/repositories"
 	"code.cloudfoundry.org/korifi/model"
-	"github.com/BooleanCat/go-functional/iter"
+	"github.com/BooleanCat/go-functional/v2/it"
+	"github.com/BooleanCat/go-functional/v2/it/itx"
 )
 
 const (
@@ -79,12 +81,12 @@ func ForServiceBinding(record repositories.ServiceBindingRecord, baseURL url.URL
 }
 
 func ForServiceBindingList(serviceBindingRecords []repositories.ServiceBindingRecord, appRecords []repositories.AppRecord, baseURL, requestURL url.URL) ListResponse[ServiceBindingResponse] {
-	includedApps := iter.Map(iter.Lift(appRecords), func(app repositories.AppRecord) model.IncludedResource {
+	includedApps := slices.Collect(it.Map(itx.FromSlice(appRecords), func(app repositories.AppRecord) model.IncludedResource {
 		return model.IncludedResource{
 			Type:     "apps",
 			Resource: ForApp(app, baseURL),
 		}
-	}).Collect()
+	}))
 
 	return ForList(ForServiceBinding, serviceBindingRecords, baseURL, requestURL, includedApps...)
 }

--- a/api/repositories/domain_repository.go
+++ b/api/repositories/domain_repository.go
@@ -3,6 +3,7 @@ package repositories
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sort"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"code.cloudfoundry.org/korifi/tools"
 	"code.cloudfoundry.org/korifi/tools/k8s"
+	"github.com/BooleanCat/go-functional/v2/it"
 	"github.com/BooleanCat/go-functional/v2/it/itx"
 	"github.com/google/uuid"
 
@@ -163,10 +165,10 @@ func (r *DomainRepo) ListDomains(ctx context.Context, authInfo authorization.Inf
 		return []DomainRecord{}, fmt.Errorf("failed to list domains in namespace %s: %w", r.rootNamespace, apierrors.FromK8sError(err, DomainResourceType))
 	}
 
-	domainRecords := itx.Map(
+	domainRecords := slices.Collect(it.Map(
 		itx.FromSlice(cfdomainList.Items).Filter(message.matches),
 		cfDomainToDomainRecord,
-	).Collect()
+	))
 	sort.Slice(domainRecords, func(i, j int) bool {
 		return domainRecords[i].CreatedAt.Before(domainRecords[j].CreatedAt)
 	})

--- a/api/repositories/domain_repository.go
+++ b/api/repositories/domain_repository.go
@@ -11,7 +11,7 @@ import (
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"code.cloudfoundry.org/korifi/tools"
 	"code.cloudfoundry.org/korifi/tools/k8s"
-	"github.com/BooleanCat/go-functional/iter"
+	"github.com/BooleanCat/go-functional/v2/it/itx"
 	"github.com/google/uuid"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -163,8 +163,8 @@ func (r *DomainRepo) ListDomains(ctx context.Context, authInfo authorization.Inf
 		return []DomainRecord{}, fmt.Errorf("failed to list domains in namespace %s: %w", r.rootNamespace, apierrors.FromK8sError(err, DomainResourceType))
 	}
 
-	domainRecords := iter.Map(
-		iter.Lift(cfdomainList.Items).Filter(message.matches),
+	domainRecords := itx.Map(
+		itx.FromSlice(cfdomainList.Items).Filter(message.matches),
 		cfDomainToDomainRecord,
 	).Collect()
 	sort.Slice(domainRecords, func(i, j int) bool {

--- a/api/repositories/droplet_repository.go
+++ b/api/repositories/droplet_repository.go
@@ -7,7 +7,7 @@ import (
 
 	"code.cloudfoundry.org/korifi/tools"
 	"code.cloudfoundry.org/korifi/tools/k8s"
-	"github.com/BooleanCat/go-functional/iter"
+	"github.com/BooleanCat/go-functional/v2/it/itx"
 
 	"code.cloudfoundry.org/korifi/api/authorization"
 	apierrors "code.cloudfoundry.org/korifi/api/errors"
@@ -170,8 +170,8 @@ func (r *DropletRepo) ListDroplets(ctx context.Context, authInfo authorization.I
 		allBuilds = append(allBuilds, buildList.Items...)
 	}
 
-	filteredBuilds := iter.Lift(allBuilds).Filter(message.matches)
-	return iter.Map(filteredBuilds, cfBuildToDropletRecord).Collect(), nil
+	filteredBuilds := itx.FromSlice(allBuilds).Filter(message.matches)
+	return itx.Map(filteredBuilds, cfBuildToDropletRecord).Collect(), nil
 }
 
 type UpdateDropletMessage struct {

--- a/api/repositories/droplet_repository.go
+++ b/api/repositories/droplet_repository.go
@@ -3,10 +3,12 @@ package repositories
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	"code.cloudfoundry.org/korifi/tools"
 	"code.cloudfoundry.org/korifi/tools/k8s"
+	"github.com/BooleanCat/go-functional/v2/it"
 	"github.com/BooleanCat/go-functional/v2/it/itx"
 
 	"code.cloudfoundry.org/korifi/api/authorization"
@@ -171,7 +173,7 @@ func (r *DropletRepo) ListDroplets(ctx context.Context, authInfo authorization.I
 	}
 
 	filteredBuilds := itx.FromSlice(allBuilds).Filter(message.matches)
-	return itx.Map(filteredBuilds, cfBuildToDropletRecord).Collect(), nil
+	return slices.Collect(it.Map(filteredBuilds, cfBuildToDropletRecord)), nil
 }
 
 type UpdateDropletMessage struct {

--- a/api/repositories/metrics_repository.go
+++ b/api/repositories/metrics_repository.go
@@ -3,10 +3,11 @@ package repositories
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"code.cloudfoundry.org/korifi/api/authorization"
 	apierrors "code.cloudfoundry.org/korifi/api/errors"
-	"github.com/BooleanCat/go-functional/iter"
+	"github.com/BooleanCat/go-functional/v2/it/itx"
 	corev1 "k8s.io/api/core/v1"
 	metricsv1beta1 "k8s.io/metrics/pkg/apis/metrics/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -44,7 +45,7 @@ func (r *MetricsRepo) GetMetrics(ctx context.Context, authInfo authorization.Inf
 		return nil, fmt.Errorf("failed to list pods: %w", apierrors.FromK8sError(err, PodResourceType))
 	}
 
-	return iter.Map(iter.Lift(podList.Items), func(pod corev1.Pod) PodMetrics {
+	return itx.Map(slices.Values(podList.Items), func(pod corev1.Pod) PodMetrics {
 		metrics := metricsv1beta1.PodMetrics{}
 		_ = userClient.Get(ctx, client.ObjectKeyFromObject(&pod), &metrics)
 		return PodMetrics{Pod: pod, Metrics: metrics}

--- a/api/repositories/metrics_repository.go
+++ b/api/repositories/metrics_repository.go
@@ -7,7 +7,7 @@ import (
 
 	"code.cloudfoundry.org/korifi/api/authorization"
 	apierrors "code.cloudfoundry.org/korifi/api/errors"
-	"github.com/BooleanCat/go-functional/v2/it/itx"
+	"github.com/BooleanCat/go-functional/v2/it"
 	corev1 "k8s.io/api/core/v1"
 	metricsv1beta1 "k8s.io/metrics/pkg/apis/metrics/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -45,9 +45,9 @@ func (r *MetricsRepo) GetMetrics(ctx context.Context, authInfo authorization.Inf
 		return nil, fmt.Errorf("failed to list pods: %w", apierrors.FromK8sError(err, PodResourceType))
 	}
 
-	return itx.Map(slices.Values(podList.Items), func(pod corev1.Pod) PodMetrics {
+	return slices.Collect(it.Map(slices.Values(podList.Items), func(pod corev1.Pod) PodMetrics {
 		metrics := metricsv1beta1.PodMetrics{}
 		_ = userClient.Get(ctx, client.ObjectKeyFromObject(&pod), &metrics)
 		return PodMetrics{Pod: pod, Metrics: metrics}
-	}).Collect(), nil
+	})), nil
 }

--- a/api/repositories/org_repository.go
+++ b/api/repositories/org_repository.go
@@ -11,7 +11,7 @@ import (
 	"code.cloudfoundry.org/korifi/tools"
 	"code.cloudfoundry.org/korifi/tools/k8s"
 
-	"github.com/BooleanCat/go-functional/iter"
+	"github.com/BooleanCat/go-functional/v2/it/itx"
 	"github.com/google/uuid"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -133,10 +133,10 @@ func (r *OrgRepo) ListOrgs(ctx context.Context, info authorization.Info, message
 		return nil, apierrors.FromK8sError(err, OrgResourceType)
 	}
 
-	filteredOrgs := iter.Lift(cfOrgList.Items).Filter(func(org korifiv1alpha1.CFOrg) bool {
+	filteredOrgs := itx.FromSlice(cfOrgList.Items).Filter(func(org korifiv1alpha1.CFOrg) bool {
 		return authorizedNamespaces[org.Name] && message.matches(org)
 	})
-	return iter.Map(filteredOrgs, cfOrgToOrgRecord).Collect(), nil
+	return itx.Map(filteredOrgs, cfOrgToOrgRecord).Collect(), nil
 }
 
 func (r *OrgRepo) GetOrg(ctx context.Context, info authorization.Info, orgGUID string) (OrgRecord, error) {

--- a/api/repositories/org_repository.go
+++ b/api/repositories/org_repository.go
@@ -3,6 +3,7 @@ package repositories
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	"code.cloudfoundry.org/korifi/api/authorization"
@@ -11,6 +12,7 @@ import (
 	"code.cloudfoundry.org/korifi/tools"
 	"code.cloudfoundry.org/korifi/tools/k8s"
 
+	"github.com/BooleanCat/go-functional/v2/it"
 	"github.com/BooleanCat/go-functional/v2/it/itx"
 	"github.com/google/uuid"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -136,7 +138,7 @@ func (r *OrgRepo) ListOrgs(ctx context.Context, info authorization.Info, message
 	filteredOrgs := itx.FromSlice(cfOrgList.Items).Filter(func(org korifiv1alpha1.CFOrg) bool {
 		return authorizedNamespaces[org.Name] && message.matches(org)
 	})
-	return itx.Map(filteredOrgs, cfOrgToOrgRecord).Collect(), nil
+	return slices.Collect(it.Map(filteredOrgs, cfOrgToOrgRecord)), nil
 }
 
 func (r *OrgRepo) GetOrg(ctx context.Context, info authorization.Info, orgGUID string) (OrgRecord, error) {

--- a/api/repositories/package_repository.go
+++ b/api/repositories/package_repository.go
@@ -14,6 +14,7 @@ import (
 	"code.cloudfoundry.org/korifi/tools/dockercfg"
 	"code.cloudfoundry.org/korifi/tools/k8s"
 
+	"github.com/BooleanCat/go-functional/v2/it"
 	"github.com/BooleanCat/go-functional/v2/it/itx"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/uuid"
@@ -336,7 +337,7 @@ func (r *PackageRepo) ListPackages(ctx context.Context, authInfo authorization.I
 	}
 
 	filteredPackages := itx.FromSlice(packages).Filter(message.matches)
-	return itx.Map(filteredPackages, r.cfPackageToPackageRecord).Collect(), nil
+	return slices.Collect(it.Map(filteredPackages, r.cfPackageToPackageRecord)), nil
 }
 
 func (r *PackageRepo) UpdatePackageSource(ctx context.Context, authInfo authorization.Info, message UpdatePackageSourceMessage) (PackageRecord, error) {

--- a/api/repositories/package_repository.go
+++ b/api/repositories/package_repository.go
@@ -14,7 +14,7 @@ import (
 	"code.cloudfoundry.org/korifi/tools/dockercfg"
 	"code.cloudfoundry.org/korifi/tools/k8s"
 
-	"github.com/BooleanCat/go-functional/iter"
+	"github.com/BooleanCat/go-functional/v2/it/itx"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
@@ -335,8 +335,8 @@ func (r *PackageRepo) ListPackages(ctx context.Context, authInfo authorization.I
 		packages = append(packages, packageList.Items...)
 	}
 
-	filteredPackages := iter.Lift(packages).Filter(message.matches)
-	return iter.Map(filteredPackages, r.cfPackageToPackageRecord).Collect(), nil
+	filteredPackages := itx.FromSlice(packages).Filter(message.matches)
+	return itx.Map(filteredPackages, r.cfPackageToPackageRecord).Collect(), nil
 }
 
 func (r *PackageRepo) UpdatePackageSource(ctx context.Context, authInfo authorization.Info, message UpdatePackageSourceMessage) (PackageRecord, error) {

--- a/api/repositories/process_repository.go
+++ b/api/repositories/process_repository.go
@@ -10,7 +10,7 @@ import (
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"code.cloudfoundry.org/korifi/tools"
 	"code.cloudfoundry.org/korifi/tools/k8s"
-	"github.com/BooleanCat/go-functional/iter"
+	"github.com/BooleanCat/go-functional/v2/it/itx"
 
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -18,9 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const (
-	ProcessResourceType = "Process"
-)
+const ProcessResourceType = "Process"
 
 func NewProcessRepo(namespaceRetriever NamespaceRetriever, userClientFactory authorization.UserK8sClientFactory, namespacePermissions *authorization.NamespacePermissions) *ProcessRepo {
 	return &ProcessRepo{
@@ -168,8 +166,8 @@ func (r *ProcessRepo) ListProcesses(ctx context.Context, authInfo authorization.
 		processes = append(processes, processList.Items...)
 	}
 
-	filteredProcesses := iter.Lift(processes).Filter(message.matches)
-	return iter.Map(filteredProcesses, cfProcessToProcessRecord).Collect(), nil
+	filteredProcesses := itx.FromSlice(processes).Filter(message.matches)
+	return itx.Map(filteredProcesses, cfProcessToProcessRecord).Collect(), nil
 }
 
 func (r *ProcessRepo) ScaleProcess(ctx context.Context, authInfo authorization.Info, scaleProcessMessage ScaleProcessMessage) (ProcessRecord, error) {

--- a/api/repositories/process_repository.go
+++ b/api/repositories/process_repository.go
@@ -3,6 +3,7 @@ package repositories
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	"code.cloudfoundry.org/korifi/api/authorization"
@@ -10,6 +11,7 @@ import (
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"code.cloudfoundry.org/korifi/tools"
 	"code.cloudfoundry.org/korifi/tools/k8s"
+	"github.com/BooleanCat/go-functional/v2/it"
 	"github.com/BooleanCat/go-functional/v2/it/itx"
 
 	corev1 "k8s.io/api/core/v1"
@@ -167,7 +169,7 @@ func (r *ProcessRepo) ListProcesses(ctx context.Context, authInfo authorization.
 	}
 
 	filteredProcesses := itx.FromSlice(processes).Filter(message.matches)
-	return itx.Map(filteredProcesses, cfProcessToProcessRecord).Collect(), nil
+	return slices.Collect(it.Map(filteredProcesses, cfProcessToProcessRecord)), nil
 }
 
 func (r *ProcessRepo) ScaleProcess(ctx context.Context, authInfo authorization.Info, scaleProcessMessage ScaleProcessMessage) (ProcessRecord, error) {

--- a/api/repositories/process_repository_test.go
+++ b/api/repositories/process_repository_test.go
@@ -195,7 +195,6 @@ var _ = Describe("ProcessRepo", func() {
 
 				It("returns an empty list", func() {
 					Expect(processes).To(BeEmpty())
-					Expect(processes).ToNot(BeNil())
 				})
 			})
 

--- a/api/repositories/relationships/repository.go
+++ b/api/repositories/relationships/repository.go
@@ -3,11 +3,13 @@ package relationships
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"code.cloudfoundry.org/korifi/api/authorization"
 	"code.cloudfoundry.org/korifi/api/repositories"
 	"code.cloudfoundry.org/korifi/model"
-	"github.com/BooleanCat/go-functional/iter"
+	"github.com/BooleanCat/go-functional/v2/it"
+	"github.com/BooleanCat/go-functional/v2/it/itx"
 )
 
 //counterfeiter:generate -o fake -fake-name ServiceOfferingRepository . ServiceOfferingRepository
@@ -41,9 +43,9 @@ func NewResourseRelationshipsRepo(
 }
 
 func (r *ResourceRelationshipsRepo) ListRelatedResources(ctx context.Context, authInfo authorization.Info, relatedResourceType string, resources []Resource) ([]Resource, error) {
-	relatedResourceGUIDs := iter.Map(iter.Lift(resources), func(r Resource) string {
+	relatedResourceGUIDs := slices.Collect(it.Map(itx.FromSlice(resources), func(r Resource) string {
 		return r.Relationships()[relatedResourceType].Data.GUID
-	}).Collect()
+	}))
 
 	switch relatedResourceType {
 	case "service_offering":
@@ -65,7 +67,7 @@ func (r *ResourceRelationshipsRepo) ListRelatedResources(ctx context.Context, au
 }
 
 func asResources[S ~[]E, E Resource](resources S, err error) ([]Resource, error) {
-	return iter.Map(iter.Lift(resources), func(o E) Resource {
+	return slices.Collect(it.Map(itx.FromSlice(resources), func(o E) Resource {
 		return o
-	}).Collect(), err
+	})), err
 }

--- a/api/repositories/role_repository.go
+++ b/api/repositories/role_repository.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/BooleanCat/go-functional/v2/it"
 	"github.com/BooleanCat/go-functional/v2/it/itx"
 	"github.com/google/uuid"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -253,7 +254,7 @@ func (r *RoleRepo) ListRoles(ctx context.Context, authInfo authorization.Info) (
 	}
 
 	cfRoleBindings := itx.FromSlice(roleBindings).Filter(r.isCFRole)
-	return itx.Map(cfRoleBindings, r.toRoleRecord).Collect(), nil
+	return slices.Collect(it.Map(cfRoleBindings, r.toRoleRecord)), nil
 }
 
 func (r *RoleRepo) isCFRole(rb rbacv1.RoleBinding) bool {
@@ -271,9 +272,9 @@ func (r *RoleRepo) getCFRoleName(k8sRoleName string) string {
 }
 
 func (r *RoleRepo) getCFRoleNames() []string {
-	return itx.Map(maps.Values(r.roleMappings), func(r config.Role) string {
+	return slices.Collect(it.Map(maps.Values(r.roleMappings), func(r config.Role) string {
 		return r.Name
-	}).Collect()
+	}))
 }
 
 func (r *RoleRepo) toRoleRecord(roleBinding rbacv1.RoleBinding) RoleRecord {

--- a/api/repositories/route_repository.go
+++ b/api/repositories/route_repository.go
@@ -12,6 +12,7 @@ import (
 	"code.cloudfoundry.org/korifi/tools"
 	"code.cloudfoundry.org/korifi/tools/k8s"
 
+	"github.com/BooleanCat/go-functional/v2/it"
 	"github.com/BooleanCat/go-functional/v2/it/itx"
 	"github.com/google/uuid"
 	v1 "k8s.io/api/core/v1"
@@ -209,7 +210,7 @@ func (r *RouteRepo) ListRoutes(ctx context.Context, authInfo authorization.Info,
 	}
 
 	filteredRoutes := itx.FromSlice(routes).Filter(message.matches)
-	return itx.Map(filteredRoutes, cfRouteToRouteRecord).Collect(), nil
+	return slices.Collect(it.Map(filteredRoutes, cfRouteToRouteRecord)), nil
 }
 
 func cfRouteToRouteRecord(cfRoute korifiv1alpha1.CFRoute) RouteRecord {
@@ -232,7 +233,7 @@ func cfRouteToRouteRecord(cfRoute korifiv1alpha1.CFRoute) RouteRecord {
 }
 
 func cfRouteDestinationsToDestinationRecords(cfRoute korifiv1alpha1.CFRoute) []DestinationRecord {
-	return itx.Map(slices.Values(cfRoute.Spec.Destinations), func(specDestination korifiv1alpha1.Destination) DestinationRecord {
+	return slices.Collect(it.Map(slices.Values(cfRoute.Spec.Destinations), func(specDestination korifiv1alpha1.Destination) DestinationRecord {
 		record := DestinationRecord{
 			GUID:        specDestination.GUID,
 			AppGUID:     specDestination.AppRef.Name,
@@ -250,7 +251,7 @@ func cfRouteDestinationsToDestinationRecords(cfRoute korifiv1alpha1.CFRoute) []D
 		}
 
 		return record
-	}).Collect()
+	}))
 }
 
 func (r *RouteRepo) ListRoutesForApp(ctx context.Context, authInfo authorization.Info, appGUID string, spaceGUID string) ([]RouteRecord, error) {
@@ -435,7 +436,7 @@ func (r *RouteRepo) fetchRouteByFields(ctx context.Context, authInfo authorizati
 }
 
 func destinationRecordsToCFDestinations(destinationRecords []DestinationRecord) []korifiv1alpha1.Destination {
-	return itx.Map(itx.FromSlice(destinationRecords), func(destinationRecord DestinationRecord) korifiv1alpha1.Destination {
+	return slices.Collect(it.Map(itx.FromSlice(destinationRecords), func(destinationRecord DestinationRecord) korifiv1alpha1.Destination {
 		return korifiv1alpha1.Destination{
 			GUID: destinationRecord.GUID,
 			Port: destinationRecord.Port,
@@ -445,7 +446,7 @@ func destinationRecordsToCFDestinations(destinationRecords []DestinationRecord) 
 			ProcessType: destinationRecord.ProcessType,
 			Protocol:    destinationRecord.Protocol,
 		}
-	}).Collect()
+	}))
 }
 
 func (r *RouteRepo) PatchRouteMetadata(ctx context.Context, authInfo authorization.Info, message PatchRouteMetadataMessage) (RouteRecord, error) {

--- a/api/repositories/service_binding_repository.go
+++ b/api/repositories/service_binding_repository.go
@@ -16,7 +16,7 @@ import (
 	"code.cloudfoundry.org/korifi/tools"
 	"code.cloudfoundry.org/korifi/tools/k8s"
 
-	"github.com/BooleanCat/go-functional/iter"
+	"github.com/BooleanCat/go-functional/v2/it/itx"
 	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -292,6 +292,6 @@ func (r *ServiceBindingRepo) ListServiceBindings(ctx context.Context, authInfo a
 		serviceBindings = append(serviceBindings, serviceBindingList.Items...)
 	}
 
-	filteredServiceBindings := iter.Lift(serviceBindings).Filter(message.matches)
-	return iter.Map(filteredServiceBindings, cfServiceBindingToRecord).Collect(), nil
+	filteredServiceBindings := itx.FromSlice(serviceBindings).Filter(message.matches)
+	return itx.Map(filteredServiceBindings, cfServiceBindingToRecord).Collect(), nil
 }

--- a/api/repositories/service_binding_repository.go
+++ b/api/repositories/service_binding_repository.go
@@ -3,6 +3,7 @@ package repositories
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	"k8s.io/apimachinery/pkg/labels"
@@ -16,6 +17,7 @@ import (
 	"code.cloudfoundry.org/korifi/tools"
 	"code.cloudfoundry.org/korifi/tools/k8s"
 
+	"github.com/BooleanCat/go-functional/v2/it"
 	"github.com/BooleanCat/go-functional/v2/it/itx"
 	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
@@ -293,5 +295,5 @@ func (r *ServiceBindingRepo) ListServiceBindings(ctx context.Context, authInfo a
 	}
 
 	filteredServiceBindings := itx.FromSlice(serviceBindings).Filter(message.matches)
-	return itx.Map(filteredServiceBindings, cfServiceBindingToRecord).Collect(), nil
+	return slices.Collect(it.Map(filteredServiceBindings, cfServiceBindingToRecord)), nil
 }

--- a/api/repositories/service_broker_repository.go
+++ b/api/repositories/service_broker_repository.go
@@ -11,7 +11,7 @@ import (
 	"code.cloudfoundry.org/korifi/model"
 	"code.cloudfoundry.org/korifi/model/services"
 	"code.cloudfoundry.org/korifi/tools"
-	"github.com/BooleanCat/go-functional/iter"
+	"github.com/BooleanCat/go-functional/v2/it/itx"
 	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -189,8 +189,9 @@ func (r *ServiceBrokerRepo) ListServiceBrokers(ctx context.Context, authInfo aut
 		return nil, fmt.Errorf("failed to list brokers: %w", apierrors.FromK8sError(err, ServiceBrokerResourceType))
 	}
 
-	brokers := iter.Lift(brokersList.Items).Filter(message.matches)
-	return iter.Map(brokers, toServiceBrokerRecord).Collect(), nil
+	brokers := itx.FromSlice(brokersList.Items).Filter(message.matches)
+
+	return itx.Map(brokers, toServiceBrokerRecord).Collect(), nil
 }
 
 func (r *ServiceBrokerRepo) GetServiceBroker(ctx context.Context, authInfo authorization.Info, guid string) (ServiceBrokerRecord, error) {

--- a/api/repositories/service_broker_repository.go
+++ b/api/repositories/service_broker_repository.go
@@ -3,6 +3,7 @@ package repositories
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	"code.cloudfoundry.org/korifi/api/authorization"
@@ -11,6 +12,7 @@ import (
 	"code.cloudfoundry.org/korifi/model"
 	"code.cloudfoundry.org/korifi/model/services"
 	"code.cloudfoundry.org/korifi/tools"
+	"github.com/BooleanCat/go-functional/v2/it"
 	"github.com/BooleanCat/go-functional/v2/it/itx"
 	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
@@ -191,7 +193,7 @@ func (r *ServiceBrokerRepo) ListServiceBrokers(ctx context.Context, authInfo aut
 
 	brokers := itx.FromSlice(brokersList.Items).Filter(message.matches)
 
-	return itx.Map(brokers, toServiceBrokerRecord).Collect(), nil
+	return slices.Collect(it.Map(brokers, toServiceBrokerRecord)), nil
 }
 
 func (r *ServiceBrokerRepo) GetServiceBroker(ctx context.Context, authInfo authorization.Info, guid string) (ServiceBrokerRecord, error) {

--- a/api/repositories/service_instance_repository.go
+++ b/api/repositories/service_instance_repository.go
@@ -12,7 +12,7 @@ import (
 	"code.cloudfoundry.org/korifi/tools"
 	"code.cloudfoundry.org/korifi/tools/k8s"
 
-	"github.com/BooleanCat/go-functional/iter"
+	"github.com/BooleanCat/go-functional/v2/it/itx"
 	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -267,8 +267,8 @@ func (r *ServiceInstanceRepo) ListServiceInstances(ctx context.Context, authInfo
 		serviceInstances = append(serviceInstances, serviceInstanceList.Items...)
 	}
 
-	filteredServiceInstances := iter.Lift(serviceInstances).Filter(message.matches)
-	return iter.Map(filteredServiceInstances, cfServiceInstanceToRecord).Collect(), nil
+	filteredServiceInstances := itx.FromSlice(serviceInstances).Filter(message.matches)
+	return itx.Map(filteredServiceInstances, cfServiceInstanceToRecord).Collect(), nil
 }
 
 func (r *ServiceInstanceRepo) GetServiceInstance(ctx context.Context, authInfo authorization.Info, guid string) (ServiceInstanceRecord, error) {

--- a/api/repositories/service_instance_repository.go
+++ b/api/repositories/service_instance_repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"code.cloudfoundry.org/korifi/api/authorization"
@@ -12,6 +13,7 @@ import (
 	"code.cloudfoundry.org/korifi/tools"
 	"code.cloudfoundry.org/korifi/tools/k8s"
 
+	"github.com/BooleanCat/go-functional/v2/it"
 	"github.com/BooleanCat/go-functional/v2/it/itx"
 	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
@@ -268,7 +270,7 @@ func (r *ServiceInstanceRepo) ListServiceInstances(ctx context.Context, authInfo
 	}
 
 	filteredServiceInstances := itx.FromSlice(serviceInstances).Filter(message.matches)
-	return itx.Map(filteredServiceInstances, cfServiceInstanceToRecord).Collect(), nil
+	return slices.Collect(it.Map(filteredServiceInstances, cfServiceInstanceToRecord)), nil
 }
 
 func (r *ServiceInstanceRepo) GetServiceInstance(ctx context.Context, authInfo authorization.Info, guid string) (ServiceInstanceRecord, error) {

--- a/api/repositories/service_offering_repository.go
+++ b/api/repositories/service_offering_repository.go
@@ -11,7 +11,8 @@ import (
 	"code.cloudfoundry.org/korifi/model"
 	"code.cloudfoundry.org/korifi/model/services"
 	"code.cloudfoundry.org/korifi/tools"
-	"github.com/BooleanCat/go-functional/iter"
+	"github.com/BooleanCat/go-functional/v2/it"
+	"github.com/BooleanCat/go-functional/v2/it/itx"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -81,7 +82,7 @@ func (r *ServiceOfferingRepo) ListOfferings(ctx context.Context, authInfo author
 		)
 	}
 
-	filteredByName := iter.Map(iter.Lift(offeringsList.Items).Filter(message.matchesName), offeringToRecord).Collect()
+	filteredByName := slices.Collect(it.Map(itx.FromSlice(offeringsList.Items).Filter(message.matchesName), offeringToRecord))
 
 	filteredByBroker := []ServiceOfferingRecord{}
 	for _, offering := range filteredByName {

--- a/api/repositories/service_plan_repository.go
+++ b/api/repositories/service_plan_repository.go
@@ -10,7 +10,8 @@ import (
 	"code.cloudfoundry.org/korifi/model"
 	"code.cloudfoundry.org/korifi/model/services"
 	"code.cloudfoundry.org/korifi/tools"
-	"github.com/BooleanCat/go-functional/iter"
+	"github.com/BooleanCat/go-functional/v2/it"
+	"github.com/BooleanCat/go-functional/v2/it/itx"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -118,7 +119,7 @@ func (r *ServicePlanRepo) ListPlans(ctx context.Context, authInfo authorization.
 		return nil, apierrors.FromK8sError(err, ServicePlanResourceType)
 	}
 
-	filteredPlans := iter.Lift(cfServicePlans.Items).Filter(message.matches).Collect()
+	filteredPlans := itx.FromSlice(cfServicePlans.Items).Filter(message.matches).Collect()
 
 	planRecords := []ServicePlanRecord{}
 	for _, plan := range filteredPlans {
@@ -224,10 +225,10 @@ func (r *ServicePlanRepo) toVisibilityOrganizations(ctx context.Context, authInf
 		return nil, fmt.Errorf("failed to list orgs for plan visibility: %w", err)
 	}
 
-	return iter.Map(iter.Lift(orgs), func(o OrgRecord) services.VisibilityOrganization {
+	return slices.Collect(it.Map(slices.Values(orgs), func(o OrgRecord) services.VisibilityOrganization {
 		return services.VisibilityOrganization{
 			GUID: o.GUID,
 			Name: o.Name,
 		}
-	}).Collect(), nil
+	})), nil
 }

--- a/api/repositories/service_plan_repository.go
+++ b/api/repositories/service_plan_repository.go
@@ -3,6 +3,7 @@ package repositories
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"code.cloudfoundry.org/korifi/api/authorization"
 	apierrors "code.cloudfoundry.org/korifi/api/errors"

--- a/api/repositories/shared.go
+++ b/api/repositories/shared.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"maps"
-	"slices"
 	"time"
 
 	"code.cloudfoundry.org/korifi/api/authorization"
@@ -70,14 +69,6 @@ func getLabelOrAnnotation(mapObj map[string]string, key string) string {
 		return ""
 	}
 	return mapObj[key]
-}
-
-func emptyOrContains[S ~[]E, E comparable](elements S, e E) bool {
-	if len(elements) == 0 {
-		return true
-	}
-
-	return slices.Contains(elements, e)
 }
 
 func authorizedSpaceNamespaces(ctx context.Context, authInfo authorization.Info, namespacePermissions *authorization.NamespacePermissions) (itx.Iterator[string], error) {

--- a/api/repositories/space_repository.go
+++ b/api/repositories/space_repository.go
@@ -3,6 +3,7 @@ package repositories
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	"code.cloudfoundry.org/korifi/api/authorization"
@@ -11,6 +12,7 @@ import (
 	"code.cloudfoundry.org/korifi/tools"
 	"code.cloudfoundry.org/korifi/tools/k8s"
 
+	"github.com/BooleanCat/go-functional/v2/it"
 	"github.com/BooleanCat/go-functional/v2/it/itx"
 	"github.com/google/uuid"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -159,7 +161,7 @@ func (r *SpaceRepo) ListSpaces(ctx context.Context, authInfo authorization.Info,
 		return authorizedSpaceNamespaces[s.Name] && message.matches(s)
 	})
 
-	return itx.Map(filteredSpaces, cfSpaceToSpaceRecord).Collect(), nil
+	return slices.Collect(it.Map(filteredSpaces, cfSpaceToSpaceRecord)), nil
 }
 
 func (r *SpaceRepo) GetSpace(ctx context.Context, info authorization.Info, spaceGUID string) (SpaceRecord, error) {

--- a/api/repositories/space_repository.go
+++ b/api/repositories/space_repository.go
@@ -11,7 +11,7 @@ import (
 	"code.cloudfoundry.org/korifi/tools"
 	"code.cloudfoundry.org/korifi/tools/k8s"
 
-	"github.com/BooleanCat/go-functional/iter"
+	"github.com/BooleanCat/go-functional/v2/it/itx"
 	"github.com/google/uuid"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -155,11 +155,11 @@ func (r *SpaceRepo) ListSpaces(ctx context.Context, authInfo authorization.Info,
 		cfSpaces = append(cfSpaces, cfSpaceList.Items...)
 	}
 
-	filteredSpaces := iter.Lift(cfSpaces).Filter(func(s korifiv1alpha1.CFSpace) bool {
+	filteredSpaces := itx.FromSlice(cfSpaces).Filter(func(s korifiv1alpha1.CFSpace) bool {
 		return authorizedSpaceNamespaces[s.Name] && message.matches(s)
 	})
 
-	return iter.Map(filteredSpaces, cfSpaceToSpaceRecord).Collect(), nil
+	return itx.Map(filteredSpaces, cfSpaceToSpaceRecord).Collect(), nil
 }
 
 func (r *SpaceRepo) GetSpace(ctx context.Context, info authorization.Info, spaceGUID string) (SpaceRecord, error) {

--- a/api/repositories/task_repository.go
+++ b/api/repositories/task_repository.go
@@ -3,6 +3,7 @@ package repositories
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	"code.cloudfoundry.org/korifi/api/authorization"
@@ -11,6 +12,7 @@ import (
 	"code.cloudfoundry.org/korifi/controllers/controllers/workloads/tasks"
 	"code.cloudfoundry.org/korifi/tools"
 	"code.cloudfoundry.org/korifi/tools/k8s"
+	"github.com/BooleanCat/go-functional/v2/it"
 	"github.com/BooleanCat/go-functional/v2/it/itx"
 	"github.com/google/uuid"
 	v1 "k8s.io/api/core/v1"
@@ -192,7 +194,7 @@ func (r *TaskRepo) ListTasks(ctx context.Context, authInfo authorization.Info, m
 	}
 
 	filteredTasks := itx.FromSlice(tasks).Filter(msg.matches)
-	return itx.Map(filteredTasks, taskToRecord).Collect(), nil
+	return slices.Collect(it.Map(filteredTasks, taskToRecord)), nil
 }
 
 func (r *TaskRepo) CancelTask(ctx context.Context, authInfo authorization.Info, taskGUID string) (TaskRecord, error) {

--- a/api/repositories/task_repository.go
+++ b/api/repositories/task_repository.go
@@ -11,7 +11,7 @@ import (
 	"code.cloudfoundry.org/korifi/controllers/controllers/workloads/tasks"
 	"code.cloudfoundry.org/korifi/tools"
 	"code.cloudfoundry.org/korifi/tools/k8s"
-	"github.com/BooleanCat/go-functional/iter"
+	"github.com/BooleanCat/go-functional/v2/it/itx"
 	"github.com/google/uuid"
 	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -191,8 +191,8 @@ func (r *TaskRepo) ListTasks(ctx context.Context, authInfo authorization.Info, m
 		tasks = append(tasks, taskList.Items...)
 	}
 
-	filteredTasks := iter.Lift(tasks).Filter(msg.matches)
-	return iter.Map(filteredTasks, taskToRecord).Collect(), nil
+	filteredTasks := itx.FromSlice(tasks).Filter(msg.matches)
+	return itx.Map(filteredTasks, taskToRecord).Collect(), nil
 }
 
 func (r *TaskRepo) CancelTask(ctx context.Context, authInfo authorization.Info, taskGUID string) (TaskRecord, error) {

--- a/controllers/controllers/workloads/k8sns/reconciler_test.go
+++ b/controllers/controllers/workloads/k8sns/reconciler_test.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
+	"slices"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"code.cloudfoundry.org/korifi/controllers/controllers/workloads/k8sns"
 	"code.cloudfoundry.org/korifi/tools"
 	"code.cloudfoundry.org/korifi/tools/k8s"
-	"golang.org/x/exp/maps"
 
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
@@ -165,7 +166,7 @@ var _ = Describe("K8S NS Reconciler Integration Tests", func() {
 			Expect(createdSecret.Type).To(Equal(imageRegistrySecret.Type))
 
 			By("omitting annotations from deployment tools", func() {
-				Expect(maps.Keys(createdSecret.Annotations)).NotTo(ContainElements("kapp.k14s.io/foo", "meta.helm.sh/baz"))
+				Expect(slices.Collect(maps.Keys(createdSecret.Annotations))).NotTo(ContainElements("kapp.k14s.io/foo", "meta.helm.sh/baz"))
 			})
 		})
 

--- a/controllers/controllers/workloads/spaces/controller_test.go
+++ b/controllers/controllers/workloads/spaces/controller_test.go
@@ -1,6 +1,8 @@
 package spaces_test
 
 import (
+	"maps"
+	"slices"
 	"time"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
@@ -10,7 +12,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
-	"golang.org/x/exp/maps"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -143,7 +144,7 @@ var _ = Describe("CFSpaceReconciler Integration Tests", func() {
 				}).Should(Succeed())
 
 				By("omitting annotations from deployment tools", func() {
-					Expect(maps.Keys(createdServiceAccount.Annotations)).To(ConsistOf("cloudfoundry.org/propagate-service-account"))
+					Expect(slices.Collect(maps.Keys(createdServiceAccount.Annotations))).To(ConsistOf("cloudfoundry.org/propagate-service-account"))
 					Expect(createdServiceAccount.Annotations["cloudfoundry.org/propagate-service-account"]).To(Equal("true"))
 				})
 			})

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23
 require (
 	code.cloudfoundry.org/bytefmt v0.0.0-20211005130812-5bb3c17173e5
 	code.cloudfoundry.org/go-loggregator/v8 v8.0.5
-	github.com/BooleanCat/go-functional/v2 v2.0.0-beta.3
+	github.com/BooleanCat/go-functional/v2 v2.0.0-beta.5
 	github.com/Masterminds/semver v1.5.0
 	github.com/PaesslerAG/jsonpath v0.1.1
 	github.com/SermoDigital/jose v0.9.2-0.20161205224733-f6df55f235c2

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,11 @@
 module code.cloudfoundry.org/korifi
 
-go 1.23
+go 1.23.0
 
 require (
 	code.cloudfoundry.org/bytefmt v0.0.0-20211005130812-5bb3c17173e5
 	code.cloudfoundry.org/go-loggregator/v8 v8.0.5
+	github.com/BooleanCat/go-functional v1.1.0
 	github.com/BooleanCat/go-functional/v2 v2.0.0-beta.5
 	github.com/Masterminds/semver v1.5.0
 	github.com/PaesslerAG/jsonpath v0.1.1
@@ -31,7 +32,7 @@ require (
 	github.com/pivotal/kpack v0.15.0
 	github.com/satori/go.uuid v1.2.0
 	github.com/servicebinding/runtime v1.0.0
-	golang.org/x/text v0.16.0
+	golang.org/x/text v0.17.0
 	gopkg.in/square/go-jose.v2 v2.6.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.30.3

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.23.0
 require (
 	code.cloudfoundry.org/bytefmt v0.0.0-20211005130812-5bb3c17173e5
 	code.cloudfoundry.org/go-loggregator/v8 v8.0.5
-	github.com/BooleanCat/go-functional v1.1.0
 	github.com/BooleanCat/go-functional/v2 v2.0.0-beta.5
 	github.com/Masterminds/semver v1.5.0
 	github.com/PaesslerAG/jsonpath v0.1.1

--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,11 @@
 module code.cloudfoundry.org/korifi
 
-go 1.22.4
-
-toolchain go1.22.5
+go 1.23
 
 require (
 	code.cloudfoundry.org/bytefmt v0.0.0-20211005130812-5bb3c17173e5
 	code.cloudfoundry.org/go-loggregator/v8 v8.0.5
-	github.com/BooleanCat/go-functional v1.1.0
+	github.com/BooleanCat/go-functional/v2 v2.0.0-beta.3
 	github.com/Masterminds/semver v1.5.0
 	github.com/PaesslerAG/jsonpath v0.1.1
 	github.com/SermoDigital/jose v0.9.2-0.20161205224733-f6df55f235c2

--- a/go.mod
+++ b/go.mod
@@ -31,8 +31,7 @@ require (
 	github.com/pivotal/kpack v0.15.0
 	github.com/satori/go.uuid v1.2.0
 	github.com/servicebinding/runtime v1.0.0
-	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
-	golang.org/x/text v0.17.0
+	golang.org/x/text v0.16.0
 	gopkg.in/square/go-jose.v2 v2.6.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.30.3
@@ -75,6 +74,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.28.0 // indirect
 	go.opentelemetry.io/otel/trace v1.28.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
+	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240311173647-c811ad7063a7 // indirect
 	reconciler.io/runtime v0.20.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 require (
 	code.cloudfoundry.org/bytefmt v0.0.0-20211005130812-5bb3c17173e5
 	code.cloudfoundry.org/go-loggregator/v8 v8.0.5
-	github.com/BooleanCat/go-functional/v2 v2.0.0-beta.5
+	github.com/BooleanCat/go-functional/v2 v2.0.0-beta.6
 	github.com/Masterminds/semver v1.5.0
 	github.com/PaesslerAG/jsonpath v0.1.1
 	github.com/SermoDigital/jose v0.9.2-0.20161205224733-f6df55f235c2

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,8 @@ github.com/Azure/go-autorest/logger v0.2.1 h1:IG7i4p/mDa2Ce4TRyAO8IHnVhAVF3RFU+Z
 github.com/Azure/go-autorest/logger v0.2.1/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZmbF5NWuPV8+WeEW8=
 github.com/Azure/go-autorest/tracing v0.6.0 h1:TYi4+3m5t6K48TGI9AUdb+IzbnSxvnvUMfuitfgcfuo=
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
-github.com/BooleanCat/go-functional/v2 v2.0.0-beta.5 h1:/AbWbCabFMF3sDWK+YrUBs2W2g8LcjvmzB7f7an4E6U=
-github.com/BooleanCat/go-functional/v2 v2.0.0-beta.5/go.mod h1:IpUUAXAc9CiWDb+YDXkJyyUhtOVqDtyICDRg/de1IaQ=
+github.com/BooleanCat/go-functional/v2 v2.0.0-beta.6 h1:oWriTGder5N8yraSGLrsSwjoulEWeKG0XR9RGZklQsw=
+github.com/BooleanCat/go-functional/v2 v2.0.0-beta.6/go.mod h1:IpUUAXAc9CiWDb+YDXkJyyUhtOVqDtyICDRg/de1IaQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8=
 github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,8 @@ github.com/Azure/go-autorest/logger v0.2.1 h1:IG7i4p/mDa2Ce4TRyAO8IHnVhAVF3RFU+Z
 github.com/Azure/go-autorest/logger v0.2.1/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZmbF5NWuPV8+WeEW8=
 github.com/Azure/go-autorest/tracing v0.6.0 h1:TYi4+3m5t6K48TGI9AUdb+IzbnSxvnvUMfuitfgcfuo=
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
-github.com/BooleanCat/go-functional/v2 v2.0.0-beta.3 h1:7lCZO6m4H2dUF5mTsWgkaaNjwvmdLX+YgL4z5V06wXY=
-github.com/BooleanCat/go-functional/v2 v2.0.0-beta.3/go.mod h1:IpUUAXAc9CiWDb+YDXkJyyUhtOVqDtyICDRg/de1IaQ=
+github.com/BooleanCat/go-functional/v2 v2.0.0-beta.5 h1:/AbWbCabFMF3sDWK+YrUBs2W2g8LcjvmzB7f7an4E6U=
+github.com/BooleanCat/go-functional/v2 v2.0.0-beta.5/go.mod h1:IpUUAXAc9CiWDb+YDXkJyyUhtOVqDtyICDRg/de1IaQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8=
 github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,6 @@ github.com/Azure/go-autorest/logger v0.2.1 h1:IG7i4p/mDa2Ce4TRyAO8IHnVhAVF3RFU+Z
 github.com/Azure/go-autorest/logger v0.2.1/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZmbF5NWuPV8+WeEW8=
 github.com/Azure/go-autorest/tracing v0.6.0 h1:TYi4+3m5t6K48TGI9AUdb+IzbnSxvnvUMfuitfgcfuo=
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
-github.com/BooleanCat/go-functional v1.1.0 h1:ZU8ejc2u/71I5LZbI5qiJI75Ttw1FueLNmoccPt8nDI=
-github.com/BooleanCat/go-functional v1.1.0/go.mod h1:Zd1xLrGFohrDdjojLUCrzSex40yf/PVP2KB86ha9Qqg=
 github.com/BooleanCat/go-functional/v2 v2.0.0-beta.5 h1:/AbWbCabFMF3sDWK+YrUBs2W2g8LcjvmzB7f7an4E6U=
 github.com/BooleanCat/go-functional/v2 v2.0.0-beta.5/go.mod h1:IpUUAXAc9CiWDb+YDXkJyyUhtOVqDtyICDRg/de1IaQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/Azure/go-autorest/logger v0.2.1 h1:IG7i4p/mDa2Ce4TRyAO8IHnVhAVF3RFU+Z
 github.com/Azure/go-autorest/logger v0.2.1/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZmbF5NWuPV8+WeEW8=
 github.com/Azure/go-autorest/tracing v0.6.0 h1:TYi4+3m5t6K48TGI9AUdb+IzbnSxvnvUMfuitfgcfuo=
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
+github.com/BooleanCat/go-functional v1.1.0 h1:ZU8ejc2u/71I5LZbI5qiJI75Ttw1FueLNmoccPt8nDI=
+github.com/BooleanCat/go-functional v1.1.0/go.mod h1:Zd1xLrGFohrDdjojLUCrzSex40yf/PVP2KB86ha9Qqg=
 github.com/BooleanCat/go-functional/v2 v2.0.0-beta.5 h1:/AbWbCabFMF3sDWK+YrUBs2W2g8LcjvmzB7f7an4E6U=
 github.com/BooleanCat/go-functional/v2 v2.0.0-beta.5/go.mod h1:IpUUAXAc9CiWDb+YDXkJyyUhtOVqDtyICDRg/de1IaQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,8 @@ github.com/Azure/go-autorest/logger v0.2.1 h1:IG7i4p/mDa2Ce4TRyAO8IHnVhAVF3RFU+Z
 github.com/Azure/go-autorest/logger v0.2.1/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZmbF5NWuPV8+WeEW8=
 github.com/Azure/go-autorest/tracing v0.6.0 h1:TYi4+3m5t6K48TGI9AUdb+IzbnSxvnvUMfuitfgcfuo=
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
-github.com/BooleanCat/go-functional v1.1.0 h1:ZU8ejc2u/71I5LZbI5qiJI75Ttw1FueLNmoccPt8nDI=
-github.com/BooleanCat/go-functional v1.1.0/go.mod h1:Zd1xLrGFohrDdjojLUCrzSex40yf/PVP2KB86ha9Qqg=
+github.com/BooleanCat/go-functional/v2 v2.0.0-beta.3 h1:7lCZO6m4H2dUF5mTsWgkaaNjwvmdLX+YgL4z5V06wXY=
+github.com/BooleanCat/go-functional/v2 v2.0.0-beta.3/go.mod h1:IpUUAXAc9CiWDb+YDXkJyyUhtOVqDtyICDRg/de1IaQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8=
 github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=

--- a/scripts/helmdoc/main.go
+++ b/scripts/helmdoc/main.go
@@ -3,18 +3,19 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"os"
+	"slices"
 	"sort"
 	"strings"
 
-	"golang.org/x/exp/maps"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 )
 
 func printDocForSchema(schema map[string]any, indentLevel int) {
 	indentStr := strings.Repeat("  ", indentLevel)
-	names := maps.Keys(schema)
+	names := slices.Collect(maps.Keys(schema))
 	sort.Slice(names, func(a, b int) bool {
 		if names[a] == "global" {
 			return true

--- a/tests/e2e/service_plans_test.go
+++ b/tests/e2e/service_plans_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
-	"github.com/BooleanCat/go-functional/iter"
+	"github.com/BooleanCat/go-functional/v2/it/itx"
 	"github.com/go-resty/resty/v2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -57,7 +57,7 @@ var _ = Describe("Service Plans", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(listResp).To(HaveRestyStatusCode(http.StatusOK))
 
-			brokerPlans := iter.Lift(plans.Resources).Filter(func(r resource) bool {
+			brokerPlans := itx.FromSlice(plans.Resources).Filter(func(r resource) bool {
 				return r.Metadata.Labels[korifiv1alpha1.RelServiceBrokerGUIDLabel] == brokerGUID
 			}).Collect()
 


### PR DESCRIPTION
## Is there a related GitHub Issue?

N/A.

## What is this change about?

You're currently using version 1 of go-functional which I'm no longer maintaining. This upgrades go-functional to v2 and uses Go 1.23's native `iter.Seq` functionality for iterators - making all iterators in this library first-class iterators supported by the language.

There's two main packages of interest:

1. `it` contains the iterators you are already using
2. `itx` contains helpers to support iterator chaining

Unfortunately it's not possible to chain `Map` because of a limitation with Go's type system (you can't declare new generic arguments on a method not present on its type). But this was also a limitation of version 1 of go functional too.

Native Go iterators can be "lifted" to their chainable type by using `itx.From(iterator)`.

If this eventually gets merged once you use Go 1.23 I'd be happy to comb through the code and find places where go-functional simplifies the codebase.

## Does this PR introduce a breaking change?

Yes - you'll need to use Go 1.23. I notice you're using rc2 in your container images but 1.23 is not declared as the minimum version in the `go.mod` yet.

## Acceptance Steps

No functional change.

## Tag your pair, your PM, and/or team

N/A.
