### PR TITLE
Do not use `controllerutil.CreateOrPatch` in repositories

### DIFF
--- a/api/actions/shared/fake/cfapp_repository.go
+++ b/api/actions/shared/fake/cfapp_repository.go
@@ -26,21 +26,6 @@ type CFAppRepository struct {
 		result1 repositories.AppRecord
 		result2 error
 	}
-	CreateOrPatchAppEnvVarsStub        func(context.Context, authorization.Info, repositories.CreateOrPatchAppEnvVarsMessage) (repositories.AppEnvVarsRecord, error)
-	createOrPatchAppEnvVarsMutex       sync.RWMutex
-	createOrPatchAppEnvVarsArgsForCall []struct {
-		arg1 context.Context
-		arg2 authorization.Info
-		arg3 repositories.CreateOrPatchAppEnvVarsMessage
-	}
-	createOrPatchAppEnvVarsReturns struct {
-		result1 repositories.AppEnvVarsRecord
-		result2 error
-	}
-	createOrPatchAppEnvVarsReturnsOnCall map[int]struct {
-		result1 repositories.AppEnvVarsRecord
-		result2 error
-	}
 	GetAppStub        func(context.Context, authorization.Info, string) (repositories.AppRecord, error)
 	getAppMutex       sync.RWMutex
 	getAppArgsForCall []struct {
@@ -152,72 +137,6 @@ func (fake *CFAppRepository) CreateAppReturnsOnCall(i int, result1 repositories.
 	}
 	fake.createAppReturnsOnCall[i] = struct {
 		result1 repositories.AppRecord
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *CFAppRepository) CreateOrPatchAppEnvVars(arg1 context.Context, arg2 authorization.Info, arg3 repositories.CreateOrPatchAppEnvVarsMessage) (repositories.AppEnvVarsRecord, error) {
-	fake.createOrPatchAppEnvVarsMutex.Lock()
-	ret, specificReturn := fake.createOrPatchAppEnvVarsReturnsOnCall[len(fake.createOrPatchAppEnvVarsArgsForCall)]
-	fake.createOrPatchAppEnvVarsArgsForCall = append(fake.createOrPatchAppEnvVarsArgsForCall, struct {
-		arg1 context.Context
-		arg2 authorization.Info
-		arg3 repositories.CreateOrPatchAppEnvVarsMessage
-	}{arg1, arg2, arg3})
-	stub := fake.CreateOrPatchAppEnvVarsStub
-	fakeReturns := fake.createOrPatchAppEnvVarsReturns
-	fake.recordInvocation("CreateOrPatchAppEnvVars", []interface{}{arg1, arg2, arg3})
-	fake.createOrPatchAppEnvVarsMutex.Unlock()
-	if stub != nil {
-		return stub(arg1, arg2, arg3)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	return fakeReturns.result1, fakeReturns.result2
-}
-
-func (fake *CFAppRepository) CreateOrPatchAppEnvVarsCallCount() int {
-	fake.createOrPatchAppEnvVarsMutex.RLock()
-	defer fake.createOrPatchAppEnvVarsMutex.RUnlock()
-	return len(fake.createOrPatchAppEnvVarsArgsForCall)
-}
-
-func (fake *CFAppRepository) CreateOrPatchAppEnvVarsCalls(stub func(context.Context, authorization.Info, repositories.CreateOrPatchAppEnvVarsMessage) (repositories.AppEnvVarsRecord, error)) {
-	fake.createOrPatchAppEnvVarsMutex.Lock()
-	defer fake.createOrPatchAppEnvVarsMutex.Unlock()
-	fake.CreateOrPatchAppEnvVarsStub = stub
-}
-
-func (fake *CFAppRepository) CreateOrPatchAppEnvVarsArgsForCall(i int) (context.Context, authorization.Info, repositories.CreateOrPatchAppEnvVarsMessage) {
-	fake.createOrPatchAppEnvVarsMutex.RLock()
-	defer fake.createOrPatchAppEnvVarsMutex.RUnlock()
-	argsForCall := fake.createOrPatchAppEnvVarsArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
-}
-
-func (fake *CFAppRepository) CreateOrPatchAppEnvVarsReturns(result1 repositories.AppEnvVarsRecord, result2 error) {
-	fake.createOrPatchAppEnvVarsMutex.Lock()
-	defer fake.createOrPatchAppEnvVarsMutex.Unlock()
-	fake.CreateOrPatchAppEnvVarsStub = nil
-	fake.createOrPatchAppEnvVarsReturns = struct {
-		result1 repositories.AppEnvVarsRecord
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *CFAppRepository) CreateOrPatchAppEnvVarsReturnsOnCall(i int, result1 repositories.AppEnvVarsRecord, result2 error) {
-	fake.createOrPatchAppEnvVarsMutex.Lock()
-	defer fake.createOrPatchAppEnvVarsMutex.Unlock()
-	fake.CreateOrPatchAppEnvVarsStub = nil
-	if fake.createOrPatchAppEnvVarsReturnsOnCall == nil {
-		fake.createOrPatchAppEnvVarsReturnsOnCall = make(map[int]struct {
-			result1 repositories.AppEnvVarsRecord
-			result2 error
-		})
-	}
-	fake.createOrPatchAppEnvVarsReturnsOnCall[i] = struct {
-		result1 repositories.AppEnvVarsRecord
 		result2 error
 	}{result1, result2}
 }
@@ -425,8 +344,6 @@ func (fake *CFAppRepository) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.createAppMutex.RLock()
 	defer fake.createAppMutex.RUnlock()
-	fake.createOrPatchAppEnvVarsMutex.RLock()
-	defer fake.createOrPatchAppEnvVarsMutex.RUnlock()
 	fake.getAppMutex.RLock()
 	defer fake.getAppMutex.RUnlock()
 	fake.listAppsMutex.RLock()

--- a/api/actions/shared/shared.go
+++ b/api/actions/shared/shared.go
@@ -23,7 +23,6 @@ type CFProcessRepository interface {
 type CFAppRepository interface {
 	GetApp(context.Context, authorization.Info, string) (repositories.AppRecord, error)
 	ListApps(context.Context, authorization.Info, repositories.ListAppsMessage) ([]repositories.AppRecord, error)
-	CreateOrPatchAppEnvVars(context.Context, authorization.Info, repositories.CreateOrPatchAppEnvVarsMessage) (repositories.AppEnvVarsRecord, error)
 	CreateApp(context.Context, authorization.Info, repositories.CreateAppMessage) (repositories.AppRecord, error)
 	PatchApp(context.Context, authorization.Info, repositories.PatchAppMessage) (repositories.AppRecord, error)
 }

--- a/api/repositories/repositories_suite_test.go
+++ b/api/repositories/repositories_suite_test.go
@@ -421,21 +421,6 @@ func createServiceBindingCR(ctx context.Context, k8sClient client.Client, servic
 	return toReturn
 }
 
-func initializeAppCreateMessage(appName string, spaceGUID string) repositories.CreateAppMessage {
-	return repositories.CreateAppMessage{
-		Name:      appName,
-		SpaceGUID: spaceGUID,
-		State:     "STOPPED",
-		Lifecycle: repositories.Lifecycle{
-			Type: "buildpack",
-			Data: repositories.LifecycleData{
-				Buildpacks: []string{},
-				Stack:      "cflinuxfs3",
-			},
-		},
-	}
-}
-
 func createApp(space string) *korifiv1alpha1.CFApp {
 	return createAppWithGUID(space, uuid.NewString())
 }


### PR DESCRIPTION

## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Just `Create` or `Patch` explicitly as repositories are pretty aware of
whether the object should be created or updated
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
