### PR TITLE
Implement POST /v3/service_plans/{guid}/visibility

### DIFF
--- a/api/handlers/fake/cfservice_plan_repository.go
+++ b/api/handlers/fake/cfservice_plan_repository.go
@@ -11,19 +11,34 @@ import (
 )
 
 type CFServicePlanRepository struct {
-	GetPlanVisibilityStub        func(context.Context, authorization.Info, string) (repositories.ServicePlanVisibilityRecord, error)
-	getPlanVisibilityMutex       sync.RWMutex
-	getPlanVisibilityArgsForCall []struct {
+	ApplyPlanVisibilityStub        func(context.Context, authorization.Info, repositories.ApplyServicePlanVisibilityMessage) (repositories.ServicePlanRecord, error)
+	applyPlanVisibilityMutex       sync.RWMutex
+	applyPlanVisibilityArgsForCall []struct {
+		arg1 context.Context
+		arg2 authorization.Info
+		arg3 repositories.ApplyServicePlanVisibilityMessage
+	}
+	applyPlanVisibilityReturns struct {
+		result1 repositories.ServicePlanRecord
+		result2 error
+	}
+	applyPlanVisibilityReturnsOnCall map[int]struct {
+		result1 repositories.ServicePlanRecord
+		result2 error
+	}
+	GetPlanStub        func(context.Context, authorization.Info, string) (repositories.ServicePlanRecord, error)
+	getPlanMutex       sync.RWMutex
+	getPlanArgsForCall []struct {
 		arg1 context.Context
 		arg2 authorization.Info
 		arg3 string
 	}
-	getPlanVisibilityReturns struct {
-		result1 repositories.ServicePlanVisibilityRecord
+	getPlanReturns struct {
+		result1 repositories.ServicePlanRecord
 		result2 error
 	}
-	getPlanVisibilityReturnsOnCall map[int]struct {
-		result1 repositories.ServicePlanVisibilityRecord
+	getPlanReturnsOnCall map[int]struct {
+		result1 repositories.ServicePlanRecord
 		result2 error
 	}
 	ListPlansStub        func(context.Context, authorization.Info, repositories.ListServicePlanMessage) ([]repositories.ServicePlanRecord, error)
@@ -45,18 +60,18 @@ type CFServicePlanRepository struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *CFServicePlanRepository) GetPlanVisibility(arg1 context.Context, arg2 authorization.Info, arg3 string) (repositories.ServicePlanVisibilityRecord, error) {
-	fake.getPlanVisibilityMutex.Lock()
-	ret, specificReturn := fake.getPlanVisibilityReturnsOnCall[len(fake.getPlanVisibilityArgsForCall)]
-	fake.getPlanVisibilityArgsForCall = append(fake.getPlanVisibilityArgsForCall, struct {
+func (fake *CFServicePlanRepository) ApplyPlanVisibility(arg1 context.Context, arg2 authorization.Info, arg3 repositories.ApplyServicePlanVisibilityMessage) (repositories.ServicePlanRecord, error) {
+	fake.applyPlanVisibilityMutex.Lock()
+	ret, specificReturn := fake.applyPlanVisibilityReturnsOnCall[len(fake.applyPlanVisibilityArgsForCall)]
+	fake.applyPlanVisibilityArgsForCall = append(fake.applyPlanVisibilityArgsForCall, struct {
 		arg1 context.Context
 		arg2 authorization.Info
-		arg3 string
+		arg3 repositories.ApplyServicePlanVisibilityMessage
 	}{arg1, arg2, arg3})
-	stub := fake.GetPlanVisibilityStub
-	fakeReturns := fake.getPlanVisibilityReturns
-	fake.recordInvocation("GetPlanVisibility", []interface{}{arg1, arg2, arg3})
-	fake.getPlanVisibilityMutex.Unlock()
+	stub := fake.ApplyPlanVisibilityStub
+	fakeReturns := fake.applyPlanVisibilityReturns
+	fake.recordInvocation("ApplyPlanVisibility", []interface{}{arg1, arg2, arg3})
+	fake.applyPlanVisibilityMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2, arg3)
 	}
@@ -66,47 +81,113 @@ func (fake *CFServicePlanRepository) GetPlanVisibility(arg1 context.Context, arg
 	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *CFServicePlanRepository) GetPlanVisibilityCallCount() int {
-	fake.getPlanVisibilityMutex.RLock()
-	defer fake.getPlanVisibilityMutex.RUnlock()
-	return len(fake.getPlanVisibilityArgsForCall)
+func (fake *CFServicePlanRepository) ApplyPlanVisibilityCallCount() int {
+	fake.applyPlanVisibilityMutex.RLock()
+	defer fake.applyPlanVisibilityMutex.RUnlock()
+	return len(fake.applyPlanVisibilityArgsForCall)
 }
 
-func (fake *CFServicePlanRepository) GetPlanVisibilityCalls(stub func(context.Context, authorization.Info, string) (repositories.ServicePlanVisibilityRecord, error)) {
-	fake.getPlanVisibilityMutex.Lock()
-	defer fake.getPlanVisibilityMutex.Unlock()
-	fake.GetPlanVisibilityStub = stub
+func (fake *CFServicePlanRepository) ApplyPlanVisibilityCalls(stub func(context.Context, authorization.Info, repositories.ApplyServicePlanVisibilityMessage) (repositories.ServicePlanRecord, error)) {
+	fake.applyPlanVisibilityMutex.Lock()
+	defer fake.applyPlanVisibilityMutex.Unlock()
+	fake.ApplyPlanVisibilityStub = stub
 }
 
-func (fake *CFServicePlanRepository) GetPlanVisibilityArgsForCall(i int) (context.Context, authorization.Info, string) {
-	fake.getPlanVisibilityMutex.RLock()
-	defer fake.getPlanVisibilityMutex.RUnlock()
-	argsForCall := fake.getPlanVisibilityArgsForCall[i]
+func (fake *CFServicePlanRepository) ApplyPlanVisibilityArgsForCall(i int) (context.Context, authorization.Info, repositories.ApplyServicePlanVisibilityMessage) {
+	fake.applyPlanVisibilityMutex.RLock()
+	defer fake.applyPlanVisibilityMutex.RUnlock()
+	argsForCall := fake.applyPlanVisibilityArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
-func (fake *CFServicePlanRepository) GetPlanVisibilityReturns(result1 repositories.ServicePlanVisibilityRecord, result2 error) {
-	fake.getPlanVisibilityMutex.Lock()
-	defer fake.getPlanVisibilityMutex.Unlock()
-	fake.GetPlanVisibilityStub = nil
-	fake.getPlanVisibilityReturns = struct {
-		result1 repositories.ServicePlanVisibilityRecord
+func (fake *CFServicePlanRepository) ApplyPlanVisibilityReturns(result1 repositories.ServicePlanRecord, result2 error) {
+	fake.applyPlanVisibilityMutex.Lock()
+	defer fake.applyPlanVisibilityMutex.Unlock()
+	fake.ApplyPlanVisibilityStub = nil
+	fake.applyPlanVisibilityReturns = struct {
+		result1 repositories.ServicePlanRecord
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *CFServicePlanRepository) GetPlanVisibilityReturnsOnCall(i int, result1 repositories.ServicePlanVisibilityRecord, result2 error) {
-	fake.getPlanVisibilityMutex.Lock()
-	defer fake.getPlanVisibilityMutex.Unlock()
-	fake.GetPlanVisibilityStub = nil
-	if fake.getPlanVisibilityReturnsOnCall == nil {
-		fake.getPlanVisibilityReturnsOnCall = make(map[int]struct {
-			result1 repositories.ServicePlanVisibilityRecord
+func (fake *CFServicePlanRepository) ApplyPlanVisibilityReturnsOnCall(i int, result1 repositories.ServicePlanRecord, result2 error) {
+	fake.applyPlanVisibilityMutex.Lock()
+	defer fake.applyPlanVisibilityMutex.Unlock()
+	fake.ApplyPlanVisibilityStub = nil
+	if fake.applyPlanVisibilityReturnsOnCall == nil {
+		fake.applyPlanVisibilityReturnsOnCall = make(map[int]struct {
+			result1 repositories.ServicePlanRecord
 			result2 error
 		})
 	}
-	fake.getPlanVisibilityReturnsOnCall[i] = struct {
-		result1 repositories.ServicePlanVisibilityRecord
+	fake.applyPlanVisibilityReturnsOnCall[i] = struct {
+		result1 repositories.ServicePlanRecord
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *CFServicePlanRepository) GetPlan(arg1 context.Context, arg2 authorization.Info, arg3 string) (repositories.ServicePlanRecord, error) {
+	fake.getPlanMutex.Lock()
+	ret, specificReturn := fake.getPlanReturnsOnCall[len(fake.getPlanArgsForCall)]
+	fake.getPlanArgsForCall = append(fake.getPlanArgsForCall, struct {
+		arg1 context.Context
+		arg2 authorization.Info
+		arg3 string
+	}{arg1, arg2, arg3})
+	stub := fake.GetPlanStub
+	fakeReturns := fake.getPlanReturns
+	fake.recordInvocation("GetPlan", []interface{}{arg1, arg2, arg3})
+	fake.getPlanMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *CFServicePlanRepository) GetPlanCallCount() int {
+	fake.getPlanMutex.RLock()
+	defer fake.getPlanMutex.RUnlock()
+	return len(fake.getPlanArgsForCall)
+}
+
+func (fake *CFServicePlanRepository) GetPlanCalls(stub func(context.Context, authorization.Info, string) (repositories.ServicePlanRecord, error)) {
+	fake.getPlanMutex.Lock()
+	defer fake.getPlanMutex.Unlock()
+	fake.GetPlanStub = stub
+}
+
+func (fake *CFServicePlanRepository) GetPlanArgsForCall(i int) (context.Context, authorization.Info, string) {
+	fake.getPlanMutex.RLock()
+	defer fake.getPlanMutex.RUnlock()
+	argsForCall := fake.getPlanArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *CFServicePlanRepository) GetPlanReturns(result1 repositories.ServicePlanRecord, result2 error) {
+	fake.getPlanMutex.Lock()
+	defer fake.getPlanMutex.Unlock()
+	fake.GetPlanStub = nil
+	fake.getPlanReturns = struct {
+		result1 repositories.ServicePlanRecord
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *CFServicePlanRepository) GetPlanReturnsOnCall(i int, result1 repositories.ServicePlanRecord, result2 error) {
+	fake.getPlanMutex.Lock()
+	defer fake.getPlanMutex.Unlock()
+	fake.GetPlanStub = nil
+	if fake.getPlanReturnsOnCall == nil {
+		fake.getPlanReturnsOnCall = make(map[int]struct {
+			result1 repositories.ServicePlanRecord
+			result2 error
+		})
+	}
+	fake.getPlanReturnsOnCall[i] = struct {
+		result1 repositories.ServicePlanRecord
 		result2 error
 	}{result1, result2}
 }
@@ -180,8 +261,10 @@ func (fake *CFServicePlanRepository) ListPlansReturnsOnCall(i int, result1 []rep
 func (fake *CFServicePlanRepository) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.getPlanVisibilityMutex.RLock()
-	defer fake.getPlanVisibilityMutex.RUnlock()
+	fake.applyPlanVisibilityMutex.RLock()
+	defer fake.applyPlanVisibilityMutex.RUnlock()
+	fake.getPlanMutex.RLock()
+	defer fake.getPlanMutex.RUnlock()
 	fake.listPlansMutex.RLock()
 	defer fake.listPlansMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/api/payloads/service_plan.go
+++ b/api/payloads/service_plan.go
@@ -30,3 +30,14 @@ func (l *ServicePlanList) DecodeFromURLValues(values url.Values) error {
 	l.ServiceOfferingGUIDs = values.Get("service_offering_guids")
 	return nil
 }
+
+type ServicePlanVisibility struct {
+	Type string `json:"type"`
+}
+
+func (p *ServicePlanVisibility) ToMessage(planGUID string) repositories.ApplyServicePlanVisibilityMessage {
+	return repositories.ApplyServicePlanVisibilityMessage{
+		PlanGUID: planGUID,
+		Type:     p.Type,
+	}
+}

--- a/api/payloads/service_plan_test.go
+++ b/api/payloads/service_plan_test.go
@@ -3,28 +3,46 @@ package payloads_test
 import (
 	"code.cloudfoundry.org/korifi/api/payloads"
 	"code.cloudfoundry.org/korifi/api/repositories"
+	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("ServicePlan", func() {
-	DescribeTable("valid query",
-		func(query string, expectedServicePlanList payloads.ServicePlanList) {
-			actualServicePlanList, decodeErr := decodeQuery[payloads.ServicePlanList](query)
+	Describe("List", func() {
+		DescribeTable("valid query",
+			func(query string, expectedServicePlanList payloads.ServicePlanList) {
+				actualServicePlanList, decodeErr := decodeQuery[payloads.ServicePlanList](query)
 
-			Expect(decodeErr).NotTo(HaveOccurred())
-			Expect(*actualServicePlanList).To(Equal(expectedServicePlanList))
-		},
-		Entry("service_offering_guids", "service_offering_guids=b1,b2", payloads.ServicePlanList{ServiceOfferingGUIDs: "b1,b2"}),
-	)
+				Expect(decodeErr).NotTo(HaveOccurred())
+				Expect(*actualServicePlanList).To(Equal(expectedServicePlanList))
+			},
+			Entry("service_offering_guids", "service_offering_guids=b1,b2", payloads.ServicePlanList{ServiceOfferingGUIDs: "b1,b2"}),
+		)
 
-	Describe("ToMessage", func() {
-		It("converts payload to repository message", func() {
-			payload := &payloads.ServicePlanList{ServiceOfferingGUIDs: "b1,b2"}
+		Describe("ToMessage", func() {
+			It("converts payload to repository message", func() {
+				payload := &payloads.ServicePlanList{ServiceOfferingGUIDs: "b1,b2"}
 
-			Expect(payload.ToMessage()).To(Equal(repositories.ListServicePlanMessage{
-				ServiceOfferingGUIDs: []string{"b1", "b2"},
-			}))
+				Expect(payload.ToMessage()).To(Equal(repositories.ListServicePlanMessage{
+					ServiceOfferingGUIDs: []string{"b1", "b2"},
+				}))
+			})
+		})
+	})
+
+	Describe("Visibility", func() {
+		Describe("ToMessage", func() {
+			It("converts payload to repository message", func() {
+				payload := &payloads.ServicePlanVisibility{
+					Type: korifiv1alpha1.PublicServicePlanVisibilityType,
+				}
+
+				Expect(payload.ToMessage("plan-guid")).To(Equal(repositories.ApplyServicePlanVisibilityMessage{
+					PlanGUID: "plan-guid",
+					Type:     korifiv1alpha1.PublicServicePlanVisibilityType,
+				}))
+			})
 		})
 	})
 })

--- a/api/presenter/service_plan.go
+++ b/api/presenter/service_plan.go
@@ -10,6 +10,7 @@ import (
 type ServicePlanLinks struct {
 	Self            Link `json:"self"`
 	ServiceOffering Link `json:"service_offering"`
+	Visibility      Link `json:"visibility"`
 }
 
 type ServicePlanResponse struct {
@@ -27,14 +28,17 @@ func ForServicePlan(servicePlan repositories.ServicePlanRecord, baseURL url.URL)
 			ServiceOffering: Link{
 				HRef: buildURL(baseURL).appendPath(serviceOfferingsBase, servicePlan.Relationships.ServiceOffering.Data.GUID).build(),
 			},
+			Visibility: Link{
+				HRef: buildURL(baseURL).appendPath(servicePlansBase, servicePlan.GUID, "visibility").build(),
+			},
 		},
 	}
 }
 
 type ServicePlanVisibilityResponse korifiv1alpha1.ServicePlanVisibility
 
-func ForServicePlanVisibility(visibility repositories.ServicePlanVisibilityRecord, _ url.URL) ServicePlanVisibilityResponse {
+func ForServicePlanVisibility(plan repositories.ServicePlanRecord, _ url.URL) ServicePlanVisibilityResponse {
 	return ServicePlanVisibilityResponse{
-		Type: visibility.Type,
+		Type: plan.VisibilityType,
 	}
 }

--- a/api/presenter/service_plan_test.go
+++ b/api/presenter/service_plan_test.go
@@ -81,6 +81,7 @@ var _ = Describe("Service Plan", func() {
 						},
 					},
 				},
+				VisibilityType: "visibility-type",
 				Relationships: repositories.ServicePlanRelationships{
 					ServiceOffering: model.ToOneRelationship{
 						Data: model.Relationship{
@@ -135,6 +136,7 @@ var _ = Describe("Service Plan", func() {
 				  }
 				},
 				"guid": "resource-guid",
+				"visibility_type": "visibility-type",
 				"created_at": "1970-01-01T00:00:01Z",
 				"updated_at": "1970-01-01T00:00:02Z",
 				"metadata": {
@@ -158,6 +160,9 @@ var _ = Describe("Service Plan", func() {
 				  },
 				  "service_offering": {
 					"href": "https://api.example.org/v3/service_offerings/service-offering-guid"
+				  },
+				  "visibility": {
+					"href": "https://api.example.org/v3/service_plans/resource-guid/visibility"
 				  }
 				}
 			}`))
@@ -165,11 +170,11 @@ var _ = Describe("Service Plan", func() {
 	})
 
 	Describe("ForServicePlanVisibility", func() {
-		var record repositories.ServicePlanVisibilityRecord
+		var record repositories.ServicePlanRecord
 
 		BeforeEach(func() {
-			record = repositories.ServicePlanVisibilityRecord{
-				Type: "admin",
+			record = repositories.ServicePlanRecord{
+				VisibilityType: "admin",
 			}
 		})
 

--- a/controllers/api/v1alpha1/cfservice_plan_types.go
+++ b/controllers/api/v1alpha1/cfservice_plan_types.go
@@ -10,10 +10,13 @@ type CFServicePlanSpec struct {
 	Visibility           ServicePlanVisibility `json:"visibility"`
 }
 
-const AdminServicePlanVisibilityType = "admin"
+const (
+	AdminServicePlanVisibilityType  = "admin"
+	PublicServicePlanVisibilityType = "public"
+)
 
 type ServicePlanVisibility struct {
-	// +kubebuilder:validation:Enum=admin
+	// +kubebuilder:validation:Enum=admin;public
 	Type string `json:"type"`
 }
 

--- a/controllers/controllers/services/brokers/controller.go
+++ b/controllers/controllers/services/brokers/controller.go
@@ -233,6 +233,11 @@ func (r *Reconciler) reconcileCatalogPlan(ctx context.Context, serviceOffering *
 			return fmt.Errorf("failed to marshal service plan %q metadata: %w", catalogPlan.ID, err)
 		}
 
+		visibilityType := korifiv1alpha1.AdminServicePlanVisibilityType
+		if servicePlan.Spec.Visibility.Type != "" {
+			visibilityType = servicePlan.Spec.Visibility.Type
+		}
+
 		servicePlan.Spec = korifiv1alpha1.CFServicePlanSpec{
 			ServicePlan: services.ServicePlan{
 				Name:        catalogPlan.Name,
@@ -251,7 +256,7 @@ func (r *Reconciler) reconcileCatalogPlan(ctx context.Context, serviceOffering *
 				Schemas: catalogPlan.Schemas,
 			},
 			Visibility: korifiv1alpha1.ServicePlanVisibility{
-				Type: korifiv1alpha1.AdminServicePlanVisibilityType,
+				Type: visibilityType,
 			},
 		}
 

--- a/helm/korifi/controllers/cf_roles/cf_admin.yaml
+++ b/helm/korifi/controllers/cf_roles/cf_admin.yaml
@@ -206,6 +206,7 @@ rules:
   verbs:
   - list
   - get
+  - patch
 
 - apiGroups:
   - rbac.authorization.k8s.io

--- a/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfserviceplans.yaml
+++ b/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfserviceplans.yaml
@@ -116,6 +116,7 @@ spec:
                   type:
                     enum:
                     - admin
+                    - public
                     type: string
                 required:
                 - type

--- a/tests/e2e/service_brokers_test.go
+++ b/tests/e2e/service_brokers_test.go
@@ -61,7 +61,18 @@ var _ = Describe("Service Brokers", func() {
 	})
 
 	Describe("List", func() {
-		var result resourceList[resource]
+		var (
+			result     resourceList[resource]
+			brokerGUID string
+		)
+
+		BeforeEach(func() {
+			brokerGUID = createBroker(serviceBrokerURL)
+		})
+
+		AfterEach(func() {
+			cleanupBroker(brokerGUID)
+		})
 
 		JustBeforeEach(func() {
 			resp, err = adminClient.R().SetResult(&result).Get("/v3/service_brokers")
@@ -71,7 +82,7 @@ var _ = Describe("Service Brokers", func() {
 		It("returns a list of brokers", func() {
 			Expect(resp).To(HaveRestyStatusCode(http.StatusOK))
 			Expect(result.Resources).To(ContainElement(MatchFields(IgnoreExtras, Fields{
-				"GUID": Equal(serviceBrokerGUID),
+				"GUID": Equal(brokerGUID),
 			})))
 		})
 	})
@@ -127,7 +138,7 @@ var _ = Describe("Service Brokers", func() {
 			Expect(resp).To(HaveRestyStatusCode(http.StatusOK))
 			Expect(servicePlans.Resources).To(ContainElement(MatchFields(IgnoreExtras, Fields{
 				"Metadata": PointTo(MatchFields(IgnoreExtras, Fields{
-					"Labels": HaveKeyWithValue(korifiv1alpha1.RelServiceBrokerLabel, serviceBrokerGUID),
+					"Labels": HaveKeyWithValue(korifiv1alpha1.RelServiceBrokerLabel, brokerGUID),
 				})),
 			})))
 		})

--- a/tests/e2e/service_offerings_test.go
+++ b/tests/e2e/service_offerings_test.go
@@ -10,7 +10,18 @@ import (
 )
 
 var _ = Describe("Service Offerings", func() {
-	var resp *resty.Response
+	var (
+		resp       *resty.Response
+		brokerGUID string
+	)
+
+	BeforeEach(func() {
+		brokerGUID = createBroker(serviceBrokerURL)
+	})
+
+	AfterEach(func() {
+		cleanupBroker(brokerGUID)
+	})
 
 	Describe("List", func() {
 		var result resourceList[resource]
@@ -26,7 +37,7 @@ var _ = Describe("Service Offerings", func() {
 			Expect(result.Resources).To(ContainElement(MatchFields(IgnoreExtras, Fields{
 				"Relationships": HaveKeyWithValue("service_broker", relationship{
 					Data: resource{
-						GUID: serviceBrokerGUID,
+						GUID: brokerGUID,
 					},
 				}),
 			})))

--- a/tests/e2e/service_plans_test.go
+++ b/tests/e2e/service_plans_test.go
@@ -13,7 +13,18 @@ import (
 )
 
 var _ = Describe("Service Plans", func() {
-	var resp *resty.Response
+	var (
+		brokerGUID string
+		resp       *resty.Response
+	)
+
+	BeforeEach(func() {
+		brokerGUID = createBroker(serviceBrokerURL)
+	})
+
+	AfterEach(func() {
+		cleanupBroker(brokerGUID)
+	})
 
 	Describe("List", func() {
 		var result resourceList[resource]
@@ -28,44 +39,68 @@ var _ = Describe("Service Plans", func() {
 			Expect(resp).To(HaveRestyStatusCode(http.StatusOK))
 			Expect(result.Resources).To(ContainElement(MatchFields(IgnoreExtras, Fields{
 				"Metadata": PointTo(MatchFields(IgnoreExtras, Fields{
-					"Labels": HaveKeyWithValue(korifiv1alpha1.RelServiceBrokerLabel, serviceBrokerGUID),
+					"Labels": HaveKeyWithValue(korifiv1alpha1.RelServiceBrokerLabel, brokerGUID),
 				})),
 			})))
 		})
 	})
 
-	Describe("Get Visibility", func() {
-		var (
-			result   planVisibilityResource
-			planGUID string
-		)
+	Describe("Visibility", func() {
+		var planGUID string
 
 		BeforeEach(func() {
 			plans := resourceList[resource]{}
-
 			listResp, err := adminClient.R().SetResult(&plans).Get("/v3/service_plans")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(listResp).To(HaveRestyStatusCode(http.StatusOK))
 
 			brokerPlans := iter.Lift(plans.Resources).Filter(func(r resource) bool {
-				return r.Metadata.Labels[korifiv1alpha1.RelServiceBrokerLabel] == serviceBrokerGUID
+				return r.Metadata.Labels[korifiv1alpha1.RelServiceBrokerLabel] == brokerGUID
 			}).Collect()
 
 			Expect(brokerPlans).NotTo(BeEmpty())
 			planGUID = brokerPlans[0].GUID
 		})
 
-		JustBeforeEach(func() {
-			var err error
-			resp, err = adminClient.R().SetResult(&result).Get(fmt.Sprintf("/v3/service_plans/%s/visibility", planGUID))
-			Expect(err).NotTo(HaveOccurred())
+		Describe("Get Visibility", func() {
+			var result planVisibilityResource
+
+			JustBeforeEach(func() {
+				var err error
+				resp, err = adminClient.R().SetResult(&result).Get(fmt.Sprintf("/v3/service_plans/%s/visibility", planGUID))
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("returns the service plan visibility", func() {
+				Expect(resp).To(HaveRestyStatusCode(http.StatusOK))
+				Expect(result).To(Equal(planVisibilityResource{
+					Type: korifiv1alpha1.AdminServicePlanVisibilityType,
+				}))
+			})
 		})
 
-		It("returns the service plan visibility", func() {
-			Expect(resp).To(HaveRestyStatusCode(http.StatusOK))
-			Expect(result).To(Equal(planVisibilityResource{
-				Type: korifiv1alpha1.AdminServicePlanVisibilityType,
-			}))
+		Describe("Apply Visibility", func() {
+			var result planVisibilityResource
+
+			JustBeforeEach(func() {
+				var err error
+				resp, err = adminClient.R().
+					SetResult(&result).
+					SetBody(planVisibilityResource{
+						Type: "public",
+					}).
+					Post(fmt.Sprintf("/v3/service_plans/%s/visibility", planGUID))
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("updates the plan visibility", func() {
+				Expect(resp).To(SatisfyAll(
+					HaveRestyStatusCode(http.StatusOK),
+					HaveRestyBody(MatchJSON(`{
+						"type": "public"
+					}`)),
+				))
+			})
 		})
 	})
 })


### PR DESCRIPTION
## Is there a related GitHub Issue?
#3275
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Implement updating service plan visibility

- For now `public` is the only allowd value other than `admin`, which is
  the default
- Bonus: Introduce the `visibility_type` field in the service plan
  resource. This makes `cf service-access` display the plan visibility
  correctly
<!-- _Please describe the change here._ -->

