### PR TITLE
Filter service plans by `available`

### DIFF
--- a/api/payloads/service_plan_test.go
+++ b/api/payloads/service_plan_test.go
@@ -5,6 +5,7 @@ import (
 	"code.cloudfoundry.org/korifi/api/repositories"
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"code.cloudfoundry.org/korifi/model/services"
+	"code.cloudfoundry.org/korifi/tools"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
@@ -21,15 +22,29 @@ var _ = Describe("ServicePlan", func() {
 			},
 			Entry("service_offering_guids", "service_offering_guids=b1,b2", payloads.ServicePlanList{ServiceOfferingGUIDs: "b1,b2"}),
 			Entry("names", "names=b1,b2", payloads.ServicePlanList{Names: "b1,b2"}),
+			Entry("available", "available=true", payloads.ServicePlanList{Available: tools.PtrTo(true)}),
+			Entry("not available", "available=false", payloads.ServicePlanList{Available: tools.PtrTo(false)}),
+		)
+
+		DescribeTable("invalid query",
+			func(query string, errMatcher types.GomegaMatcher) {
+				_, decodeErr := decodeQuery[payloads.ServicePlanList](query)
+				Expect(decodeErr).To(errMatcher)
+			},
+			Entry("invalid available", "available=invalid", MatchError(ContainSubstring("failed to parse"))),
 		)
 
 		Describe("ToMessage", func() {
 			It("converts payload to repository message", func() {
-				payload := &payloads.ServicePlanList{ServiceOfferingGUIDs: "b1,b2", Names: "n1,n2"}
-
+				payload := payloads.ServicePlanList{
+					ServiceOfferingGUIDs: "b1,b2",
+					Names:                "n1,n2",
+					Available:            tools.PtrTo(true),
+				}
 				Expect(payload.ToMessage()).To(Equal(repositories.ListServicePlanMessage{
 					ServiceOfferingGUIDs: []string{"b1", "b2"},
 					Names:                []string{"n1", "n2"},
+					Available:            tools.PtrTo(true),
 				}))
 			})
 		})

--- a/api/presenter/service_plan.go
+++ b/api/presenter/service_plan.go
@@ -22,6 +22,7 @@ type ServicePlanResponse struct {
 	services.ServicePlan
 	model.CFResource
 	VisibilityType string                   `json:"visibility_type"`
+	Available      bool                     `json:"available"`
 	Relationships  ServicePlanRelationships `json:"relationships"`
 	Links          ServicePlanLinks         `json:"links"`
 }
@@ -31,6 +32,7 @@ func ForServicePlan(servicePlan repositories.ServicePlanRecord, baseURL url.URL)
 		ServicePlan:    servicePlan.ServicePlan,
 		CFResource:     servicePlan.CFResource,
 		VisibilityType: servicePlan.Visibility.Type,
+		Available:      servicePlan.Available,
 		Relationships: ServicePlanRelationships{
 			ServiceOffering: model.ToOneRelationship{
 				Data: model.Relationship{

--- a/api/presenter/service_plan_test.go
+++ b/api/presenter/service_plan_test.go
@@ -85,6 +85,7 @@ var _ = Describe("Service Plan", func() {
 					Type: "visibility-type",
 				},
 				ServiceOfferingGUID: "service-offering-guid",
+				Available:           true,
 			}
 		})
 
@@ -133,6 +134,7 @@ var _ = Describe("Service Plan", func() {
 				},
 				"guid": "resource-guid",
 				"visibility_type": "visibility-type",
+				"available": true,
 				"created_at": "1970-01-01T00:00:01Z",
 				"updated_at": "1970-01-01T00:00:02Z",
 				"metadata": {

--- a/tools/collections.go
+++ b/tools/collections.go
@@ -17,3 +17,11 @@ func EmptyOrContains[S ~[]E, E comparable](elements S, e E) bool {
 
 	return slices.Contains(elements, e)
 }
+
+func NilOrEquals[E comparable](value *E, expectedValue E) bool {
+	if value == nil {
+		return true
+	}
+
+	return expectedValue == *value
+}

--- a/tools/collections_test.go
+++ b/tools/collections_test.go
@@ -23,4 +23,13 @@ var _ = Describe("Collections", func() {
 		Entry("contains element", []string{"nail", "needle", "pin"}, BeTrue()),
 		Entry("does not contain element", []string{"nail", "pin"}, BeFalse()),
 	)
+
+	DescribeTable("NilOrEquals",
+		func(value *string, match types.GomegaMatcher) {
+			Expect(tools.NilOrEquals(value, "needle")).To(match)
+		},
+		Entry("nil", nil, BeTrue()),
+		Entry("equal", tools.PtrTo("needle"), BeTrue()),
+		Entry("not-equal", tools.PtrTo("not-needle"), BeFalse()),
+	)
 })


### PR DESCRIPTION
## Is there a related GitHub Issue?
#3278
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Filter service plans by `available`

A plan is `available` when its visbility is not `admin`.
See
https://github.com/cloudfoundry/cloud_controller_ng/blob/d543a6668838174d99fdf54945398055dab5bc79/app/models/services/service_plan.rb#L88-L103
for reference
