### PR TITLE
Patching Reconciler names logger after recounciled resource

### DIFF
--- a/job-task-runner/controllers/integration/suite_test.go
+++ b/job-task-runner/controllers/integration/suite_test.go
@@ -80,7 +80,7 @@ var _ = BeforeSuite(func() {
 		logger,
 		k8sManager.GetClient(),
 		k8sManager.GetScheme(),
-		controllers.NewStatusGetter(logger, k8sManager.GetClient()),
+		controllers.NewStatusGetter(k8sManager.GetClient()),
 		time.Minute,
 		false,
 	)

--- a/job-task-runner/controllers/status.go
+++ b/job-task-runner/controllers/status.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
-	"github.com/go-logr/logr"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -13,13 +12,11 @@ import (
 )
 
 type StatusGetter struct {
-	logger    logr.Logger
 	k8sClient client.Client
 }
 
-func NewStatusGetter(logger logr.Logger, k8sClient client.Client) *StatusGetter {
+func NewStatusGetter(k8sClient client.Client) *StatusGetter {
 	return &StatusGetter{
-		logger:    logger,
 		k8sClient: k8sClient,
 	}
 }

--- a/job-task-runner/controllers/status_test.go
+++ b/job-task-runner/controllers/status_test.go
@@ -14,7 +14,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -31,7 +30,7 @@ var _ = Describe("StatusGetter", func() {
 			Status: batchv1.JobStatus{},
 		}
 
-		statusGetter = controllers.NewStatusGetter(ctrl.Log.WithName("test"), fakeClient)
+		statusGetter = controllers.NewStatusGetter(fakeClient)
 	})
 
 	JustBeforeEach(func() {

--- a/tools/k8s/reconcile.go
+++ b/tools/k8s/reconcile.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"context"
 	"fmt"
+	"reflect"
 
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
@@ -32,7 +33,9 @@ func NewPatchingReconciler[T any, PT ObjectWithDeepCopy[T]](log logr.Logger, k8s
 }
 
 func (r *PatchingReconciler[T, PT]) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	log := r.log.WithValues("namespace", req.Namespace, "name", req.Name, "logID", uuid.NewString())
+	log := r.log.
+		WithName(reflect.TypeFor[T]().Name()).
+		WithValues("namespace", req.Namespace, "name", req.Name, "logID", uuid.NewString())
 	ctx = logr.NewContext(ctx, log)
 
 	obj := PT(new(T))


### PR DESCRIPTION
## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Slight improvement of controllers logger wiring. We can save some typing if we
make the patching reconciler create the logger named after the resource baing
reconciled
<!-- _Please describe the change here._ -->

