### PR TITLE
Inline the ready condition builder in the patching reconciler

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -128,14 +128,14 @@ func main() {
 		privilegedCRClient,
 		userClientFactory,
 		nsPermissions,
-		conditions.NewConditionAwaiter[*korifiv1alpha1.CFOrg, korifiv1alpha1.CFOrgList](conditionTimeout),
+		conditions.NewConditionAwaiter[*korifiv1alpha1.CFOrg, korifiv1alpha1.CFOrg, korifiv1alpha1.CFOrgList](conditionTimeout),
 	)
 	spaceRepo := repositories.NewSpaceRepo(
 		namespaceRetriever,
 		orgRepo,
 		userClientFactory,
 		nsPermissions,
-		conditions.NewConditionAwaiter[*korifiv1alpha1.CFSpace, korifiv1alpha1.CFSpaceList](conditionTimeout),
+		conditions.NewConditionAwaiter[*korifiv1alpha1.CFSpace, korifiv1alpha1.CFSpace, korifiv1alpha1.CFSpaceList](conditionTimeout),
 	)
 	processRepo := repositories.NewProcessRepo(
 		namespaceRetriever,
@@ -149,7 +149,7 @@ func main() {
 		namespaceRetriever,
 		userClientFactory,
 		nsPermissions,
-		conditions.NewConditionAwaiter[*korifiv1alpha1.CFApp, korifiv1alpha1.CFAppList](conditionTimeout),
+		conditions.NewConditionAwaiter[*korifiv1alpha1.CFApp, korifiv1alpha1.CFApp, korifiv1alpha1.CFAppList](conditionTimeout),
 	)
 	dropletRepo := repositories.NewDropletRepo(
 		userClientFactory,
@@ -189,19 +189,19 @@ func main() {
 		nsPermissions,
 		toolsregistry.NewRepositoryCreator(cfg.ContainerRegistryType),
 		cfg.ContainerRepositoryPrefix,
-		conditions.NewConditionAwaiter[*korifiv1alpha1.CFPackage, korifiv1alpha1.CFPackageList](conditionTimeout),
+		conditions.NewConditionAwaiter[*korifiv1alpha1.CFPackage, korifiv1alpha1.CFPackage, korifiv1alpha1.CFPackageList](conditionTimeout),
 	)
 	serviceInstanceRepo := repositories.NewServiceInstanceRepo(
 		namespaceRetriever,
 		userClientFactory,
 		nsPermissions,
-		conditions.NewConditionAwaiter[*korifiv1alpha1.CFServiceInstance, korifiv1alpha1.CFServiceInstanceList](conditionTimeout),
+		conditions.NewConditionAwaiter[*korifiv1alpha1.CFServiceInstance, korifiv1alpha1.CFServiceInstance, korifiv1alpha1.CFServiceInstanceList](conditionTimeout),
 	)
 	serviceBindingRepo := repositories.NewServiceBindingRepo(
 		namespaceRetriever,
 		userClientFactory,
 		nsPermissions,
-		conditions.NewConditionAwaiter[*korifiv1alpha1.CFServiceBinding, korifiv1alpha1.CFServiceBindingList](conditionTimeout),
+		conditions.NewConditionAwaiter[*korifiv1alpha1.CFServiceBinding, korifiv1alpha1.CFServiceBinding, korifiv1alpha1.CFServiceBindingList](conditionTimeout),
 	)
 	buildpackRepo := repositories.NewBuildpackRepository(cfg.BuilderName,
 		userClientFactory,
@@ -228,7 +228,7 @@ func main() {
 		userClientFactory,
 		namespaceRetriever,
 		nsPermissions,
-		conditions.NewConditionAwaiter[*korifiv1alpha1.CFTask, korifiv1alpha1.CFTaskList](conditionTimeout),
+		conditions.NewConditionAwaiter[*korifiv1alpha1.CFTask, korifiv1alpha1.CFTask, korifiv1alpha1.CFTaskList](conditionTimeout),
 	)
 	metricsRepo := repositories.NewMetricsRepo(userClientFactory)
 	serviceBrokerRepo := repositories.NewServiceBrokerRepo(userClientFactory, cfg.RootNamespace)

--- a/api/repositories/app_repository_test.go
+++ b/api/repositories/app_repository_test.go
@@ -38,6 +38,7 @@ var _ = Describe("AppRepository", func() {
 	var (
 		appAwaiter *fakeawaiter.FakeAwaiter[
 			*korifiv1alpha1.CFApp,
+			korifiv1alpha1.CFApp,
 			korifiv1alpha1.CFAppList,
 			*korifiv1alpha1.CFAppList,
 		]
@@ -50,6 +51,7 @@ var _ = Describe("AppRepository", func() {
 	BeforeEach(func() {
 		appAwaiter = &fakeawaiter.FakeAwaiter[
 			*korifiv1alpha1.CFApp,
+			korifiv1alpha1.CFApp,
 			korifiv1alpha1.CFAppList,
 			*korifiv1alpha1.CFAppList,
 		]{}

--- a/api/repositories/conditions/await.go
+++ b/api/repositories/conditions/await.go
@@ -5,38 +5,34 @@ import (
 	"fmt"
 	"time"
 
+	"code.cloudfoundry.org/korifi/tools/k8s"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
-
-type RuntimeObjectWithStatusConditions interface {
-	client.Object
-	StatusConditions() []metav1.Condition
-}
 
 type ObjectList[L any] interface {
 	*L
 	client.ObjectList
 }
 
-type Awaiter[T RuntimeObjectWithStatusConditions, L any, PL ObjectList[L]] struct {
+type Awaiter[T k8s.RuntimeObjectWithStatusConditions[TT], TT any, L any, PL ObjectList[L]] struct {
 	timeout time.Duration
 }
 
-func NewConditionAwaiter[T RuntimeObjectWithStatusConditions, L any, PL ObjectList[L]](timeout time.Duration) *Awaiter[T, L, PL] {
-	return &Awaiter[T, L, PL]{
+func NewConditionAwaiter[T k8s.RuntimeObjectWithStatusConditions[TT], TT any, L any, PL ObjectList[L]](timeout time.Duration) *Awaiter[T, TT, L, PL] {
+	return &Awaiter[T, TT, L, PL]{
 		timeout: timeout,
 	}
 }
 
-func (a *Awaiter[T, L, PL]) AwaitCondition(ctx context.Context, k8sClient client.WithWatch, object client.Object, conditionType string) (T, error) {
+func (a *Awaiter[T, TT, L, PL]) AwaitCondition(ctx context.Context, k8sClient client.WithWatch, object client.Object, conditionType string) (T, error) {
 	return a.AwaitState(ctx, k8sClient, object, func(o T) error {
 		return checkConditionIsTrue(o, conditionType)
 	})
 }
 
-func (a *Awaiter[T, L, PL]) AwaitState(ctx context.Context, k8sClient client.WithWatch, object client.Object, checkState func(T) error) (T, error) {
+func (a *Awaiter[T, TT, L, PL]) AwaitState(ctx context.Context, k8sClient client.WithWatch, object client.Object, checkState func(T) error) (T, error) {
 	var empty T
 	objList := PL(new(L))
 
@@ -71,8 +67,8 @@ func (a *Awaiter[T, L, PL]) AwaitState(ctx context.Context, k8sClient client.Wit
 	)
 }
 
-func checkConditionIsTrue[T RuntimeObjectWithStatusConditions](obj T, conditionType string) error {
-	condition := meta.FindStatusCondition(obj.StatusConditions(), conditionType)
+func checkConditionIsTrue[T k8s.RuntimeObjectWithStatusConditions[L], L any](obj T, conditionType string) error {
+	condition := meta.FindStatusCondition(*obj.StatusConditions(), conditionType)
 
 	if condition == nil {
 		return fmt.Errorf("condition %s not set yet", conditionType)

--- a/api/repositories/conditions/await_test.go
+++ b/api/repositories/conditions/await_test.go
@@ -17,7 +17,7 @@ import (
 
 var _ = Describe("ConditionAwaiter", func() {
 	var (
-		awaiter     *conditions.Awaiter[*korifiv1alpha1.CFTask, korifiv1alpha1.CFTaskList, *korifiv1alpha1.CFTaskList]
+		awaiter     *conditions.Awaiter[*korifiv1alpha1.CFTask, korifiv1alpha1.CFTask, korifiv1alpha1.CFTaskList, *korifiv1alpha1.CFTaskList]
 		task        *korifiv1alpha1.CFTask
 		awaitedTask *korifiv1alpha1.CFTask
 		awaitErr    error
@@ -43,7 +43,7 @@ var _ = Describe("ConditionAwaiter", func() {
 	}
 
 	BeforeEach(func() {
-		awaiter = conditions.NewConditionAwaiter[*korifiv1alpha1.CFTask, korifiv1alpha1.CFTaskList](time.Second)
+		awaiter = conditions.NewConditionAwaiter[*korifiv1alpha1.CFTask, korifiv1alpha1.CFTask, korifiv1alpha1.CFTaskList](time.Second)
 		awaitedTask = nil
 		awaitErr = nil
 

--- a/api/repositories/fakeawaiter/await.go
+++ b/api/repositories/fakeawaiter/await.go
@@ -4,10 +4,11 @@ import (
 	"context"
 
 	"code.cloudfoundry.org/korifi/api/repositories/conditions"
+	"code.cloudfoundry.org/korifi/tools/k8s"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-type FakeAwaiter[T conditions.RuntimeObjectWithStatusConditions, L any, PL conditions.ObjectList[L]] struct {
+type FakeAwaiter[T k8s.RuntimeObjectWithStatusConditions[TT], TT any, L any, PL conditions.ObjectList[L]] struct {
 	awaitConditionCalls []struct {
 		obj           client.Object
 		conditionType string
@@ -20,7 +21,7 @@ type FakeAwaiter[T conditions.RuntimeObjectWithStatusConditions, L any, PL condi
 	}
 }
 
-func (a *FakeAwaiter[T, L, PL]) AwaitCondition(ctx context.Context, k8sClient client.WithWatch, object client.Object, conditionType string) (T, error) {
+func (a *FakeAwaiter[T, TT, L, PL]) AwaitCondition(ctx context.Context, k8sClient client.WithWatch, object client.Object, conditionType string) (T, error) {
 	a.awaitConditionCalls = append(a.awaitConditionCalls, struct {
 		obj           client.Object
 		conditionType string
@@ -36,21 +37,21 @@ func (a *FakeAwaiter[T, L, PL]) AwaitCondition(ctx context.Context, k8sClient cl
 	return a.AwaitConditionStub(ctx, k8sClient, object, conditionType)
 }
 
-func (a *FakeAwaiter[T, L, PL]) AwaitConditionReturns(object T, err error) {
+func (a *FakeAwaiter[T, TT, L, PL]) AwaitConditionReturns(object T, err error) {
 	a.AwaitConditionStub = func(ctx context.Context, k8sClient client.WithWatch, object client.Object, conditionType string) (T, error) {
 		return object.(T), err
 	}
 }
 
-func (a *FakeAwaiter[T, L, PL]) AwaitConditionCallCount() int {
+func (a *FakeAwaiter[T, TT, L, PL]) AwaitConditionCallCount() int {
 	return len(a.awaitConditionCalls)
 }
 
-func (a *FakeAwaiter[T, L, PL]) AwaitConditionArgsForCall(i int) (client.Object, string) {
+func (a *FakeAwaiter[T, TT, L, PL]) AwaitConditionArgsForCall(i int) (client.Object, string) {
 	return a.awaitConditionCalls[i].obj, a.awaitConditionCalls[i].conditionType
 }
 
-func (a *FakeAwaiter[T, L, PL]) AwaitState(ctx context.Context, k8sClient client.WithWatch, object client.Object, checkState func(T) error) (T, error) {
+func (a *FakeAwaiter[T, TT, L, PL]) AwaitState(ctx context.Context, k8sClient client.WithWatch, object client.Object, checkState func(T) error) (T, error) {
 	a.awaitStateCalls = append(a.awaitStateCalls, struct {
 		obj        client.Object
 		checkState func(T) error
@@ -66,16 +67,16 @@ func (a *FakeAwaiter[T, L, PL]) AwaitState(ctx context.Context, k8sClient client
 	return a.AwaitStateStub(ctx, k8sClient, object, checkState)
 }
 
-func (a *FakeAwaiter[T, L, PL]) AwaitStateReturns(object T, err error) {
+func (a *FakeAwaiter[T, TT, L, PL]) AwaitStateReturns(object T, err error) {
 	a.AwaitStateStub = func(ctx context.Context, k8sClient client.WithWatch, object client.Object, _ func(T) error) (T, error) {
 		return object.(T), err
 	}
 }
 
-func (a *FakeAwaiter[T, L, PL]) AwaitStateCallCount() int {
+func (a *FakeAwaiter[T, TT, L, PL]) AwaitStateCallCount() int {
 	return len(a.awaitStateCalls)
 }
 
-func (a *FakeAwaiter[T, L, PL]) AwaitStateArgsForCall(i int) (client.Object, func(T) error) {
+func (a *FakeAwaiter[T, TT, L, PL]) AwaitStateArgsForCall(i int) (client.Object, func(T) error) {
 	return a.awaitStateCalls[i].obj, a.awaitStateCalls[i].checkState
 }

--- a/api/repositories/org_repository_test.go
+++ b/api/repositories/org_repository_test.go
@@ -27,6 +27,7 @@ var _ = Describe("OrgRepository", func() {
 	var (
 		conditionAwaiter *fakeawaiter.FakeAwaiter[
 			*korifiv1alpha1.CFOrg,
+			korifiv1alpha1.CFOrg,
 			korifiv1alpha1.CFOrgList,
 			*korifiv1alpha1.CFOrgList,
 		]
@@ -36,6 +37,7 @@ var _ = Describe("OrgRepository", func() {
 	BeforeEach(func() {
 		conditionAwaiter = &fakeawaiter.FakeAwaiter[
 			*korifiv1alpha1.CFOrg,
+			korifiv1alpha1.CFOrg,
 			korifiv1alpha1.CFOrgList,
 			*korifiv1alpha1.CFOrgList,
 		]{}

--- a/api/repositories/package_repository_test.go
+++ b/api/repositories/package_repository_test.go
@@ -31,6 +31,7 @@ var _ = Describe("PackageRepository", func() {
 		repoCreator      *fake.RepositoryCreator
 		conditionAwaiter *fakeawaiter.FakeAwaiter[
 			*korifiv1alpha1.CFPackage,
+			korifiv1alpha1.CFPackage,
 			korifiv1alpha1.CFPackageList,
 			*korifiv1alpha1.CFPackageList,
 		]
@@ -45,6 +46,7 @@ var _ = Describe("PackageRepository", func() {
 		repoCreator = new(fake.RepositoryCreator)
 		conditionAwaiter = &fakeawaiter.FakeAwaiter[
 			*korifiv1alpha1.CFPackage,
+			korifiv1alpha1.CFPackage,
 			korifiv1alpha1.CFPackageList,
 			*korifiv1alpha1.CFPackageList,
 		]{}

--- a/api/repositories/role_repository_test.go
+++ b/api/repositories/role_repository_test.go
@@ -46,11 +46,13 @@ var _ = Describe("RoleRepository", func() {
 		}
 		orgRepo := repositories.NewOrgRepo(rootNamespace, k8sClient, userClientFactory, nsPerms, &fakeawaiter.FakeAwaiter[
 			*korifiv1alpha1.CFOrg,
+			korifiv1alpha1.CFOrg,
 			korifiv1alpha1.CFOrgList,
 			*korifiv1alpha1.CFOrgList,
 		]{})
 		spaceRepo := repositories.NewSpaceRepo(namespaceRetriever, orgRepo, userClientFactory, nsPerms, &fakeawaiter.FakeAwaiter[
 			*korifiv1alpha1.CFSpace,
+			korifiv1alpha1.CFSpace,
 			korifiv1alpha1.CFSpaceList,
 			*korifiv1alpha1.CFSpaceList,
 		]{})

--- a/api/repositories/service_binding_repository_test.go
+++ b/api/repositories/service_binding_repository_test.go
@@ -33,6 +33,7 @@ var _ = Describe("ServiceBindingRepo", func() {
 		bindingName         *string
 		conditionAwaiter    *fakeawaiter.FakeAwaiter[
 			*korifiv1alpha1.CFServiceBinding,
+			korifiv1alpha1.CFServiceBinding,
 			korifiv1alpha1.CFServiceBindingList,
 			*korifiv1alpha1.CFServiceBindingList,
 		]
@@ -42,6 +43,7 @@ var _ = Describe("ServiceBindingRepo", func() {
 		testCtx = context.Background()
 		conditionAwaiter = &fakeawaiter.FakeAwaiter[
 			*korifiv1alpha1.CFServiceBinding,
+			korifiv1alpha1.CFServiceBinding,
 			korifiv1alpha1.CFServiceBindingList,
 			*korifiv1alpha1.CFServiceBindingList,
 		]{}

--- a/api/repositories/service_instance_repository_test.go
+++ b/api/repositories/service_instance_repository_test.go
@@ -33,6 +33,7 @@ var _ = Describe("ServiceInstanceRepository", func() {
 		serviceInstanceRepo *repositories.ServiceInstanceRepo
 		conditionAwaiter    *fakeawaiter.FakeAwaiter[
 			*korifiv1alpha1.CFServiceInstance,
+			korifiv1alpha1.CFServiceInstance,
 			korifiv1alpha1.CFServiceInstanceList,
 			*korifiv1alpha1.CFServiceInstanceList,
 		]
@@ -46,6 +47,7 @@ var _ = Describe("ServiceInstanceRepository", func() {
 		testCtx = context.Background()
 		conditionAwaiter = &fakeawaiter.FakeAwaiter[
 			*korifiv1alpha1.CFServiceInstance,
+			korifiv1alpha1.CFServiceInstance,
 			korifiv1alpha1.CFServiceInstanceList,
 			*korifiv1alpha1.CFServiceInstanceList,
 		]{}

--- a/api/repositories/service_plan_repository_test.go
+++ b/api/repositories/service_plan_repository_test.go
@@ -28,6 +28,7 @@ var _ = Describe("ServicePlanRepo", func() {
 	BeforeEach(func() {
 		orgRepo := repositories.NewOrgRepo(rootNamespace, k8sClient, userClientFactory, nsPerms, &fakeawaiter.FakeAwaiter[
 			*korifiv1alpha1.CFOrg,
+			korifiv1alpha1.CFOrg,
 			korifiv1alpha1.CFOrgList,
 			*korifiv1alpha1.CFOrgList,
 		]{})

--- a/api/repositories/space_repository_test.go
+++ b/api/repositories/space_repository_test.go
@@ -27,6 +27,7 @@ var _ = Describe("SpaceRepository", func() {
 		orgRepo          *repositories.OrgRepo
 		conditionAwaiter *fakeawaiter.FakeAwaiter[
 			*korifiv1alpha1.CFSpace,
+			korifiv1alpha1.CFSpace,
 			korifiv1alpha1.CFSpaceList,
 			*korifiv1alpha1.CFSpaceList,
 		]
@@ -36,12 +37,14 @@ var _ = Describe("SpaceRepository", func() {
 	BeforeEach(func() {
 		orgRepo = repositories.NewOrgRepo(rootNamespace, k8sClient, userClientFactory, nsPerms, &fakeawaiter.FakeAwaiter[
 			*korifiv1alpha1.CFOrg,
+			korifiv1alpha1.CFOrg,
 			korifiv1alpha1.CFOrgList,
 			*korifiv1alpha1.CFOrgList,
 		]{})
 
 		conditionAwaiter = &fakeawaiter.FakeAwaiter[
 			*korifiv1alpha1.CFSpace,
+			korifiv1alpha1.CFSpace,
 			korifiv1alpha1.CFSpaceList,
 			*korifiv1alpha1.CFSpaceList,
 		]{}

--- a/api/repositories/task_repository_test.go
+++ b/api/repositories/task_repository_test.go
@@ -28,6 +28,7 @@ var _ = Describe("TaskRepository", func() {
 	var (
 		conditionAwaiter *fakeawaiter.FakeAwaiter[
 			*korifiv1alpha1.CFTask,
+			korifiv1alpha1.CFTask,
 			korifiv1alpha1.CFTaskList,
 			*korifiv1alpha1.CFTaskList,
 		]
@@ -40,6 +41,7 @@ var _ = Describe("TaskRepository", func() {
 	BeforeEach(func() {
 		conditionAwaiter = &fakeawaiter.FakeAwaiter[
 			*korifiv1alpha1.CFTask,
+			korifiv1alpha1.CFTask,
 			korifiv1alpha1.CFTaskList,
 			*korifiv1alpha1.CFTaskList,
 		]{}

--- a/controllers/api/v1alpha1/appworkload_types.go
+++ b/controllers/api/v1alpha1/appworkload_types.go
@@ -78,6 +78,10 @@ type AppWorkload struct {
 	Status AppWorkloadStatus `json:"status,omitempty"`
 }
 
+func (w *AppWorkload) StatusConditions() *[]metav1.Condition {
+	return &w.Status.Conditions
+}
+
 //+kubebuilder:object:root=true
 
 // AppWorkloadList contains a list of AppWorkload

--- a/controllers/api/v1alpha1/builderinfo_types.go
+++ b/controllers/api/v1alpha1/builderinfo_types.go
@@ -64,6 +64,10 @@ type BuilderInfo struct {
 	Status BuilderInfoStatus `json:"status,omitempty"`
 }
 
+func (i *BuilderInfo) StatusConditions() *[]metav1.Condition {
+	return &i.Status.Conditions
+}
+
 //+kubebuilder:object:root=true
 
 // BuilderInfoList contains a list of BuilderInfo

--- a/controllers/api/v1alpha1/buildworkload_types.go
+++ b/controllers/api/v1alpha1/buildworkload_types.go
@@ -70,6 +70,10 @@ type BuildWorkload struct {
 	Status BuildWorkloadStatus `json:"status,omitempty"`
 }
 
+func (w *BuildWorkload) StatusConditions() *[]metav1.Condition {
+	return &w.Status.Conditions
+}
+
 //+kubebuilder:object:root=true
 
 // BuildWorkloadList contains a list of BuildWorkload

--- a/controllers/api/v1alpha1/cfapp_types.go
+++ b/controllers/api/v1alpha1/cfapp_types.go
@@ -100,8 +100,8 @@ func init() {
 	SchemeBuilder.Register(&CFApp{}, &CFAppList{})
 }
 
-func (a CFApp) StatusConditions() []metav1.Condition {
-	return a.Status.Conditions
+func (a *CFApp) StatusConditions() *[]metav1.Condition {
+	return &a.Status.Conditions
 }
 
 func (a CFApp) UniqueName() string {

--- a/controllers/api/v1alpha1/cfbuild_types.go
+++ b/controllers/api/v1alpha1/cfbuild_types.go
@@ -86,6 +86,10 @@ type CFBuild struct {
 	Status CFBuildStatus `json:"status,omitempty"`
 }
 
+func (b *CFBuild) StatusConditions() *[]metav1.Condition {
+	return &b.Status.Conditions
+}
+
 //+kubebuilder:object:root=true
 
 // CFBuildList contains a list of CFBuild

--- a/controllers/api/v1alpha1/cfdomain_types.go
+++ b/controllers/api/v1alpha1/cfdomain_types.go
@@ -54,6 +54,10 @@ type CFDomain struct {
 	Status CFDomainStatus `json:"status,omitempty"`
 }
 
+func (d *CFDomain) StatusConditions() *[]metav1.Condition {
+	return &d.Status.Conditions
+}
+
 //+kubebuilder:object:root=true
 
 // CFDomainList contains a list of CFDomain

--- a/controllers/api/v1alpha1/cforg_types.go
+++ b/controllers/api/v1alpha1/cforg_types.go
@@ -90,8 +90,8 @@ func (o *CFOrg) GetStatus() status.NamespaceStatus {
 	return &o.Status
 }
 
-func (o CFOrg) StatusConditions() []metav1.Condition {
-	return o.Status.Conditions
+func (o *CFOrg) StatusConditions() *[]metav1.Condition {
+	return &o.Status.Conditions
 }
 
 func (s *CFOrgStatus) GetConditions() *[]metav1.Condition {

--- a/controllers/api/v1alpha1/cfpackage_types.go
+++ b/controllers/api/v1alpha1/cfpackage_types.go
@@ -83,6 +83,6 @@ func init() {
 	SchemeBuilder.Register(&CFPackage{}, &CFPackageList{})
 }
 
-func (p CFPackage) StatusConditions() []metav1.Condition {
-	return p.Status.Conditions
+func (p *CFPackage) StatusConditions() *[]metav1.Condition {
+	return &p.Status.Conditions
 }

--- a/controllers/api/v1alpha1/cfprocess_types.go
+++ b/controllers/api/v1alpha1/cfprocess_types.go
@@ -116,12 +116,16 @@ type CFProcessList struct {
 	Items           []CFProcess `json:"items"`
 }
 
-func (r *CFProcess) SetStableName(appGUID string) {
-	r.Name = strings.Join([]string{processNamePrefix, appGUID, r.Spec.ProcessType}, "-")
-	if r.Labels == nil {
-		r.Labels = map[string]string{}
+func (p *CFProcess) SetStableName(appGUID string) {
+	p.Name = strings.Join([]string{processNamePrefix, appGUID, p.Spec.ProcessType}, "-")
+	if p.Labels == nil {
+		p.Labels = map[string]string{}
 	}
-	r.Labels[CFProcessGUIDLabelKey] = r.Name
+	p.Labels[CFProcessGUIDLabelKey] = p.Name
+}
+
+func (p *CFProcess) StatusConditions() *[]metav1.Condition {
+	return &p.Status.Conditions
 }
 
 func init() {

--- a/controllers/api/v1alpha1/cfroute_types.go
+++ b/controllers/api/v1alpha1/cfroute_types.go
@@ -125,3 +125,7 @@ func (r CFRoute) UniqueValidationErrorMessage() string {
 
 	return fmt.Sprintf("Route already exists with host '%s'%s for domain '%s'.", r.Spec.Host, pathDetails, r.Status.FQDN)
 }
+
+func (r *CFRoute) StatusConditions() *[]metav1.Condition {
+	return &r.Status.Conditions
+}

--- a/controllers/api/v1alpha1/cfservicebinding_types.go
+++ b/controllers/api/v1alpha1/cfservicebinding_types.go
@@ -81,8 +81,8 @@ type CFServiceBindingList struct {
 	Items           []CFServiceBinding `json:"items"`
 }
 
-func (b CFServiceBinding) StatusConditions() []metav1.Condition {
-	return b.Status.Conditions
+func (b *CFServiceBinding) StatusConditions() *[]metav1.Condition {
+	return &b.Status.Conditions
 }
 
 func (b CFServiceBinding) UniqueName() string {

--- a/controllers/api/v1alpha1/cfservicebroker_types.go
+++ b/controllers/api/v1alpha1/cfservicebroker_types.go
@@ -51,6 +51,10 @@ func (b CFServiceBroker) UniqueValidationErrorMessage() string {
 	return "Name must be unique"
 }
 
+func (b *CFServiceBroker) StatusConditions() *[]metav1.Condition {
+	return &b.Status.Conditions
+}
+
 // +kubebuilder:object:root=true
 type CFServiceBrokerList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/controllers/api/v1alpha1/cfserviceinstance_types.go
+++ b/controllers/api/v1alpha1/cfserviceinstance_types.go
@@ -97,8 +97,8 @@ func (si CFServiceInstance) UniqueValidationErrorMessage() string {
 	return fmt.Sprintf("The service instance name is taken: %s", si.Spec.DisplayName)
 }
 
-func (si CFServiceInstance) StatusConditions() []metav1.Condition {
-	return si.Status.Conditions
+func (si *CFServiceInstance) StatusConditions() *[]metav1.Condition {
+	return &si.Status.Conditions
 }
 
 //+kubebuilder:object:root=true

--- a/controllers/api/v1alpha1/cfspace_types.go
+++ b/controllers/api/v1alpha1/cfspace_types.go
@@ -81,8 +81,8 @@ type CFSpaceList struct {
 	Items           []CFSpace `json:"items"`
 }
 
-func (s CFSpace) StatusConditions() []metav1.Condition {
-	return s.Status.Conditions
+func (s *CFSpace) StatusConditions() *[]metav1.Condition {
+	return &s.Status.Conditions
 }
 
 func (s *CFSpace) GetStatus() status.NamespaceStatus {

--- a/controllers/api/v1alpha1/cftask_types.go
+++ b/controllers/api/v1alpha1/cftask_types.go
@@ -83,6 +83,6 @@ func init() {
 	SchemeBuilder.Register(&CFTask{}, &CFTaskList{})
 }
 
-func (t CFTask) StatusConditions() []metav1.Condition {
-	return t.Status.Conditions
+func (t *CFTask) StatusConditions() *[]metav1.Condition {
+	return &t.Status.Conditions
 }

--- a/controllers/api/v1alpha1/runnerinfo_types.go
+++ b/controllers/api/v1alpha1/runnerinfo_types.go
@@ -55,6 +55,10 @@ type RunnerInfo struct {
 	Status RunnerInfoStatus `json:"status,omitempty"`
 }
 
+func (i *RunnerInfo) StatusConditions() *[]metav1.Condition {
+	return &i.Status.Conditions
+}
+
 //+kubebuilder:object:root=true
 
 // RunnerInfoList contains a list of RunnerInfo

--- a/controllers/api/v1alpha1/taskworkload_types.go
+++ b/controllers/api/v1alpha1/taskworkload_types.go
@@ -73,6 +73,6 @@ func init() {
 	SchemeBuilder.Register(&TaskWorkload{}, &TaskWorkloadList{})
 }
 
-func (t TaskWorkload) StatusConditions() []metav1.Condition {
-	return t.Status.Conditions
+func (t *TaskWorkload) StatusConditions() *[]metav1.Condition {
+	return &t.Status.Conditions
 }

--- a/controllers/controllers/networking/domains/controller.go
+++ b/controllers/controllers/networking/domains/controller.go
@@ -25,7 +25,6 @@ import (
 	"code.cloudfoundry.org/korifi/tools/k8s"
 
 	"github.com/go-logr/logr"
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -60,12 +59,6 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) *builder.Builder {
 func (r *Reconciler) ReconcileResource(ctx context.Context, cfDomain *korifiv1alpha1.CFDomain) (ctrl.Result, error) {
 	log := logr.FromContextOrDiscard(ctx)
 
-	var err error
-	readyConditionBuilder := k8s.NewReadyConditionBuilder(cfDomain)
-	defer func() {
-		meta.SetStatusCondition(&cfDomain.Status.Conditions, readyConditionBuilder.WithError(err).Build())
-	}()
-
 	if !cfDomain.GetDeletionTimestamp().IsZero() {
 		return r.finalizeCFDomain(ctx, cfDomain)
 	}
@@ -73,7 +66,6 @@ func (r *Reconciler) ReconcileResource(ctx context.Context, cfDomain *korifiv1al
 	cfDomain.Status.ObservedGeneration = cfDomain.Generation
 	log.V(1).Info("set observed generation", "generation", cfDomain.Status.ObservedGeneration)
 
-	readyConditionBuilder.Ready()
 	return ctrl.Result{}, nil
 }
 

--- a/controllers/controllers/shared/index.go
+++ b/controllers/controllers/shared/index.go
@@ -7,8 +7,6 @@ import (
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 
 	"github.com/go-logr/logr"
-	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
@@ -111,26 +109,6 @@ func serviceBindingAppGUIDIndexFn(rawObj client.Object) []string {
 func serviceBindingServiceInstanceGUIDIndexFn(rawObj client.Object) []string {
 	serviceBinding := rawObj.(*korifiv1alpha1.CFServiceBinding)
 	return []string{serviceBinding.Spec.Service.Name}
-}
-
-// GetConditionOrSetAsUnknown is a helper function that retrieves the value of the provided conditionType, like
-// "Succeeded" and returns the value: "True", "False", or "Unknown". If the value is not present, the pointer to the
-// list of conditions provided to the function is used to add an entry to the list of Conditions with a value of
-// "Unknown" and "Unknown" is returned
-func GetConditionOrSetAsUnknown(conditions *[]metav1.Condition, conditionType string, generation int64) metav1.ConditionStatus {
-	if conditionStatus := meta.FindStatusCondition(*conditions, conditionType); conditionStatus != nil {
-		return conditionStatus.Status
-	}
-
-	meta.SetStatusCondition(conditions, metav1.Condition{
-		Type:               conditionType,
-		Status:             metav1.ConditionUnknown,
-		Reason:             "Unknown",
-		Message:            "Unknown",
-		ObservedGeneration: generation,
-	})
-
-	return metav1.ConditionUnknown
 }
 
 func RemovePackageManagerKeys(src map[string]string, log logr.Logger) map[string]string {

--- a/controllers/controllers/workloads/build/buildpack/controller.go
+++ b/controllers/controllers/workloads/build/buildpack/controller.go
@@ -132,8 +132,8 @@ func (r *buildpackBuildReconciler) ReconcileBuild(
 ) (ctrl.Result, error) {
 	log := logr.FromContextOrDiscard(ctx)
 
-	stagingStatus := shared.GetConditionOrSetAsUnknown(&cfBuild.Status.Conditions, korifiv1alpha1.StagingConditionType, cfBuild.Generation)
-	if stagingStatus == metav1.ConditionUnknown {
+	stagingStatus := meta.FindStatusCondition(cfBuild.Status.Conditions, korifiv1alpha1.StagingConditionType)
+	if stagingStatus == nil {
 		err := r.createBuildWorkload(ctx, cfBuild, cfApp, cfPackage)
 		if err != nil {
 			log.Info("failed to create BuildWorkload", "reason", err)

--- a/controllers/controllers/workloads/build/buildpack/controller_test.go
+++ b/controllers/controllers/workloads/build/buildpack/controller_test.go
@@ -209,11 +209,6 @@ var _ = Describe("CFBuildpackBuildReconciler Integration Tests", func() {
 			g.Expect(stagingCondition.Status).To(Equal(metav1.ConditionTrue))
 			g.Expect(stagingCondition.Reason).To(Equal("BuildRunning"))
 			g.Expect(stagingCondition.ObservedGeneration).To(Equal(cfBuild.Generation))
-
-			succeededCondition := meta.FindStatusCondition(cfBuild.Status.Conditions, korifiv1alpha1.SucceededConditionType)
-			g.Expect(succeededCondition).NotTo(BeNil())
-			g.Expect(succeededCondition.Status).To(Equal(metav1.ConditionUnknown))
-			g.Expect(succeededCondition.ObservedGeneration).To(Equal(cfBuild.Generation))
 		}).Should(Succeed())
 	})
 
@@ -274,7 +269,7 @@ var _ = Describe("CFBuildpackBuildReconciler Integration Tests", func() {
 			Expect(adminClient.Create(ctx, existingBuildWorkload)).To(Succeed())
 		})
 
-		It("sets the status conditions on the CFBuild to running", func() {
+		It("sets the staging status condition on the CFBuild to running", func() {
 			Eventually(func(g Gomega) {
 				g.Expect(adminClient.Get(context.Background(), client.ObjectKeyFromObject(cfBuild), cfBuild)).To(Succeed())
 
@@ -283,11 +278,6 @@ var _ = Describe("CFBuildpackBuildReconciler Integration Tests", func() {
 				g.Expect(stagingCondition.Status).To(Equal(metav1.ConditionTrue))
 				g.Expect(stagingCondition.Reason).To(Equal("BuildRunning"))
 				g.Expect(stagingCondition.ObservedGeneration).To(Equal(cfBuild.Generation))
-
-				succeededCondition := meta.FindStatusCondition(cfBuild.Status.Conditions, korifiv1alpha1.SucceededConditionType)
-				g.Expect(succeededCondition).NotTo(BeNil())
-				g.Expect(succeededCondition.Status).To(Equal(metav1.ConditionUnknown))
-				g.Expect(succeededCondition.ObservedGeneration).To(Equal(cfBuild.Generation))
 			}).Should(Succeed())
 		})
 	})

--- a/controllers/controllers/workloads/build/controller.go
+++ b/controllers/controllers/workloads/build/controller.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
-	"code.cloudfoundry.org/korifi/controllers/controllers/shared"
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -82,8 +81,8 @@ func (r *Reconciler) ReconcileResource(ctx context.Context, cfBuild *korifiv1alp
 		log.Info("unable to clean up old builds", "reason", err)
 	}
 
-	succeededStatus := shared.GetConditionOrSetAsUnknown(&cfBuild.Status.Conditions, korifiv1alpha1.SucceededConditionType, cfBuild.Generation)
-	if succeededStatus != metav1.ConditionUnknown {
+	succeededStatus := meta.FindStatusCondition(cfBuild.Status.Conditions, korifiv1alpha1.SucceededConditionType)
+	if succeededStatus != nil {
 		log.Info("build status indicates completion", "status", succeededStatus)
 		return ctrl.Result{}, nil
 	}

--- a/controllers/controllers/workloads/build/docker/controller.go
+++ b/controllers/controllers/workloads/build/docker/controller.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
-	"code.cloudfoundry.org/korifi/controllers/controllers/shared"
 	"code.cloudfoundry.org/korifi/controllers/controllers/workloads/build"
 	"code.cloudfoundry.org/korifi/tools/image"
 	"code.cloudfoundry.org/korifi/tools/k8s"
@@ -93,8 +92,9 @@ func (r *dockerBuildReconciler) ReconcileBuild(
 	cfPackage *korifiv1alpha1.CFPackage,
 ) (ctrl.Result, error) {
 	log := logr.FromContextOrDiscard(ctx)
-	succeededStatus := shared.GetConditionOrSetAsUnknown(&cfBuild.Status.Conditions, korifiv1alpha1.SucceededConditionType, cfBuild.Generation)
-	if succeededStatus != metav1.ConditionUnknown {
+
+	succeededStatus := meta.FindStatusCondition(cfBuild.Status.Conditions, korifiv1alpha1.SucceededConditionType)
+	if succeededStatus != nil {
 		log.Info("build status indicates completion", "status", succeededStatus)
 		return ctrl.Result{}, nil
 	}

--- a/controllers/controllers/workloads/orgs/controller.go
+++ b/controllers/controllers/workloads/orgs/controller.go
@@ -27,7 +27,6 @@ import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -121,18 +120,11 @@ func (r *Reconciler) enqueueCFOrgRequests(ctx context.Context, object client.Obj
 //+kubebuilder:rbac:groups="policy",resources=podsecuritypolicies,verbs=use
 
 func (r *Reconciler) ReconcileResource(ctx context.Context, cfOrg *korifiv1alpha1.CFOrg) (ctrl.Result, error) {
-	var err error
-	readyConditionBuilder := k8s.NewReadyConditionBuilder(cfOrg)
-	defer func() {
-		meta.SetStatusCondition(&cfOrg.Status.Conditions, readyConditionBuilder.WithError(err).Build())
-	}()
-
 	nsReconcileResult, err := r.namespaceReconciler.ReconcileResource(ctx, cfOrg)
 	if (nsReconcileResult != ctrl.Result{}) || (err != nil) {
 		return nsReconcileResult, err
 	}
 
-	readyConditionBuilder.Ready()
 	return ctrl.Result{}, nil
 }
 

--- a/kpack-image-builder/controllers/builderinfo_controller_test.go
+++ b/kpack-image-builder/controllers/builderinfo_controller_test.go
@@ -133,8 +133,6 @@ var _ = Describe("BuilderInfoReconciler", Serial, func() {
 				readyCondition := meta.FindStatusCondition(info.Status.Conditions, "Ready")
 				Expect(readyCondition).NotTo(BeNil())
 				Expect(readyCondition.Status).To(Equal(metav1.ConditionTrue))
-				Expect(readyCondition.Reason).To(Equal("ClusterBuilderReady"))
-				Expect(readyCondition.Message).To(Equal(fmt.Sprintf("ClusterBuilder %q is ready", clusterBuilderName)))
 				Expect(readyCondition.ObservedGeneration).To(Equal(info.Generation))
 			})
 
@@ -195,7 +193,6 @@ var _ = Describe("BuilderInfoReconciler", Serial, func() {
 						g.Expect(readyCondition).NotTo(BeNil())
 						g.Expect(readyCondition.Status).To(Equal(metav1.ConditionFalse))
 						g.Expect(readyCondition.Reason).To(Equal("ClusterBuilderNotReady"))
-						g.Expect(readyCondition.Message).To(Equal(fmt.Sprintf("ClusterBuilder %q is not ready: resource not reconciled", clusterBuilderName)))
 						g.Expect(readyCondition.ObservedGeneration).To(Equal(info.Generation))
 					}).Should(Succeed())
 				})
@@ -391,8 +388,6 @@ var _ = Describe("BuilderInfoReconciler", Serial, func() {
 			Expect(readyCondition).NotTo(BeNil())
 			Expect(readyCondition.Status).To(Equal(metav1.ConditionFalse))
 			Expect(readyCondition.Reason).To(Equal("ClusterBuilderMissing"))
-			Expect(readyCondition.Message).To(ContainSubstring(clusterBuilderName))
-			Expect(readyCondition.Message).To(Equal(fmt.Sprintf("Error fetching ClusterBuilder %q: ClusterBuilder.kpack.io %q not found", clusterBuilderName, clusterBuilderName)))
 			Expect(readyCondition.ObservedGeneration).To(Equal(info.Generation))
 		})
 

--- a/statefulset-runner/controllers/appworkload_controller.go
+++ b/statefulset-runner/controllers/appworkload_controller.go
@@ -20,12 +20,10 @@ import (
 	"context"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
-	"code.cloudfoundry.org/korifi/controllers/controllers/shared"
 	"code.cloudfoundry.org/korifi/tools/k8s"
 
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -151,16 +149,8 @@ func filterAppWorkloads(object client.Object) bool {
 func (r *AppWorkloadReconciler) ReconcileResource(ctx context.Context, appWorkload *korifiv1alpha1.AppWorkload) (ctrl.Result, error) {
 	log := logr.FromContextOrDiscard(ctx)
 
-	var err error
-	readyConditionBuilder := k8s.NewReadyConditionBuilder(appWorkload)
-	defer func() {
-		meta.SetStatusCondition(&appWorkload.Status.Conditions, readyConditionBuilder.WithError(err).Build())
-	}()
-
 	appWorkload.Status.ObservedGeneration = appWorkload.Generation
 	log.V(1).Info("set observed generation", "generation", appWorkload.Status.ObservedGeneration)
-
-	shared.GetConditionOrSetAsUnknown(&appWorkload.Status.Conditions, korifiv1alpha1.StatusConditionReady, appWorkload.Generation)
 
 	statefulSet, err := r.workloadsToStSet.Convert(appWorkload)
 	// Not clear what errors this would produce, but we may use it later
@@ -196,6 +186,5 @@ func (r *AppWorkloadReconciler) ReconcileResource(ctx context.Context, appWorklo
 
 	appWorkload.Status.ActualInstances = createdStSet.Status.Replicas
 
-	readyConditionBuilder.Ready()
 	return ctrl.Result{}, nil
 }

--- a/tests/crds/crds_suite_test.go
+++ b/tests/crds/crds_suite_test.go
@@ -138,7 +138,7 @@ var _ = BeforeEach(func() {
 	Expect(k8sClient.Create(ctx, testOrg)).To(Succeed())
 	Eventually(func(g Gomega) {
 		g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(testOrg), testOrg)).To(Succeed())
-		g.Expect(meta.IsStatusConditionTrue(testOrg.StatusConditions(), korifiv1alpha1.StatusConditionReady)).To(BeTrue())
+		g.Expect(meta.IsStatusConditionTrue(*testOrg.StatusConditions(), korifiv1alpha1.StatusConditionReady)).To(BeTrue())
 	}).Should(Succeed())
 
 	testSpace = &korifiv1alpha1.CFSpace{
@@ -154,7 +154,7 @@ var _ = BeforeEach(func() {
 	Expect(k8sClient.Create(ctx, testSpace)).To(Succeed())
 	Eventually(func(g Gomega) {
 		g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(testSpace), testSpace)).To(Succeed())
-		g.Expect(meta.IsStatusConditionTrue(testSpace.StatusConditions(), korifiv1alpha1.StatusConditionReady)).To(BeTrue())
+		g.Expect(meta.IsStatusConditionTrue(*testSpace.StatusConditions(), korifiv1alpha1.StatusConditionReady)).To(BeTrue())
 	}).Should(Succeed())
 })
 

--- a/tests/matchers/conditions.go
+++ b/tests/matchers/conditions.go
@@ -20,6 +20,10 @@ func HasReason(matcher types.GomegaMatcher) types.GomegaMatcher {
 	return &conditionMatcher{field: "Reason", matcher: matcher}
 }
 
+func HasMessage(matcher types.GomegaMatcher) types.GomegaMatcher {
+	return &conditionMatcher{field: "Message", matcher: matcher}
+}
+
 func HasObservedGeneration(matcher types.GomegaMatcher) types.GomegaMatcher {
 	return &conditionMatcher{field: "ObservedGeneration", matcher: matcher}
 }

--- a/tools/k8s/condition_builder.go
+++ b/tools/k8s/condition_builder.go
@@ -1,9 +1,11 @@
 package k8s
 
 import (
+	"fmt"
 	"time"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
+	"code.cloudfoundry.org/korifi/tools"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -34,7 +36,9 @@ func (b *ReadyConditionBuilder) WithReason(reason string) *ReadyConditionBuilder
 }
 
 func (b *ReadyConditionBuilder) WithMessage(message string) *ReadyConditionBuilder {
-	b.message = message
+	if message != "" {
+		b.message = message
+	}
 	return b
 }
 
@@ -67,4 +71,48 @@ func (b *ReadyConditionBuilder) Build() metav1.Condition {
 	}
 
 	return result
+}
+
+type NotReadyError struct {
+	cause        error
+	reason       string
+	message      string
+	requeueAfter *time.Duration
+	noRequeue    bool
+}
+
+func (e NotReadyError) Error() string {
+	if e.cause != nil {
+		return fmt.Sprintf("%s: %s", e.message, e.cause.Error())
+	}
+	return e.message
+}
+
+func NewNotReadyError() NotReadyError {
+	return NotReadyError{}
+}
+
+func (e NotReadyError) WithCause(cause error) NotReadyError {
+	e.cause = cause
+	return e
+}
+
+func (e NotReadyError) WithRequeueAfter(duration time.Duration) NotReadyError {
+	e.requeueAfter = tools.PtrTo(duration)
+	return e
+}
+
+func (e NotReadyError) WithNoRequeue() NotReadyError {
+	e.noRequeue = true
+	return e
+}
+
+func (e NotReadyError) WithReason(reason string) NotReadyError {
+	e.reason = reason
+	return e
+}
+
+func (e NotReadyError) WithMessage(message string) NotReadyError {
+	e.message = message
+	return e
 }

--- a/tools/k8s/condition_builder_test.go
+++ b/tools/k8s/condition_builder_test.go
@@ -74,8 +74,18 @@ var _ = Describe("ReadyConditionBuilder", func() {
 			builder.WithError(errors.New("some-error"))
 		})
 
-		It("sets the reason", func() {
+		It("sets the message", func() {
 			Expect(condition.Message).To(Equal("some-error"))
+		})
+
+		When("message is set to empty string", func() {
+			BeforeEach(func() {
+				builder.WithMessage("")
+			})
+
+			It("sets the message from the error", func() {
+				Expect(condition.Message).To(Equal("some-error"))
+			})
 		})
 	})
 

--- a/tools/k8s/reconcile.go
+++ b/tools/k8s/reconcile.go
@@ -2,29 +2,37 @@ package k8s
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-type ObjectReconciler[T any, PT ObjectWithDeepCopy[T]] interface {
+type RuntimeObjectWithStatusConditions[T any] interface {
+	ObjectWithDeepCopy[T]
+	StatusConditions() *[]metav1.Condition
+}
+
+type ObjectReconciler[T any, PT RuntimeObjectWithStatusConditions[T]] interface {
 	ReconcileResource(ctx context.Context, obj PT) (ctrl.Result, error)
 	SetupWithManager(mgr ctrl.Manager) *builder.Builder
 }
 
-type PatchingReconciler[T any, PT ObjectWithDeepCopy[T]] struct {
+type PatchingReconciler[T any, PT RuntimeObjectWithStatusConditions[T]] struct {
 	log              logr.Logger
 	k8sClient        client.Client
 	objectReconciler ObjectReconciler[T, PT]
 }
 
-func NewPatchingReconciler[T any, PT ObjectWithDeepCopy[T]](log logr.Logger, k8sClient client.Client, objectReconciler ObjectReconciler[T, PT]) *PatchingReconciler[T, PT] {
+func NewPatchingReconciler[T any, PT RuntimeObjectWithStatusConditions[T]](log logr.Logger, k8sClient client.Client, objectReconciler ObjectReconciler[T, PT]) *PatchingReconciler[T, PT] {
 	return &PatchingReconciler[T, PT]{
 		log:              log,
 		k8sClient:        k8sClient,
@@ -41,7 +49,7 @@ func (r *PatchingReconciler[T, PT]) Reconcile(ctx context.Context, req ctrl.Requ
 	obj := PT(new(T))
 	err := r.k8sClient.Get(ctx, req.NamespacedName, obj)
 	if err != nil {
-		if apierrors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) {
 			return ctrl.Result{}, nil
 		}
 		log.Info(fmt.Sprintf("unable to fetch %T", obj), "reason", err)
@@ -54,7 +62,31 @@ func (r *PatchingReconciler[T, PT]) Reconcile(ctx context.Context, req ctrl.Requ
 	)
 
 	err = Patch(ctx, r.k8sClient, obj, func() {
+		readyConditionBuilder := NewReadyConditionBuilder(obj)
+		defer func() {
+			meta.SetStatusCondition(obj.StatusConditions(), readyConditionBuilder.WithError(delegateErr).Build())
+		}()
+
 		result, delegateErr = r.objectReconciler.ReconcileResource(ctx, obj)
+		if delegateErr == nil {
+			readyConditionBuilder.Ready()
+			return
+		}
+
+		var notReadyErr NotReadyError
+		if errors.As(delegateErr, &notReadyErr) {
+			readyConditionBuilder.WithReason(notReadyErr.reason).WithMessage(notReadyErr.message)
+
+			if notReadyErr.noRequeue {
+				result = ctrl.Result{}
+				delegateErr = nil
+			}
+
+			if notReadyErr.requeueAfter != nil {
+				result = ctrl.Result{RequeueAfter: *notReadyErr.requeueAfter}
+				delegateErr = nil
+			}
+		}
 	})
 	if err != nil {
 		log.Info("patch object failed", "reason", err)


### PR DESCRIPTION
## Is there a related GitHub Issue?
#2098
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
* introduce `k8s.RuntimeObjectWithStatusConditions`
* replace `conditions.RuntimeObjectWithStatusConditions` with
  `k8s.RuntimeObjectWithStatusConditions` - that made the generic
  signature of the awaiter a bit awkward
* Make the ready condition builder availble into the patching reconciler
  and remove it from all the controllers
* introduce the `k8s.NotReadyError` error. By returning that error in
  controllers, the patching reconciler sets the `Ready` condition
  accordingly
* The kpack build reconciler no longer uses the patching reconciler as
  kpack build custom resource does not implement the
  `RuntimeObjectWithStatusConditions` interface
<!-- _Please describe the change here._ -->


## Tag your pair, your PM, and/or team
@georgethebeatle
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
