### PR TITLE
Use `EnsurePatch` in OSBAPI client factory tests

### DIFF
--- a/controllers/controllers/services/instances/managed/controller_test.go
+++ b/controllers/controllers/services/instances/managed/controller_test.go
@@ -419,6 +419,11 @@ var _ = Describe("CFServiceInstance", func() {
 					Status: metav1.ConditionTrue,
 					Reason: "ProvisionFailed",
 				})
+				meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+					Type:   korifiv1alpha1.StatusConditionReady,
+					Status: metav1.ConditionFalse,
+					Reason: "ProvisionFailed",
+				})
 			})).To(Succeed())
 		})
 


### PR DESCRIPTION
## Is there a related GitHub Issue?
Flakes:

https://ci.korifi.cf-app.com/teams/main/pipelines/main/jobs/run-tests-periodic/builds/19051
https://ci.korifi.cf-app.com/teams/main/pipelines/main/jobs/run-tests-periodic/builds/19049
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
The client factory is an utility and its tests are not executed in the
context of the controllers retry loop. Therefore, in order to avoid
flakes from k8s eventual consistency, we use `EnsurePatch` in tests
instead of `k8sClient.Patch` to ensure that the factory sees the state
of the objects the test setup creates.
<!-- _Please describe the change here._ -->


## Tag your pair, your PM, and/or team
@georgethebeatle
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
