### PR TITLE
Use make targets to install binary dependencies

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,0 @@
-source <(setup-envtest use -p env --bin-dir "$PWD/testbin")
-export APICONFIG=$PWD/config/base/apiconfig/
-export CONTROLLERSCONFIG=$PWD/config/base/controllersconfig/

--- a/Makefile
+++ b/Makefile
@@ -21,48 +21,47 @@ help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 ##@ Development
-BIN_PATH = $(shell pwd)/bin
+export GOBIN = $(shell pwd)/bin
 export PATH := $(shell pwd)/bin:$(PATH)
 
 CONTROLLERS=controllers job-task-runner kpack-image-builder statefulset-runner
 COMPONENTS=api $(CONTROLLERS)
 
-manifests: install-controller-gen
-	$(CONTROLLER_GEN) \
+manifests: bin/controller-gen
+	controller-gen \
 		paths="./model/..." \
 		crd \
 		output:crd:artifacts:config=helm/korifi/controllers/crds
 	@for comp in $(COMPONENTS); do make -C $$comp manifests; done
 
-generate: install-controller-gen
-	$(CONTROLLER_GEN) object:headerFile="controllers/hack/boilerplate.go.txt" paths="./model/..."
+generate: bin/controller-gen
+	controller-gen object:headerFile="controllers/hack/boilerplate.go.txt" paths="./model/..."
 	@for comp in $(CONTROLLERS); do make -C $$comp generate; done
 	go run ./scripts/helmdoc/main.go > README.helm.md
 
-CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
-install-controller-gen:
-	GOBIN=$(shell pwd)/bin go install sigs.k8s.io/controller-tools/cmd/controller-gen
+bin/controller-gen: bin
+	go install sigs.k8s.io/controller-tools/cmd/controller-gen
 
 generate-fakes:
 	go generate ./...
 
-fmt: install-gofumpt install-shfmt
-	$(GOFUMPT) -w .
-	$(SHFMT) -f . | grep -v '^tests/vendor' | xargs $(SHFMT) -w -i 2 -ci
+fmt: bin/gofumpt bin/shfmt
+	gofumpt -w .
+	shfmt -f . | grep -v '^tests/vendor' | xargs shfmt -w -i 2 -ci
 
 vet: ## Run go vet against code.
 	go vet ./...
 
 lint: fmt vet gosec staticcheck golangci-lint
 
-gosec: install-gosec
-	$(GOSEC) --exclude=G101,G304,G401,G404,G505 --exclude-dir=tests ./...
+gosec: bin/gosec
+	gosec --exclude=G101,G304,G401,G404,G505 --exclude-dir=tests ./...
 
-staticcheck: install-staticcheck
-	$(STATICCHECK) ./...
+staticcheck: bin/staticcheck
+	staticcheck ./...
 
-golangci-lint: install-golangci-lint
-	$(GOLANGCILINT) run
+golangci-lint: bin/golangci-lint
+	golangci-lint run
 
 test: lint
 	@for comp in $(COMPONENTS); do make -C $$comp test; done
@@ -87,37 +86,39 @@ build-dorifi:
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -C tests/assets/dorifi-golang -o ../multi-process/dorifi .
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -C tests/assets/sample-broker-golang -o ../sample-broker/sample-broker .
 
-GOFUMPT = $(shell go env GOPATH)/bin/gofumpt
-install-gofumpt:
+bin:
+	mkdir -p bin
+
+bin/gofumpt:
 	go install mvdan.cc/gofumpt@latest
 
-SHFMT = $(shell go env GOPATH)/bin/shfmt
-install-shfmt:
+bin/shfmt:
 	go install mvdan.cc/sh/v3/cmd/shfmt@latest
 
-VENDIR = $(shell go env GOPATH)/bin/vendir
-install-vendir:
+bin/vendir:
 	go install carvel.dev/vendir/cmd/vendir@latest
 
-GOSEC = $(shell go env GOPATH)/bin/gosec
-install-gosec:
+bin/gosec:
 	go install github.com/securego/gosec/v2/cmd/gosec@latest
 
-STATICCHECK = $(shell go env GOPATH)/bin/staticcheck
-install-staticcheck:
+bin/staticcheck:
 	go install honnef.co/go/tools/cmd/staticcheck@latest
 
-GOLANGCILINT = $(shell go env GOPATH)/bin/golangci-lint
-install-golangci-lint:
+bin/golangci-lint:
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 
 bin/cf:
-	mkdir -p $(BIN_PATH)
+	mkdir -p $(GOBIN)
 	curl -fsSL "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=v8&source=github" \
 	  | tar -zx cf8 \
-	  && mv cf8 $(BIN_PATH)/cf \
-	  && chmod +x $(BIN_PATH)/cf
+	  && mv cf8 $(GOBIN)/cf \
+	  && chmod +x $(GOBIN)/cf
 
+bin/yq: bin
+	go install github.com/mikefarah/yq/v4@latest
 
-vendir-update-dependencies: install-vendir
-	$(VENDIR) sync --chdir tests
+bin/setup-envtest: bin
+	go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+
+vendir-update-dependencies: bin/vendir
+	vendir sync --chdir tests

--- a/api/Makefile
+++ b/api/Makefile
@@ -1,10 +1,3 @@
-# Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
-ifeq (,$(shell go env GOBIN))
-GOBIN=$(shell go env GOPATH)/bin
-else
-GOBIN=$(shell go env GOBIN)
-endif
-
 # Use gsed on Mac, sed on linux
 ifeq (,$(shell which gsed))
 SED=sed
@@ -35,25 +28,26 @@ help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 ##@ Development
+export GOBIN = $(shell pwd)/bin
+export PATH := $(shell pwd)/bin:$(PATH)
 
-manifests: install-controller-gen install-yq
-	$(CONTROLLER_GEN) \
+manifests: bin/controller-gen bin/yq
+	controller-gen \
 		paths=./... \
 		output:rbac:artifacts:config=../helm/korifi/api \
 		rbac:roleName=korifi-api-system-role
 
-	$(YQ) -i 'with(.metadata | select(.namespace == "ROOT_NAMESPACE"); .namespace="{{ .Values.rootNamespace }}")' ../helm/korifi/api/role.yaml
+	yq -i 'with(.metadata | select(.namespace == "ROOT_NAMESPACE"); .namespace="{{ .Values.rootNamespace }}")' ../helm/korifi/api/role.yaml
 
-test: install-ginkgo
+
+test:
 	../scripts/run-tests.sh --skip-package=test
 
-CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
-install-controller-gen:
-	GOBIN=$(shell pwd)/bin go install sigs.k8s.io/controller-tools/cmd/controller-gen
+bin:
+	mkdir -p bin
 
-install-ginkgo:
-	go install github.com/onsi/ginkgo/v2/ginkgo
+bin/controller-gen: bin
+	go install sigs.k8s.io/controller-tools/cmd/controller-gen
 
-YQ = $(shell pwd)/bin/yq
-install-yq:
-	GOBIN=$(shell pwd)/bin go install github.com/mikefarah/yq/v4@latest
+bin/yq: bin
+	go install github.com/mikefarah/yq/v4@latest

--- a/controllers/Makefile
+++ b/controllers/Makefile
@@ -5,13 +5,6 @@ ifdef GINKGO_NODES
 CONTROLLERS_GINKGO_NODES = $(GINKGO_NODES)
 endif
 
-# Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
-ifeq (,$(shell go env GOBIN))
-GOBIN=$(shell go env GOPATH)/bin
-else
-GOBIN=$(shell go env GOBIN)
-endif
-
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # This is a requirement for 'setup-envtest.sh' in the test target.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
@@ -35,10 +28,12 @@ help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 ##@ Development
+export GOBIN = $(shell pwd)/bin
+export PATH := $(shell pwd)/bin:$(PATH)
 
 webhooks-file = ../helm/korifi/controllers/manifests.yaml
-manifests: install-controller-gen install-yq
-	$(CONTROLLER_GEN) \
+manifests: bin/controller-gen bin/yq
+	controller-gen \
 		paths="./..." \
 		crd \
 		rbac:roleName=korifi-controllers-manager-role \
@@ -47,24 +42,23 @@ manifests: install-controller-gen install-yq
 		output:rbac:artifacts:config=../helm/korifi/controllers \
 		output:webhook:artifacts:config=../helm/korifi/controllers
 
-	$(YQ) -i 'with(.metadata; .annotations["cert-manager.io/inject-ca-from"]="{{ .Release.Namespace }}/korifi-controllers-serving-cert")' $(webhooks-file)
-	$(YQ) -i 'with(.metadata; .name="korifi-controllers-" + .name)' $(webhooks-file)
-	$(YQ) -i 'with(.webhooks[]; .clientConfig.service.namespace="{{ .Release.Namespace }}")' $(webhooks-file)
-	$(YQ) -i 'with(.webhooks[]; .clientConfig.service.name="korifi-controllers-" + .clientConfig.service.name)' $(webhooks-file)
+	yq -i 'with(.metadata; .annotations["cert-manager.io/inject-ca-from"]="{{ .Release.Namespace }}/korifi-controllers-serving-cert")' $(webhooks-file)
+	yq -i 'with(.metadata; .name="korifi-controllers-" + .name)' $(webhooks-file)
+	yq -i 'with(.webhooks[]; .clientConfig.service.namespace="{{ .Release.Namespace }}")' $(webhooks-file)
+	yq -i 'with(.webhooks[]; .clientConfig.service.name="korifi-controllers-" + .clientConfig.service.name)' $(webhooks-file)
 
-generate: install-controller-gen
-	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
+generate: bin/controller-gen
+	controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
-test: install-ginkgo manifests generate ## Run tests.
+test: manifests generate
 	GINKGO_NODES=$(CONTROLLERS_GINKGO_NODES) ../scripts/run-tests.sh
 
-CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
-install-controller-gen:
-	GOBIN=$(shell pwd)/bin go install sigs.k8s.io/controller-tools/cmd/controller-gen
+bin:
+	mkdir -p bin
 
-install-ginkgo:
-	go install github.com/onsi/ginkgo/v2/ginkgo
+bin/controller-gen: bin
+	go install sigs.k8s.io/controller-tools/cmd/controller-gen
 
-YQ = $(shell pwd)/bin/yq
-install-yq:
-	GOBIN=$(shell pwd)/bin go install github.com/mikefarah/yq/v4@latest
+bin/yq: bin
+	go install github.com/mikefarah/yq/v4@latest
+

--- a/job-task-runner/Makefile
+++ b/job-task-runner/Makefile
@@ -5,21 +5,11 @@ IMG_JTR ?= cloudfoundry/korifi-job-task-runner:latest
 ENVTEST_K8S_VERSION = 1.24.1
 CLUSTER_NAME ?= "e2e"
 
-# Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
-ifeq (,$(shell go env GOBIN))
-GOBIN=$(shell go env GOPATH)/bin
-else
-GOBIN=$(shell go env GOBIN)
-endif
-
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # This is a requirement for 'setup-envtest.sh' in the test target.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
-
-.PHONY: all
-all: build
 
 ##@ General
 
@@ -39,26 +29,27 @@ help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 ##@ Development
+export GOBIN = $(shell pwd)/bin
+export PATH := $(shell pwd)/bin:$(PATH)
+
 .PHONY: manifests
-manifests: install-controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) \
+manifests: bin/controller-gen
+	controller-gen \
 		paths="./..." \
 		rbac:roleName=korifi-job-task-runner-taskworkload-manager-role \
 		output:rbac:artifacts:config=../helm/korifi/job-task-runner
 
 .PHONY: generate
-generate: install-controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
-	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
+generate: bin/controller-gen
+	controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
 .PHONY: test
-test: install-ginkgo manifests generate ## Run tests.
+test: manifests generate
 	../scripts/run-tests.sh
 
 ##@ Build Dependencies
-.PHONY: install-controller-gen
-CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
-install-controller-gen:
-	GOBIN=$(shell pwd)/bin go install sigs.k8s.io/controller-tools/cmd/controller-gen
+bin:
+	mkdir -p bin
 
-install-ginkgo:
-	go install github.com/onsi/ginkgo/v2/ginkgo
+bin/controller-gen: bin
+	go install sigs.k8s.io/controller-tools/cmd/controller-gen

--- a/kpack-image-builder/Makefile
+++ b/kpack-image-builder/Makefile
@@ -4,21 +4,11 @@ IMG_KIB ?= cloudfoundry/korifi-kpack-image-builder:latest
 ENVTEST_K8S_VERSION = 1.23
 CLUSTER_NAME ?= "e2e"
 
-# Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
-ifeq (,$(shell go env GOBIN))
-GOBIN=$(shell go env GOPATH)/bin
-else
-GOBIN=$(shell go env GOBIN)
-endif
-
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # This is a requirement for 'setup-envtest.sh' in the test target.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
-
-.PHONY: all
-all: build
 
 ##@ General
 
@@ -38,42 +28,41 @@ help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 ##@ Development
+export GOBIN = $(shell pwd)/bin
+export PATH := $(shell pwd)/bin:$(PATH)
 
 .PHONY: manifests
-manifests: install-controller-gen install-yq
+manifests: bin/controller-gen bin/yq
 webhooks-file = ../helm/korifi/kpack-image-builder/manifests.yaml
-manifests: install-controller-gen
-	$(CONTROLLER_GEN) \
+manifests: bin/controller-gen
+	controller-gen \
 		paths="./..." \
 		rbac:roleName=korifi-kpack-build-manager-role \
 		webhook \
 		output:rbac:artifacts:config=../helm/korifi/kpack-image-builder \
 		output:webhook:artifacts:config=../helm/korifi/kpack-image-builder
 
-	$(YQ) -i 'with(.metadata; .annotations["cert-manager.io/inject-ca-from"]="{{ .Release.Namespace }}/korifi-controllers-serving-cert")' $(webhooks-file)
-	$(YQ) -i 'with(.metadata; .name="korifi-kpack-image-builder-" + .name)' $(webhooks-file)
-	$(YQ) -i 'with(.webhooks[]; .clientConfig.service.namespace="{{ .Release.Namespace }}")' $(webhooks-file)
-	$(YQ) -i 'with(.webhooks[]; .clientConfig.service.name="korifi-controllers-" + .clientConfig.service.name)' $(webhooks-file)
+	yq -i 'with(.metadata; .annotations["cert-manager.io/inject-ca-from"]="{{ .Release.Namespace }}/korifi-controllers-serving-cert")' $(webhooks-file)
+	yq -i 'with(.metadata; .name="korifi-kpack-image-builder-" + .name)' $(webhooks-file)
+	yq -i 'with(.webhooks[]; .clientConfig.service.namespace="{{ .Release.Namespace }}")' $(webhooks-file)
+	yq -i 'with(.webhooks[]; .clientConfig.service.name="korifi-controllers-" + .clientConfig.service.name)' $(webhooks-file)
 
 
 
 
 .PHONY: generate
-generate: install-controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
-	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
+generate: bin/controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
+	controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
 .PHONY: test
-test: install-ginkgo manifests generate ## Run tests.
+test: manifests generate
 	../scripts/run-tests.sh
 
-.PHONY: install-controller-gen
-CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
-install-controller-gen:
-	GOBIN=$(shell pwd)/bin go install sigs.k8s.io/controller-tools/cmd/controller-gen
+bin:
+	mkdir -p bin
 
-install-ginkgo:
-	go install github.com/onsi/ginkgo/v2/ginkgo
+bin/controller-gen: bin
+	go install sigs.k8s.io/controller-tools/cmd/controller-gen
 
-YQ = $(shell pwd)/bin/yq
-install-yq:
-	GOBIN=$(shell pwd)/bin go install github.com/mikefarah/yq/v4@latest
+bin/yq: bin
+	go install github.com/mikefarah/yq/v4@latest

--- a/scripts/deploy-on-kind.sh
+++ b/scripts/deploy-on-kind.sh
@@ -70,10 +70,6 @@ function parse_cmdline_args() {
   fi
 }
 
-function install_yq() {
-  GOBIN="${ROOT_DIR}/bin" go install github.com/mikefarah/yq/v4@latest
-}
-
 function validate_registry_params() {
   local registry_env_vars
   registry_env_vars="\$DOCKER_SERVER \$DOCKER_USERNAME \$DOCKER_PASSWORD \$REPOSITORY_PREFIX \$KPACK_BUILDER_REPOSITORY"
@@ -251,8 +247,9 @@ function create_registry_secret() {
 }
 
 function main() {
+  make -C "$ROOT_DIR" bin/yq
+
   parse_cmdline_args "$@"
-  install_yq
   validate_registry_params
   ensure_kind_cluster "$CLUSTER_NAME"
   ensure_local_registry

--- a/statefulset-runner/Makefile
+++ b/statefulset-runner/Makefile
@@ -5,21 +5,11 @@ IMG_SSR ?= cloudfoundry/korifi-statefulset-runner:latest
 ENVTEST_K8S_VERSION = 1.23
 CLUSTER_NAME ?= "e2e"
 
-# Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
-ifeq (,$(shell go env GOBIN))
-GOBIN=$(shell go env GOPATH)/bin
-else
-GOBIN=$(shell go env GOBIN)
-endif
-
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # This is a requirement for 'setup-envtest.sh' in the test target.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
-
-.PHONY: all
-all: build
 
 ##@ General
 
@@ -39,40 +29,39 @@ help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 ##@ Development
+export GOBIN = $(shell pwd)/bin
+export PATH := $(shell pwd)/bin:$(PATH)
 
 webhooks-file = ../helm/korifi/statefulset-runner/manifests.yaml
 .PHONY: manifests
-manifests: install-controller-gen install-yq
-	$(CONTROLLER_GEN) \
+manifests: bin/controller-gen bin/yq
+	controller-gen \
 		paths="./..." \
 		rbac:roleName=korifi-statefulset-runner-appworkload-manager-role \
 		webhook \
 		output:rbac:artifacts:config=../helm/korifi/statefulset-runner \
 		output:webhook:artifacts:config=../helm/korifi/statefulset-runner
 
-	$(YQ) -i 'with(.metadata; .annotations["cert-manager.io/inject-ca-from"]="{{ .Release.Namespace }}/korifi-controllers-serving-cert")' $(webhooks-file)
-	$(YQ) -i 'with(.metadata; .name="korifi-statefulset-runner-" + .name)' $(webhooks-file)
-	$(YQ) -i 'with(.webhooks[]; .clientConfig.service.namespace="{{ .Release.Namespace }}")' $(webhooks-file)
-	$(YQ) -i 'with(.webhooks[]; .clientConfig.service.name="korifi-controllers-" + .clientConfig.service.name)' $(webhooks-file)
-	$(YQ) -i 'with(.webhooks[]; .objectSelector.matchLabels["korifi.cloudfoundry.org/add-stsr-index"]="true")' $(webhooks-file)
+	yq -i 'with(.metadata; .annotations["cert-manager.io/inject-ca-from"]="{{ .Release.Namespace }}/korifi-controllers-serving-cert")' $(webhooks-file)
+	yq -i 'with(.metadata; .name="korifi-statefulset-runner-" + .name)' $(webhooks-file)
+	yq -i 'with(.webhooks[]; .clientConfig.service.namespace="{{ .Release.Namespace }}")' $(webhooks-file)
+	yq -i 'with(.webhooks[]; .clientConfig.service.name="korifi-controllers-" + .clientConfig.service.name)' $(webhooks-file)
+	yq -i 'with(.webhooks[]; .objectSelector.matchLabels["korifi.cloudfoundry.org/add-stsr-index"]="true")' $(webhooks-file)
 
 
 .PHONY: generate
-generate: install-controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
-	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
+generate: bin/controller-gen
+	controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
 .PHONY: test
-test: install-ginkgo manifests generate ## Run tests.
+test: manifests generate
 	../scripts/run-tests.sh
 
-.PHONY: install-controller-gen
-CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
-install-controller-gen:
-	GOBIN=$(shell pwd)/bin go install sigs.k8s.io/controller-tools/cmd/controller-gen
+bin:
+	mkdir -p bin
 
-install-ginkgo:
-	go install github.com/onsi/ginkgo/v2/ginkgo
+bin/controller-gen: bin
+	go install sigs.k8s.io/controller-tools/cmd/controller-gen
 
-YQ = $(shell pwd)/bin/yq
-install-yq:
-	GOBIN=$(shell pwd)/bin go install github.com/mikefarah/yq/v4@latest
+bin/yq: bin
+	go install github.com/mikefarah/yq/v4@latest

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,18 +1,8 @@
-# Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
-ifeq (,$(shell go env GOBIN))
-GOBIN=$(shell go env GOPATH)/bin
-else
-GOBIN=$(shell go env GOBIN)
-endif
-
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # This is a requirement for 'setup-envtest.sh' in the test target.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
-
-.PHONY: all
-all: build
 
 ##@ General
 
@@ -32,10 +22,9 @@ help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 ##@ Development
+export GOBIN = $(shell pwd)/bin
+export PATH := $(shell pwd)/bin:$(PATH)
 
 .PHONY: test
-test: install-ginkgo ## Run tests.
+test:
 	../scripts/run-tests.sh
-
-install-ginkgo:
-	go install github.com/onsi/ginkgo/v2/ginkgo


### PR DESCRIPTION
## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
* Make use of file-based rules as make targets to ensure that binaries
  are only installed if not already available
* Configure `GOBIN` env var to `./bin`. Thus `go install` installs
  binaries in `./bin`
* Add `GOBIN` to path
* Use simple binary names as `GOBIN` is on the `PATH`
<!-- _Please describe the change here._ -->


## Tag your pair, your PM, and/or team
@georgethebeatle
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
