### PR TITLE
Write `Succeeded` condition only after adding droplet info into `BuildWorkload` status

### DIFF
--- a/kpack-image-builder/controllers/buildworkload_controller.go
+++ b/kpack-image-builder/controllers/buildworkload_controller.go
@@ -257,14 +257,6 @@ func (r *BuildWorkloadReconciler) ReconcileResource(ctx context.Context, buildWo
 			ObservedGeneration: buildWorkload.Generation,
 		})
 	} else if latestBuildSuccessful.IsTrue() {
-		meta.SetStatusCondition(&buildWorkload.Status.Conditions, metav1.Condition{
-			Type:               korifiv1alpha1.SucceededConditionType,
-			Status:             metav1.ConditionTrue,
-			Reason:             "BuildSucceeded",
-			Message:            "Image built successfully",
-			ObservedGeneration: buildWorkload.Generation,
-		})
-
 		foundServiceAccount := corev1.ServiceAccount{}
 		err = r.k8sClient.Get(ctx, types.NamespacedName{
 			Namespace: buildWorkload.Namespace,
@@ -280,6 +272,14 @@ func (r *BuildWorkloadReconciler) ReconcileResource(ctx context.Context, buildWo
 			log.Info("error when compiling the DropletStatus", "reason", err)
 			return ctrl.Result{}, err
 		}
+
+		meta.SetStatusCondition(&buildWorkload.Status.Conditions, metav1.Condition{
+			Type:               korifiv1alpha1.SucceededConditionType,
+			Status:             metav1.ConditionTrue,
+			Reason:             "BuildSucceeded",
+			Message:            "Image built successfully",
+			ObservedGeneration: buildWorkload.Generation,
+		})
 	}
 
 	return ctrl.Result{}, nil

--- a/kpack-image-builder/controllers/buildworkload_controller_test.go
+++ b/kpack-image-builder/controllers/buildworkload_controller_test.go
@@ -2,6 +2,7 @@ package controllers_test
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"strconv"
 
@@ -1147,6 +1148,58 @@ var _ = Describe("BuildWorkloadReconciler", func() {
 					g.Expect(adminClient.Get(ctx, client.ObjectKeyFromObject(kpackBuild), foundKpackBuild)).To(Succeed())
 				}).Should(Succeed())
 			})
+		})
+	})
+
+	FWhen("failure during generateDropletStatus call", func() {
+		var (
+			build *buildv1alpha2.Build
+		)
+		BeforeEach(func() {
+			fakeImageConfigGetter.ConfigReturns(image.Config{}, errors.New("fake error"))
+			buildWorkload = buildWorkloadObject(buildWorkloadGUID, namespaceGUID, source, env, services, reconcilerName, buildpacks)
+			Expect(adminClient.Create(ctx, buildWorkload)).To(Succeed())
+
+			createdKpackImage := new(buildv1alpha2.Image)
+			Eventually(func() error {
+				return adminClient.Get(ctx, types.NamespacedName{Name: appGUID, Namespace: namespaceGUID}, createdKpackImage)
+			}).Should(Succeed())
+
+			build = &buildv1alpha2.Build{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "build",
+					Namespace: namespaceGUID,
+					Labels: map[string]string{
+						buildv1alpha2.ImageLabel:           appGUID,
+						buildv1alpha2.ImageGenerationLabel: "1",
+						buildv1alpha2.BuildNumberLabel:     "1",
+					},
+				},
+			}
+
+			Expect(adminClient.Create(ctx, build)).To(Succeed())
+		})
+
+		JustBeforeEach(func() {
+			Expect(k8s.Patch(ctx, adminClient, build, func() {
+				build.Status.Conditions = append(build.Status.Conditions, corev1alpha1.Condition{
+					Type:   corev1alpha1.ConditionType("Succeeded"),
+					Status: corev1.ConditionStatus("True"),
+					Reason: "",
+				})
+
+				build.Status.Stack.ID = "cflinux3"
+				build.Status.LatestImage = "foo/bar:asd"
+			})).To(Succeed())
+		})
+
+		It("does not set the Succeeded condition", func() {
+			Eventually(func(g Gomega) {
+				g.Expect(adminClient.Get(ctx, client.ObjectKeyFromObject(buildWorkload), buildWorkload)).To(Succeed())
+				g.Expect(mustHaveCondition(g, buildWorkload.Status.Conditions, "Succeeded").Status).To(Equal(metav1.ConditionUnknown))
+				g.Expect(mustHaveCondition(g, buildWorkload.Status.Conditions, "Ready").Status).To(Equal(metav1.ConditionFalse))
+				g.Expect(mustHaveCondition(g, buildWorkload.Status.Conditions, "Ready").Message).To(Equal("failed getting image config: fake error"))
+			}).Should(Succeed())
 		})
 	})
 })

--- a/kpack-image-builder/controllers/buildworkload_controller_test.go
+++ b/kpack-image-builder/controllers/buildworkload_controller_test.go
@@ -1151,7 +1151,7 @@ var _ = Describe("BuildWorkloadReconciler", func() {
 		})
 	})
 
-	FWhen("failure during generateDropletStatus call", func() {
+	When("failure during generateDropletStatus call", func() {
 		var (
 			build *buildv1alpha2.Build
 		)


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

no

## What is this change about?
<!-- _Please describe the change here._ -->

If an error is thrown during the [generation of droplet status](https://github.com/cloudfoundry/korifi/blob/7b38428e46429002e303e8cbd428422ce2a859d3/kpack-image-builder/controllers/buildworkload_controller.go#L268-L282), the `BuildWorkload` object ends up in a deadlock situation, where each subsequent reconciliation loop exits early and no droplet info is written.

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

no

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
