### PR TITLE
Refactor binding controller

### DIFF
--- a/controllers/controllers/services/bindings/suite_test.go
+++ b/controllers/controllers/services/bindings/suite_test.go
@@ -24,6 +24,7 @@ import (
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"code.cloudfoundry.org/korifi/controllers/controllers/services/bindings"
+	"code.cloudfoundry.org/korifi/controllers/controllers/services/bindings/upsi"
 	"code.cloudfoundry.org/korifi/controllers/controllers/shared"
 	"code.cloudfoundry.org/korifi/tests/helpers"
 
@@ -36,6 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 var (
@@ -44,6 +46,7 @@ var (
 	stopClientCache context.CancelFunc
 	testEnv         *envtest.Environment
 	adminClient     client.Client
+	k8sManager      manager.Manager
 )
 
 func TestAPIs(t *testing.T) {
@@ -51,7 +54,7 @@ func TestAPIs(t *testing.T) {
 	SetDefaultEventuallyPollingInterval(250 * time.Millisecond)
 
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Service Binding Controller Integration Suite")
+	RunSpecs(t, "USPI Controller Integration Suite")
 }
 
 var _ = BeforeSuite(func() {
@@ -72,24 +75,32 @@ var _ = BeforeSuite(func() {
 
 	Expect(korifiv1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
 	Expect(servicebindingv1beta1.AddToScheme(scheme.Scheme)).To(Succeed())
+})
 
-	k8sManager := helpers.NewK8sManager(testEnv, filepath.Join("helm", "korifi", "controllers", "role.yaml"))
+var _ = AfterSuite(func() {
+	Expect(testEnv.Stop()).To(Succeed())
+})
+
+var _ = BeforeEach(func() {
+	k8sManager = helpers.NewK8sManager(testEnv, filepath.Join("helm", "korifi", "controllers", "role.yaml"))
 	Expect(shared.SetupIndexWithManager(k8sManager)).To(Succeed())
 
 	adminClient, stopClientCache = helpers.NewCachedClient(testEnv.Config)
 
-	err = bindings.NewReconciler(
+	err := bindings.NewReconciler(
 		k8sManager.GetClient(),
 		k8sManager.GetScheme(),
 		ctrl.Log.WithName("controllers").WithName("CFServiceBinding"),
+		upsi.NewReconciler(k8sManager.GetClient(), k8sManager.GetScheme()),
 	).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
+})
 
+var _ = JustBeforeEach(func() {
 	stopManager = helpers.StartK8sManager(k8sManager)
 })
 
-var _ = AfterSuite(func() {
+var _ = AfterEach(func() {
 	stopClientCache()
 	stopManager()
-	Expect(testEnv.Stop()).To(Succeed())
 })

--- a/controllers/controllers/services/bindings/upsi/controller.go
+++ b/controllers/controllers/services/bindings/upsi/controller.go
@@ -1,0 +1,145 @@
+package upsi
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"code.cloudfoundry.org/korifi/tools/k8s"
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
+	"code.cloudfoundry.org/korifi/controllers/controllers/services/credentials"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+type CredentialsReconciler struct {
+	k8sClient client.Client
+	scheme    *runtime.Scheme
+}
+
+func NewReconciler(k8sClient client.Client, scheme *runtime.Scheme) *CredentialsReconciler {
+	return &CredentialsReconciler{
+		k8sClient: k8sClient,
+		scheme:    scheme,
+	}
+}
+
+func (r *CredentialsReconciler) ReconcileResource(ctx context.Context, cfServiceBinding *korifiv1alpha1.CFServiceBinding) (ctrl.Result, error) {
+	log := logr.FromContextOrDiscard(ctx)
+	// start upsiCredentialsReconsiler.ReconcileResource
+
+	cfServiceInstance := new(korifiv1alpha1.CFServiceInstance)
+	err := r.k8sClient.Get(ctx, types.NamespacedName{Name: cfServiceBinding.Spec.Service.Name, Namespace: cfServiceBinding.Namespace}, cfServiceInstance)
+	if err != nil {
+		log.Info("service instance not found", "service-instance", cfServiceBinding.Spec.Service.Name, "error", err)
+		return ctrl.Result{}, err
+	}
+
+	if cfServiceInstance.Status.Credentials.Name == "" {
+		return ctrl.Result{}, k8s.NewNotReadyError().
+			WithReason("CredentialsSecretNotAvailable").
+			WithMessage("Service instance credentials not available yet").
+			WithRequeueAfter(time.Second)
+	}
+
+	err = r.reconcileCredentials(ctx, cfServiceInstance, cfServiceBinding)
+	if err != nil {
+		if k8serrors.IsInvalid(err) {
+			err = r.k8sClient.Delete(ctx, &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      cfServiceBinding.Name,
+					Namespace: cfServiceBinding.Namespace,
+				},
+			})
+			return ctrl.Result{}, errors.Wrap(err, "failed to delete outdated binding secret")
+		}
+
+		log.Error(err, "failed to reconcile credentials secret")
+		return ctrl.Result{}, err
+	}
+
+	// end of upsiCredentialsReconsiler.ReconcileResource
+
+	return ctrl.Result{}, nil
+}
+
+func isLegacyServiceBinding(cfServiceBinding *korifiv1alpha1.CFServiceBinding, cfServiceInstance *korifiv1alpha1.CFServiceInstance) bool {
+	if cfServiceBinding.Status.Binding.Name == "" {
+		return false
+	}
+
+	// When reconciling existing legacy service bindings we make
+	// use of the fact that the service binding used to reference
+	// the secret of the sevice instance that shares the sevice
+	// instance name. See ADR 16 for more datails.
+	return cfServiceInstance.Name == cfServiceBinding.Status.Binding.Name && cfServiceInstance.Spec.SecretName == cfServiceBinding.Status.Binding.Name
+}
+
+func (r *CredentialsReconciler) reconcileCredentials(ctx context.Context, cfServiceInstance *korifiv1alpha1.CFServiceInstance, cfServiceBinding *korifiv1alpha1.CFServiceBinding) error {
+	cfServiceBinding.Status.Credentials.Name = cfServiceInstance.Status.Credentials.Name
+
+	if isLegacyServiceBinding(cfServiceBinding, cfServiceInstance) {
+		bindingSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      cfServiceBinding.Status.Binding.Name,
+				Namespace: cfServiceBinding.Namespace,
+			},
+		}
+
+		// For legacy sevice bindings we want to keep the binding secret
+		// unchanged in order to avoid unexpected app restarts. See ADR 16 for more details.
+		err := r.k8sClient.Get(ctx, client.ObjectKeyFromObject(bindingSecret), bindingSecret)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	credentialsSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: cfServiceInstance.Namespace,
+			Name:      cfServiceInstance.Status.Credentials.Name,
+		},
+	}
+	err := r.k8sClient.Get(ctx, client.ObjectKeyFromObject(credentialsSecret), credentialsSecret)
+	if err != nil {
+		return fmt.Errorf("failed to get service instance credentials secret %q: %w", cfServiceInstance.Status.Credentials.Name, err)
+	}
+
+	bindingSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cfServiceBinding.Name,
+			Namespace: cfServiceBinding.Namespace,
+		},
+	}
+
+	_, err = controllerutil.CreateOrPatch(ctx, r.k8sClient, bindingSecret, func() error {
+		bindingSecret.Type, err = credentials.GetBindingSecretType(credentialsSecret)
+		if err != nil {
+			return err
+		}
+		bindingSecret.Data, err = credentials.GetServiceBindingIOSecretData(credentialsSecret)
+		if err != nil {
+			return err
+		}
+
+		return controllerutil.SetControllerReference(cfServiceBinding, bindingSecret, r.scheme)
+	})
+	if err != nil {
+		return errors.Wrap(err, "failed to create binding secret")
+	}
+
+	cfServiceBinding.Status.Binding.Name = bindingSecret.Name
+
+	return nil
+}

--- a/controllers/controllers/services/instances/upsi/controller.go
+++ b/controllers/controllers/services/instances/upsi/controller.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
-	"code.cloudfoundry.org/korifi/controllers/controllers/services/bindings"
+	"code.cloudfoundry.org/korifi/controllers/controllers/services/credentials"
 	"code.cloudfoundry.org/korifi/controllers/controllers/shared"
 	"code.cloudfoundry.org/korifi/tools"
 	"code.cloudfoundry.org/korifi/tools/k8s"
@@ -144,7 +144,7 @@ func (r *Reconciler) ReconcileResource(ctx context.Context, cfServiceInstance *k
 }
 
 func (r *Reconciler) reconcileCredentials(ctx context.Context, credentialsSecret *corev1.Secret, cfServiceInstance *korifiv1alpha1.CFServiceInstance) (*corev1.Secret, error) {
-	if !strings.HasPrefix(string(credentialsSecret.Type), bindings.ServiceBindingSecretTypePrefix) {
+	if !strings.HasPrefix(string(credentialsSecret.Type), credentials.ServiceBindingSecretTypePrefix) {
 		return credentialsSecret, nil
 	}
 

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -30,9 +30,10 @@ import (
 	"code.cloudfoundry.org/korifi/controllers/controllers/networking/domains"
 	"code.cloudfoundry.org/korifi/controllers/controllers/networking/routes"
 	"code.cloudfoundry.org/korifi/controllers/controllers/services/bindings"
+	upsi_bindings "code.cloudfoundry.org/korifi/controllers/controllers/services/bindings/upsi"
 	"code.cloudfoundry.org/korifi/controllers/controllers/services/brokers"
 	"code.cloudfoundry.org/korifi/controllers/controllers/services/instances/managed"
-	"code.cloudfoundry.org/korifi/controllers/controllers/services/instances/upsi"
+	upsi_instances "code.cloudfoundry.org/korifi/controllers/controllers/services/instances/upsi"
 	"code.cloudfoundry.org/korifi/controllers/controllers/services/osbapi"
 	"code.cloudfoundry.org/korifi/controllers/controllers/shared"
 	"code.cloudfoundry.org/korifi/controllers/controllers/workloads/apps"
@@ -228,7 +229,7 @@ func main() {
 			os.Exit(1)
 		}
 
-		if err = (upsi.NewReconciler(
+		if err = (upsi_instances.NewReconciler(
 			mgr.GetClient(),
 			mgr.GetScheme(),
 			controllersLog,
@@ -241,6 +242,7 @@ func main() {
 			mgr.GetClient(),
 			mgr.GetScheme(),
 			controllersLog,
+			upsi_bindings.NewReconciler(mgr.GetClient(), mgr.GetScheme()),
 		)).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "CFServiceBinding")
 			os.Exit(1)


### PR DESCRIPTION

## What is this change about?
Introdce a sub-controller for user provided services that
has the responsibility to create the binding credentials secret

This refactoring makes it possible to support managed services in the
future by adding a managed services credentials sub-controller that
knows how to retrieve credentials from a broker
## Does this PR introduce a breaking change?
No

