### PR TITLE
Patching reconciler ensures non-empty status reason

### DIFF
--- a/tools/k8s/condition_builder.go
+++ b/tools/k8s/condition_builder.go
@@ -1,11 +1,9 @@
 package k8s
 
 import (
-	"fmt"
 	"time"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
-	"code.cloudfoundry.org/korifi/tools"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -71,54 +69,4 @@ func (b *ReadyConditionBuilder) Build() metav1.Condition {
 	}
 
 	return result
-}
-
-type NotReadyError struct {
-	cause        error
-	reason       string
-	message      string
-	requeueAfter *time.Duration
-	requeue      bool
-	noRequeue    bool
-}
-
-func (e NotReadyError) Error() string {
-	if e.cause != nil {
-		return fmt.Sprintf("%s: %s", e.message, e.cause.Error())
-	}
-	return e.message
-}
-
-func NewNotReadyError() NotReadyError {
-	return NotReadyError{}
-}
-
-func (e NotReadyError) WithCause(cause error) NotReadyError {
-	e.cause = cause
-	return e
-}
-
-func (e NotReadyError) WithRequeue() NotReadyError {
-	e.requeue = true
-	return e
-}
-
-func (e NotReadyError) WithRequeueAfter(duration time.Duration) NotReadyError {
-	e.requeueAfter = tools.PtrTo(duration)
-	return e
-}
-
-func (e NotReadyError) WithNoRequeue() NotReadyError {
-	e.noRequeue = true
-	return e
-}
-
-func (e NotReadyError) WithReason(reason string) NotReadyError {
-	e.reason = reason
-	return e
-}
-
-func (e NotReadyError) WithMessage(message string) NotReadyError {
-	e.message = message
-	return e
 }


### PR DESCRIPTION

<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
No, but a log line in a flake:
https://ci.korifi.cf-app.com/teams/main/pipelines/main/jobs/run-e2es-periodic/builds/17452#L66b8eb5f:5768
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Status conditions must have non-empty reason, otherwise the patch
operation is rejected by kubernetes.

When constructing the `NotReadyError`, a reconciler might set the cause
but not be able to determine the reason. Instead of trying to adhere to
always setting the reason in the controllers, the patching reconciler
now ensures that it is defaulted to `Unknown`.

While being here, move the `NotReadyError` type into the `reconcile.go`
file - it logically makes sense to be there
<!-- _Please describe the change here._ -->


## Tag your pair, your PM, and/or team
@georgethebeatle
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
