### PR TITLE
Allow Gateway `spec.listeners[].port` and `spec.infrastructure` configuration via Helm values

### DIFF
--- a/helm/korifi/templates/gateway.yaml
+++ b/helm/korifi/templates/gateway.yaml
@@ -25,19 +25,23 @@ metadata:
   namespace: {{ .Release.Namespace }}-gateway
 spec:
   gatewayClassName: {{ .Values.networking.gatewayClass }}
+  {{- if .Values.networking.gatewayInfrastructure }}
+  infrastructure:
+    {{- .Values.networking.gatewayInfrastructure | toYaml | nindent 4 }}
+  {{- end }}
   listeners:
   - allowedRoutes:
       namespaces:
         from: All
     name: http-apps
-    port: 80
+    port: {{ .Values.networking.gatewayPorts.http }}
     protocol: HTTP
   - allowedRoutes:
       namespaces:
         from: All
     hostname: {{ .Values.api.apiServer.url }}
     name: https-api
-    port: 443
+    port: {{ .Values.networking.gatewayPorts.https }}
     protocol: TLS
     tls:
       mode: Passthrough
@@ -46,7 +50,7 @@ spec:
         from: All
     hostname: "*.{{ .Values.defaultAppDomainName }}"
     name: https-apps
-    port: 443
+    port: {{ .Values.networking.gatewayPorts.https }}
     protocol: HTTPS
     tls:
       certificateRefs:

--- a/helm/korifi/values.schema.json
+++ b/helm/korifi/values.schema.json
@@ -574,6 +574,26 @@
         "gatewayClass": {
           "description": "The name of the GatewayClass Korifi Gateway references",
           "type": "string"
+        },
+        "gatewayPorts": {
+          "description": "Ports for the Gateway listeners",
+          "type": "object",
+          "properties": {
+            "http": {
+              "description": "HTTP port",
+              "type": "integer",
+              "default": 80
+            },
+            "https": {
+              "description": "HTTPS port",
+              "type": "integer",
+              "default": 443
+            }
+          }
+        },
+        "gatewayInfrastructure": {
+          "description": "GatewayInfrastructure property of the Gateway, see https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.GatewayInfrastructure for contents",
+          "type": ["object", "null"]
         }
       },
       "required": ["gatewayClass"]

--- a/helm/korifi/values.yaml
+++ b/helm/korifi/values.yaml
@@ -139,6 +139,10 @@ helm:
   hooksImage: alpine/k8s:1.25.2
 
 networking:
+  gatewayPorts:
+    http: 80
+    https: 443
+  gatewayInfrastructure:
   gatewayClass:
 
 experimental:

--- a/scripts/deploy-on-kind.sh
+++ b/scripts/deploy-on-kind.sh
@@ -128,10 +128,6 @@ function install_dependencies() {
 }
 
 function configure_contour() {
-  kubectl -n korifi-gateway patch gateway korifi --type='json' -p='[{"op": "replace", "path": "/spec/listeners/0/port", "value":32080}]'
-  kubectl -n korifi-gateway patch gateway korifi --type='json' -p='[{"op": "replace", "path": "/spec/listeners/1/port", "value":32443}]'
-  kubectl -n korifi-gateway patch gateway korifi --type='json' -p='[{"op": "replace", "path": "/spec/listeners/2/port", "value":32443}]'
-
   kubectl apply -f - <<EOF
 kind: GatewayClass
 apiVersion: gateway.networking.k8s.io/v1beta1
@@ -207,6 +203,8 @@ function deploy_korifi() {
       --set=kpackImageBuilder.clusterStackRunImage="paketobuildpacks/run-jammy-base" \
       --set=kpackImageBuilder.builderRepository="$KPACK_BUILDER_REPOSITORY" \
       --set=networking.gatewayClass="contour" \
+      --set=networking.gatewayPorts.http="32080" \
+      --set=networking.gatewayPorts.https="32443" \
       --set=experimental.managedServices.include="true" \
       --set=experimental.managedServices.trustInsecureBrokers="true" \
       --wait

--- a/scripts/installer/install-korifi-kind.yaml
+++ b/scripts/installer/install-korifi-kind.yaml
@@ -111,15 +111,13 @@ spec:
             --set=kpackImageBuilder.clusterStackRunImage="paketobuildpacks/run-jammy-base" \
             --set=kpackImageBuilder.builderRepository="localregistry-docker-registry.default.svc.cluster.local:30050/kpack-builder" \
             --set=networking.gatewayClass="contour" \
+            --set=networking.gatewayPorts.http="32080" \
+            --set=networking.gatewayPorts.https="32443" \
             --set=experimental.managedServices.include="true" \
             --set=experimental.managedServices.trustInsecureBrokers="true" \
             --wait
 
           kubectl wait --for=condition=ready clusterbuilder --all=true --timeout=15m
-
-          kubectl -n korifi-gateway patch gateway korifi --type='json' -p='[{"op": "replace", "path": "/spec/listeners/0/port", "value":32080}]'
-          kubectl -n korifi-gateway patch gateway korifi --type='json' -p='[{"op": "replace", "path": "/spec/listeners/1/port", "value":32443}]'
-          kubectl -n korifi-gateway patch gateway korifi --type='json' -p='[{"op": "replace", "path": "/spec/listeners/2/port", "value":32443}]'
 
           kubectl apply -f - <<EOF
           kind: GatewayClass


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

no

## What is this change about?
<!-- _Please describe the change here._ -->

This change adds new values to the Helm chart for configuring `listeners[].port` and `spec.infrastructure` properties of the Gateway object. These properties simplify local setup as well as improve integration with various components around the Gateway and it's generated resources (like passing annotations from gateway down to the generated `Service` object, which might be used by Gardener's [`external-dns-management`](https://github.com/gardener/external-dns-management) component).


## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

no

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
