### PR TITLE
Fails service instance when provisioning fails

### DIFF
--- a/README.helm.md
+++ b/README.helm.md
@@ -112,6 +112,10 @@ Here are all the values that can be set for the chart:
 - `logLevel` (_String_): Sets level of logging for api and controllers components. Can be 'info' or 'debug'.
 - `networking`: Networking configuration
   - `gatewayClass` (_String_): The name of the GatewayClass Korifi Gateway references
+  - `gatewayInfrastructure`: Optional GatewayInfrastructure property of the Gateway, see https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.GatewayInfrastructure for contents
+  - `gatewayPorts`: Ports for the Gateway listeners
+    - `http` (_Integer_): HTTP port
+    - `https` (_Integer_): HTTPS port
 - `reconcilers`:
   - `app` (_String_): ID of the workload runner to set on all `AppWorkload` objects. Defaults to `statefulset-runner`.
   - `build` (_String_): ID of the image builder to set on all `BuildWorkload` objects. Defaults to `kpack-image-builder`.

--- a/helm/korifi/values.schema.json
+++ b/helm/korifi/values.schema.json
@@ -592,7 +592,7 @@
           }
         },
         "gatewayInfrastructure": {
-          "description": "GatewayInfrastructure property of the Gateway, see https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.GatewayInfrastructure for contents",
+          "description": "Optional GatewayInfrastructure property of the Gateway, see https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.GatewayInfrastructure for contents",
           "type": ["object", "null"]
         }
       },

--- a/scripts/helmdoc/main.go
+++ b/scripts/helmdoc/main.go
@@ -9,6 +9,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/BooleanCat/go-functional/v2/it"
+	"github.com/BooleanCat/go-functional/v2/it/itx"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 )
@@ -33,7 +35,7 @@ func printDocForSchema(schema map[string]any, indentLevel int) {
 			desc = " " + descAny.(string)
 		}
 
-		typeStr := value["type"].(string)
+		typeStr := normalizeType(value["type"])
 		if typeStr == "object" {
 			typeStr = ""
 		} else {
@@ -41,10 +43,30 @@ func printDocForSchema(schema map[string]any, indentLevel int) {
 		}
 
 		fmt.Printf("%s- `%s`%s:%s\n", indentStr, name, typeStr, desc)
-		if value["type"].(string) == "object" {
-			printDocForSchema(value["properties"].(map[string]any), indentLevel+1)
+		if normalizeType(value["type"]) == "object" {
+			properties, hasProperties := value["properties"]
+			if hasProperties {
+				printDocForSchema(properties.(map[string]any), indentLevel+1)
+			}
 		}
 	}
+}
+
+func normalizeType(t any) string {
+	typeString, isString := t.(string)
+	if isString {
+		return typeString
+	}
+
+	typeArr := t.([]any)
+	types := slices.Collect(it.Exclude(itx.FromSlice(typeArr), func(v any) bool {
+		return v == "null"
+	}))
+	if len(types) != 1 {
+		panic(fmt.Errorf("unsupported type: %v", t))
+	}
+
+	return types[0].(string)
 }
 
 func main() {


### PR DESCRIPTION

## Is there a related GitHub Issue?
No
## What is this change about?
When the provision request fails (i.e. the broker returns a not OK
status code), we fail the service instance (set its
`ProvisioningFailedCondition` status condition). Thus the service
instance controller will not request provisioning again.

## Does this PR introduce a breaking change?
No