### PR TITLE
helm md generator: Remove obsolete code

### DIFF
--- a/scripts/helmdoc/main.go
+++ b/scripts/helmdoc/main.go
@@ -19,12 +19,6 @@ func printDocForSchema(schema map[string]any, indentLevel int) {
 	indentStr := strings.Repeat("  ", indentLevel)
 	names := slices.Collect(maps.Keys(schema))
 	sort.Slice(names, func(a, b int) bool {
-		if names[a] == "global" {
-			return true
-		}
-		if names[b] == "global" {
-			return false
-		}
 		return names[a] < names[b]
 	})
 


### PR DESCRIPTION
Commit a426011560e4a3f1e04cd38c4c07d1e18c68690e moved global helm values to top-level.

## Is there a related GitHub Issue?
No

## What is this change about?
There is some reference to a property named 'global' which does not exist anymore.

## Does this PR introduce a breaking change?
No.

## Acceptance Steps
Run `make generate` and the file `README.helm.md` should be unmodified.