### PR TITLE
Rename experimental services flag

### DIFF
--- a/helm/korifi/api/configmap.yaml
+++ b/helm/korifi/api/configmap.yaml
@@ -53,7 +53,7 @@ data:
     {{- if .Values.eksContainerRegistryRoleARN }}
     containerRegistryType: "ECR"
     {{- end }}
-    experimentalManagedServicesEnabled: {{ .Values.experimental.managedServices.include }}
+    experimentalManagedServicesEnabled: {{ .Values.experimental.managedServices.enabled }}
   role_mappings_config.yaml: |
     roleMappings:
       admin:

--- a/helm/korifi/controllers/configmap.yaml
+++ b/helm/korifi/controllers/configmap.yaml
@@ -57,6 +57,6 @@ data:
     networking:
       gatewayNamespace: {{ .Release.Namespace }}-gateway
       gatewayName: korifi
-    experimentalManagedServicesEnabled: {{ .Values.experimental.managedServices.include }}
+    experimentalManagedServicesEnabled: {{ .Values.experimental.managedServices.enabled }}
     trustInsecureServiceBrokers: {{ .Values.experimental.managedServices.trustInsecureBrokers }}
 

--- a/helm/korifi/values.yaml
+++ b/helm/korifi/values.yaml
@@ -10,8 +10,6 @@ eksContainerRegistryRoleARN: ""
 containerRegistryCACertSecret:
 systemImagePullSecrets: []
 
-experimentalManagedServicesEnabled: false
-
 reconcilers:
   build: kpack-image-builder
   run: statefulset-runner
@@ -145,5 +143,5 @@ networking:
 
 experimental:
   managedServices:
-    include: false
+    enabled: false
     trustInsecureBrokers: false

--- a/scripts/deploy-on-kind.sh
+++ b/scripts/deploy-on-kind.sh
@@ -205,7 +205,7 @@ function deploy_korifi() {
       --set=networking.gatewayClass="contour" \
       --set=networking.gatewayPorts.http="32080" \
       --set=networking.gatewayPorts.https="32443" \
-      --set=experimental.managedServices.include="true" \
+      --set=experimental.managedServices.enabled="true" \
       --set=experimental.managedServices.trustInsecureBrokers="true" \
       --wait
   }

--- a/scripts/installer/install-korifi-kind.yaml
+++ b/scripts/installer/install-korifi-kind.yaml
@@ -113,7 +113,7 @@ spec:
             --set=networking.gatewayClass="contour" \
             --set=networking.gatewayPorts.http="32080" \
             --set=networking.gatewayPorts.https="32443" \
-            --set=experimental.managedServices.include="true" \
+            --set=experimental.managedServices.enabled="true" \
             --set=experimental.managedServices.trustInsecureBrokers="true" \
             --wait
 


### PR DESCRIPTION
## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Rename the flag that enables experimental service support to ```
experimental.managedServices.enabled ```

The PR is intentionally marked as draft because it would fail CI chacks anyway,
as the flag is called differently in the CI scripts

The flag is already called experimentalManagedServicesEnabled in the configmap
and in the code, so let's be consistent

Enabled sounds more appropriate than include, since it is a crosscutting
feature and not a component the you can include/exclude
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
Yes, CI should be updated accordingly
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
Wdyt @danail-branekov
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
