### PR TITLE
tests: Fix time comparison by using UTC timezone

### DIFF
--- a/api/presenter/service_broker_test.go
+++ b/api/presenter/service_broker_test.go
@@ -32,8 +32,8 @@ var _ = Describe("Service Broker", func() {
 			},
 			CFResource: model.CFResource{
 				GUID:      "resource-guid",
-				CreatedAt: time.UnixMilli(1000),
-				UpdatedAt: tools.PtrTo(time.UnixMilli(2000)),
+				CreatedAt: time.UnixMilli(1000).UTC(),
+				UpdatedAt: tools.PtrTo(time.UnixMilli(2000).UTC()),
 				Metadata: model.Metadata{
 					Labels: map[string]string{
 						"label": "broker-label",

--- a/api/presenter/service_offering_test.go
+++ b/api/presenter/service_offering_test.go
@@ -49,8 +49,8 @@ var _ = Describe("Service Offering", func() {
 			},
 			CFResource: model.CFResource{
 				GUID:      "resource-guid",
-				CreatedAt: time.UnixMilli(1000),
-				UpdatedAt: tools.PtrTo(time.UnixMilli(2000)),
+				CreatedAt: time.UnixMilli(1000).UTC(),
+				UpdatedAt: tools.PtrTo(time.UnixMilli(2000).UTC()),
 				Metadata: model.Metadata{
 					Labels: map[string]string{
 						"label": "label-foo",

--- a/api/presenter/service_plan_test.go
+++ b/api/presenter/service_plan_test.go
@@ -70,8 +70,8 @@ var _ = Describe("Service Plan", func() {
 				},
 				CFResource: model.CFResource{
 					GUID:      "resource-guid",
-					CreatedAt: time.UnixMilli(1000),
-					UpdatedAt: tools.PtrTo(time.UnixMilli(2000)),
+					CreatedAt: time.UnixMilli(1000).UTC(),
+					UpdatedAt: tools.PtrTo(time.UnixMilli(2000).UTC()),
 					Metadata: model.Metadata{
 						Labels: map[string]string{
 							"label": "label-foo",


### PR DESCRIPTION
## Is there a related GitHub Issue?
No.

https://cloudfoundry.slack.com/archives/C0297673ASK/p1729171006582719

## What is this change about?

When running unit tests locally, some unit tests were failing on machines with local time != UTC.

Here's an extract (some lines left out):

```
Summarizing 3 Failures:
  [FAIL] Service Offering [It] returns the expected JSON
  .../api/presenter/service_offering_test.go:75
  [FAIL] Service Broker [It] returns the expected JSON
  .../api/presenter/service_broker_test.go:57
  [FAIL] Service Plan ForServicePlan [It] returns the expected JSON
  .../api/presenter/service_plan_test.go:100

expected
  "created_at": "1970-01-01T01:00:01+01:00",
to match JSON of
  "created_at": "1970-01-01T00:00:01Z",
  
  first mismatched key: "created_at"
```


## Does this PR introduce a breaking change?
No.