### PR TITLE
Unpin java and ruby buildpack versions

### DIFF
--- a/helm/korifi/kpack-image-builder/cluster-builder.yaml
+++ b/helm/korifi/kpack-image-builder/cluster-builder.yaml
@@ -5,9 +5,9 @@ metadata:
   name: cf-default-buildpacks
 spec:
   sources:
-  - image: gcr.io/paketo-buildpacks/java:15.0.0
+  - image: gcr.io/paketo-buildpacks/java
   - image: gcr.io/paketo-buildpacks/nodejs
-  - image: gcr.io/paketo-buildpacks/ruby:0.46.1
+  - image: gcr.io/paketo-buildpacks/ruby
   - image: gcr.io/paketo-buildpacks/procfile
   - image: gcr.io/paketo-buildpacks/go
 


### PR DESCRIPTION
## Is there a related GitHub Issue?
#3362
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Unpin java and ruby buildpack versons
<!-- _Please describe the change here._ -->

