### PR TITLE
Retry starting testenv

### DIFF
--- a/tests/helpers/test_env.go
+++ b/tests/helpers/test_env.go
@@ -81,7 +81,10 @@ func StartK8sManager(k8sManager manager.Manager) context.CancelFunc {
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
 		defer GinkgoRecover()
-		Expect(k8sManager.Start(ctx)).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			g.Expect(k8sManager.Start(ctx)).To(Succeed())
+		}).Should(Succeed())
 	}()
 
 	Eventually(func(g Gomega) {


### PR DESCRIPTION
## Is there a related GitHub Issue?
CI flakes
https://ci.korifi.cf-app.com/teams/main/pipelines/main/jobs/run-tests-periodic/builds/19700
https://ci.korifi.cf-app.com/teams/main/pipelines/main/jobs/run-tests-periodic/builds/19695

<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
We have been seeing test env failing to bind to a port quite
frequently, especially that now we are starting test env on every `It`
rather than once per suite.
This change retries starting test env - we hope that this should make
such failures disappear
<!-- _Please describe the change here._ -->
