### PR TITLE
Configure servicebinding.io bindings for managed services

### DIFF
--- a/controllers/api/v1alpha1/cfservicebinding_types.go
+++ b/controllers/api/v1alpha1/cfservicebinding_types.go
@@ -26,6 +26,8 @@ import (
 const (
 	BindingFailedCondition    = "BindingFailed"
 	BindingRequestedCondition = "BindingRequested"
+
+	ServiceInstanceTypeAnnotationKey = "korifi.cloudfoundry.org/service-instance-type"
 )
 
 // CFServiceBindingSpec defines the desired state of CFServiceBinding

--- a/controllers/controllers/services/bindings/controller.go
+++ b/controllers/controllers/services/bindings/controller.go
@@ -154,6 +154,11 @@ func (r *Reconciler) ReconcileResource(ctx context.Context, cfServiceBinding *ko
 	cfServiceBinding.Status.ObservedGeneration = cfServiceBinding.Generation
 	log.V(1).Info("set observed generation", "generation", cfServiceBinding.Status.ObservedGeneration)
 
+	if cfServiceBinding.Annotations == nil {
+		cfServiceBinding.Annotations = map[string]string{}
+	}
+	cfServiceBinding.Annotations[korifiv1alpha1.ServiceInstanceTypeAnnotationKey] = string(cfServiceInstance.Spec.Type)
+
 	err = controllerutil.SetOwnerReference(cfServiceInstance, cfServiceBinding, r.scheme)
 	if err != nil {
 		log.Info("error when making the service instance owner of the service binding", "reason", err)
@@ -216,14 +221,14 @@ func isSbServiceBindingReady(sbServiceBinding *servicebindingv1beta1.ServiceBind
 }
 
 func (r *Reconciler) reconcileSBServiceBinding(ctx context.Context, cfServiceBinding *korifiv1alpha1.CFServiceBinding) (*servicebindingv1beta1.ServiceBinding, error) {
-	credentialsSecret := &corev1.Secret{
+	bindingSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      cfServiceBinding.Name,
+			Name:      cfServiceBinding.Status.Binding.Name,
 			Namespace: cfServiceBinding.Namespace,
 		},
 	}
 
-	err := r.k8sClient.Get(ctx, client.ObjectKeyFromObject(credentialsSecret), credentialsSecret)
+	err := r.k8sClient.Get(ctx, client.ObjectKeyFromObject(bindingSecret), bindingSecret)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get service binding credentials secret %q: %w", cfServiceBinding.Status.Binding.Name, err)
 	}
@@ -233,14 +238,16 @@ func (r *Reconciler) reconcileSBServiceBinding(ctx context.Context, cfServiceBin
 	_, err = controllerutil.CreateOrPatch(ctx, r.k8sClient, sbServiceBinding, func() error {
 		sbServiceBinding.Spec.Name = getSBServiceBindingName(cfServiceBinding)
 
-		secretType, hasType := credentialsSecret.Data["type"]
-		if hasType && len(secretType) > 0 {
-			sbServiceBinding.Spec.Type = string(secretType)
-		}
+		if cfServiceBinding.Annotations[korifiv1alpha1.ServiceInstanceTypeAnnotationKey] == korifiv1alpha1.UserProvidedType {
+			secretType, hasType := bindingSecret.Data["type"]
+			if hasType && len(secretType) > 0 {
+				sbServiceBinding.Spec.Type = string(secretType)
+			}
 
-		secretProvider, hasProvider := credentialsSecret.Data["provider"]
-		if hasProvider {
-			sbServiceBinding.Spec.Provider = string(secretProvider)
+			secretProvider, hasProvider := bindingSecret.Data["provider"]
+			if hasProvider {
+				sbServiceBinding.Spec.Provider = string(secretProvider)
+			}
 		}
 		return controllerutil.SetControllerReference(cfServiceBinding, sbServiceBinding, r.scheme)
 	})
@@ -263,7 +270,7 @@ func (r *Reconciler) toSBServiceBinding(cfServiceBinding *korifiv1alpha1.CFServi
 			},
 		},
 		Spec: servicebindingv1beta1.ServiceBindingSpec{
-			Type: "user-provided",
+			Type: cfServiceBinding.Annotations[korifiv1alpha1.ServiceInstanceTypeAnnotationKey],
 			Workload: servicebindingv1beta1.ServiceBindingWorkloadReference{
 				APIVersion: "apps/v1",
 				Kind:       "StatefulSet",


### PR DESCRIPTION
Also, annotate the `CFServiceBinding` object with the `korifi.cloudfoundry.org/service-instance-type` annotation. This helps for determining the type of the instance it references without looking up the instance.

fixes #3294
