### PR TITLE
Use service instance type for VCAP_SERVICES

### DIFF
--- a/api/repositories/app_repository_test.go
+++ b/api/repositories/app_repository_test.go
@@ -1363,7 +1363,7 @@ func generateVcapServiceSecretDataByte() (map[string][]byte, error) {
 	}
 
 	vcapServicesData, err := json.Marshal(env.VCAPServices{
-		env.UserProvided: []env.ServiceDetails{
+		"user-provided": []env.ServiceDetails{
 			serviceDetails,
 		},
 	})

--- a/controllers/api/v1alpha1/cfserviceinstance_types.go
+++ b/controllers/api/v1alpha1/cfserviceinstance_types.go
@@ -47,7 +47,8 @@ type CFServiceInstanceSpec struct {
 	Type InstanceType `json:"type"`
 
 	// Service label to use when adding this instance to VCAP_SERVICES. If not
-	// set, the service instance Type would be used.
+	// set, the service instance Type would be used. For managed services the
+	// value is defaulted to the offering name
 	// +optional
 	ServiceLabel *string `json:"serviceLabel,omitempty"`
 

--- a/controllers/api/v1alpha1/cfserviceinstance_types.go
+++ b/controllers/api/v1alpha1/cfserviceinstance_types.go
@@ -46,8 +46,8 @@ type CFServiceInstanceSpec struct {
 	// Type of the Service Instance. Must be `user-provided` or `managed`
 	Type InstanceType `json:"type"`
 
-	// Service label to use when adding this instance to VCAP_Services
-	// Defaults to `user-provided` when this field is not set
+	// Service label to use when adding this instance to VCAP_SERVICES. If not
+	// set, the service instance Type would be used.
 	// +optional
 	ServiceLabel *string `json:"serviceLabel,omitempty"`
 

--- a/controllers/controllers/services/instances/managed/controller.go
+++ b/controllers/controllers/services/instances/managed/controller.go
@@ -24,6 +24,7 @@ import (
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"code.cloudfoundry.org/korifi/controllers/controllers/services/osbapi"
+	"code.cloudfoundry.org/korifi/tools"
 	"code.cloudfoundry.org/korifi/tools/k8s"
 
 	"github.com/go-logr/logr"
@@ -119,6 +120,10 @@ func (r *Reconciler) ReconcileResource(ctx context.Context, serviceInstance *kor
 	if err != nil {
 		log.Error(err, "failed to get service offering")
 		return ctrl.Result{}, err
+	}
+
+	if serviceInstance.Spec.ServiceLabel == nil {
+		serviceInstance.Spec.ServiceLabel = tools.PtrTo(serviceOffering.Spec.Name)
 	}
 
 	osbapiClient, err := r.osbapiClientFactory.CreateClient(ctx, serviceBroker)

--- a/controllers/controllers/services/instances/managed/suite_test.go
+++ b/controllers/controllers/services/instances/managed/suite_test.go
@@ -56,6 +56,8 @@ var (
 func TestAPIs(t *testing.T) {
 	SetDefaultEventuallyTimeout(30 * time.Second)
 	SetDefaultEventuallyPollingInterval(250 * time.Millisecond)
+	SetDefaultConsistentlyDuration(5 * time.Second)
+	SetDefaultConsistentlyPollingInterval(250 * time.Millisecond)
 
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Services Instance Controller Integration Suite")

--- a/controllers/controllers/workloads/env/vcap_services_builder.go
+++ b/controllers/controllers/workloads/env/vcap_services_builder.go
@@ -15,8 +15,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const UserProvided = "user-provided"
-
 type VCAPServicesEnvValueBuilder struct {
 	k8sClient client.Client
 }
@@ -71,7 +69,7 @@ func buildSingleServiceEnv(ctx context.Context, k8sClient client.Client, service
 		return ServiceDetails{}, "", fmt.Errorf("credentials secret name not set for service binding %q", serviceBinding.Name)
 	}
 
-	serviceLabel := UserProvided
+	serviceLabel := serviceBinding.Annotations[korifiv1alpha1.ServiceInstanceTypeAnnotationKey]
 
 	serviceInstance := korifiv1alpha1.CFServiceInstance{}
 	err := k8sClient.Get(ctx, types.NamespacedName{Namespace: serviceBinding.Namespace, Name: serviceBinding.Spec.Service.Name}, &serviceInstance)

--- a/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfserviceinstances.yaml
+++ b/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfserviceinstances.yaml
@@ -62,7 +62,8 @@ spec:
               serviceLabel:
                 description: |-
                   Service label to use when adding this instance to VCAP_SERVICES. If not
-                  set, the service instance Type would be used.
+                  set, the service instance Type would be used. For managed services the
+                  value is defaulted to the offering name
                 type: string
               tags:
                 description: Tags are used by apps to identify service instances

--- a/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfserviceinstances.yaml
+++ b/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfserviceinstances.yaml
@@ -61,8 +61,8 @@ spec:
                 type: string
               serviceLabel:
                 description: |-
-                  Service label to use when adding this instance to VCAP_Services
-                  Defaults to `user-provided` when this field is not set
+                  Service label to use when adding this instance to VCAP_SERVICES. If not
+                  set, the service instance Type would be used.
                 type: string
               tags:
                 description: Tags are used by apps to identify service instances


### PR DESCRIPTION
Service bindings in `VCAP_SERVICES` are by default grouped within a key that matches their instance type (`user-provided` or `managed`)

fixes #3295

