### PR TITLE
Support floating point number values for disk_quota and memory

### DIFF
--- a/api/payloads/manifest.go
+++ b/api/payloads/manifest.go
@@ -256,7 +256,7 @@ func (s ManifestApplicationService) Validate() error {
 	return validation.ValidateStruct(&s, validation.Field(&s.Name, validation.Required))
 }
 
-var unitAmount = regexp.MustCompile(`^\d+(?:B|K|KB|M|m|MB|mb|G|g|GB|gb|T|t|TB|tb)$`)
+var unitAmount = regexp.MustCompile(`^\d+(?:\.\d+)?(?:B|K|KB|M|m|MB|mb|G|g|GB|gb|T|t|TB|tb)$`)
 
 func validateAmountWithUnit(value any) error {
 	v, isNil := validation.Indirect(value)

--- a/api/payloads/manifest_test.go
+++ b/api/payloads/manifest_test.go
@@ -123,6 +123,16 @@ var _ = Describe("Manifest payload", func() {
 				})
 			})
 
+			When("the disk quota is a floating point number", func() {
+				BeforeEach(func() {
+					testManifest.DiskQuota = tools.PtrTo("1.5G")
+				})
+
+				It("does not return a validation error", func() {
+					Expect(validateErr).NotTo(HaveOccurred())
+				})
+			})
+
 			When("the alt disk quota doesn't supply a unit", func() {
 				BeforeEach(func() {
 					testManifest.AltDiskQuota = tools.PtrTo("1024")
@@ -201,6 +211,16 @@ var _ = Describe("Manifest payload", func() {
 
 				It("returns a validation error", func() {
 					expectUnprocessableEntityError(validateErr, "memory must be greater than 0MB")
+				})
+			})
+
+			When("the memory is a floating point number", func() {
+				BeforeEach(func() {
+					testManifest.Memory = tools.PtrTo("0.5G")
+				})
+
+				It("does not return a validation error", func() {
+					Expect(validateErr).NotTo(HaveOccurred())
 				})
 			})
 
@@ -436,6 +456,16 @@ var _ = Describe("Manifest payload", func() {
 				})
 			})
 
+			When("the disk quota is a floating point number", func() {
+				BeforeEach(func() {
+					testManifestProcess.DiskQuota = tools.PtrTo("1.5G")
+				})
+
+				It("does not return a validation error", func() {
+					Expect(validateErr).NotTo(HaveOccurred())
+				})
+			})
+
 			When("the alt disk quota doesn't supply a unit", func() {
 				BeforeEach(func() {
 					testManifestProcess.AltDiskQuota = tools.PtrTo("1024")
@@ -514,6 +544,16 @@ var _ = Describe("Manifest payload", func() {
 
 				It("returns a validation error", func() {
 					expectUnprocessableEntityError(validateErr, "memory must be greater than 0MB")
+				})
+			})
+
+			When("the memory is a floating point number", func() {
+				BeforeEach(func() {
+					testManifestProcess.Memory = tools.PtrTo("0.5G")
+				})
+
+				It("does not return a validation error", func() {
+					Expect(validateErr).NotTo(HaveOccurred())
 				})
 			})
 


### PR DESCRIPTION
## Is there a related GitHub Issue?
#3546

## What is this change about?
disk_quota can be a floating point number under CF for VMs.

I've looked up cloudcontroller_ng and found
https://github.com/cloudfoundry/cloud_controller_ng/blob/9a1dcf1faf466aa286d4372623b6e75ad7d2ce1b/lib/cloud_controller/app_manifest/byte_converter.rb#L11
and tried to apply it to the current validation we have in Korifi.

I checked whether I could add some positive test cases (that 1.5G gets successfully accepted), but could not find any existing test cases so far and how it could be done with the current code setup.

Nevertheless, I've checked locally with kind to push an app with 1.5 GB disk_quota and 0.5G memory and it was successfully translated to the corresponding resources.

```diff
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,7 @@
 ---
 applications:
   - name: test-app
-    memory: 256M
+    memory: 0.5G
     instances: 1
     random-route: true
+    disk_quota: 1.5G
```

```json
                "resources": {
                    "limits": {
                        "ephemeral-storage": "1536Mi",
                        "memory": "512Mi"
                    },
                    "requests": {
                        "cpu": "50m",
                        "ephemeral-storage": "1536Mi",
                        "memory": "512Mi"
                    }
                }
```

## Does this PR introduce a breaking change?
No.

## Acceptance Steps
Try to push apps with disk_quota and memory set to floating point numbers.