### PR TITLE
Remove watching of the CFApp resource

### DIFF
--- a/controllers/controllers/services/bindings/controller.go
+++ b/controllers/controllers/services/bindings/controller.go
@@ -81,10 +81,6 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) *builder.Builder {
 		Watches(
 			&korifiv1alpha1.CFServiceInstance{},
 			handler.EnqueueRequestsFromMapFunc(r.serviceInstanceToServiceBindings),
-		).
-		Watches(
-			&korifiv1alpha1.CFApp{},
-			handler.EnqueueRequestsFromMapFunc(r.appToServiceBindings),
 		)
 }
 
@@ -95,31 +91,6 @@ func (r *Reconciler) serviceInstanceToServiceBindings(ctx context.Context, o cli
 	if err := r.k8sClient.List(ctx, &serviceBindings,
 		client.InNamespace(serviceInstance.Namespace),
 		client.MatchingFields{shared.IndexServiceBindingServiceInstanceGUID: serviceInstance.Name},
-	); err != nil {
-		return []reconcile.Request{}
-	}
-
-	requests := []reconcile.Request{}
-	for _, sb := range serviceBindings.Items {
-		requests = append(requests, reconcile.Request{
-			NamespacedName: types.NamespacedName{
-				Name:      sb.Name,
-				Namespace: sb.Namespace,
-			},
-		})
-	}
-
-	return requests
-}
-
-func (r *Reconciler) appToServiceBindings(ctx context.Context, o client.Object) []reconcile.Request {
-	cfApp := o.(*korifiv1alpha1.CFApp)
-
-	serviceBindings := &korifiv1alpha1.CFServiceBindingList{}
-
-	if err := r.k8sClient.List(ctx, serviceBindings,
-		client.InNamespace(cfApp.Namespace),
-		client.MatchingFields{shared.IndexServiceBindingAppGUID: cfApp.Name},
 	); err != nil {
 		return []reconcile.Request{}
 	}
@@ -172,13 +143,6 @@ func (r *Reconciler) ReconcileResource(ctx context.Context, cfServiceBinding *ko
 			log.Error(err, "failed to reconcile binding credentials")
 		}
 		return res, err
-	}
-
-	cfApp := new(korifiv1alpha1.CFApp)
-	err = r.k8sClient.Get(ctx, types.NamespacedName{Name: cfServiceBinding.Spec.AppRef.Name, Namespace: cfServiceBinding.Namespace}, cfApp)
-	if err != nil {
-		log.Info("error when fetching CFApp", "reason", err)
-		return ctrl.Result{}, err
 	}
 
 	sbServiceBinding, err := r.reconcileSBServiceBinding(ctx, cfServiceBinding)


### PR DESCRIPTION
The binding controller does not get any data from the CFApp, therefore watching CFApps does not make sense. The only reason we had the watch is to make the binding not ready when the app is gone. In an ideal world however this is not a valid state, as app finalization [deletes all bindings for the app](https://github.com/cloudfoundry/korifi/blob/df9925de6b12eeb51cc05d3dd70019250b8e0175/controllers/controllers/workloads/apps/controller.go#L364-L386)

fixes #3527


