### PR TITLE
Improve logic for cleaning up of service resources

### DIFF
--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"code.cloudfoundry.org/korifi/tests/helpers"
-	"code.cloudfoundry.org/korifi/tests/helpers/broker"
 	"code.cloudfoundry.org/korifi/tests/helpers/fail_handler"
 
 	"code.cloudfoundry.org/go-loggregator/v8/rpc/loggregator_v2"
@@ -1227,12 +1226,6 @@ func createBroker(brokerURL string) string {
 	}
 
 	return brokerGUID
-}
-
-func cleanupBroker(brokerGUID string) {
-	GinkgoHelper()
-
-	broker.NewCatalogDeleter(rootNamespace).ForBrokerGUID(brokerGUID).Delete()
 }
 
 func expectJobCompletes(resp *resty.Response) {

--- a/tests/e2e/service_bindings_test.go
+++ b/tests/e2e/service_bindings_test.go
@@ -3,6 +3,7 @@ package e2e_test
 import (
 	"net/http"
 
+	"code.cloudfoundry.org/korifi/tests/helpers/broker"
 	"github.com/go-resty/resty/v2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -54,13 +55,15 @@ var _ = Describe("Service Bindings", func() {
 		})
 
 		When("binding to a managed service instance", func() {
-			BeforeEach(func() {
-				brokerGUID := createBroker(serviceBrokerURL)
-				DeferCleanup(func() {
-					cleanupBroker(brokerGUID)
-				})
+			var brokerGUID string
 
+			BeforeEach(func() {
+				brokerGUID = createBroker(serviceBrokerURL)
 				instanceGUID = createManagedServiceInstance(brokerGUID, spaceGUID)
+			})
+
+			AfterEach(func() {
+				broker.NewCatalogDeleter(rootNamespace).ForBrokerGUID(brokerGUID).Delete()
 			})
 
 			It("succeeds with a job redirect", func() {
@@ -112,14 +115,17 @@ var _ = Describe("Service Bindings", func() {
 		})
 
 		When("bound to a managed service instance", func() {
+			var brokerGUID string
+
 			BeforeEach(func() {
-				brokerGUID := createBroker(serviceBrokerURL)
-				DeferCleanup(func() {
-					cleanupBroker(brokerGUID)
-				})
+				brokerGUID = createBroker(serviceBrokerURL)
 
 				instanceGUID := createManagedServiceInstance(brokerGUID, spaceGUID)
 				bindingGUID = createManagedServiceBinding(appGUID, instanceGUID, "")
+			})
+
+			AfterEach(func() {
+				broker.NewCatalogDeleter(rootNamespace).ForBrokerGUID(brokerGUID).Delete()
 			})
 
 			It("succeeds with a job redirect", func() {

--- a/tests/e2e/service_brokers_test.go
+++ b/tests/e2e/service_brokers_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
+	"code.cloudfoundry.org/korifi/tests/helpers/broker"
 	"github.com/go-resty/resty/v2"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
@@ -50,7 +51,7 @@ var _ = Describe("Service Brokers", func() {
 			jobURLSplit := strings.Split(jobURL, "~")
 			Expect(jobURLSplit).To(HaveLen(2))
 			DeferCleanup(func() {
-				cleanupBroker(jobURLSplit[1])
+				broker.NewCatalogDeleter(rootNamespace).ForBrokerGUID(jobURLSplit[1]).Delete()
 			})
 		})
 	})
@@ -63,10 +64,10 @@ var _ = Describe("Service Brokers", func() {
 
 		BeforeEach(func() {
 			brokerGUID = createBroker(serviceBrokerURL)
+		})
 
-			DeferCleanup(func() {
-				cleanupBroker(brokerGUID)
-			})
+		AfterEach(func() {
+			broker.NewCatalogDeleter(rootNamespace).ForBrokerGUID(brokerGUID).Delete()
 		})
 
 		JustBeforeEach(func() {
@@ -97,7 +98,7 @@ var _ = Describe("Service Brokers", func() {
 		})
 
 		AfterEach(func() {
-			cleanupBroker(brokerGUID)
+			broker.NewCatalogDeleter(rootNamespace).ForBrokerGUID(brokerGUID).Delete()
 		})
 
 		JustBeforeEach(func() {
@@ -140,7 +141,7 @@ var _ = Describe("Service Brokers", func() {
 		})
 
 		AfterEach(func() {
-			cleanupBroker(brokerGUID)
+			broker.NewCatalogDeleter(rootNamespace).ForBrokerGUID(brokerGUID).Delete()
 		})
 
 		JustBeforeEach(func() {

--- a/tests/e2e/service_offerings_test.go
+++ b/tests/e2e/service_offerings_test.go
@@ -3,6 +3,7 @@ package e2e_test
 import (
 	"net/http"
 
+	"code.cloudfoundry.org/korifi/tests/helpers/broker"
 	"github.com/go-resty/resty/v2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -20,7 +21,7 @@ var _ = Describe("Service Offerings", func() {
 	})
 
 	AfterEach(func() {
-		cleanupBroker(brokerGUID)
+		broker.NewCatalogDeleter(rootNamespace).ForBrokerGUID(brokerGUID).Delete()
 	})
 
 	Describe("List", func() {

--- a/tests/e2e/service_plans_test.go
+++ b/tests/e2e/service_plans_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
+	"code.cloudfoundry.org/korifi/tests/helpers/broker"
 	"github.com/BooleanCat/go-functional/v2/it/itx"
 	"github.com/go-resty/resty/v2"
 	. "github.com/onsi/ginkgo/v2"
@@ -23,7 +24,7 @@ var _ = Describe("Service Plans", func() {
 	})
 
 	AfterEach(func() {
-		cleanupBroker(brokerGUID)
+		broker.NewCatalogDeleter(rootNamespace).ForBrokerGUID(brokerGUID).Delete()
 	})
 
 	Describe("List", func() {

--- a/tests/smoke/catalog_test.go
+++ b/tests/smoke/catalog_test.go
@@ -2,6 +2,7 @@ package smoke_test
 
 import (
 	"code.cloudfoundry.org/korifi/tests/helpers"
+	"code.cloudfoundry.org/korifi/tests/helpers/broker"
 
 	"github.com/BooleanCat/go-functional/v2/it"
 	"github.com/google/uuid"
@@ -25,7 +26,7 @@ var _ = Describe("Service Catalog", func() {
 	})
 
 	AfterEach(func() {
-		cleanupBroker(brokerName)
+		broker.NewCatalogDeleter(sharedData.RootNamespace).ForBrokerName(brokerName).Delete()
 	})
 
 	Describe("cf service-brokers", func() {

--- a/tests/smoke/services_test.go
+++ b/tests/smoke/services_test.go
@@ -2,6 +2,7 @@ package smoke_test
 
 import (
 	"code.cloudfoundry.org/korifi/tests/helpers"
+	"code.cloudfoundry.org/korifi/tests/helpers/broker"
 
 	"github.com/BooleanCat/go-functional/v2/it"
 	"github.com/google/uuid"
@@ -26,7 +27,7 @@ var _ = Describe("Services", func() {
 	})
 
 	AfterEach(func() {
-		cleanupBroker(brokerName)
+		broker.NewCatalogDeleter(sharedData.RootNamespace).ForBrokerName(brokerName).Delete()
 	})
 
 	Describe("cf create-service", func() {

--- a/tests/smoke/suite_test.go
+++ b/tests/smoke/suite_test.go
@@ -11,7 +11,6 @@ import (
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"code.cloudfoundry.org/korifi/tests/helpers"
-	"code.cloudfoundry.org/korifi/tests/helpers/broker"
 	"code.cloudfoundry.org/korifi/tests/helpers/fail_handler"
 
 	"github.com/google/uuid"
@@ -191,12 +190,6 @@ func getAppGUID(appName string) string {
 	session := helpers.Cf("app", appName, "--guid")
 	Expect(session).To(Exit(0))
 	return string(session.Out.Contents())
-}
-
-func cleanupBroker(brokerName string) {
-	GinkgoHelper()
-
-	broker.NewCatalogDeleter(sharedData.RootNamespace).ForBrokerName(brokerName).Delete()
 }
 
 func matchSubstrings(substrings ...string) types.GomegaMatcher {


### PR DESCRIPTION

<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?

Leaked service instances and bindings have caused some problems to CI
clusters, since they have finalizers and prevent the namespaces in which
they are created to go away. Resolving this problem requres manual
intervention. This commit makes the logic retry until no binding or
instances are left for each service plan of the related broker
<!-- _Please describe the change here._ -->

