### PR TITLE
Do not fail service instance on broker server error

### DIFF
--- a/controllers/controllers/services/osbapi/client.go
+++ b/controllers/controllers/services/osbapi/client.go
@@ -26,19 +26,27 @@ func (c ConflictError) Error() string {
 	return "The service binding already exists"
 }
 
+type UnrecoverableError struct {
+	Status int
+}
+
+func (c UnrecoverableError) Error() string {
+	return fmt.Sprintf("The server responded with status: %d", c.Status)
+}
+
 func IgnoreGone(err error) error {
-	if IsGone(err) {
+	if errors.As(err, &GoneError{}) {
 		return nil
 	}
 	return err
 }
 
-func IsGone(err error) bool {
+func IsUnrecoveralbeError(err error) bool {
 	if err == nil {
 		return false
 	}
 
-	return errors.As(err, &GoneError{})
+	return errors.As(err, &UnrecoverableError{})
 }
 
 type Client struct {
@@ -87,6 +95,9 @@ func (c *Client) Provision(ctx context.Context, payload InstanceProvisionPayload
 		)
 	if err != nil {
 		return ServiceInstanceOperationResponse{}, fmt.Errorf("provision request failed: %w", err)
+	}
+	if statusCode == http.StatusBadRequest || statusCode == http.StatusConflict || statusCode == http.StatusUnprocessableEntity {
+		return ServiceInstanceOperationResponse{}, UnrecoverableError{Status: statusCode}
 	}
 
 	if statusCode >= 300 {

--- a/controllers/controllers/services/osbapi/client_test.go
+++ b/controllers/controllers/services/osbapi/client_test.go
@@ -205,9 +205,39 @@ var _ = Describe("OSBAPI Client", func() {
 				})
 			})
 
+			When("the provision request fails with 400 BadRequest error", func() {
+				BeforeEach(func() {
+					brokerServer = brokerServer.WithResponse("/v2/service_instances/{id}", nil, http.StatusBadRequest)
+				})
+
+				It("returns an unrecoverable error", func() {
+					Expect(provisionErr).To(Equal(osbapi.UnrecoverableError{Status: http.StatusBadRequest}))
+				})
+			})
+
+			When("the provision request fails with 409 Conflict error", func() {
+				BeforeEach(func() {
+					brokerServer = brokerServer.WithResponse("/v2/service_instances/{id}", nil, http.StatusConflict)
+				})
+
+				It("returns an unrecoverable error", func() {
+					Expect(provisionErr).To(Equal(osbapi.UnrecoverableError{Status: http.StatusConflict}))
+				})
+			})
+
+			When("the provision request fails with 422 Unprocessable entity error", func() {
+				BeforeEach(func() {
+					brokerServer = brokerServer.WithResponse("/v2/service_instances/{id}", nil, http.StatusUnprocessableEntity)
+				})
+
+				It("returns an unrecoverable error", func() {
+					Expect(provisionErr).To(Equal(osbapi.UnrecoverableError{Status: http.StatusUnprocessableEntity}))
+				})
+			})
+
 			When("the provision request fails", func() {
 				BeforeEach(func() {
-					brokerServer = brokerServer.WithResponse("/v2/service_instances/{id}", nil, http.StatusTeapot)
+					brokerServer = brokerServer.WithResponse("/v2/service_instances/{id}", nil, http.StatusInternalServerError)
 				})
 
 				It("returns an error", func() {


### PR DESCRIPTION
## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Do not fail service instance on broker server error

Previously we were setting the ProvisioningFailedCondition to true if
the broker returned error on provision, no matter the error. The problem
with doing this is that the error can be recoverable, such as the
network flaking, but the instance is sent to a state from which it
cannot recover (When the ProvisioningFailedCondition is set the
reconciler gives up early in the reconciliation loop).

This change fixes the problem described above by defining a new
UnrecoverableError type in the osbapi client. The controller would then set the
ProvisioningFailedCondition only if the error it received is an
UnrecoverableError.

According to the OSBAPI spec unrecoverable perovision error codes are
400, 409 and 422.

<!-- _Please describe the change here._ -->

