### PR TITLE
Fix service instance purging

### DIFF
--- a/api/repositories/service_instance_repository.go
+++ b/api/repositories/service_instance_repository.go
@@ -474,16 +474,19 @@ func (r *ServiceInstanceRepo) DeleteServiceInstance(ctx context.Context, authInf
 		},
 	}
 
-	if err := userClient.Get(ctx, client.ObjectKeyFromObject(serviceInstance), serviceInstance); err != nil {
+	if err = userClient.Get(ctx, client.ObjectKeyFromObject(serviceInstance), serviceInstance); err != nil {
 		return ServiceInstanceRecord{}, fmt.Errorf("failed to get service instance: %w", apierrors.FromK8sError(err, ServiceInstanceResourceType))
 	}
 
 	if message.Purge {
-		err := k8s.PatchResource(ctx, userClient, serviceInstance, func() {
+		if err = k8s.PatchResource(ctx, userClient, serviceInstance, func() {
 			controllerutil.RemoveFinalizer(serviceInstance, korifiv1alpha1.CFManagedServiceInstanceFinalizerName)
-		})
-		if err != nil {
+		}); err != nil {
 			return ServiceInstanceRecord{}, fmt.Errorf("failed to remove finalizer for service instance: %s, %w", message.GUID, apierrors.FromK8sError(err, ServiceInstanceResourceType))
+		}
+
+		if err = r.DeleteServiceBindings(ctx, userClient, namespace, message.GUID); err != nil {
+			return ServiceInstanceRecord{}, fmt.Errorf("failed delete related service bindings for instance: %s, %w", message.GUID, apierrors.FromK8sError(err, ServiceBindingResourceType))
 		}
 	}
 
@@ -517,6 +520,28 @@ func (r *ServiceInstanceRepo) GetDeletedAt(ctx context.Context, authInfo authori
 		return nil, err
 	}
 	return serviceInstance.DeletedAt, nil
+}
+
+func (r *ServiceInstanceRepo) DeleteServiceBindings(ctx context.Context, userClient client.WithWatch, namespace, instanceGUID string) error {
+	serviceBindings := new(korifiv1alpha1.CFServiceBindingList)
+	if err := userClient.List(ctx, serviceBindings, client.InNamespace(namespace)); err != nil {
+		return fmt.Errorf("failed to get service bindings: %w", apierrors.FromK8sError(err, ServiceBindingResourceType))
+	}
+
+	filtered := itx.FromSlice(serviceBindings.Items).Filter(func(serviceBinding korifiv1alpha1.CFServiceBinding) bool {
+		return instanceGUID == serviceBinding.Spec.Service.Name
+	}).Collect()
+
+	for _, binding := range filtered {
+		err := k8s.PatchResource(ctx, userClient, &binding, func() {
+			controllerutil.RemoveFinalizer(&binding, korifiv1alpha1.CFServiceBindingFinalizerName)
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func cfServiceInstanceToRecord(cfServiceInstance korifiv1alpha1.CFServiceInstance) ServiceInstanceRecord {


### PR DESCRIPTION
 * Remove the finalizers from all related bindings

<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->
https://github.com/cloudfoundry/korifi/issues/3615

## What is this change about?
<!-- _Please describe the change here._ -->
Previously  the service bindings did not have a finalizer, but now they do. So when purging a service instance, we need to remove them from every related service binding. 

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->
No 

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
