### PR TITLE
Allow skipping CRDs installation

### DIFF
--- a/helm/korifi/templates/components.yaml
+++ b/helm/korifi/templates/components.yaml
@@ -6,7 +6,14 @@
 {{- end }}
 {{- end }}
 
-{{- range $path, $_ := .Files.Glob "controllers/**/*.yaml" }}
+{{- if .Values.crds.include }}
+{{- range $path, $_ := .Files.Glob "controllers/crds/*.yaml" }}
+---
+{{ tpl ($.Files.Get $path) $ctx }}
+{{- end }}
+{{- end }}
+
+{{- range $path, $_ := .Files.Glob "controllers/cf_roles/*.yaml" }}
 ---
 {{ tpl ($.Files.Get $path) $ctx }}
 {{- end }}

--- a/helm/korifi/values.schema.json
+++ b/helm/korifi/values.schema.json
@@ -86,6 +86,16 @@
       },
       "required": ["memoryMB", "diskMB", "buildCacheMB"]
     },
+    "crds": {
+      "type": "object",
+      "required": ["include"],
+      "properties": {
+        "include": {
+          "description": "Install CRDs as part of the Helm installation.",
+          "type": "boolean"
+        }
+      }
+    },
     "api": {
       "properties": {
         "include": {

--- a/helm/korifi/values.yaml
+++ b/helm/korifi/values.yaml
@@ -19,6 +19,9 @@ stagingRequirements:
   diskMB: 0
   buildCacheMB: 2048
 
+crds:
+  include: true
+
 api:
   include: true
 


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

no

## What is this change about?
<!-- _Please describe the change here._ -->

This change adds new value `crds.include` to the chart. When set to `crds.include: false`, no CRDs will be installed as part of the Helm installation. It's a common pattern to manage CRDs separately due to the [Helm limitations](https://helm.sh/docs/topics/charts/#limitations-on-crds)

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

no

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
