### PR TITLE
Experimental UAA support

### DIFF
--- a/README.helm.md
+++ b/README.helm.md
@@ -78,8 +78,11 @@ Here are all the values that can be set for the chart:
 - `eksContainerRegistryRoleARN` (_String_): Amazon Resource Name (ARN) of the IAM role to use to access the ECR registry from an EKS deployed Korifi. Required if containerRegistrySecret not set.
 - `experimental`: Experimental features. No guarantees are provided and breaking/backwards incompatible changes should be expected. These features are not recommended for use in production environments.
   - `managedServices`:
-    - `include` (_Boolean_): Enable managed services support
+    - `enabled` (_Boolean_): Enable managed services support
     - `trustInsecureBrokers` (_Boolean_): Disable service broker certificate validation. Not recommended to be set to 'true' in production environments
+  - `uaa`:
+    - `enabled` (_Boolean_): Enable UAA support
+    - `url` (_String_): The url of a UAA instance
 - `generateIngressCertificates` (_Boolean_): Use `cert-manager` to generate self-signed certificates for the API and app endpoints.
 - `helm`:
   - `hooksImage` (_String_): Image for the helm hooks containing kubectl

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -48,7 +48,21 @@ type (
 		AuthProxyCACert string        `yaml:"authProxyCACert"`
 		LogLevel        zapcore.Level `yaml:"logLevel"`
 
-		ExperimentalManagedServicesEnabled bool `yaml:"experimentalManagedServicesEnabled"`
+		Experimental Experimental `yaml:"experimental"`
+	}
+
+	Experimental struct {
+		ManagedServices ManagedServices `yaml:"managedServices"`
+		UAA             UAA             `yaml:"uaa"`
+	}
+
+	ManagedServices struct {
+		Enabled bool `yaml:"enabled"`
+	}
+
+	UAA struct {
+		Enabled bool   `yaml:"enabled"`
+		URL     string `yaml:"url"`
 	}
 
 	RoleLevel string

--- a/api/config/config_test.go
+++ b/api/config/config_test.go
@@ -46,7 +46,11 @@ var _ = Describe("Config", func() {
 				Stack:           "lc-stack",
 				StagingMemoryMB: 10,
 			},
-			"experimentalManagedServicesEnabled": true,
+			"experimental": map[string]any{
+				"managedServices": map[string]any{
+					"enabled": true,
+				},
+			},
 		}
 	})
 
@@ -89,7 +93,7 @@ var _ = Describe("Config", func() {
 			StagingMemoryMB: 10,
 		}))
 		Expect(cfg.ContainerRegistryType).To(BeEmpty())
-		Expect(cfg.ExperimentalManagedServicesEnabled).To(BeTrue())
+		Expect(cfg.Experimental.ManagedServices.Enabled).To(BeTrue())
 	})
 
 	When("the FQDN is not specified", func() {

--- a/api/handlers/root.go
+++ b/api/handlers/root.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/url"
 
+	"code.cloudfoundry.org/korifi/api/config"
 	"code.cloudfoundry.org/korifi/api/presenter"
 	"code.cloudfoundry.org/korifi/api/routing"
 )
@@ -13,17 +14,19 @@ const (
 )
 
 type Root struct {
-	baseURL url.URL
+	baseURL   url.URL
+	uaaConfig config.UAA
 }
 
-func NewRoot(baseURL url.URL) *Root {
+func NewRoot(baseURL url.URL, uaaConfig config.UAA) *Root {
 	return &Root{
-		baseURL: baseURL,
+		baseURL:   baseURL,
+		uaaConfig: uaaConfig,
 	}
 }
 
 func (h *Root) get(r *http.Request) (*routing.Response, error) {
-	return routing.NewResponse(http.StatusOK).WithBody(presenter.ForRoot(h.baseURL)), nil
+	return routing.NewResponse(http.StatusOK).WithBody(presenter.ForRoot(h.baseURL, h.uaaConfig)), nil
 }
 
 func (h *Root) UnauthenticatedRoutes() []routing.Route {

--- a/api/handlers/root_test.go
+++ b/api/handlers/root_test.go
@@ -3,6 +3,7 @@ package handlers_test
 import (
 	"net/http"
 
+	"code.cloudfoundry.org/korifi/api/config"
 	"code.cloudfoundry.org/korifi/api/handlers"
 	. "code.cloudfoundry.org/korifi/tests/matchers"
 
@@ -11,14 +12,17 @@ import (
 )
 
 var _ = Describe("Root", func() {
-	var req *http.Request
+	var (
+		apiHandler *handlers.Root
+		req        *http.Request
+	)
 
 	BeforeEach(func() {
-		apiHandler := handlers.NewRoot(*serverURL)
-		routerBuilder.LoadRoutes(apiHandler)
+		apiHandler = handlers.NewRoot(*serverURL, config.UAA{})
 	})
 
 	JustBeforeEach(func() {
+		routerBuilder.LoadRoutes(apiHandler)
 		routerBuilder.Build().ServeHTTP(rr, req)
 	})
 
@@ -34,9 +38,29 @@ var _ = Describe("Root", func() {
 			Expect(rr).To(HaveHTTPHeaderWithValue("Content-Type", "application/json"))
 
 			Expect(rr).To(HaveHTTPBody(SatisfyAll(
+				MatchJSONPath("$.cf_on_k8s", true),
 				MatchJSONPath("$.links.self.href", "https://api.example.org"),
 				MatchJSONPath("$.links.cloud_controller_v3.href", "https://api.example.org/v3"),
 			)))
+		})
+
+		When("UAA support is enabled", func() {
+			BeforeEach(func() {
+				apiHandler = handlers.NewRoot(*serverURL, config.UAA{
+					Enabled: true,
+					URL:     "https://my.uaa",
+				})
+			})
+
+			It("returns the uaa config", func() {
+				Expect(rr).To(HaveHTTPStatus(http.StatusOK))
+
+				Expect(rr).To(HaveHTTPBody(SatisfyAll(
+					MatchJSONPath("$.cf_on_k8s", false),
+					MatchJSONPath("$.links.uaa.href", "https://my.uaa"),
+					MatchJSONPath("$.links.login.href", "https://my.uaa"),
+				)))
+			})
 		})
 	})
 })

--- a/api/main.go
+++ b/api/main.go
@@ -266,7 +266,7 @@ func main() {
 		chiMiddlewares.StripSlashes,
 	)
 
-	if !cfg.ExperimentalManagedServicesEnabled {
+	if !cfg.Experimental.ManagedServices.Enabled {
 		routerBuilder.UseMiddleware(middleware.DisableManagedServices)
 	}
 
@@ -292,7 +292,7 @@ func main() {
 
 	apiHandlers := []routing.Routable{
 		handlers.NewRootV3(*serverURL),
-		handlers.NewRoot(*serverURL),
+		handlers.NewRoot(*serverURL, cfg.Experimental.UAA),
 		handlers.NewInfoV3(
 			*serverURL,
 			cfg.InfoConfig,

--- a/api/payloads/role_test.go
+++ b/api/payloads/role_test.go
@@ -92,12 +92,27 @@ var _ = Describe("RoleCreate", func() {
 	})
 
 	Context("ToMessage()", func() {
+		var msg repositories.CreateRoleMessage
+
+		JustBeforeEach(func() {
+			msg = roleCreate.ToMessage()
+		})
+
 		It("converts to repo message correctly", func() {
-			msg := roleCreate.ToMessage()
 			Expect(msg.Type).To(Equal("space_manager"))
 			Expect(msg.Space).To(Equal("cf-space-guid"))
 			Expect(msg.User).To(Equal("cf-service-account"))
 			Expect(msg.Kind).To(Equal(rbacv1.UserKind))
+		})
+
+		When("user origin is specified", func() {
+			BeforeEach(func() {
+				createPayload.Relationships.User.Data.Origin = "my-origin"
+			})
+
+			It("uses the origin in the message user", func() {
+				Expect(msg.User).To(Equal("my-origin:cf-service-account"))
+			})
 		})
 	})
 

--- a/api/presenter/root.go
+++ b/api/presenter/root.go
@@ -1,6 +1,10 @@
 package presenter
 
-import "net/url"
+import (
+	"net/url"
+
+	"code.cloudfoundry.org/korifi/api/config"
+)
 
 type APILink struct {
 	Link
@@ -18,8 +22,8 @@ type RootResponse struct {
 
 const V3APIVersion = "3.117.0+cf-k8s"
 
-func ForRoot(baseURL url.URL) RootResponse {
-	return RootResponse{
+func ForRoot(baseURL url.URL, uaaConfig config.UAA) RootResponse {
+	rootResponse := RootResponse{
 		Links: map[string]*APILink{
 			"self": {
 				Link: Link{
@@ -57,6 +61,22 @@ func ForRoot(baseURL url.URL) RootResponse {
 		},
 		CFOnK8s: true,
 	}
+
+	if uaaConfig.Enabled {
+		rootResponse.CFOnK8s = false
+		rootResponse.Links["uaa"] = &APILink{
+			Link: Link{
+				HRef: uaaConfig.URL,
+			},
+		}
+		rootResponse.Links["login"] = &APILink{
+			Link: Link{
+				HRef: uaaConfig.URL,
+			},
+		}
+	}
+
+	return rootResponse
 }
 
 type RootV3Response struct {

--- a/helm/korifi/api/configmap.yaml
+++ b/helm/korifi/api/configmap.yaml
@@ -53,7 +53,12 @@ data:
     {{- if .Values.eksContainerRegistryRoleARN }}
     containerRegistryType: "ECR"
     {{- end }}
-    experimentalManagedServicesEnabled: {{ .Values.experimental.managedServices.enabled }}
+    experimental:
+      managedServices:
+        enabled: {{ .Values.experimental.managedServices.enabled }}
+      uaa:
+        enabled: {{ .Values.experimental.uaa.enabled }}
+        url: {{ .Values.experimental.uaa.url }}
   role_mappings_config.yaml: |
     roleMappings:
       admin:

--- a/helm/korifi/values.schema.json
+++ b/helm/korifi/values.schema.json
@@ -613,13 +613,26 @@
       "properties": {
         "managedServices": {
           "properties": {
-            "include": {
+            "enabled": {
               "description": "Enable managed services support",
               "type": "boolean"
             },
             "trustInsecureBrokers": {
               "description": "Disable service broker certificate validation. Not recommended to be set to 'true' in production environments",
               "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "uaa": {
+          "properties": {
+            "enabled": {
+              "description": "Enable UAA support",
+              "type": "boolean"
+            },
+            "url": {
+              "description": "The url of a UAA instance",
+              "type": "string"
             }
           },
           "type": "object"

--- a/helm/korifi/values.yaml
+++ b/helm/korifi/values.yaml
@@ -148,3 +148,6 @@ experimental:
   managedServices:
     enabled: false
     trustInsecureBrokers: false
+  uaa:
+    enabled: false
+    url: ""


### PR DESCRIPTION
## Is there a related GitHub Issue?
#2243
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
* New experimental helm values to configure UAA
* The configured uaa url will be returned by the `/` endpoint
* When UAA support is enabled `cf_on_k8s` in the `/` endpoint is false
* This will make `cf login` talks to the configured UAA instead of
  reading the kubeconfig
* Note that the cluster should be configured to trust the UAA via
  [oidc](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#configuring-the-api-server)
<!-- _Please describe the change here._ -->

