### PR TITLE
Check if OpenSSL is availabile

### DIFF
--- a/scripts/create-new-user.sh
+++ b/scripts/create-new-user.sh
@@ -11,6 +11,12 @@ createCert() {
   trap "rm -f $csr_file" EXIT
   csr_name="$(echo ${RANDOM} | shasum | head -c 40)"
 
+  # Check if openssl is available
+  if ! command -v openssl &>/dev/null; then
+    echo "Error: 'openssl' is not installed or not available in PATH." >&2
+    exit 1
+  fi
+  
   openssl req -new -newkey rsa:4096 \
     -keyout "${priv_key_file}" \
     -out "${csr_file}" \


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
This change adds a check for the availability of the `openssl` command in the `createCert` function.
If `openssl` is not installed or not available in the system's PATH, the script will print an error message and exit with a non-zero status.

The [Korifi installation guide](https://tutorials.cloudfoundry.org/korifi/local-install/) does not list openssl as a prerequisite. 

While running the `deploy-on-kind.sh` script, I encountered an issue where the script silently failed during certificate creation. Instead of an informative error message, the output was misleading:

```bash
./deploy-on-kind.sh korifi
make: Entering directory '/home/user/repos/korifi'
make: 'bin/yq' is up to date.
make: Leaving directory '/home/user/repos/korifi'
None of $DOCKER_SERVER $DOCKER_USERNAME $DOCKER_PASSWORD $REPOSITORY_PREFIX $KPACK_BUILDER_REPOSITORY are set. Assuming local registry.
Set kubectl context to "kind-korifi"
"twuni" already exists with the same configuration, skipping
Release "localregistry" has been upgraded. Happy Helming!
NAME: localregistry
LAST DEPLOYED: Tue Dec 10 10:53:56 2024
NAMESPACE: default
STATUS: deployed
REVISION: 13
TEST SUITE: None
NOTES:
1. Get the application URL by running these commands:
  export NODE_PORT=$(kubectl get --namespace default -o jsonpath="{.spec.ports[0].nodePort}" services localregistry-docker-registry)
  export NODE_IP=$(kubectl get nodes --namespace default -o jsonpath="{.items[0].status.addresses[0].address}")
  echo http://$NODE_IP:$NODE_PORT
**************************
 Creating 'cf-admin' user
**************************
```
The script had stopped without any indication of the real issue. 
After significant investigation, I found out that the root cause was the absence of `openssl` on my system. 

The `2>/dev/null` in the `openssl` command suppresses error messages, which could have pointed to the issue earlier.

One alternative solution is to remove the `2>/dev/null` from the `openssl` command. 
So from this 
```bash
 openssl req -new -newkey rsa:4096 \
    -keyout "${priv_key_file}" \
    -out "${csr_file}" \
    -nodes \
    -subj "/CN=${username}" 2>/dev/null
```
to 

```bash
 openssl req -new -newkey rsa:4096 \
    -keyout "${priv_key_file}" \
    -out "${csr_file}" \
    -nodes \
    -subj "/CN=${username}"
```

However, this may have been introduced to suppress non-critical warnings from `openssl`.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
1. Ensure `openssl` is not installed on your system.
2. Run the deployment script: `./deploy-on-kind.sh korifi`
3. Observe that the script exits early with the error message:
`Error: 'openssl' is not installed or not available in PATH.`
4. Install openssl and rerun the script to verify successful execution.