### PR TITLE
Fix zsh compatibility issue with debug flag boolean conversion in helm upgrade

### DIFF
--- a/scripts/deploy-on-kind.sh
+++ b/scripts/deploy-on-kind.sh
@@ -193,7 +193,7 @@ function deploy_korifi() {
       --set=defaultAppDomainName="apps-127-0-0-1.nip.io" \
       --set=generateIngressCertificates="true" \
       --set=logLevel="debug" \
-      --set=debug="$DEBUG" \
+      --set=debug=$([ "$DEBUG" = "true" ] && echo true || echo false) \
       --set=stagingRequirements.buildCacheMB="1024" \
       --set=api.apiServer.url="localhost" \
       --set=controllers.taskTTL="5s" \


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->
No

## What is this change about?
Guarantee a cross-shell solution: `zsh` is more strict about type checking then `bash`.
The `helm upgrade` command fails when using `zsh` because  `debug` variable needs to be a boolean as per this error message

```
Error: UPGRADE FAILED: values don't meet the specifications of the schema(s) in the following chart(s):
korifi:
- debug: Invalid type. Expected: boolean, given: string
```

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->
No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->
Use a `zsh` shell and set up the env vars

```bash
LOCAL_DOCKER_REGISTRY_ADDRESS="localregistry-docker-registry.default.svc.cluster.local:30050"
DOCKER_SERVER="$LOCAL_DOCKER_REGISTRY_ADDRESS"
REPOSITORY_PREFIX="$DOCKER_SERVER/"
KPACK_BUILDER_REPOSITORY="$DOCKER_SERVER/kpack-builder"
DEBUG="false"
```
execute 

```bash
helm upgrade --install korifi helm/korifi \
      --dry-run \
      --namespace korifi \
      --values="$values_file" \
      --set=adminUserName="cf-admin" \
      --set=defaultAppDomainName="apps-127-0-0-1.nip.io" \
      --set=generateIngressCertificates="true" \
      --set=logLevel="debug" \
      --set=debug=$( [ "$DEBUG" == "true" ] && echo true || echo false ) \
      --set=stagingRequirements.buildCacheMB="1024" \
      --set=api.apiServer.url="localhost" \
      --set=controllers.taskTTL="5s" \
      --set=jobTaskRunner.jobTTL="5s" \
      --set=containerRepositoryPrefix="$REPOSITORY_PREFIX" \
      --set=kpackImageBuilder.clusterStackBuildImage="paketobuildpacks/build-jammy-base" \
      --set=kpackImageBuilder.clusterStackRunImage="paketobuildpacks/run-jammy-base" \
      --set=kpackImageBuilder.builderRepository="$KPACK_BUILDER_REPOSITORY" \
      --set=networking.gatewayClass="contour" \
      --set=networking.gatewayPorts.http="32080" \
      --set=networking.gatewayPorts.https="32443" \
      --set=experimental.managedServices.enabled="true" \
      --set=experimental.managedServices.trustInsecureBrokers="true" \
      --wait
```
**Before:**
```bash
Error: UPGRADE FAILED: values don't meet the specifications of the schema(s) in the following chart(s):
korifi:
- debug: Invalid type. Expected: boolean, given: string
```
**After**
It shows rendered Kubernetes manifests.

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
