### PR TITLE
Implement unbind from managed service instance

### DIFF
--- a/controllers/api/v1alpha1/cfservicebinding_types.go
+++ b/controllers/api/v1alpha1/cfservicebinding_types.go
@@ -24,9 +24,9 @@ import (
 )
 
 const (
-	BindingFailedCondition      = "BindingFailed"
-	BindingRequestedCondition   = "BindingRequested"
-	UnbindingRequestedCondition = "UnbindingRequested"
+	BindingFailedCondition = "BindingFailed"
+
+	UnbindingFailedCondition = "UnbindingFailed"
 
 	ServiceInstanceTypeAnnotationKey = "korifi.cloudfoundry.org/service-instance-type"
 	PlanGUIDLabelKey                 = "korifi.cloudfoundry.org/plan-guid"
@@ -56,20 +56,6 @@ type CFServiceBindingStatus struct {
 	// servicebinding.io [spec](https://servicebinding.io/spec/core/1.0.0-rc3/#Duck%20Type)
 	// +optional
 	Binding v1.LocalObjectReference `json:"binding"`
-
-	// The
-	// [operation](https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#binding)
-	// of the bind request to the the OSBAPI broker. Only makes sense for
-	// bindings to managed service instances
-	// +optional
-	BindingOperation string `json:"bindingOperation"`
-
-	// The
-	// [operation](https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#unbinding)
-	// of the unbind request to the the OSBAPI broker. Only makes sense for
-	// bindings to managed service instances
-	// +optional
-	UnbindingOperation string `json:"unbindingOperation"`
 
 	// A reference to the Secret containing the binding Credentials object. For
 	// bindings to user-provided services this refers to the credentials secret

--- a/controllers/controllers/services/instances/managed/controller_test.go
+++ b/controllers/controllers/services/instances/managed/controller_test.go
@@ -38,7 +38,7 @@ var _ = Describe("CFServiceInstance", func() {
 		brokerClient = new(fake.BrokerClient)
 		brokerClientFactory.CreateClientReturns(brokerClient, nil)
 
-		brokerClient.ProvisionReturns(osbapi.ServiceInstanceOperationResponse{
+		brokerClient.ProvisionReturns(osbapi.ProvisionResponse{
 			IsAsync:   true,
 			Operation: "operation-1",
 		}, nil)
@@ -185,9 +185,9 @@ var _ = Describe("CFServiceInstance", func() {
 		Eventually(func(g Gomega) {
 			g.Expect(brokerClient.ProvisionCallCount()).NotTo(BeZero())
 			_, payload := brokerClient.ProvisionArgsForCall(0)
-			g.Expect(payload).To(Equal(osbapi.InstanceProvisionPayload{
+			g.Expect(payload).To(Equal(osbapi.ProvisionPayload{
 				InstanceID: instance.Name,
-				InstanceProvisionRequest: osbapi.InstanceProvisionRequest{
+				ProvisionRequest: osbapi.ProvisionRequest{
 					ServiceId: "service-offering-id",
 					PlanID:    "service-plan-id",
 					SpaceGUID: "space-guid",
@@ -200,7 +200,7 @@ var _ = Describe("CFServiceInstance", func() {
 
 			g.Expect(brokerClient.GetServiceInstanceLastOperationCallCount()).To(BeNumerically(">", 0))
 			_, lastOp := brokerClient.GetServiceInstanceLastOperationArgsForCall(brokerClient.GetServiceInstanceLastOperationCallCount() - 1)
-			g.Expect(lastOp).To(Equal(osbapi.GetServiceInstanceLastOperationRequest{
+			g.Expect(lastOp).To(Equal(osbapi.GetInstanceLastOperationRequest{
 				InstanceID: instance.Name,
 				GetLastOperationRequestParameters: osbapi.GetLastOperationRequestParameters{
 					ServiceId: "service-offering-id",
@@ -298,7 +298,7 @@ var _ = Describe("CFServiceInstance", func() {
 
 	When("the provisioning is synchronous", func() {
 		BeforeEach(func() {
-			brokerClient.ProvisionReturns(osbapi.ServiceInstanceOperationResponse{}, nil)
+			brokerClient.ProvisionReturns(osbapi.ProvisionResponse{}, nil)
 		})
 
 		It("does not check last operation", func() {
@@ -321,16 +321,16 @@ var _ = Describe("CFServiceInstance", func() {
 
 	When("service provisioning fails with recoverable error", func() {
 		BeforeEach(func() {
-			brokerClient.ProvisionReturns(osbapi.ServiceInstanceOperationResponse{}, errors.New("provision-failed"))
+			brokerClient.ProvisionReturns(osbapi.ProvisionResponse{}, errors.New("provision-failed"))
 		})
 
 		It("keeps trying to provision the instance", func() {
 			Eventually(func(g Gomega) {
 				g.Expect(brokerClient.ProvisionCallCount()).To(BeNumerically(">", 1))
 				_, provisionPayload := brokerClient.ProvisionArgsForCall(1)
-				g.Expect(provisionPayload).To(Equal(osbapi.InstanceProvisionPayload{
+				g.Expect(provisionPayload).To(Equal(osbapi.ProvisionPayload{
 					InstanceID: instance.Name,
-					InstanceProvisionRequest: osbapi.InstanceProvisionRequest{
+					ProvisionRequest: osbapi.ProvisionRequest{
 						ServiceId: "service-offering-id",
 						PlanID:    "service-plan-id",
 						SpaceGUID: "space-guid",
@@ -357,7 +357,7 @@ var _ = Describe("CFServiceInstance", func() {
 
 	When("service provisioning fails with unrecoverable error", func() {
 		BeforeEach(func() {
-			brokerClient.ProvisionReturns(osbapi.ServiceInstanceOperationResponse{}, osbapi.UnrecoverableError{Status: http.StatusBadRequest})
+			brokerClient.ProvisionReturns(osbapi.ProvisionResponse{}, osbapi.UnrecoverableError{Status: http.StatusBadRequest})
 		})
 
 		It("fails the instance", func() {
@@ -441,7 +441,7 @@ var _ = Describe("CFServiceInstance", func() {
 			Eventually(func(g Gomega) {
 				g.Expect(brokerClient.GetServiceInstanceLastOperationCallCount()).To(BeNumerically(">", 1))
 				_, actualLastOpPayload := brokerClient.GetServiceInstanceLastOperationArgsForCall(1)
-				g.Expect(actualLastOpPayload).To(Equal(osbapi.GetServiceInstanceLastOperationRequest{
+				g.Expect(actualLastOpPayload).To(Equal(osbapi.GetInstanceLastOperationRequest{
 					InstanceID: instance.Name,
 					GetLastOperationRequestParameters: osbapi.GetLastOperationRequestParameters{
 						ServiceId: "service-offering-id",
@@ -730,7 +730,7 @@ var _ = Describe("CFServiceInstance", func() {
 
 	Describe("instance deletion", func() {
 		BeforeEach(func() {
-			brokerClient.DeprovisionReturns(osbapi.ServiceInstanceOperationResponse{
+			brokerClient.DeprovisionReturns(osbapi.ProvisionResponse{
 				Operation: "deprovision-op",
 			}, nil)
 		})
@@ -748,9 +748,9 @@ var _ = Describe("CFServiceInstance", func() {
 
 				g.Expect(brokerClient.DeprovisionCallCount()).To(Equal(1))
 				_, actualDeprovisionRequest := brokerClient.DeprovisionArgsForCall(0)
-				Expect(actualDeprovisionRequest).To(Equal(osbapi.InstanceDeprovisionPayload{
+				Expect(actualDeprovisionRequest).To(Equal(osbapi.DeprovisionPayload{
 					ID: instance.Name,
-					InstanceDeprovisionRequest: osbapi.InstanceDeprovisionRequest{
+					DeprovisionRequest: osbapi.DeprovisionRequest{
 						ServiceId: "service-offering-id",
 						PlanID:    "service-plan-id",
 					},
@@ -760,7 +760,7 @@ var _ = Describe("CFServiceInstance", func() {
 
 		When("deprovision fails", func() {
 			BeforeEach(func() {
-				brokerClient.DeprovisionReturns(osbapi.ServiceInstanceOperationResponse{}, errors.New("deprovision-failed"))
+				brokerClient.DeprovisionReturns(osbapi.ProvisionResponse{}, errors.New("deprovision-failed"))
 			})
 
 			It("the instance is not deleted", func() {
@@ -773,7 +773,7 @@ var _ = Describe("CFServiceInstance", func() {
 
 		When("the instance is deleted asynchronously", func() {
 			BeforeEach(func() {
-				brokerClient.DeprovisionReturns(osbapi.ServiceInstanceOperationResponse{
+				brokerClient.DeprovisionReturns(osbapi.ProvisionResponse{
 					IsAsync:   true,
 					Operation: "deprovision-op",
 				}, nil)
@@ -812,7 +812,7 @@ var _ = Describe("CFServiceInstance", func() {
 					Eventually(func(g Gomega) {
 						g.Expect(brokerClient.GetServiceInstanceLastOperationCallCount()).To(BeNumerically(">", 1))
 						_, actualLastOpPayload := brokerClient.GetServiceInstanceLastOperationArgsForCall(1)
-						g.Expect(actualLastOpPayload).To(Equal(osbapi.GetServiceInstanceLastOperationRequest{
+						g.Expect(actualLastOpPayload).To(Equal(osbapi.GetInstanceLastOperationRequest{
 							InstanceID: instance.Name,
 							GetLastOperationRequestParameters: osbapi.GetLastOperationRequestParameters{
 								ServiceId: "service-offering-id",
@@ -861,16 +861,16 @@ var _ = Describe("CFServiceInstance", func() {
 
 			When("service deprovisioning fails with recoverable error", func() {
 				BeforeEach(func() {
-					brokerClient.DeprovisionReturns(osbapi.ServiceInstanceOperationResponse{}, errors.New("deprovision-failed"))
+					brokerClient.DeprovisionReturns(osbapi.ProvisionResponse{}, errors.New("deprovision-failed"))
 				})
 
 				It("keeps trying to deprovision the instance", func() {
 					Eventually(func(g Gomega) {
 						g.Expect(brokerClient.DeprovisionCallCount()).To(BeNumerically(">", 1))
 						_, actualDeprovisionRequest := brokerClient.DeprovisionArgsForCall(0)
-						g.Expect(actualDeprovisionRequest).To(Equal(osbapi.InstanceDeprovisionPayload{
+						g.Expect(actualDeprovisionRequest).To(Equal(osbapi.DeprovisionPayload{
 							ID: instance.Name,
-							InstanceDeprovisionRequest: osbapi.InstanceDeprovisionRequest{
+							DeprovisionRequest: osbapi.DeprovisionRequest{
 								ServiceId: "service-offering-id",
 								PlanID:    "service-plan-id",
 							},
@@ -892,7 +892,7 @@ var _ = Describe("CFServiceInstance", func() {
 
 			When("service deprovisioning fails with unrecoverable error", func() {
 				BeforeEach(func() {
-					brokerClient.DeprovisionReturns(osbapi.ServiceInstanceOperationResponse{}, osbapi.UnrecoverableError{Status: http.StatusGone})
+					brokerClient.DeprovisionReturns(osbapi.ProvisionResponse{}, osbapi.UnrecoverableError{Status: http.StatusUnprocessableEntity})
 				})
 
 				It("fails the instance", func() {
@@ -908,7 +908,7 @@ var _ = Describe("CFServiceInstance", func() {
 								HasType(Equal(korifiv1alpha1.DeprovisioningFailedCondition)),
 								HasStatus(Equal(metav1.ConditionTrue)),
 								HasReason(Equal("DeprovisionFailed")),
-								HasMessage(ContainSubstring("The server responded with status: 410")),
+								HasMessage(ContainSubstring("The server responded with status: 422")),
 							),
 						))
 					}).Should(Succeed())
@@ -922,6 +922,19 @@ var _ = Describe("CFServiceInstance", func() {
 							Type:  "delete",
 							State: "failed",
 						}))
+					}).Should(Succeed())
+				})
+			})
+
+			When("the instance is gone", func() {
+				BeforeEach(func() {
+					brokerClient.DeprovisionReturns(osbapi.ProvisionResponse{}, osbapi.GoneError{})
+				})
+
+				It("deletes the instance", func() {
+					Eventually(func(g Gomega) {
+						err := adminClient.Get(ctx, client.ObjectKeyFromObject(instance), instance)
+						g.Expect(k8serrors.IsNotFound(err)).To(BeTrue())
 					}).Should(Succeed())
 				})
 			})

--- a/controllers/controllers/services/osbapi/clientfactory.go
+++ b/controllers/controllers/services/osbapi/clientfactory.go
@@ -17,14 +17,13 @@ import (
 
 //counterfeiter:generate -o fake -fake-name BrokerClient code.cloudfoundry.org/korifi/controllers/controllers/services/osbapi.BrokerClient
 type BrokerClient interface {
-	Provision(context.Context, InstanceProvisionPayload) (ServiceInstanceOperationResponse, error)
-	Deprovision(context.Context, InstanceDeprovisionPayload) (ServiceInstanceOperationResponse, error)
-	GetServiceInstanceLastOperation(context.Context, GetServiceInstanceLastOperationRequest) (LastOperationResponse, error)
+	Provision(context.Context, ProvisionPayload) (ProvisionResponse, error)
+	Deprovision(context.Context, DeprovisionPayload) (ProvisionResponse, error)
+	GetServiceInstanceLastOperation(context.Context, GetInstanceLastOperationRequest) (LastOperationResponse, error)
 	GetCatalog(context.Context) (Catalog, error)
 	Bind(context.Context, BindPayload) (BindResponse, error)
 	Unbind(context.Context, UnbindPayload) (UnbindResponse, error)
-	GetServiceBindingLastOperation(context.Context, GetServiceBindingLastOperationRequest) (LastOperationResponse, error)
-	GetServiceBinding(context.Context, GetServiceBindingRequest) (GetBindingResponse, error)
+	GetServiceBindingLastOperation(context.Context, GetBindingLastOperationRequest) (LastOperationResponse, error)
 }
 
 //counterfeiter:generate -o fake -fake-name BrokerClientFactory code.cloudfoundry.org/korifi/controllers/controllers/services/osbapi.BrokerClientFactory

--- a/controllers/controllers/services/osbapi/fake/broker_client.go
+++ b/controllers/controllers/services/osbapi/fake/broker_client.go
@@ -23,18 +23,18 @@ type BrokerClient struct {
 		result1 osbapi.BindResponse
 		result2 error
 	}
-	DeprovisionStub        func(context.Context, osbapi.InstanceDeprovisionPayload) (osbapi.ServiceInstanceOperationResponse, error)
+	DeprovisionStub        func(context.Context, osbapi.DeprovisionPayload) (osbapi.ProvisionResponse, error)
 	deprovisionMutex       sync.RWMutex
 	deprovisionArgsForCall []struct {
 		arg1 context.Context
-		arg2 osbapi.InstanceDeprovisionPayload
+		arg2 osbapi.DeprovisionPayload
 	}
 	deprovisionReturns struct {
-		result1 osbapi.ServiceInstanceOperationResponse
+		result1 osbapi.ProvisionResponse
 		result2 error
 	}
 	deprovisionReturnsOnCall map[int]struct {
-		result1 osbapi.ServiceInstanceOperationResponse
+		result1 osbapi.ProvisionResponse
 		result2 error
 	}
 	GetCatalogStub        func(context.Context) (osbapi.Catalog, error)
@@ -50,11 +50,11 @@ type BrokerClient struct {
 		result1 osbapi.Catalog
 		result2 error
 	}
-	GetServiceBindingStub        func(context.Context, osbapi.GetServiceBindingRequest) (osbapi.GetBindingResponse, error)
+	GetServiceBindingStub        func(context.Context, osbapi.GetBindingRequest) (osbapi.GetBindingResponse, error)
 	getServiceBindingMutex       sync.RWMutex
 	getServiceBindingArgsForCall []struct {
 		arg1 context.Context
-		arg2 osbapi.GetServiceBindingRequest
+		arg2 osbapi.GetBindingRequest
 	}
 	getServiceBindingReturns struct {
 		result1 osbapi.GetBindingResponse
@@ -64,11 +64,11 @@ type BrokerClient struct {
 		result1 osbapi.GetBindingResponse
 		result2 error
 	}
-	GetServiceBindingLastOperationStub        func(context.Context, osbapi.GetServiceBindingLastOperationRequest) (osbapi.LastOperationResponse, error)
+	GetServiceBindingLastOperationStub        func(context.Context, osbapi.GetBindingLastOperationRequest) (osbapi.LastOperationResponse, error)
 	getServiceBindingLastOperationMutex       sync.RWMutex
 	getServiceBindingLastOperationArgsForCall []struct {
 		arg1 context.Context
-		arg2 osbapi.GetServiceBindingLastOperationRequest
+		arg2 osbapi.GetBindingLastOperationRequest
 	}
 	getServiceBindingLastOperationReturns struct {
 		result1 osbapi.LastOperationResponse
@@ -78,11 +78,11 @@ type BrokerClient struct {
 		result1 osbapi.LastOperationResponse
 		result2 error
 	}
-	GetServiceInstanceLastOperationStub        func(context.Context, osbapi.GetServiceInstanceLastOperationRequest) (osbapi.LastOperationResponse, error)
+	GetServiceInstanceLastOperationStub        func(context.Context, osbapi.GetInstanceLastOperationRequest) (osbapi.LastOperationResponse, error)
 	getServiceInstanceLastOperationMutex       sync.RWMutex
 	getServiceInstanceLastOperationArgsForCall []struct {
 		arg1 context.Context
-		arg2 osbapi.GetServiceInstanceLastOperationRequest
+		arg2 osbapi.GetInstanceLastOperationRequest
 	}
 	getServiceInstanceLastOperationReturns struct {
 		result1 osbapi.LastOperationResponse
@@ -92,18 +92,18 @@ type BrokerClient struct {
 		result1 osbapi.LastOperationResponse
 		result2 error
 	}
-	ProvisionStub        func(context.Context, osbapi.InstanceProvisionPayload) (osbapi.ServiceInstanceOperationResponse, error)
+	ProvisionStub        func(context.Context, osbapi.ProvisionPayload) (osbapi.ProvisionResponse, error)
 	provisionMutex       sync.RWMutex
 	provisionArgsForCall []struct {
 		arg1 context.Context
-		arg2 osbapi.InstanceProvisionPayload
+		arg2 osbapi.ProvisionPayload
 	}
 	provisionReturns struct {
-		result1 osbapi.ServiceInstanceOperationResponse
+		result1 osbapi.ProvisionResponse
 		result2 error
 	}
 	provisionReturnsOnCall map[int]struct {
-		result1 osbapi.ServiceInstanceOperationResponse
+		result1 osbapi.ProvisionResponse
 		result2 error
 	}
 	UnbindStub        func(context.Context, osbapi.UnbindPayload) (osbapi.UnbindResponse, error)
@@ -189,12 +189,12 @@ func (fake *BrokerClient) BindReturnsOnCall(i int, result1 osbapi.BindResponse, 
 	}{result1, result2}
 }
 
-func (fake *BrokerClient) Deprovision(arg1 context.Context, arg2 osbapi.InstanceDeprovisionPayload) (osbapi.ServiceInstanceOperationResponse, error) {
+func (fake *BrokerClient) Deprovision(arg1 context.Context, arg2 osbapi.DeprovisionPayload) (osbapi.ProvisionResponse, error) {
 	fake.deprovisionMutex.Lock()
 	ret, specificReturn := fake.deprovisionReturnsOnCall[len(fake.deprovisionArgsForCall)]
 	fake.deprovisionArgsForCall = append(fake.deprovisionArgsForCall, struct {
 		arg1 context.Context
-		arg2 osbapi.InstanceDeprovisionPayload
+		arg2 osbapi.DeprovisionPayload
 	}{arg1, arg2})
 	stub := fake.DeprovisionStub
 	fakeReturns := fake.deprovisionReturns
@@ -215,41 +215,41 @@ func (fake *BrokerClient) DeprovisionCallCount() int {
 	return len(fake.deprovisionArgsForCall)
 }
 
-func (fake *BrokerClient) DeprovisionCalls(stub func(context.Context, osbapi.InstanceDeprovisionPayload) (osbapi.ServiceInstanceOperationResponse, error)) {
+func (fake *BrokerClient) DeprovisionCalls(stub func(context.Context, osbapi.DeprovisionPayload) (osbapi.ProvisionResponse, error)) {
 	fake.deprovisionMutex.Lock()
 	defer fake.deprovisionMutex.Unlock()
 	fake.DeprovisionStub = stub
 }
 
-func (fake *BrokerClient) DeprovisionArgsForCall(i int) (context.Context, osbapi.InstanceDeprovisionPayload) {
+func (fake *BrokerClient) DeprovisionArgsForCall(i int) (context.Context, osbapi.DeprovisionPayload) {
 	fake.deprovisionMutex.RLock()
 	defer fake.deprovisionMutex.RUnlock()
 	argsForCall := fake.deprovisionArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *BrokerClient) DeprovisionReturns(result1 osbapi.ServiceInstanceOperationResponse, result2 error) {
+func (fake *BrokerClient) DeprovisionReturns(result1 osbapi.ProvisionResponse, result2 error) {
 	fake.deprovisionMutex.Lock()
 	defer fake.deprovisionMutex.Unlock()
 	fake.DeprovisionStub = nil
 	fake.deprovisionReturns = struct {
-		result1 osbapi.ServiceInstanceOperationResponse
+		result1 osbapi.ProvisionResponse
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *BrokerClient) DeprovisionReturnsOnCall(i int, result1 osbapi.ServiceInstanceOperationResponse, result2 error) {
+func (fake *BrokerClient) DeprovisionReturnsOnCall(i int, result1 osbapi.ProvisionResponse, result2 error) {
 	fake.deprovisionMutex.Lock()
 	defer fake.deprovisionMutex.Unlock()
 	fake.DeprovisionStub = nil
 	if fake.deprovisionReturnsOnCall == nil {
 		fake.deprovisionReturnsOnCall = make(map[int]struct {
-			result1 osbapi.ServiceInstanceOperationResponse
+			result1 osbapi.ProvisionResponse
 			result2 error
 		})
 	}
 	fake.deprovisionReturnsOnCall[i] = struct {
-		result1 osbapi.ServiceInstanceOperationResponse
+		result1 osbapi.ProvisionResponse
 		result2 error
 	}{result1, result2}
 }
@@ -318,12 +318,12 @@ func (fake *BrokerClient) GetCatalogReturnsOnCall(i int, result1 osbapi.Catalog,
 	}{result1, result2}
 }
 
-func (fake *BrokerClient) GetServiceBinding(arg1 context.Context, arg2 osbapi.GetServiceBindingRequest) (osbapi.GetBindingResponse, error) {
+func (fake *BrokerClient) GetServiceBinding(arg1 context.Context, arg2 osbapi.GetBindingRequest) (osbapi.GetBindingResponse, error) {
 	fake.getServiceBindingMutex.Lock()
 	ret, specificReturn := fake.getServiceBindingReturnsOnCall[len(fake.getServiceBindingArgsForCall)]
 	fake.getServiceBindingArgsForCall = append(fake.getServiceBindingArgsForCall, struct {
 		arg1 context.Context
-		arg2 osbapi.GetServiceBindingRequest
+		arg2 osbapi.GetBindingRequest
 	}{arg1, arg2})
 	stub := fake.GetServiceBindingStub
 	fakeReturns := fake.getServiceBindingReturns
@@ -344,13 +344,13 @@ func (fake *BrokerClient) GetServiceBindingCallCount() int {
 	return len(fake.getServiceBindingArgsForCall)
 }
 
-func (fake *BrokerClient) GetServiceBindingCalls(stub func(context.Context, osbapi.GetServiceBindingRequest) (osbapi.GetBindingResponse, error)) {
+func (fake *BrokerClient) GetServiceBindingCalls(stub func(context.Context, osbapi.GetBindingRequest) (osbapi.GetBindingResponse, error)) {
 	fake.getServiceBindingMutex.Lock()
 	defer fake.getServiceBindingMutex.Unlock()
 	fake.GetServiceBindingStub = stub
 }
 
-func (fake *BrokerClient) GetServiceBindingArgsForCall(i int) (context.Context, osbapi.GetServiceBindingRequest) {
+func (fake *BrokerClient) GetServiceBindingArgsForCall(i int) (context.Context, osbapi.GetBindingRequest) {
 	fake.getServiceBindingMutex.RLock()
 	defer fake.getServiceBindingMutex.RUnlock()
 	argsForCall := fake.getServiceBindingArgsForCall[i]
@@ -383,12 +383,12 @@ func (fake *BrokerClient) GetServiceBindingReturnsOnCall(i int, result1 osbapi.G
 	}{result1, result2}
 }
 
-func (fake *BrokerClient) GetServiceBindingLastOperation(arg1 context.Context, arg2 osbapi.GetServiceBindingLastOperationRequest) (osbapi.LastOperationResponse, error) {
+func (fake *BrokerClient) GetServiceBindingLastOperation(arg1 context.Context, arg2 osbapi.GetBindingLastOperationRequest) (osbapi.LastOperationResponse, error) {
 	fake.getServiceBindingLastOperationMutex.Lock()
 	ret, specificReturn := fake.getServiceBindingLastOperationReturnsOnCall[len(fake.getServiceBindingLastOperationArgsForCall)]
 	fake.getServiceBindingLastOperationArgsForCall = append(fake.getServiceBindingLastOperationArgsForCall, struct {
 		arg1 context.Context
-		arg2 osbapi.GetServiceBindingLastOperationRequest
+		arg2 osbapi.GetBindingLastOperationRequest
 	}{arg1, arg2})
 	stub := fake.GetServiceBindingLastOperationStub
 	fakeReturns := fake.getServiceBindingLastOperationReturns
@@ -409,13 +409,13 @@ func (fake *BrokerClient) GetServiceBindingLastOperationCallCount() int {
 	return len(fake.getServiceBindingLastOperationArgsForCall)
 }
 
-func (fake *BrokerClient) GetServiceBindingLastOperationCalls(stub func(context.Context, osbapi.GetServiceBindingLastOperationRequest) (osbapi.LastOperationResponse, error)) {
+func (fake *BrokerClient) GetServiceBindingLastOperationCalls(stub func(context.Context, osbapi.GetBindingLastOperationRequest) (osbapi.LastOperationResponse, error)) {
 	fake.getServiceBindingLastOperationMutex.Lock()
 	defer fake.getServiceBindingLastOperationMutex.Unlock()
 	fake.GetServiceBindingLastOperationStub = stub
 }
 
-func (fake *BrokerClient) GetServiceBindingLastOperationArgsForCall(i int) (context.Context, osbapi.GetServiceBindingLastOperationRequest) {
+func (fake *BrokerClient) GetServiceBindingLastOperationArgsForCall(i int) (context.Context, osbapi.GetBindingLastOperationRequest) {
 	fake.getServiceBindingLastOperationMutex.RLock()
 	defer fake.getServiceBindingLastOperationMutex.RUnlock()
 	argsForCall := fake.getServiceBindingLastOperationArgsForCall[i]
@@ -448,12 +448,12 @@ func (fake *BrokerClient) GetServiceBindingLastOperationReturnsOnCall(i int, res
 	}{result1, result2}
 }
 
-func (fake *BrokerClient) GetServiceInstanceLastOperation(arg1 context.Context, arg2 osbapi.GetServiceInstanceLastOperationRequest) (osbapi.LastOperationResponse, error) {
+func (fake *BrokerClient) GetServiceInstanceLastOperation(arg1 context.Context, arg2 osbapi.GetInstanceLastOperationRequest) (osbapi.LastOperationResponse, error) {
 	fake.getServiceInstanceLastOperationMutex.Lock()
 	ret, specificReturn := fake.getServiceInstanceLastOperationReturnsOnCall[len(fake.getServiceInstanceLastOperationArgsForCall)]
 	fake.getServiceInstanceLastOperationArgsForCall = append(fake.getServiceInstanceLastOperationArgsForCall, struct {
 		arg1 context.Context
-		arg2 osbapi.GetServiceInstanceLastOperationRequest
+		arg2 osbapi.GetInstanceLastOperationRequest
 	}{arg1, arg2})
 	stub := fake.GetServiceInstanceLastOperationStub
 	fakeReturns := fake.getServiceInstanceLastOperationReturns
@@ -474,13 +474,13 @@ func (fake *BrokerClient) GetServiceInstanceLastOperationCallCount() int {
 	return len(fake.getServiceInstanceLastOperationArgsForCall)
 }
 
-func (fake *BrokerClient) GetServiceInstanceLastOperationCalls(stub func(context.Context, osbapi.GetServiceInstanceLastOperationRequest) (osbapi.LastOperationResponse, error)) {
+func (fake *BrokerClient) GetServiceInstanceLastOperationCalls(stub func(context.Context, osbapi.GetInstanceLastOperationRequest) (osbapi.LastOperationResponse, error)) {
 	fake.getServiceInstanceLastOperationMutex.Lock()
 	defer fake.getServiceInstanceLastOperationMutex.Unlock()
 	fake.GetServiceInstanceLastOperationStub = stub
 }
 
-func (fake *BrokerClient) GetServiceInstanceLastOperationArgsForCall(i int) (context.Context, osbapi.GetServiceInstanceLastOperationRequest) {
+func (fake *BrokerClient) GetServiceInstanceLastOperationArgsForCall(i int) (context.Context, osbapi.GetInstanceLastOperationRequest) {
 	fake.getServiceInstanceLastOperationMutex.RLock()
 	defer fake.getServiceInstanceLastOperationMutex.RUnlock()
 	argsForCall := fake.getServiceInstanceLastOperationArgsForCall[i]
@@ -513,12 +513,12 @@ func (fake *BrokerClient) GetServiceInstanceLastOperationReturnsOnCall(i int, re
 	}{result1, result2}
 }
 
-func (fake *BrokerClient) Provision(arg1 context.Context, arg2 osbapi.InstanceProvisionPayload) (osbapi.ServiceInstanceOperationResponse, error) {
+func (fake *BrokerClient) Provision(arg1 context.Context, arg2 osbapi.ProvisionPayload) (osbapi.ProvisionResponse, error) {
 	fake.provisionMutex.Lock()
 	ret, specificReturn := fake.provisionReturnsOnCall[len(fake.provisionArgsForCall)]
 	fake.provisionArgsForCall = append(fake.provisionArgsForCall, struct {
 		arg1 context.Context
-		arg2 osbapi.InstanceProvisionPayload
+		arg2 osbapi.ProvisionPayload
 	}{arg1, arg2})
 	stub := fake.ProvisionStub
 	fakeReturns := fake.provisionReturns
@@ -539,41 +539,41 @@ func (fake *BrokerClient) ProvisionCallCount() int {
 	return len(fake.provisionArgsForCall)
 }
 
-func (fake *BrokerClient) ProvisionCalls(stub func(context.Context, osbapi.InstanceProvisionPayload) (osbapi.ServiceInstanceOperationResponse, error)) {
+func (fake *BrokerClient) ProvisionCalls(stub func(context.Context, osbapi.ProvisionPayload) (osbapi.ProvisionResponse, error)) {
 	fake.provisionMutex.Lock()
 	defer fake.provisionMutex.Unlock()
 	fake.ProvisionStub = stub
 }
 
-func (fake *BrokerClient) ProvisionArgsForCall(i int) (context.Context, osbapi.InstanceProvisionPayload) {
+func (fake *BrokerClient) ProvisionArgsForCall(i int) (context.Context, osbapi.ProvisionPayload) {
 	fake.provisionMutex.RLock()
 	defer fake.provisionMutex.RUnlock()
 	argsForCall := fake.provisionArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *BrokerClient) ProvisionReturns(result1 osbapi.ServiceInstanceOperationResponse, result2 error) {
+func (fake *BrokerClient) ProvisionReturns(result1 osbapi.ProvisionResponse, result2 error) {
 	fake.provisionMutex.Lock()
 	defer fake.provisionMutex.Unlock()
 	fake.ProvisionStub = nil
 	fake.provisionReturns = struct {
-		result1 osbapi.ServiceInstanceOperationResponse
+		result1 osbapi.ProvisionResponse
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *BrokerClient) ProvisionReturnsOnCall(i int, result1 osbapi.ServiceInstanceOperationResponse, result2 error) {
+func (fake *BrokerClient) ProvisionReturnsOnCall(i int, result1 osbapi.ProvisionResponse, result2 error) {
 	fake.provisionMutex.Lock()
 	defer fake.provisionMutex.Unlock()
 	fake.ProvisionStub = nil
 	if fake.provisionReturnsOnCall == nil {
 		fake.provisionReturnsOnCall = make(map[int]struct {
-			result1 osbapi.ServiceInstanceOperationResponse
+			result1 osbapi.ProvisionResponse
 			result2 error
 		})
 	}
 	fake.provisionReturnsOnCall[i] = struct {
-		result1 osbapi.ServiceInstanceOperationResponse
+		result1 osbapi.ProvisionResponse
 		result2 error
 	}{result1, result2}
 }

--- a/controllers/controllers/services/osbapi/types.go
+++ b/controllers/controllers/services/osbapi/types.go
@@ -30,12 +30,24 @@ type Service struct {
 	Plans []Plan `json:"plans"`
 }
 
-type InstanceProvisionPayload struct {
-	InstanceID string
-	InstanceProvisionRequest
+type Plan struct {
+	ID               string                      `json:"id"`
+	Name             string                      `json:"name"`
+	Description      string                      `json:"description"`
+	Metadata         map[string]any              `json:"metadata"`
+	Free             bool                        `json:"free"`
+	Bindable         bool                        `json:"bindable"`
+	BindingRotatable bool                        `json:"binding_rotatable"`
+	PlanUpdateable   bool                        `json:"plan_updateable"`
+	Schemas          services.ServicePlanSchemas `json:"schemas"`
 }
 
-type InstanceProvisionRequest struct {
+type ProvisionPayload struct {
+	InstanceID string
+	ProvisionRequest
+}
+
+type ProvisionRequest struct {
 	ServiceId  string         `json:"service_id"`
 	PlanID     string         `json:"plan_id"`
 	SpaceGUID  string         `json:"space_guid"`
@@ -43,18 +55,12 @@ type InstanceProvisionRequest struct {
 	Parameters map[string]any `json:"parameters"`
 }
 
-type GetServiceInstanceLastOperationRequest struct {
-	InstanceID string
-	GetLastOperationRequestParameters
+type ProvisionResponse struct {
+	IsAsync   bool
+	Operation string `json:"operation,omitempty"`
 }
 
-type GetServiceBindingLastOperationRequest struct {
-	InstanceID string
-	BindingID  string
-	GetLastOperationRequestParameters
-}
-
-type GetServiceBindingRequest struct {
+type GetBindingRequest struct {
 	InstanceID string
 	BindingID  string
 	ServiceId  string
@@ -65,18 +71,28 @@ type GetBindingResponse struct {
 	Credentials map[string]any `json:"credentials"`
 }
 
+type GetInstanceLastOperationRequest struct {
+	InstanceID string
+	GetLastOperationRequestParameters
+}
+
+type GetBindingLastOperationRequest struct {
+	InstanceID string
+	BindingID  string
+	GetLastOperationRequestParameters
+}
+
 type GetLastOperationRequestParameters struct {
 	ServiceId string
 	PlanID    string
 	Operation string
 }
-
-type InstanceDeprovisionPayload struct {
+type DeprovisionPayload struct {
 	ID string
-	InstanceDeprovisionRequest
+	DeprovisionRequest
 }
 
-type InstanceDeprovisionRequest struct {
+type DeprovisionRequest struct {
 	ServiceId string `json:"service_id"`
 	PlanID    string `json:"plan_id"`
 }
@@ -98,7 +114,7 @@ type BindPayload struct {
 type BindResponse struct {
 	Credentials map[string]any `json:"credentials"`
 	Operation   string         `json:"operation"`
-	Complete    bool
+	IsAsync     bool
 }
 
 type BindResource struct {
@@ -117,28 +133,12 @@ type UnbindRequestParameters struct {
 }
 
 type UnbindResponse struct {
+	IsAsync   bool
 	Operation string `json:"operation,omitempty"`
 }
 
 func (r UnbindResponse) IsComplete() bool {
 	return r.Operation == ""
-}
-
-type Plan struct {
-	ID               string                      `json:"id"`
-	Name             string                      `json:"name"`
-	Description      string                      `json:"description"`
-	Metadata         map[string]any              `json:"metadata"`
-	Free             bool                        `json:"free"`
-	Bindable         bool                        `json:"bindable"`
-	BindingRotatable bool                        `json:"binding_rotatable"`
-	PlanUpdateable   bool                        `json:"plan_updateable"`
-	Schemas          services.ServicePlanSchemas `json:"schemas"`
-}
-
-type ServiceInstanceOperationResponse struct {
-	IsAsync   bool
-	Operation string `json:"operation,omitempty"`
 }
 
 type LastOperationResponse struct {

--- a/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfservicebindings.yaml
+++ b/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfservicebindings.yaml
@@ -134,13 +134,6 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
-              bindingOperation:
-                description: |-
-                  The
-                  [operation](https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#binding)
-                  of the bind request to the the OSBAPI broker. Only makes sense for
-                  bindings to managed service instances
-                type: string
               conditions:
                 items:
                   description: Condition contains details for one aspect of the current
@@ -221,13 +214,6 @@ spec:
                   the CFServiceBinding that has been reconciled
                 format: int64
                 type: integer
-              unbindingOperation:
-                description: |-
-                  The
-                  [operation](https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#unbinding)
-                  of the unbind request to the the OSBAPI broker. Only makes sense for
-                  bindings to managed service instances
-                type: string
             type: object
         type: object
     served: true


### PR DESCRIPTION
- Added IsAsync flag to UnbindResponse in OSBAPI and the logic in the Unbind method
- Added returning Gone error
- Implementing the Unbind call in binding controller and also polling the last operation for the unbind response
- Refactor binding controller so that the calls for the Bind, Unbind and Provison and Deprovision in the services controller are identical
- Implement Setting owner reference with BlockOwnerDeletion=true and added 'foregroundDeletion' finalizer in binding controller

fixes #3296


## Is there a related GitHub Issue?
#3296


## Does this PR introduce a breaking change?
No

