### PR TITLE
An app is staged when it has current droplet set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,5 +120,8 @@ bin/yq: bin
 bin/setup-envtest: bin
 	go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
+clean-bin:
+	rm -f **/bin/*
+
 vendir-update-dependencies: bin/vendir
 	vendir sync --chdir tests

--- a/api/repositories/app_repository.go
+++ b/api/repositories/app_repository.go
@@ -22,7 +22,6 @@ import (
 	"github.com/BooleanCat/go-functional/v2/it/itx"
 	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -670,7 +669,7 @@ func cfAppToAppRecord(cfApp korifiv1alpha1.CFApp) AppRecord {
 		CreatedAt:             cfApp.CreationTimestamp.Time,
 		UpdatedAt:             getLastUpdatedTime(&cfApp),
 		DeletedAt:             golangTime(cfApp.DeletionTimestamp),
-		IsStaged:              meta.IsStatusConditionTrue(cfApp.Status.Conditions, korifiv1alpha1.StatusConditionReady),
+		IsStaged:              cfApp.Spec.CurrentDropletRef.Name != "",
 		envSecretName:         cfApp.Spec.EnvSecretName,
 		vcapServiceSecretName: cfApp.Status.VCAPServicesSecretName,
 		vcapAppSecretName:     cfApp.Status.VCAPApplicationSecretName,


### PR DESCRIPTION
## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
An app is staged when it has current droplet set

Checking for the ready condition on the app to determine whether the app
is staged does not make sense as during an app restart, the app becomes
unready (but remains staged as it references a valid droplet)
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->


## Tag your pair, your PM, and/or team
@georgethebeatle
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
