### PR TITLE
Unpin CF cli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ bin/golangci-lint:
 
 bin/cf:
 	mkdir -p $(GOBIN)
-	curl -fsSL "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=8.8.3&source=github-rel" \
+	curl -fsSL "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=v8&source=github" \
 	  | tar -zx cf8 \
 	  && mv cf8 $(GOBIN)/cf \
 	  && chmod +x $(GOBIN)/cf

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # This is a requirement for 'setup-envtest.sh' in the test target.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
-SHELL = /usr/bin/env bash -o pipefail
+SHELL = /usr/bin/env bash -o pipefail -O globstar
 .SHELLFLAGS = -ec
 
 ##@ General


### PR DESCRIPTION
## Is there a related GitHub Issue?
#3649
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
- **Revert "Temporarily pin cf cli version to 8.8.3"**
- **Enable `globstar` option when running bash commands**
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
No
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Tag your pair, your PM, and/or team
@georgethebeatle @uzabanov
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
