### PR TITLE
Update Makefile to be compatible with bash 3.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # This is a requirement for 'setup-envtest.sh' in the test target.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
-SHELL = /usr/bin/env bash -o pipefail -O globstar
+SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
 ##@ General
@@ -121,7 +121,8 @@ bin/setup-envtest: bin
 	go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
 clean-bin:
-	rm -f **/bin/*
+	# globstar (e.g. in rm -f **/bin/*) isn't available in the version of bash packaged with MacOS
+	find . -wholename '*/bin/*' -delete
 
 vendir-update-dependencies: bin/vendir
 	vendir sync --chdir tests


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
Related pull:
https://github.com/cloudfoundry/korifi/pull/3702

## What is this change about?
Keeps Makefile working with version of bash bundled with MacOS

## Does this PR introduce a breaking change?
No

## Acceptance Steps
After building binaries, running `make clean-bin` should still remove all built files from bin directories.

## Tag your pair, your PM, and/or team
@danail-branekov @georgethebeatle 

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
