### PR TITLE
Improve OSBPI compatibility

### DIFF
--- a/controllers/controllers/services/instances/managed/controller.go
+++ b/controllers/controllers/services/instances/managed/controller.go
@@ -311,7 +311,7 @@ func (r *Reconciler) deprovisionServiceInstance(
 	}
 	deprovisionResponse, err := osbapiClient.Deprovision(ctx, osbapi.DeprovisionPayload{
 		ID: serviceInstance.Name,
-		DeprovisionRequest: osbapi.DeprovisionRequest{
+		DeprovisionRequestParamaters: osbapi.DeprovisionRequestParamaters{
 			ServiceId: assets.ServiceOffering.Spec.BrokerCatalog.ID,
 			PlanID:    assets.ServicePlan.Spec.BrokerCatalog.ID,
 		},

--- a/controllers/controllers/services/instances/managed/controller_test.go
+++ b/controllers/controllers/services/instances/managed/controller_test.go
@@ -743,7 +743,7 @@ var _ = Describe("CFServiceInstance", func() {
 				_, actualDeprovisionRequest := brokerClient.DeprovisionArgsForCall(0)
 				Expect(actualDeprovisionRequest).To(Equal(osbapi.DeprovisionPayload{
 					ID: instance.Name,
-					DeprovisionRequest: osbapi.DeprovisionRequest{
+					DeprovisionRequestParamaters: osbapi.DeprovisionRequestParamaters{
 						ServiceId: "service-offering-id",
 						PlanID:    "service-plan-id",
 					},
@@ -863,7 +863,7 @@ var _ = Describe("CFServiceInstance", func() {
 						_, actualDeprovisionRequest := brokerClient.DeprovisionArgsForCall(0)
 						g.Expect(actualDeprovisionRequest).To(Equal(osbapi.DeprovisionPayload{
 							ID: instance.Name,
-							DeprovisionRequest: osbapi.DeprovisionRequest{
+							DeprovisionRequestParamaters: osbapi.DeprovisionRequestParamaters{
 								ServiceId: "service-offering-id",
 								PlanID:    "service-plan-id",
 							},

--- a/controllers/controllers/services/osbapi/client.go
+++ b/controllers/controllers/services/osbapi/client.go
@@ -118,8 +118,11 @@ func (c *Client) Deprovision(ctx context.Context, payload DeprovisionPayload) (P
 			ctx,
 			"/v2/service_instances/"+payload.ID,
 			http.MethodDelete,
+			map[string]string{
+				"service_id": payload.ServiceId,
+				"plan_id":    payload.PlanID,
+			},
 			nil,
-			payload.DeprovisionRequest,
 		)
 	if err != nil {
 		return ProvisionResponse{}, fmt.Errorf("deprovision request failed: %w", err)
@@ -348,6 +351,8 @@ func (r *brokerRequester) sendRequest(ctx context.Context, requestPath string, m
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed to create new HTTP request: %w", err)
 	}
+
+	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("X-Broker-API-Version", osbapiVersion)
 
 	queryValues := req.URL.Query()

--- a/controllers/controllers/services/osbapi/types.go
+++ b/controllers/controllers/services/osbapi/types.go
@@ -89,10 +89,10 @@ type GetLastOperationRequestParameters struct {
 }
 type DeprovisionPayload struct {
 	ID string
-	DeprovisionRequest
+	DeprovisionRequestParamaters
 }
 
-type DeprovisionRequest struct {
+type DeprovisionRequestParamaters struct {
 	ServiceId string `json:"service_id"`
 	PlanID    string `json:"plan_id"`
 }

--- a/tests/helpers/broker/broker.go
+++ b/tests/helpers/broker/broker.go
@@ -32,6 +32,8 @@ func (b *BrokerServer) WithResponse(pattern string, response map[string]any, sta
 	Expect(err).NotTo(HaveOccurred())
 
 	return b.withHandler(pattern, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		Expect(r.Header).To(HaveKeyWithValue("Content-Type", ConsistOf("application/json")))
+		Expect(r.Header).To(HaveKeyWithValue("X-Broker-Api-Version", ConsistOf("2.17")))
 		w.WriteHeader(statusCode)
 		_, err := w.Write(respBytes)
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
## Is there a related GitHub Issue?
#3716

## What is this change about?
 - Send 'service_id' and 'plan_id' as querry params in the Deprovision
   request
 - Always send Content-Type: 'application'json' header

