### PR TITLE
Collect logs from optional Korifi controllers

### DIFF
--- a/tests/helpers/fail_handler/pods.go
+++ b/tests/helpers/fail_handler/pods.go
@@ -215,6 +215,24 @@ func PrintKorifiLogs(config *rest.Config, correlationId string, since time.Time)
 			LabelValue: "korifi-controllers",
 			Since:      tools.PtrTo(metav1.NewTime(since)),
 		},
+		{
+			Namespace:  "korifi",
+			LabelKey:   "app",
+			LabelValue: "kpack-image-builder",
+			Since:      tools.PtrTo(metav1.NewTime(since)),
+		},
+		{
+			Namespace:  "korifi",
+			LabelKey:   "app",
+			LabelValue: "statefulset-runner",
+			Since:      tools.PtrTo(metav1.NewTime(since)),
+		},
+		{
+			Namespace:  "korifi",
+			LabelKey:   "app",
+			LabelValue: "job-task-runner",
+			Since:      tools.PtrTo(metav1.NewTime(since)),
+		},
 	})
 }
 


### PR DESCRIPTION
## Is there a related GitHub Issue?
#3721
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Collect logs for the statefulset runner, kpack image builder and job task runner on e2e/smoke/crd tests failure

## Tag your pair, your PM, and/or team
@georgethebeatle @uzabanov
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
