### PR TITLE
Temporarily disable dependabot PR grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,6 @@ updates:
   directory: "/"
   schedule:
     interval: "daily"
-  groups:
-    gomod:
-      patterns:
-        - "*"
 
 - package-ecosystem: "docker"
   directory: "/api"


### PR DESCRIPTION
## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
We are temporarily disabling dependabot PR grouping, until we resolve
the blocker aound bumping controller runtime to 0.20.0, which contains
breaking changes and will take some time to fix
<!-- _Please describe the change here._ -->

