### PR TITLE
Stop appworkload reconciliation when DeletionTimestamp is set

### DIFF
--- a/statefulset-runner/controllers/appworkload_controller.go
+++ b/statefulset-runner/controllers/appworkload_controller.go
@@ -149,6 +149,10 @@ func (r *AppWorkloadReconciler) ReconcileResource(ctx context.Context, appWorklo
 	appWorkload.Status.ObservedGeneration = appWorkload.Generation
 	log.V(1).Info("set observed generation", "generation", appWorkload.Status.ObservedGeneration)
 
+	if !appWorkload.GetDeletionTimestamp().IsZero() {
+		return ctrl.Result{}, nil
+	}
+
 	statefulSet, err := r.workloadsToStSet.Convert(appWorkload)
 	// Not clear what errors this would produce, but we may use it later
 	if err != nil {

--- a/statefulset-runner/controllers/appworkload_controller_test.go
+++ b/statefulset-runner/controllers/appworkload_controller_test.go
@@ -3,6 +3,7 @@ package controllers_test
 import (
 	"context"
 	"errors"
+	"time"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"code.cloudfoundry.org/korifi/statefulset-runner/controllers"
@@ -170,6 +171,22 @@ var _ = Describe("AppWorkload Reconcile", func() {
 		It("returns an empty result and does not return error", func() {
 			Expect(reconcileResult).To(Equal(ctrl.Result{}))
 			Expect(reconcileErr).NotTo(HaveOccurred())
+		})
+	})
+
+	When("the appworkload is being deleted gracefully", func() {
+		BeforeEach(func() {
+			appWorkload.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+		})
+
+		It("returns an empty result and does not return error", func() {
+			Expect(reconcileResult).To(Equal(ctrl.Result{}))
+			Expect(reconcileErr).NotTo(HaveOccurred())
+		})
+
+		It("creates no statefulset", func() {
+			Expect(fakeWorkloadToStSet.ConvertCallCount()).To(Equal(0))
+			Expect(fakeClient.CreateCallCount()).To(Equal(0))
 		})
 	})
 


### PR DESCRIPTION
## Is there a related GitHub Issue?
#3687
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
If we do not do this the appworkload controller keeps re-creating the
same statefulSet over and over again while it is being deleted by the
recursive foreground delete operation incurred by deletig the org (the
same happens on app deletion for similar reasons). This persistent
re-creation of the statefulset results in a significant slowdown of the
convergence of the delete operation

With this chage the reconciler stops creating statefulSets once it sees
that DeletionTimestamp is set, this speeding up the deletion convergence
