### PR TITLE
Skip reconciling objects being deleted when no finalization needed

### DIFF
--- a/controllers/controllers/workloads/build/controller.go
+++ b/controllers/controllers/workloads/build/controller.go
@@ -66,6 +66,10 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) *builder.Builder {
 func (r *Reconciler) ReconcileResource(ctx context.Context, cfBuild *korifiv1alpha1.CFBuild) (ctrl.Result, error) {
 	log := logr.FromContextOrDiscard(ctx)
 
+	if !cfBuild.GetDeletionTimestamp().IsZero() {
+		return ctrl.Result{}, nil
+	}
+
 	cfBuild.Status.ObservedGeneration = cfBuild.Generation
 	log.V(1).Info("set observed generation", "generation", cfBuild.Status.ObservedGeneration)
 

--- a/controllers/controllers/workloads/build/suite_test.go
+++ b/controllers/controllers/workloads/build/suite_test.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -40,6 +41,7 @@ var (
 	testEnv         *envtest.Environment
 	adminClient     client.Client
 	testNamespace   string
+	k8sManager      manager.Manager
 
 	reconciledBuildsSync sync.Map
 	buildCleanupsSync    sync.Map
@@ -72,7 +74,7 @@ var _ = BeforeSuite(func() {
 
 	Expect(korifiv1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
 
-	k8sManager := helpers.NewK8sManager(testEnv, filepath.Join("helm", "korifi", "controllers", "role.yaml"))
+	k8sManager = helpers.NewK8sManager(testEnv, filepath.Join("helm", "korifi", "controllers", "role.yaml"))
 	Expect(shared.SetupIndexWithManager(k8sManager)).To(Succeed())
 
 	adminClient, stopClientCache = helpers.NewCachedClient(testEnv.Config)

--- a/controllers/controllers/workloads/processes/controller.go
+++ b/controllers/controllers/workloads/processes/controller.go
@@ -126,6 +126,10 @@ func (r *Reconciler) enqueueCFProcessRequestsForRoute(ctx context.Context, o cli
 func (r *Reconciler) ReconcileResource(ctx context.Context, cfProcess *korifiv1alpha1.CFProcess) (ctrl.Result, error) {
 	log := logr.FromContextOrDiscard(ctx)
 
+	if !cfProcess.GetDeletionTimestamp().IsZero() {
+		return ctrl.Result{}, nil
+	}
+
 	cfProcess.Status.ObservedGeneration = cfProcess.Generation
 	log.V(1).Info("set observed generation", "generation", cfProcess.Status.ObservedGeneration)
 

--- a/controllers/controllers/workloads/processes/suite_test.go
+++ b/controllers/controllers/workloads/processes/suite_test.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 var (
@@ -34,6 +35,7 @@ var (
 	testEnv         *envtest.Environment
 	adminClient     client.Client
 	testNamespace   string
+	k8sManager      manager.Manager
 )
 
 func TestWorkloadsControllers(t *testing.T) {
@@ -62,7 +64,7 @@ var _ = BeforeSuite(func() {
 	Expect(korifiv1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
 	Expect(corev1.AddToScheme(scheme.Scheme)).To(Succeed())
 
-	k8sManager := helpers.NewK8sManager(testEnv, filepath.Join("helm", "korifi", "controllers", "role.yaml"))
+	k8sManager = helpers.NewK8sManager(testEnv, filepath.Join("helm", "korifi", "controllers", "role.yaml"))
 	Expect(shared.SetupIndexWithManager(k8sManager)).To(Succeed())
 
 	adminClient, stopClientCache = helpers.NewCachedClient(testEnv.Config)

--- a/controllers/controllers/workloads/tasks/controller.go
+++ b/controllers/controllers/workloads/tasks/controller.go
@@ -92,6 +92,10 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) *builder.Builder {
 func (r *Reconciler) ReconcileResource(ctx context.Context, cfTask *korifiv1alpha1.CFTask) (ctrl.Result, error) {
 	log := logr.FromContextOrDiscard(ctx)
 
+	if !cfTask.GetDeletionTimestamp().IsZero() {
+		return ctrl.Result{}, nil
+	}
+
 	cfTask.Status.ObservedGeneration = cfTask.Generation
 	log.V(1).Info("set observed generation", "generation", cfTask.Status.ObservedGeneration)
 

--- a/controllers/controllers/workloads/tasks/suite_test.go
+++ b/controllers/controllers/workloads/tasks/suite_test.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 var (
@@ -35,6 +36,7 @@ var (
 	adminClient     client.Client
 	testNamespace   string
 	eventRecorder   *controllerfake.EventRecorder
+	k8sManager      manager.Manager
 )
 
 func TestWorkloadsControllers(t *testing.T) {
@@ -63,7 +65,7 @@ var _ = BeforeSuite(func() {
 	Expect(korifiv1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
 	Expect(corev1.AddToScheme(scheme.Scheme)).To(Succeed())
 
-	k8sManager := helpers.NewK8sManager(testEnv, filepath.Join("helm", "korifi", "controllers", "role.yaml"))
+	k8sManager = helpers.NewK8sManager(testEnv, filepath.Join("helm", "korifi", "controllers", "role.yaml"))
 	Expect(shared.SetupIndexWithManager(k8sManager)).To(Succeed())
 
 	adminClient, stopClientCache = helpers.NewCachedClient(testEnv.Config)

--- a/job-task-runner/controllers/taskworkload_controller.go
+++ b/job-task-runner/controllers/taskworkload_controller.go
@@ -91,6 +91,10 @@ func (r *TaskWorkloadReconciler) SetupWithManager(mgr ctrl.Manager) *builder.Bui
 func (r *TaskWorkloadReconciler) ReconcileResource(ctx context.Context, taskWorkload *korifiv1alpha1.TaskWorkload) (ctrl.Result, error) {
 	log := logr.FromContextOrDiscard(ctx)
 
+	if !taskWorkload.GetDeletionTimestamp().IsZero() {
+		return ctrl.Result{}, nil
+	}
+
 	taskWorkload.Status.ObservedGeneration = taskWorkload.Generation
 	log.V(1).Info("set observed generation", "generation", taskWorkload.Status.ObservedGeneration)
 

--- a/kpack-image-builder/controllers/builderinfo_controller.go
+++ b/kpack-image-builder/controllers/builderinfo_controller.go
@@ -107,6 +107,10 @@ func (r *BuilderInfoReconciler) filterBuilderInfos(object client.Object) bool {
 func (r *BuilderInfoReconciler) ReconcileResource(ctx context.Context, info *korifiv1alpha1.BuilderInfo) (ctrl.Result, error) {
 	log := logr.FromContextOrDiscard(ctx)
 
+	if !info.GetDeletionTimestamp().IsZero() {
+		return ctrl.Result{}, nil
+	}
+
 	info.Status.ObservedGeneration = info.Generation
 	log.V(1).Info("set observed generation", "generation", info.Status.ObservedGeneration)
 

--- a/kpack-image-builder/controllers/suite_test.go
+++ b/kpack-image-builder/controllers/suite_test.go
@@ -44,6 +44,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -65,6 +66,7 @@ var (
 	buildWorkloadReconciler *k8s.PatchingReconciler[korifiv1alpha1.BuildWorkload, *korifiv1alpha1.BuildWorkload]
 	rootNamespace           *v1.Namespace
 	imageRepoCreator        *fake.RepositoryCreator
+	k8sManager              manager.Manager
 )
 
 func TestAPIs(t *testing.T) {
@@ -101,7 +103,7 @@ var _ = BeforeSuite(func() {
 	Expect(korifiv1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
 	Expect(buildv1alpha2.AddToScheme(scheme.Scheme)).To(Succeed())
 
-	k8sManager := helpers.NewK8sManager(testEnv, filepath.Join("helm", "korifi", "kpack-image-builder", "role.yaml"))
+	k8sManager = helpers.NewK8sManager(testEnv, filepath.Join("helm", "korifi", "kpack-image-builder", "role.yaml"))
 	adminClient, stopClientCache = helpers.NewCachedClient(testEnv.Config)
 
 	finalizer.NewKpackImageBuilderFinalizerWebhook().SetupWebhookWithManager(k8sManager)

--- a/statefulset-runner/controllers/runnerinfo_controller.go
+++ b/statefulset-runner/controllers/runnerinfo_controller.go
@@ -71,6 +71,10 @@ func filterRunnerInfos(object client.Object) bool {
 func (r *RunnerInfoReconciler) ReconcileResource(ctx context.Context, runnerInfo *korifiv1alpha1.RunnerInfo) (ctrl.Result, error) {
 	log := logr.FromContextOrDiscard(ctx)
 
+	if !runnerInfo.GetDeletionTimestamp().IsZero() {
+		return ctrl.Result{}, nil
+	}
+
 	runnerInfo.Status.ObservedGeneration = runnerInfo.Generation
 	log.V(1).Info("set observed generation", "generation", runnerInfo.Status.ObservedGeneration)
 


### PR DESCRIPTION
## Is there a related GitHub Issue?
#3687
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Skip reconciling objects being deleted when no finalization needed

Though not really related to the issue, not wasting time reconciling objects that are being deleted is generally a good idea.

PS: Please don't judge about `builderinfo_controller_test.go`, I have at least filed a [chore](https://github.com/cloudfoundry/korifi/issues/3743) about it
<!-- _Please describe the change here._ -->

## Tag your pair, your PM, and/or team
@georgethebeatle @uzabanov
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
