### PR TITLE
Assign closed issues to the `release-candidate` milestone

### DIFF
--- a/.github/workflows/assign-closed-issues-to-rc-milestone.yml
+++ b/.github/workflows/assign-closed-issues-to-rc-milestone.yml
@@ -1,0 +1,19 @@
+name: Assign closed issues to the `release-candidate` milestone
+
+on:
+  issues:
+    types: [closed]
+
+jobs:
+  update-milestone:
+    runs-on: ubuntu-latest
+    name: Assign to release-candidate milestone
+    steps:
+      - name: Set Milestone for Issue
+        uses: hustcer/milestone-action@v2
+        if: github.event.issue.state == 'closed'
+        with:
+          action: bind-issue
+          milestone: release-candidate
+        env:
+          GITHUB_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
By doing that we would keep the release-candidate milestone up to date
with things that are done.
<!-- _Please describe the change here._ -->


## Tag your pair, your PM, and/or team
@georgethebeatle
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
