### PR TITLE
Refactor kpack-image-builder tests

### DIFF
--- a/kpack-image-builder/controllers/builderinfo_controller_test.go
+++ b/kpack-image-builder/controllers/builderinfo_controller_test.go
@@ -3,10 +3,10 @@ package controllers_test
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"code.cloudfoundry.org/korifi/kpack-image-builder/controllers"
+	"code.cloudfoundry.org/korifi/tests/helpers"
 	"code.cloudfoundry.org/korifi/tools/k8s"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -20,7 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("BuilderInfoReconciler", Serial, func() {
+var _ = Describe("BuilderInfoReconciler", func() {
 	const (
 		stack                  = "ubuntu-kreepy-koala"
 		golangBuildpackName    = "golang"
@@ -37,29 +37,14 @@ var _ = Describe("BuilderInfoReconciler", Serial, func() {
 	)
 
 	BeforeEach(func() {
-		info = nil
-		clusterBuilder = nil
-	})
-
-	AfterEach(func() {
-		if info != nil {
-			Expect(client.IgnoreNotFound(adminClient.Delete(context.Background(), info))).To(Succeed())
+		clusterBuilder = &buildv1alpha2.ClusterBuilder{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: clusterBuilderName,
+			},
 		}
-		if clusterBuilder != nil {
-			Expect(adminClient.Delete(context.Background(), clusterBuilder)).To(Succeed())
-		}
-	})
 
-	When("the ClusterBuilder exists and is ready", func() {
-		BeforeEach(func() {
-			clusterBuilder = &buildv1alpha2.ClusterBuilder{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: clusterBuilderName,
-				},
-			}
-
-			Expect(adminClient.Create(context.Background(), clusterBuilder)).To(Succeed())
-
+		Expect(adminClient.Create(context.Background(), clusterBuilder)).To(Succeed())
+		Expect(k8s.Patch(ctx, adminClient, clusterBuilder, func() {
 			clusterBuilder.Status = buildv1alpha2.BuilderStatus{
 				Order: []corev1alpha1.OrderEntry{
 					{Group: []corev1alpha1.BuildpackRef{
@@ -80,180 +65,160 @@ var _ = Describe("BuilderInfoReconciler", Serial, func() {
 				Type:   "Ready",
 				Status: "True",
 			})
-			Expect(adminClient.Status().Update(context.Background(), clusterBuilder)).To(Succeed())
+		})).To(Succeed())
+
+		info = &v1alpha1.BuilderInfo{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       controllers.BuilderInfoName,
+				Namespace:  rootNamespace.Name,
+				Generation: 1,
+			},
+		}
+	})
+
+	JustBeforeEach(func() {
+		Expect(adminClient.Create(context.Background(), info)).To(Succeed())
+	})
+
+	It("sets the buildpacks on the BuilderInfo", func() {
+		Eventually(func(g Gomega) []v1alpha1.BuilderInfoStatusBuildpack {
+			g.Expect(adminClient.Get(context.Background(), client.ObjectKeyFromObject(info), info)).To(Succeed())
+			return info.Status.Buildpacks
+		}).ShouldNot(BeEmpty())
+
+		Expect(info.Status.Buildpacks[0]).To(MatchFields(IgnoreExtras, Fields{
+			"Name":    Equal(golangBuildpackName),
+			"Version": Equal(golangBuildpackVersion),
+			"Stack":   Equal(stack),
+		}))
+		Expect(info.Status.Buildpacks[1]).To(MatchFields(IgnoreExtras, Fields{
+			"Name":    Equal(pythonBuildpackName),
+			"Version": Equal(pythonBuildpackVersion),
+			"Stack":   Equal(stack),
+		}))
+		Expect(info.Status.Buildpacks[2]).To(MatchFields(IgnoreExtras, Fields{
+			"Name":    Equal(javaBuildpackName),
+			"Version": Equal(javaBuildpackVersion),
+			"Stack":   Equal(stack),
+		}))
+	})
+
+	It("sets the stacks on the BuilderInfo", func() {
+		Eventually(func(g Gomega) {
+			g.Expect(adminClient.Get(context.Background(), client.ObjectKeyFromObject(info), info)).To(Succeed())
+			g.Expect(info.Status.Stacks).To(HaveLen(1))
+		}).Should(Succeed())
+
+		Expect(info.Status.Stacks[0]).To(HaveField("Name", Equal(stack)))
+	})
+
+	It("marks the BuilderInfo as ready", func() {
+		Eventually(func(g Gomega) []v1alpha1.BuilderInfoStatusBuildpack {
+			g.Expect(adminClient.Get(context.Background(), client.ObjectKeyFromObject(info), info)).To(Succeed())
+			return info.Status.Buildpacks
+		}).ShouldNot(BeEmpty())
+
+		readyCondition := meta.FindStatusCondition(info.Status.Conditions, "Ready")
+		Expect(readyCondition).NotTo(BeNil())
+		Expect(readyCondition.Status).To(Equal(metav1.ConditionTrue))
+		Expect(readyCondition.ObservedGeneration).To(Equal(info.Generation))
+	})
+
+	It("sets the ObservedGeneration status field", func() {
+		Eventually(func(g Gomega) {
+			g.Expect(adminClient.Get(context.Background(), client.ObjectKeyFromObject(info), info)).To(Succeed())
+			g.Expect(info.Status.ObservedGeneration).To(Equal(info.Generation))
+		}).Should(Succeed())
+	})
+
+	When("the builder info is being deleted gracefully", func() {
+		BeforeEach(func() {
+			info.Finalizers = []string{"do-not-delete-yet"}
 		})
 
-		When("the BuilderInfo is first created", func() {
-			JustBeforeEach(func() {
-				info = &v1alpha1.BuilderInfo{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      controllers.BuilderInfoName,
-						Namespace: rootNamespace.Name,
-					},
+		JustBeforeEach(func() {
+			Expect(k8sManager.GetClient().Delete(ctx, info)).To(Succeed())
+		})
+
+		It("does not reconcile the process", func() {
+			helpers.EventuallyShouldHold(func(g Gomega) {
+				g.Expect(adminClient.Get(ctx, client.ObjectKeyFromObject(info), info)).To(Succeed())
+				g.Expect(info.Status.ObservedGeneration).NotTo(Equal(info.Generation))
+			})
+		})
+	})
+
+	When("the cluster builder status is not ready", func() {
+		BeforeEach(func() {
+			Expect(k8s.Patch(ctx, adminClient, clusterBuilder, func() {
+				ok := false
+				for i, cond := range clusterBuilder.Status.Conditions {
+					if cond.Type == "Ready" {
+						clusterBuilder.Status.Conditions[i].Status = v1.ConditionFalse
+						clusterBuilder.Status.Conditions[i].Message = "something happened"
+						ok = true
+						break
+					}
 				}
-				Expect(adminClient.Create(context.Background(), info)).To(Succeed())
-			})
+				Expect(ok).To(BeTrue())
+			})).To(Succeed())
+		})
 
-			It("sets the buildpacks on the BuilderInfo", func() {
-				Eventually(func(g Gomega) []v1alpha1.BuilderInfoStatusBuildpack {
-					g.Expect(adminClient.Get(context.Background(), client.ObjectKeyFromObject(info), info)).To(Succeed())
-					return info.Status.Buildpacks
-				}).ShouldNot(BeEmpty())
-
-				Expect(info.Status.Buildpacks[0]).To(MatchFields(IgnoreExtras, Fields{
-					"Name":    Equal(golangBuildpackName),
-					"Version": Equal(golangBuildpackVersion),
-					"Stack":   Equal(stack),
-				}))
-				Expect(info.Status.Buildpacks[1]).To(MatchFields(IgnoreExtras, Fields{
-					"Name":    Equal(pythonBuildpackName),
-					"Version": Equal(pythonBuildpackVersion),
-					"Stack":   Equal(stack),
-				}))
-				Expect(info.Status.Buildpacks[2]).To(MatchFields(IgnoreExtras, Fields{
-					"Name":    Equal(javaBuildpackName),
-					"Version": Equal(javaBuildpackVersion),
-					"Stack":   Equal(stack),
-				}))
-			})
-
-			It("sets the stacks on the BuilderInfo", func() {
-				Eventually(func(g Gomega) {
-					g.Expect(adminClient.Get(context.Background(), client.ObjectKeyFromObject(info), info)).To(Succeed())
-					g.Expect(info.Status.Stacks).To(HaveLen(1))
-				}).Should(Succeed())
-
-				Expect(info.Status.Stacks[0]).To(HaveField("Name", Equal(stack)))
-			})
-
-			It("marks the BuilderInfo as ready", func() {
-				Eventually(func(g Gomega) []v1alpha1.BuilderInfoStatusBuildpack {
-					g.Expect(adminClient.Get(context.Background(), client.ObjectKeyFromObject(info), info)).To(Succeed())
-					return info.Status.Buildpacks
-				}).ShouldNot(BeEmpty())
-
+		It("marks the BuilderInfo as not ready", func() {
+			Eventually(func(g Gomega) {
+				g.Expect(adminClient.Get(context.Background(), client.ObjectKeyFromObject(info), info)).To(Succeed())
 				readyCondition := meta.FindStatusCondition(info.Status.Conditions, "Ready")
-				Expect(readyCondition).NotTo(BeNil())
-				Expect(readyCondition.Status).To(Equal(metav1.ConditionTrue))
-				Expect(readyCondition.ObservedGeneration).To(Equal(info.Generation))
-			})
+				g.Expect(readyCondition).NotTo(BeNil())
+				g.Expect(readyCondition.Status).To(Equal(metav1.ConditionFalse))
+				g.Expect(readyCondition.Reason).To(Equal("ClusterBuilderNotReady"))
+				g.Expect(readyCondition.Message).To(Equal(fmt.Sprintf("ClusterBuilder %q is not ready: something happened", clusterBuilderName)))
+				g.Expect(readyCondition.ObservedGeneration).To(Equal(info.Generation))
+			}).Should(Succeed())
+		})
+	})
 
-			It("sets the ObservedGeneration status field", func() {
-				Eventually(func(g Gomega) {
-					g.Expect(adminClient.Get(context.Background(), client.ObjectKeyFromObject(info), info)).To(Succeed())
-					g.Expect(info.Status.ObservedGeneration).To(Equal(info.Generation))
-				}).Should(Succeed())
-			})
-
-			When("the builder info is being deleted gracefully", func() {
-				JustBeforeEach(func() {
-					Expect(k8s.PatchResource(ctx, adminClient, info, func() {
-						info.Finalizers = []string{"do-not-delete-yet"}
-					})).To(Succeed())
-
-					Expect(k8sManager.GetClient().Delete(ctx, info)).To(Succeed())
-					Expect(k8s.Patch(ctx, adminClient, info, func() {
-						info.Status.Buildpacks = []v1alpha1.BuilderInfoStatusBuildpack{{
-							Name:              "foobar",
-							CreationTimestamp: metav1.NewTime(time.Now()),
-							UpdatedTimestamp:  metav1.NewTime(time.Now()),
-						}}
-					})).To(Succeed())
-				})
-
-				It("does not reconcile the process", func() {
-					Consistently(func(g Gomega) {
-						g.Expect(adminClient.Get(ctx, client.ObjectKeyFromObject(info), info)).To(Succeed())
-						g.Expect(info.Status.ObservedGeneration).NotTo(Equal(info.Generation))
-					}).Should(Succeed())
-
-					// Gross workaround to make `AfterEach` that ensures the info is gone happy
-					// see https://github.com/cloudfoundry/korifi/issues/3743
-					Expect(k8s.PatchResource(ctx, adminClient, info, func() {
-						info.Finalizers = []string{}
-					})).To(Succeed())
-				})
-			})
-
-			When("the cluster builder status is not ready", func() {
-				JustBeforeEach(func() {
-					ok := false
-					for i, cond := range clusterBuilder.Status.Conditions {
-						if cond.Type == "Ready" {
-							clusterBuilder.Status.Conditions[i].Status = v1.ConditionFalse
-							clusterBuilder.Status.Conditions[i].Message = "something happened"
-							ok = true
-							break
-						}
+	When("the cluster builder status is missing a message", func() {
+		BeforeEach(func() {
+			Expect(k8s.Patch(ctx, adminClient, clusterBuilder, func() {
+				ok := false
+				for i, cond := range clusterBuilder.Status.Conditions {
+					if cond.Type == "Ready" {
+						clusterBuilder.Status.Conditions[i].Status = v1.ConditionFalse
+						clusterBuilder.Status.Conditions[i].Message = ""
+						ok = true
+						break
 					}
-					Expect(ok).To(BeTrue())
-					Expect(adminClient.Status().Update(context.Background(), clusterBuilder)).To(Succeed())
-				})
-
-				It("marks the BuilderInfo as not ready", func() {
-					Eventually(func(g Gomega) {
-						g.Expect(adminClient.Get(context.Background(), client.ObjectKeyFromObject(info), info)).To(Succeed())
-						readyCondition := meta.FindStatusCondition(info.Status.Conditions, "Ready")
-						g.Expect(readyCondition).NotTo(BeNil())
-						g.Expect(readyCondition.Status).To(Equal(metav1.ConditionFalse))
-						g.Expect(readyCondition.Reason).To(Equal("ClusterBuilderNotReady"))
-						g.Expect(readyCondition.Message).To(Equal(fmt.Sprintf("ClusterBuilder %q is not ready: something happened", clusterBuilderName)))
-						g.Expect(readyCondition.ObservedGeneration).To(Equal(info.Generation))
-					}).Should(Succeed())
-				})
-			})
-
-			When("the cluster builder status is missing a message", func() {
-				JustBeforeEach(func() {
-					ok := false
-					for i, cond := range clusterBuilder.Status.Conditions {
-						if cond.Type == "Ready" {
-							clusterBuilder.Status.Conditions[i].Status = v1.ConditionFalse
-							clusterBuilder.Status.Conditions[i].Message = ""
-							ok = true
-							break
-						}
-					}
-					Expect(ok).To(BeTrue())
-					Expect(adminClient.Status().Update(context.Background(), clusterBuilder)).To(Succeed())
-				})
-
-				It("marks the BuilderInfo as not ready", func() {
-					Eventually(func(g Gomega) {
-						g.Expect(adminClient.Get(context.Background(), client.ObjectKeyFromObject(info), info)).To(Succeed())
-						readyCondition := meta.FindStatusCondition(info.Status.Conditions, "Ready")
-						g.Expect(readyCondition).NotTo(BeNil())
-						g.Expect(readyCondition.Status).To(Equal(metav1.ConditionFalse))
-						g.Expect(readyCondition.Reason).To(Equal("ClusterBuilderNotReady"))
-						g.Expect(readyCondition.ObservedGeneration).To(Equal(info.Generation))
-					}).Should(Succeed())
-				})
-			})
+				}
+				Expect(ok).To(BeTrue())
+			})).To(Succeed())
 		})
 
-		When("the ClusterBuilder changes after the BuilderInfo has reconciled", func() {
-			const (
-				rustBuildpackName    = "rust"
-				rustBuildpackVersion = "42.0"
-				newStack             = "ubuntu-lucky-leopard"
-			)
+		It("marks the BuilderInfo as not ready", func() {
+			Eventually(func(g Gomega) {
+				g.Expect(adminClient.Get(context.Background(), client.ObjectKeyFromObject(info), info)).To(Succeed())
+				readyCondition := meta.FindStatusCondition(info.Status.Conditions, "Ready")
+				g.Expect(readyCondition).NotTo(BeNil())
+				g.Expect(readyCondition.Status).To(Equal(metav1.ConditionFalse))
+				g.Expect(readyCondition.Reason).To(Equal("ClusterBuilderNotReady"))
+				g.Expect(readyCondition.ObservedGeneration).To(Equal(info.Generation))
+			}).Should(Succeed())
+		})
+	})
 
-			BeforeEach(func() {
-				info = &v1alpha1.BuilderInfo{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      controllers.BuilderInfoName,
-						Namespace: rootNamespace.Name,
-					},
-				}
-				Expect(adminClient.Create(context.Background(), info)).To(Succeed())
+	When("the ClusterBuilder changes after the BuilderInfo has reconciled", func() {
+		const (
+			rustBuildpackName    = "rust"
+			rustBuildpackVersion = "42.0"
+			newStack             = "ubuntu-lucky-leopard"
+		)
 
-				Eventually(func(g Gomega) []v1alpha1.BuilderInfoStatusBuildpack {
-					g.Expect(adminClient.Get(context.Background(), client.ObjectKeyFromObject(info), info)).To(Succeed())
-					return info.Status.Buildpacks
-				}).ShouldNot(BeEmpty())
-			})
+		JustBeforeEach(func() {
+			Eventually(func(g Gomega) {
+				g.Expect(adminClient.Get(context.Background(), client.ObjectKeyFromObject(info), info)).To(Succeed())
+				g.Expect(info.Status.Buildpacks).NotTo(BeEmpty())
+			}).Should(Succeed())
 
-			JustBeforeEach(func() {
+			Expect(k8s.Patch(ctx, adminClient, clusterBuilder, func() {
 				clusterBuilder.Status = buildv1alpha2.BuilderStatus{
 					Order: []corev1alpha1.OrderEntry{
 						{Group: []corev1alpha1.BuildpackRef{
@@ -279,201 +244,95 @@ var _ = Describe("BuilderInfoReconciler", Serial, func() {
 						}},
 					},
 				}
-				Expect(adminClient.Status().Update(context.Background(), clusterBuilder)).To(Succeed())
-			})
-
-			It("updates the buildpacks on the BuilderInfo", func() {
-				Eventually(func(g Gomega) {
-					g.Expect(adminClient.Get(context.Background(), client.ObjectKeyFromObject(info), info)).To(Succeed())
-					g.Expect(info.Status.Buildpacks).To(HaveLen(4))
-				}).Should(Succeed())
-
-				Expect(info.Status.Buildpacks[0]).To(MatchFields(IgnoreExtras, Fields{
-					"Name":    Equal(javaBuildpackName),
-					"Version": Equal(javaBuildpackVersion),
-					"Stack":   Equal(newStack),
-				}))
-				Expect(info.Status.Buildpacks[1]).To(MatchFields(IgnoreExtras, Fields{
-					"Name":    Equal(golangBuildpackName),
-					"Version": Equal(golangBuildpackVersion),
-					"Stack":   Equal(newStack),
-				}))
-				Expect(info.Status.Buildpacks[2]).To(MatchFields(IgnoreExtras, Fields{
-					"Name":    Equal(pythonBuildpackName),
-					"Version": Equal(pythonBuildpackVersion),
-					"Stack":   Equal(newStack),
-				}))
-				Expect(info.Status.Buildpacks[3]).To(MatchFields(IgnoreExtras, Fields{
-					"Name":    Equal(rustBuildpackName),
-					"Version": Equal(rustBuildpackVersion),
-					"Stack":   Equal(newStack),
-				}))
-				Expect(meta.IsStatusConditionFalse(info.Status.Conditions, "Ready")).To(BeTrue())
-			})
-
-			It("updates the stacks on the BuilderInfo", func() {
-				Eventually(func(g Gomega) {
-					g.Expect(adminClient.Get(context.Background(), client.ObjectKeyFromObject(info), info)).To(Succeed())
-					g.Expect(info.Status.Stacks).To(ConsistOf(HaveField("Name", newStack)))
-				}).Should(Succeed())
-			})
+			})).To(Succeed())
 		})
 
-		When("a BuilderInfo with the wrong name exists", func() {
-			JustBeforeEach(func() {
-				info = &v1alpha1.BuilderInfo{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "some-other-build-reconciler",
-						Namespace: rootNamespace.Name,
-					},
-				}
-				Expect(adminClient.Create(context.Background(), info)).To(Succeed())
-			})
+		It("updates the buildpacks on the BuilderInfo", func() {
+			Eventually(func(g Gomega) {
+				g.Expect(adminClient.Get(context.Background(), client.ObjectKeyFromObject(info), info)).To(Succeed())
+				g.Expect(info.Status.Buildpacks).To(HaveLen(4))
+			}).Should(Succeed())
 
-			It("doesn't modify that resource", func() {
-				Eventually(func(g Gomega) {
-					g.Expect(adminClient.Get(context.Background(), client.ObjectKeyFromObject(info), info)).To(Succeed())
-				}).Should(Succeed())
-
-				Consistently(func(g Gomega) {
-					g.Expect(adminClient.Get(context.Background(), client.ObjectKeyFromObject(info), info)).To(Succeed())
-					g.Expect(info.Status.Buildpacks).To(BeEmpty())
-				}).Should(Succeed())
-			})
+			Expect(info.Status.Buildpacks[0]).To(MatchFields(IgnoreExtras, Fields{
+				"Name":    Equal(javaBuildpackName),
+				"Version": Equal(javaBuildpackVersion),
+				"Stack":   Equal(newStack),
+			}))
+			Expect(info.Status.Buildpacks[1]).To(MatchFields(IgnoreExtras, Fields{
+				"Name":    Equal(golangBuildpackName),
+				"Version": Equal(golangBuildpackVersion),
+				"Stack":   Equal(newStack),
+			}))
+			Expect(info.Status.Buildpacks[2]).To(MatchFields(IgnoreExtras, Fields{
+				"Name":    Equal(pythonBuildpackName),
+				"Version": Equal(pythonBuildpackVersion),
+				"Stack":   Equal(newStack),
+			}))
+			Expect(info.Status.Buildpacks[3]).To(MatchFields(IgnoreExtras, Fields{
+				"Name":    Equal(rustBuildpackName),
+				"Version": Equal(rustBuildpackVersion),
+				"Stack":   Equal(newStack),
+			}))
+			Expect(meta.IsStatusConditionFalse(info.Status.Conditions, "Ready")).To(BeTrue())
 		})
 
-		When("the BuilderInfo is in a namespace other than the root namespace", func() {
-			JustBeforeEach(func() {
-				wrongNamespace := &v1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: PrefixedGUID("wrong-namespace"),
-					},
-				}
-				Expect(adminClient.Create(context.Background(), wrongNamespace)).To(Succeed())
+		It("updates the stacks on the BuilderInfo", func() {
+			Eventually(func(g Gomega) {
+				g.Expect(adminClient.Get(context.Background(), client.ObjectKeyFromObject(info), info)).To(Succeed())
+				g.Expect(info.Status.Stacks).To(ConsistOf(HaveField("Name", newStack)))
+			}).Should(Succeed())
+		})
+	})
 
-				info = &v1alpha1.BuilderInfo{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      controllers.BuilderInfoName,
-						Namespace: wrongNamespace.Name,
-					},
-				}
-				Expect(adminClient.Create(context.Background(), info)).To(Succeed())
-			})
+	When("a BuilderInfo with the wrong name exists", func() {
+		BeforeEach(func() {
+			info.Name = "some-other-build-reconciler"
+		})
 
-			It("doesn't modify that resource", func() {
-				Eventually(func(g Gomega) {
-					g.Expect(adminClient.Get(context.Background(), client.ObjectKeyFromObject(info), info)).To(Succeed())
-				}).Should(Succeed())
+		It("doesn't modify that resource", func() {
+			Consistently(func(g Gomega) {
+				g.Expect(adminClient.Get(context.Background(), client.ObjectKeyFromObject(info), info)).To(Succeed())
+				g.Expect(info.Status.Buildpacks).To(BeEmpty())
+			}).Should(Succeed())
+		})
+	})
 
-				Consistently(func(g Gomega) {
-					g.Expect(adminClient.Get(context.Background(), client.ObjectKeyFromObject(info), info)).To(Succeed())
-					g.Expect(info.Status.Buildpacks).To(BeEmpty())
-				}).Should(Succeed())
-			})
+	When("the BuilderInfo is in a namespace other than the root namespace", func() {
+		BeforeEach(func() {
+			wrongNamespace := &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: PrefixedGUID("wrong-namespace"),
+				},
+			}
+			Expect(adminClient.Create(context.Background(), wrongNamespace)).To(Succeed())
+
+			info.Namespace = wrongNamespace.Name
+		})
+
+		It("doesn't modify that resource", func() {
+			Consistently(func(g Gomega) {
+				g.Expect(adminClient.Get(context.Background(), client.ObjectKeyFromObject(info), info)).To(Succeed())
+				g.Expect(info.Status.Buildpacks).To(BeEmpty())
+			}).Should(Succeed())
 		})
 	})
 
 	When("the ClusterBuilder doesn't exist", func() {
-		var wrongClusterBuilder *buildv1alpha2.ClusterBuilder
-
 		BeforeEach(func() {
-			info = &v1alpha1.BuilderInfo{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      controllers.BuilderInfoName,
-					Namespace: rootNamespace.Name,
-				},
-			}
-			Expect(adminClient.Create(context.Background(), info)).To(Succeed())
-
-			wrongClusterBuilder = &buildv1alpha2.ClusterBuilder{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "wrong-cluster-builder",
-				},
-			}
-
-			Expect(adminClient.Create(context.Background(), wrongClusterBuilder)).To(Succeed())
-
-			wrongClusterBuilder.Status = buildv1alpha2.BuilderStatus{
-				Order: []corev1alpha1.OrderEntry{
-					{Group: []corev1alpha1.BuildpackRef{
-						{BuildpackInfo: corev1alpha1.BuildpackInfo{Id: golangBuildpackName, Version: golangBuildpackVersion}},
-					}},
-				},
-				Stack: corev1alpha1.BuildStack{
-					ID: stack,
-				},
-			}
-			Expect(adminClient.Status().Update(context.Background(), wrongClusterBuilder)).To(Succeed())
-		})
-
-		AfterEach(func() {
-			Expect(adminClient.Delete(context.Background(), wrongClusterBuilder)).To(Succeed())
+			Expect(adminClient.Delete(ctx, clusterBuilder)).To(Succeed())
 		})
 
 		It("doesn't set the buildpacks on the BuilderInfo", func() {
-			Consistently(func(g Gomega) []v1alpha1.BuilderInfoStatusBuildpack {
+			Consistently(func(g Gomega) {
 				g.Expect(adminClient.Get(context.Background(), client.ObjectKeyFromObject(info), info)).To(Succeed())
-				return info.Status.Buildpacks
-			}).Should(BeEmpty())
+				g.Expect(info.Status.Buildpacks).To(BeEmpty())
+			}).Should(Succeed())
 
 			readyCondition := meta.FindStatusCondition(info.Status.Conditions, "Ready")
 			Expect(readyCondition).NotTo(BeNil())
 			Expect(readyCondition.Status).To(Equal(metav1.ConditionFalse))
 			Expect(readyCondition.Reason).To(Equal("ClusterBuilderMissing"))
 			Expect(readyCondition.ObservedGeneration).To(Equal(info.Generation))
-		})
-
-		When("the ClusterBuilder is created", func() {
-			BeforeEach(func() {
-				clusterBuilder = &buildv1alpha2.ClusterBuilder{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: clusterBuilderName,
-					},
-				}
-
-				Expect(adminClient.Create(context.Background(), clusterBuilder)).To(Succeed())
-
-				clusterBuilder.Status = buildv1alpha2.BuilderStatus{
-					Order: []corev1alpha1.OrderEntry{
-						{Group: []corev1alpha1.BuildpackRef{
-							{BuildpackInfo: corev1alpha1.BuildpackInfo{Id: pythonBuildpackName, Version: pythonBuildpackVersion}},
-						}},
-					},
-					Stack: corev1alpha1.BuildStack{
-						ID: stack,
-					},
-					Status: corev1alpha1.Status{
-						Conditions: []corev1alpha1.Condition{{
-							Type:   "Ready",
-							Status: "True",
-						}},
-					},
-				}
-				Expect(adminClient.Status().Update(context.Background(), clusterBuilder)).To(Succeed())
-			})
-
-			It("sets the buildpacks on the BuilderInfo", func() {
-				Eventually(func(g Gomega) []v1alpha1.BuilderInfoStatusBuildpack {
-					g.Expect(adminClient.Get(context.Background(), client.ObjectKeyFromObject(info), info)).To(Succeed())
-					return info.Status.Buildpacks
-				}).ShouldNot(BeEmpty())
-
-				Expect(info.Status.Buildpacks[0]).To(MatchFields(IgnoreExtras, Fields{
-					"Name":    Equal(pythonBuildpackName),
-					"Version": Equal(pythonBuildpackVersion),
-					"Stack":   Equal(stack),
-				}))
-				Expect(meta.IsStatusConditionTrue(info.Status.Conditions, "Ready")).To(BeTrue())
-			})
-
-			It("sets the stack", func() {
-				Eventually(func(g Gomega) []v1alpha1.BuilderInfoStatusStack {
-					g.Expect(adminClient.Get(context.Background(), client.ObjectKeyFromObject(info), info)).To(Succeed())
-					return info.Status.Stacks
-				}).Should(HaveLen(1))
-
-				Expect(info.Status.Stacks[0]).To(HaveField("Name", Equal(stack)))
-			})
 		})
 	})
 })

--- a/kpack-image-builder/controllers/buildworkload_controller_test.go
+++ b/kpack-image-builder/controllers/buildworkload_controller_test.go
@@ -63,7 +63,7 @@ var _ = Describe("BuildWorkloadReconciler", func() {
 
 		clusterBuilder = &buildv1alpha2.ClusterBuilder{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "cf-kpack-builder",
+				Name: clusterBuilderName,
 			},
 			Spec: buildv1alpha2.ClusterBuilderSpec{
 				BuilderSpec: buildv1alpha2.BuilderSpec{
@@ -212,7 +212,7 @@ var _ = Describe("BuildWorkloadReconciler", func() {
 					g.Expect(kpackImage.Spec.Build.Resources.Requests.Memory().String()).To(Equal(fmt.Sprintf("%dM", 1234)))
 
 					g.Expect(kpackImage.Spec.Builder.Kind).To(Equal("ClusterBuilder"))
-					g.Expect(kpackImage.Spec.Builder.Name).To(Equal("cf-kpack-builder")) // default builder
+					g.Expect(kpackImage.Spec.Builder.Name).To(Equal(clusterBuilder.Name)) // default builder
 					g.Expect(kpackImage.Spec.Cache.Volume.Size.Equal(resource.MustParse(expectedCacheVolumeSize))).To(BeTrue())
 				}).Should(Succeed())
 			})

--- a/tests/helpers/eventually.go
+++ b/tests/helpers/eventually.go
@@ -12,7 +12,7 @@ import (
 func EventuallyShouldHold(condition func(g Gomega)) {
 	GinkgoHelper()
 
-	Eventually(condition).WithTimeout(EventuallyTimeout()).Should(Succeed())
+	Eventually(condition).Should(Succeed())
 	Consistently(condition).Should(Succeed())
 }
 


### PR DESCRIPTION
## Is there a related GitHub Issue?
#3743
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
The builder info is created in `JustBeforeEach` so that the test could
conifugure its finalizers in `BeforeEach`. This is to address a flake in
the test when the builder info is being deleted, e.g
https://ci.korifi.cf-app.com/teams/main/pipelines/main/jobs/run-tests-periodic/builds/21592

While being here,
- refactor the suite to create the test root namespace and start the controller in `BeforeEach`. Thus test could not bother cleaning up.
- remove`Serial` from the builder info controller test
- Simplify the builder info controller test by removing contexts that do
  not contribute changes to the default setup
- Remove test cases that verify that the builder info controller is
  listening on cluster builder eventually deletion. The test verifies
  that the info is reconciled on builder change, no need to check the
  same on cluster builder delete (as from controller's point of view,
  the change type does not really matter)
<!-- _Please describe the change here._ -->


## Tag your pair, your PM, and/or team
@georgethebeatle @uzabanov
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
