### PR TITLE
Do not add chores to the release-candidate milestone

### DIFF
--- a/.github/workflows/assign-closed-issues-to-rc-milestone.yml
+++ b/.github/workflows/assign-closed-issues-to-rc-milestone.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Set Milestone for Issue
         uses: hustcer/milestone-action@v2
-        if: github.event.issue.state == 'closed'
+        if: github.event.issue.state == 'closed' && !contains(github.event.issue.labels.*.name, 'chore')
         with:
           action: bind-issue
           milestone: release-candidate


### PR DESCRIPTION
## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Do not add chores to the release-candidate milestone
<!-- _Please describe the change here._ -->

