### PR TITLE
Simplify binding sub-controllers interface

### DIFF
--- a/controllers/controllers/services/bindings/controller.go
+++ b/controllers/controllers/services/bindings/controller.go
@@ -43,7 +43,7 @@ const (
 )
 
 type DelegateReconciler interface {
-	ReconcileResource(ctx context.Context, cfServiceBinding *korifiv1alpha1.CFServiceBinding, cfServiceInstance *korifiv1alpha1.CFServiceInstance) (ctrl.Result, error)
+	ReconcileResource(ctx context.Context, cfServiceBinding *korifiv1alpha1.CFServiceBinding) (ctrl.Result, error)
 }
 
 type Reconciler struct {
@@ -151,10 +151,10 @@ func (r *Reconciler) ReconcileResource(ctx context.Context, cfServiceBinding *ko
 
 func (r *Reconciler) reconcileByType(ctx context.Context, cfServiceInstance *korifiv1alpha1.CFServiceInstance, cfServiceBinding *korifiv1alpha1.CFServiceBinding) (ctrl.Result, error) {
 	if cfServiceInstance.Spec.Type == korifiv1alpha1.UserProvidedType {
-		return r.upsiReconciler.ReconcileResource(ctx, cfServiceBinding, cfServiceInstance)
+		return r.upsiReconciler.ReconcileResource(ctx, cfServiceBinding)
 	}
 
-	return r.managedReconciler.ReconcileResource(ctx, cfServiceBinding, cfServiceInstance)
+	return r.managedReconciler.ReconcileResource(ctx, cfServiceBinding)
 }
 
 func needsRequeue(res ctrl.Result, err error) bool {

--- a/controllers/controllers/services/bindings/managed/controller.go
+++ b/controllers/controllers/services/bindings/managed/controller.go
@@ -40,7 +40,7 @@ func NewReconciler(k8sClient client.Client, brokerClientFactory osbapi.BrokerCli
 	}
 }
 
-func (r *ManagedBindingsReconciler) ReconcileResource(ctx context.Context, cfServiceBinding *korifiv1alpha1.CFServiceBinding, _ *korifiv1alpha1.CFServiceInstance) (ctrl.Result, error) {
+func (r *ManagedBindingsReconciler) ReconcileResource(ctx context.Context, cfServiceBinding *korifiv1alpha1.CFServiceBinding) (ctrl.Result, error) {
 	log := logr.FromContextOrDiscard(ctx).WithName("reconcile-managed-service-binding")
 
 	assets, err := r.assets.GetServiceBindingAssets(ctx, cfServiceBinding)


### PR DESCRIPTION
## Is there a related GitHub Issue?
#3273
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Remove the `service instance` argument from `ReconcileResource`. It was
unused in the managed sub-controller, the upsi one can look the instance
up itself.

This helps for a cleaner interface
<!-- _Please describe the change here._ -->


## Tag your pair, your PM, and/or team
@uzabanov @georgethebeatle
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
