### PR TITLE
Makefile: build-dorifi: Set GOARCH to `amd64`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,9 +82,9 @@ test-smoke: build-dorifi bin/cf
 
 
 build-dorifi:
-	CGO_ENABLED=0 GOOS=linux go build -C tests/assets/dorifi-golang -o ../dorifi/dorifi .
-	CGO_ENABLED=0 GOOS=linux go build -C tests/assets/dorifi-golang -o ../multi-process/dorifi .
-	CGO_ENABLED=0 GOOS=linux go build -C tests/assets/sample-broker-golang -o ../sample-broker/sample-broker .
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -C tests/assets/dorifi-golang -o ../dorifi/dorifi .
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -C tests/assets/dorifi-golang -o ../multi-process/dorifi .
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -C tests/assets/sample-broker-golang -o ../sample-broker/sample-broker .
 
 bin:
 	mkdir -p bin


### PR DESCRIPTION
## Is there a related GitHub Issue?
No.

## What is this change about?
I'm running the smoke tests from my local arm64 machine against an amd64 Korifi instance.
When creating the sample apps on `arm64` machine, but pushing to `amd64` Korifi instance, the tests will fail.

## Does this PR introduce a breaking change?
No, as long as the smoke apps run on amd64 for the time being.

## Acceptance Steps
Run smoke tests.

## Things to remember
Might be possible to switch to go buildpacks instead of binaries in the future.