### PR TITLE
Temporarily pin golangci-lint to 1.63.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ bin/staticcheck:
 	go install honnef.co/go/tools/cmd/staticcheck@latest
 
 bin/golangci-lint:
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.63.4
 
 bin/cf:
 	mkdir -p $(GOBIN)


### PR DESCRIPTION
## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
golangci-lint 1.64.2 reports false positives with the ginkgolinter, see https://github.com/golangci/golangci-lint/issues/5398
<!-- _Please describe the change here._ -->

