### PR TITLE
fix binding controller flake

### DIFF
--- a/controllers/controllers/networking/domains/suite_test.go
+++ b/controllers/controllers/networking/domains/suite_test.go
@@ -76,7 +76,7 @@ var _ = BeforeEach(func() {
 })
 
 var _ = AfterSuite(func() {
-	stopClientCache()
 	stopManager()
+	stopClientCache()
 	Expect(testEnv.Stop()).To(Succeed())
 })

--- a/controllers/controllers/networking/routes/suite_test.go
+++ b/controllers/controllers/networking/routes/suite_test.go
@@ -89,7 +89,7 @@ var _ = BeforeEach(func() {
 })
 
 var _ = AfterSuite(func() {
-	stopClientCache()
 	stopManager()
+	stopClientCache()
 	Expect(testEnv.Stop()).To(Succeed())
 })

--- a/controllers/controllers/services/bindings/controller_test.go
+++ b/controllers/controllers/services/bindings/controller_test.go
@@ -1,6 +1,7 @@
 package bindings_test
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -963,15 +964,17 @@ var _ = Describe("CFServiceBinding", func() {
 
 			When("last operation has succeeded", func() {
 				BeforeEach(func() {
-					brokerClient.GetServiceBindingLastOperationReturns(osbapi.LastOperationResponse{
-						State: "succeeded",
-					}, nil)
+					brokerClient.GetServiceBindingLastOperationStub = func(context.Context, osbapi.GetBindingLastOperationRequest) (osbapi.LastOperationResponse, error) {
+						brokerClient.BindReturns(osbapi.BindResponse{
+							Credentials: map[string]any{
+								"foo": "bar",
+							},
+						}, nil)
 
-					brokerClient.BindReturnsOnCall(3, osbapi.BindResponse{
-						Credentials: map[string]any{
-							"foo": "bar",
-						},
-					}, nil)
+						return osbapi.LastOperationResponse{
+							State: "succeeded",
+						}, nil
+					}
 				})
 
 				It("sets the ready condition to true", func() {

--- a/controllers/controllers/services/bindings/suite_test.go
+++ b/controllers/controllers/services/bindings/suite_test.go
@@ -120,6 +120,6 @@ var _ = JustBeforeEach(func() {
 })
 
 var _ = AfterEach(func() {
-	stopClientCache()
 	stopManager()
+	stopClientCache()
 })

--- a/controllers/controllers/services/brokers/suite_test.go
+++ b/controllers/controllers/services/brokers/suite_test.go
@@ -112,6 +112,6 @@ var _ = JustBeforeEach(func() {
 })
 
 var _ = AfterEach(func() {
-	stopClientCache()
 	stopManager()
+	stopClientCache()
 })

--- a/controllers/controllers/services/instances/managed/suite_test.go
+++ b/controllers/controllers/services/instances/managed/suite_test.go
@@ -115,6 +115,6 @@ var _ = JustBeforeEach(func() {
 })
 
 var _ = AfterEach(func() {
-	stopClientCache()
 	stopManager()
+	stopClientCache()
 })

--- a/controllers/controllers/services/instances/upsi/suite_test.go
+++ b/controllers/controllers/services/instances/upsi/suite_test.go
@@ -86,7 +86,7 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	stopClientCache()
 	stopManager()
+	stopClientCache()
 	Expect(testEnv.Stop()).To(Succeed())
 })

--- a/controllers/controllers/workloads/env/env_suite_test.go
+++ b/controllers/controllers/workloads/env/env_suite_test.go
@@ -74,8 +74,8 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	stopClientCache()
 	stopManager()
+	stopClientCache()
 	Expect(testEnv.Stop()).To(Succeed())
 })
 

--- a/controllers/webhooks/finalizer/suite_test.go
+++ b/controllers/webhooks/finalizer/suite_test.go
@@ -84,7 +84,7 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	stopClientCache()
 	stopManager()
+	stopClientCache()
 	Expect(testEnv.Stop()).To(Succeed())
 })

--- a/controllers/webhooks/relationships/suite_test.go
+++ b/controllers/webhooks/relationships/suite_test.go
@@ -77,7 +77,7 @@ var _ = BeforeEach(func() {
 })
 
 var _ = AfterSuite(func() {
-	stopClientCache()
 	stopManager()
+	stopClientCache()
 	Expect(testEnv.Stop()).To(Succeed())
 })

--- a/controllers/webhooks/version/suite_test.go
+++ b/controllers/webhooks/version/suite_test.go
@@ -80,7 +80,7 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	stopClientCache()
 	stopManager()
+	stopClientCache()
 	Expect(testEnv.Stop()).To(Succeed())
 })

--- a/controllers/webhooks/workloads/apps/suite_test.go
+++ b/controllers/webhooks/workloads/apps/suite_test.go
@@ -101,7 +101,7 @@ var _ = BeforeEach(func() {
 })
 
 var _ = AfterSuite(func() {
-	stopClientCache()
 	stopManager()
+	stopClientCache()
 	Expect(testEnv.Stop()).To(Succeed())
 })

--- a/controllers/webhooks/workloads/orgs/suite_test.go
+++ b/controllers/webhooks/workloads/orgs/suite_test.go
@@ -99,7 +99,7 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	stopClientCache()
 	stopManager()
+	stopClientCache()
 	Expect(testEnv.Stop()).To(Succeed())
 })

--- a/controllers/webhooks/workloads/packages/suite_test.go
+++ b/controllers/webhooks/workloads/packages/suite_test.go
@@ -95,7 +95,7 @@ var _ = BeforeEach(func() {
 })
 
 var _ = AfterSuite(func() {
-	stopClientCache()
 	stopManager()
+	stopClientCache()
 	Expect(testEnv.Stop()).To(Succeed())
 })

--- a/controllers/webhooks/workloads/spaces/suite_test.go
+++ b/controllers/webhooks/workloads/spaces/suite_test.go
@@ -99,7 +99,7 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	stopClientCache()
 	stopManager()
+	stopClientCache()
 	Expect(testEnv.Stop()).To(Succeed())
 })

--- a/controllers/webhooks/workloads/tasks/suite_test.go
+++ b/controllers/webhooks/workloads/tasks/suite_test.go
@@ -100,7 +100,7 @@ var _ = BeforeEach(func() {
 })
 
 var _ = AfterSuite(func() {
-	stopClientCache()
 	stopManager()
+	stopClientCache()
 	Expect(testEnv.Stop()).To(Succeed())
 })

--- a/job-task-runner/controllers/integration/suite_test.go
+++ b/job-task-runner/controllers/integration/suite_test.go
@@ -92,8 +92,8 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	stopClient()
 	stopManager()
+	stopClient()
 	Expect(testEnv.Stop()).To(Succeed())
 })
 

--- a/kpack-image-builder/controllers/suite_test.go
+++ b/kpack-image-builder/controllers/suite_test.go
@@ -182,6 +182,6 @@ var _ = BeforeEach(func() {
 })
 
 var _ = AfterEach(func() {
-	stopClientCache()
 	stopManager()
+	stopClientCache()
 })

--- a/kpack-image-builder/controllers/webhooks/finalizer/suite_integration_test.go
+++ b/kpack-image-builder/controllers/webhooks/finalizer/suite_integration_test.go
@@ -91,7 +91,7 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	stopClientCache()
 	stopManager()
+	stopClientCache()
 	Expect(testEnv.Stop()).To(Succeed())
 })

--- a/statefulset-runner/controllers/integration/suite_test.go
+++ b/statefulset-runner/controllers/integration/suite_test.go
@@ -116,8 +116,8 @@ var _ = JustBeforeEach(func() {
 })
 
 var _ = AfterEach(func() {
-	stopClientCache()
 	stopManager()
+	stopClientCache()
 })
 
 var _ = AfterSuite(func() {


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Flake: https://ci.korifi.cf-app.com/teams/main/pipelines/main/jobs/run-tests-periodic/builds/22068

According to failure logs, the service binding is being reconciled
multiple times before the binding gets into its ready state.

This means that if we stub the broker client to return a sync response
on invocation 3 only, it is quite probable that the fake's sync response
is not properly processed and subsequent reconciles still see that the
operation is ongoing.

Therefore, this change alters stubs the broker client to return a sync
response (i.e. override the default async one) when it returns a
succeeded operation

While being here, also fix the order of shutting down the the k8s client cache and manager
<!-- _Please describe the change here._ -->


## Tag your pair, your PM, and/or team
@georgethebeatle @uzabanov
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
