### PR TITLE
Making route controller optional enabling customising of route controllers

### DIFF
--- a/controllers/config/config.go
+++ b/controllers/config/config.go
@@ -49,11 +49,10 @@ type Networking struct {
 }
 
 const (
-	defaultTaskTTL                      = 30 * 24 * time.Hour
-	defaultTimeout                int32 = 60
-	defaultJobTTL                       = 24 * time.Hour
-	defaultBuildCacheMB                 = 2048
-	defaultDisableRouteController       = false
+	defaultTaskTTL            = 30 * 24 * time.Hour
+	defaultTimeout      int32 = 60
+	defaultJobTTL             = 24 * time.Hour
+	defaultBuildCacheMB       = 2048
 )
 
 func LoadFromPath(path string) (*ControllerConfig, error) {

--- a/controllers/config/config.go
+++ b/controllers/config/config.go
@@ -28,6 +28,7 @@ type ControllerConfig struct {
 
 	ExperimentalManagedServicesEnabled bool `yaml:"experimentalManagedServicesEnabled"`
 	TrustInsecureServiceBrokers        bool `yaml:"trustInsecureServiceBrokers"`
+	DisableRouteController             bool `yaml:"disableRouteController"`
 }
 
 type CFProcessDefaults struct {
@@ -48,10 +49,11 @@ type Networking struct {
 }
 
 const (
-	defaultTaskTTL            = 30 * 24 * time.Hour
-	defaultTimeout      int32 = 60
-	defaultJobTTL             = 24 * time.Hour
-	defaultBuildCacheMB       = 2048
+	defaultTaskTTL                      = 30 * 24 * time.Hour
+	defaultTimeout                int32 = 60
+	defaultJobTTL                       = 24 * time.Hour
+	defaultBuildCacheMB                 = 2048
+	defaultDisableRouteController       = false
 )
 
 func LoadFromPath(path string) (*ControllerConfig, error) {

--- a/controllers/config/config_test.go
+++ b/controllers/config/config_test.go
@@ -53,7 +53,6 @@ var _ = Describe("LoadFromPath", func() {
 			},
 			ExperimentalManagedServicesEnabled: true,
 			TrustInsecureServiceBrokers:        true,
-			DisableRouteController:             false,
 		}
 	})
 
@@ -97,7 +96,6 @@ var _ = Describe("LoadFromPath", func() {
 			},
 			ExperimentalManagedServicesEnabled: true,
 			TrustInsecureServiceBrokers:        true,
-			DisableRouteController:             false,
 		}))
 	})
 
@@ -108,6 +106,15 @@ var _ = Describe("LoadFromPath", func() {
 
 		It("uses the default", func() {
 			Expect(retConfig.CFProcessDefaults.Timeout).To(gstruct.PointTo(BeEquivalentTo(60)))
+		})
+	})
+
+	When("the disable route controller is not set", func() {
+		BeforeEach(func() {
+		})
+
+		It("uses the default", func() {
+			Expect(retConfig.DisableRouteController).To(Equal(false))
 		})
 	})
 

--- a/controllers/config/config_test.go
+++ b/controllers/config/config_test.go
@@ -53,6 +53,7 @@ var _ = Describe("LoadFromPath", func() {
 			},
 			ExperimentalManagedServicesEnabled: true,
 			TrustInsecureServiceBrokers:        true,
+			DisableRouteController:             false,
 		}
 	})
 
@@ -96,6 +97,7 @@ var _ = Describe("LoadFromPath", func() {
 			},
 			ExperimentalManagedServicesEnabled: true,
 			TrustInsecureServiceBrokers:        true,
+			DisableRouteController:             false,
 		}))
 	})
 

--- a/controllers/config/config_test.go
+++ b/controllers/config/config_test.go
@@ -114,7 +114,7 @@ var _ = Describe("LoadFromPath", func() {
 		})
 
 		It("uses the default", func() {
-			Expect(retConfig.DisableRouteController).To(Equal(false))
+			Expect(retConfig.DisableRouteController).To(BeFalse())
 		})
 	})
 

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"code.cloudfoundry.org/korifi/controllers/controllers/networking/routes"
 	"context"
 	"flag"
 	"fmt"
@@ -29,6 +28,7 @@ import (
 	"code.cloudfoundry.org/korifi/controllers/cleanup"
 	"code.cloudfoundry.org/korifi/controllers/config"
 	"code.cloudfoundry.org/korifi/controllers/controllers/networking/domains"
+	"code.cloudfoundry.org/korifi/controllers/controllers/networking/routes"
 	"code.cloudfoundry.org/korifi/controllers/controllers/services/bindings"
 	managed_bindings "code.cloudfoundry.org/korifi/controllers/controllers/services/bindings/managed"
 	upsi_bindings "code.cloudfoundry.org/korifi/controllers/controllers/services/bindings/upsi"

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"code.cloudfoundry.org/korifi/controllers/controllers/networking/routes"
 	"context"
 	"flag"
 	"fmt"
@@ -28,7 +29,6 @@ import (
 	"code.cloudfoundry.org/korifi/controllers/cleanup"
 	"code.cloudfoundry.org/korifi/controllers/config"
 	"code.cloudfoundry.org/korifi/controllers/controllers/networking/domains"
-	"code.cloudfoundry.org/korifi/controllers/controllers/networking/routes"
 	"code.cloudfoundry.org/korifi/controllers/controllers/services/bindings"
 	managed_bindings "code.cloudfoundry.org/korifi/controllers/controllers/services/bindings/managed"
 	upsi_bindings "code.cloudfoundry.org/korifi/controllers/controllers/services/bindings/upsi"
@@ -336,16 +336,17 @@ func main() {
 			os.Exit(1)
 		}
 
-		if err = routes.NewReconciler(
-			mgr.GetClient(),
-			mgr.GetScheme(),
-			controllersLog,
-			controllerConfig,
-		).SetupWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create controller", "controller", "CFRoute")
-			os.Exit(1)
+		if !controllerConfig.DisableRouteController {
+			if err = routes.NewReconciler(
+				mgr.GetClient(),
+				mgr.GetScheme(),
+				controllersLog,
+				controllerConfig,
+			).SetupWithManager(mgr); err != nil {
+				setupLog.Error(err, "unable to create controller", "controller", "CFRoute")
+				os.Exit(1)
+			}
 		}
-
 	}
 
 	// Setup webhooks with manager

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -28,7 +28,6 @@ import (
 	"code.cloudfoundry.org/korifi/controllers/cleanup"
 	"code.cloudfoundry.org/korifi/controllers/config"
 	"code.cloudfoundry.org/korifi/controllers/controllers/networking/domains"
-	"code.cloudfoundry.org/korifi/controllers/controllers/networking/routes"
 	"code.cloudfoundry.org/korifi/controllers/controllers/services/bindings"
 	managed_bindings "code.cloudfoundry.org/korifi/controllers/controllers/services/bindings/managed"
 	upsi_bindings "code.cloudfoundry.org/korifi/controllers/controllers/services/bindings/upsi"
@@ -337,17 +336,6 @@ func main() {
 			setupLog.Error(err, "unable to setup index on manager")
 			os.Exit(1)
 		}
-
-		if err = routes.NewReconciler(
-			mgr.GetClient(),
-			mgr.GetScheme(),
-			controllersLog,
-			controllerConfig,
-		).SetupWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create controller", "controller", "CFRoute")
-			os.Exit(1)
-		}
-
 	}
 
 	// Setup webhooks with manager

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -28,6 +28,7 @@ import (
 	"code.cloudfoundry.org/korifi/controllers/cleanup"
 	"code.cloudfoundry.org/korifi/controllers/config"
 	"code.cloudfoundry.org/korifi/controllers/controllers/networking/domains"
+	"code.cloudfoundry.org/korifi/controllers/controllers/networking/routes"
 	"code.cloudfoundry.org/korifi/controllers/controllers/services/bindings"
 	managed_bindings "code.cloudfoundry.org/korifi/controllers/controllers/services/bindings/managed"
 	upsi_bindings "code.cloudfoundry.org/korifi/controllers/controllers/services/bindings/upsi"
@@ -77,7 +78,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
-	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -93,7 +93,6 @@ var (
 func init() {
 	utilruntime.Must(buildv1alpha2.AddToScheme(scheme))
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-	utilruntime.Must(gatewayv1beta1.Install(scheme))
 	utilruntime.Must(korifiv1alpha1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
 }
@@ -336,6 +335,17 @@ func main() {
 			setupLog.Error(err, "unable to setup index on manager")
 			os.Exit(1)
 		}
+
+		if err = routes.NewReconciler(
+			mgr.GetClient(),
+			mgr.GetScheme(),
+			controllersLog,
+			controllerConfig,
+		).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "CFRoute")
+			os.Exit(1)
+		}
+
 	}
 
 	// Setup webhooks with manager


### PR DESCRIPTION
## What is this change about?

This change makes cf routing controller optional. A boolean controller config property "DisableRouteController" was introduced for it. It allows to define custom routing controllers in future.

## Does this PR introduce a breaking change?

The default value of the boolean config property "DisableRouteController" is false, so everything stays the same, for those using default routing controller.

## Acceptance Steps

make test
