### PR TITLE
Remove redundant eventually statements in e2e tests

### DIFF
--- a/tests/e2e/buildpacks_test.go
+++ b/tests/e2e/buildpacks_test.go
@@ -12,7 +12,7 @@ import (
 var _ = Describe("Buildpacks", func() {
 	Describe("list", func() {
 		var (
-			result resourceList[responseResource]
+			result resourceList[buildpackResource]
 			resp   *resty.Response
 		)
 
@@ -27,7 +27,9 @@ var _ = Describe("Buildpacks", func() {
 		It("returns a list of buildpacks", func() {
 			Expect(resp).To(HaveRestyStatusCode(http.StatusOK))
 			Expect(result.Resources).To(ContainElements(
-				MatchFields(IgnoreExtras, Fields{"Name": ContainSubstring("java")}),
+				MatchFields(IgnoreExtras, Fields{
+					"Stack": Not(BeEmpty()),
+				}),
 			))
 		})
 	})

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -303,6 +303,11 @@ type planVisibilityResource struct {
 	Organizations []services.VisibilityOrganization `json:"organizations"`
 }
 
+type buildpackResource struct {
+	resource `json:",inline"`
+	Stack    string `json:"stack"`
+}
+
 func TestE2E(t *testing.T) {
 	RegisterFailHandler(fail_handler.New("E2E Tests",
 		fail_handler.Hook{

--- a/tests/e2e/multi_process_test.go
+++ b/tests/e2e/multi_process_test.go
@@ -22,8 +22,7 @@ var _ = Describe("Multi Process", func() {
 		spaceGUID = createSpace(generateGUID("space"), commonTestOrgGUID)
 		appGUID, _ = pushTestApp(spaceGUID, multiProcessAppBitsFile)
 		workerProcessGUID = getProcess(appGUID, "worker").GUID
-		body := curlApp(appGUID, "")
-		Expect(body).To(ContainSubstring("Hi, I'm Dorifi (web)!"))
+		Expect(curlApp(appGUID)).To(ContainSubstring("Hi, I'm Dorifi (web)!"))
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Remove redundant eventually statements in e2e tests

Bonus improvements
- introdude new utility finctions for app start and restart
- introduce utility to get the app response as a json object
- Fix buildpack e2e test
<!-- _Please describe the change here._ -->

