### PR TITLE
Group all gomod dependency bumps into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
   directory: "/"
   schedule:
     interval: "daily"
+  groups:
+    gomod:
+      patterns:
+        - "*"
 
 - package-ecosystem: "docker"
   directory: "/api"


### PR DESCRIPTION
## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Group all gomod dependency bumps into one PR

This reverts commit c4277ac8ba3b86bc59c8c9f8721329b6118e7189.

We had to disable PR grouping for a while until we adopted
controller-runtime 0.20.0. Now that we have already done that, we can
bring PR grouping back
<!-- _Please describe the change here._ -->

