### PR TITLE
Added missing links - domains and default_domain

### DIFF
--- a/api/presenter/org.go
+++ b/api/presenter/org.go
@@ -47,6 +47,12 @@ func ForOrg(org repositories.OrgRecord, apiBaseURL url.URL, includes ...include.
 			Self: &Link{
 				HRef: buildURL(apiBaseURL).appendPath(orgsBase, org.GUID).build(),
 			},
+			Domains: &Link{
+				HRef: buildURL(apiBaseURL).appendPath(orgsBase, org.GUID, "domains").build(),
+			},
+			DefaultDomain: &Link{
+				HRef: buildURL(apiBaseURL).appendPath(orgsBase, org.GUID, "domains/default").build(),
+			},
 		},
 	}
 }

--- a/api/presenter/org_test.go
+++ b/api/presenter/org_test.go
@@ -65,6 +65,12 @@ var _ = Describe("Org", func() {
 			"links": {
 				"self": {
 					"href": "https://api.example.org/v3/organizations/org-guid"
+				},
+				"domains": {
+					"href": "https://api.example.org/v3/organizations/org-guid/domains"
+				},
+				"default_domain": {
+					"href": "https://api.example.org/v3/organizations/org-guid/domains/default"
 				}
 			}
 		}`))


### PR DESCRIPTION

## Is there a related GitHub Issue?
[issue](https://github.com/cloudfoundry/korifi/issues/3848)

## What is this change about?
There are two fields missing in the json response section links for endpoint **GET /v3/orgs/{guid}**

## Does this PR introduce a breaking change?
No

