### PR TITLE
Updated org patch endpoint to support org name

### DIFF
--- a/api/handlers/fake/cforg_repository.go
+++ b/api/handlers/fake/cforg_repository.go
@@ -85,18 +85,18 @@ type CFOrgRepository struct {
 		result1 []repositories.OrgRecord
 		result2 error
 	}
-	PatchOrgMetadataStub        func(context.Context, authorization.Info, repositories.PatchOrgMetadataMessage) (repositories.OrgRecord, error)
-	patchOrgMetadataMutex       sync.RWMutex
-	patchOrgMetadataArgsForCall []struct {
+	PatchOrgStub        func(context.Context, authorization.Info, repositories.PatchOrgMessage) (repositories.OrgRecord, error)
+	patchOrgMutex       sync.RWMutex
+	patchOrgArgsForCall []struct {
 		arg1 context.Context
 		arg2 authorization.Info
-		arg3 repositories.PatchOrgMetadataMessage
+		arg3 repositories.PatchOrgMessage
 	}
-	patchOrgMetadataReturns struct {
+	patchOrgReturns struct {
 		result1 repositories.OrgRecord
 		result2 error
 	}
-	patchOrgMetadataReturnsOnCall map[int]struct {
+	patchOrgReturnsOnCall map[int]struct {
 		result1 repositories.OrgRecord
 		result2 error
 	}
@@ -431,18 +431,18 @@ func (fake *CFOrgRepository) ListOrgsReturnsOnCall(i int, result1 []repositories
 	}{result1, result2}
 }
 
-func (fake *CFOrgRepository) PatchOrgMetadata(arg1 context.Context, arg2 authorization.Info, arg3 repositories.PatchOrgMetadataMessage) (repositories.OrgRecord, error) {
-	fake.patchOrgMetadataMutex.Lock()
-	ret, specificReturn := fake.patchOrgMetadataReturnsOnCall[len(fake.patchOrgMetadataArgsForCall)]
-	fake.patchOrgMetadataArgsForCall = append(fake.patchOrgMetadataArgsForCall, struct {
+func (fake *CFOrgRepository) PatchOrg(arg1 context.Context, arg2 authorization.Info, arg3 repositories.PatchOrgMessage) (repositories.OrgRecord, error) {
+	fake.patchOrgMutex.Lock()
+	ret, specificReturn := fake.patchOrgReturnsOnCall[len(fake.patchOrgArgsForCall)]
+	fake.patchOrgArgsForCall = append(fake.patchOrgArgsForCall, struct {
 		arg1 context.Context
 		arg2 authorization.Info
-		arg3 repositories.PatchOrgMetadataMessage
+		arg3 repositories.PatchOrgMessage
 	}{arg1, arg2, arg3})
-	stub := fake.PatchOrgMetadataStub
-	fakeReturns := fake.patchOrgMetadataReturns
-	fake.recordInvocation("PatchOrgMetadata", []interface{}{arg1, arg2, arg3})
-	fake.patchOrgMetadataMutex.Unlock()
+	stub := fake.PatchOrgStub
+	fakeReturns := fake.patchOrgReturns
+	fake.recordInvocation("PatchOrg", []interface{}{arg1, arg2, arg3})
+	fake.patchOrgMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2, arg3)
 	}
@@ -452,46 +452,46 @@ func (fake *CFOrgRepository) PatchOrgMetadata(arg1 context.Context, arg2 authori
 	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *CFOrgRepository) PatchOrgMetadataCallCount() int {
-	fake.patchOrgMetadataMutex.RLock()
-	defer fake.patchOrgMetadataMutex.RUnlock()
-	return len(fake.patchOrgMetadataArgsForCall)
+func (fake *CFOrgRepository) PatchOrgCallCount() int {
+	fake.patchOrgMutex.RLock()
+	defer fake.patchOrgMutex.RUnlock()
+	return len(fake.patchOrgArgsForCall)
 }
 
-func (fake *CFOrgRepository) PatchOrgMetadataCalls(stub func(context.Context, authorization.Info, repositories.PatchOrgMetadataMessage) (repositories.OrgRecord, error)) {
-	fake.patchOrgMetadataMutex.Lock()
-	defer fake.patchOrgMetadataMutex.Unlock()
-	fake.PatchOrgMetadataStub = stub
+func (fake *CFOrgRepository) PatchOrgCalls(stub func(context.Context, authorization.Info, repositories.PatchOrgMessage) (repositories.OrgRecord, error)) {
+	fake.patchOrgMutex.Lock()
+	defer fake.patchOrgMutex.Unlock()
+	fake.PatchOrgStub = stub
 }
 
-func (fake *CFOrgRepository) PatchOrgMetadataArgsForCall(i int) (context.Context, authorization.Info, repositories.PatchOrgMetadataMessage) {
-	fake.patchOrgMetadataMutex.RLock()
-	defer fake.patchOrgMetadataMutex.RUnlock()
-	argsForCall := fake.patchOrgMetadataArgsForCall[i]
+func (fake *CFOrgRepository) PatchOrgArgsForCall(i int) (context.Context, authorization.Info, repositories.PatchOrgMessage) {
+	fake.patchOrgMutex.RLock()
+	defer fake.patchOrgMutex.RUnlock()
+	argsForCall := fake.patchOrgArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
-func (fake *CFOrgRepository) PatchOrgMetadataReturns(result1 repositories.OrgRecord, result2 error) {
-	fake.patchOrgMetadataMutex.Lock()
-	defer fake.patchOrgMetadataMutex.Unlock()
-	fake.PatchOrgMetadataStub = nil
-	fake.patchOrgMetadataReturns = struct {
+func (fake *CFOrgRepository) PatchOrgReturns(result1 repositories.OrgRecord, result2 error) {
+	fake.patchOrgMutex.Lock()
+	defer fake.patchOrgMutex.Unlock()
+	fake.PatchOrgStub = nil
+	fake.patchOrgReturns = struct {
 		result1 repositories.OrgRecord
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *CFOrgRepository) PatchOrgMetadataReturnsOnCall(i int, result1 repositories.OrgRecord, result2 error) {
-	fake.patchOrgMetadataMutex.Lock()
-	defer fake.patchOrgMetadataMutex.Unlock()
-	fake.PatchOrgMetadataStub = nil
-	if fake.patchOrgMetadataReturnsOnCall == nil {
-		fake.patchOrgMetadataReturnsOnCall = make(map[int]struct {
+func (fake *CFOrgRepository) PatchOrgReturnsOnCall(i int, result1 repositories.OrgRecord, result2 error) {
+	fake.patchOrgMutex.Lock()
+	defer fake.patchOrgMutex.Unlock()
+	fake.PatchOrgStub = nil
+	if fake.patchOrgReturnsOnCall == nil {
+		fake.patchOrgReturnsOnCall = make(map[int]struct {
 			result1 repositories.OrgRecord
 			result2 error
 		})
 	}
-	fake.patchOrgMetadataReturnsOnCall[i] = struct {
+	fake.patchOrgReturnsOnCall[i] = struct {
 		result1 repositories.OrgRecord
 		result2 error
 	}{result1, result2}
@@ -510,8 +510,8 @@ func (fake *CFOrgRepository) Invocations() map[string][][]interface{} {
 	defer fake.getOrgMutex.RUnlock()
 	fake.listOrgsMutex.RLock()
 	defer fake.listOrgsMutex.RUnlock()
-	fake.patchOrgMetadataMutex.RLock()
-	defer fake.patchOrgMetadataMutex.RUnlock()
+	fake.patchOrgMutex.RLock()
+	defer fake.patchOrgMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/api/handlers/org.go
+++ b/api/handlers/org.go
@@ -33,7 +33,7 @@ type CFOrgRepository interface {
 	ListOrgs(context.Context, authorization.Info, repositories.ListOrgsMessage) ([]repositories.OrgRecord, error)
 	DeleteOrg(context.Context, authorization.Info, repositories.DeleteOrgMessage) error
 	GetOrg(context.Context, authorization.Info, string) (repositories.OrgRecord, error)
-	PatchOrgMetadata(context.Context, authorization.Info, repositories.PatchOrgMetadataMessage) (repositories.OrgRecord, error)
+	PatchOrg(context.Context, authorization.Info, repositories.PatchOrgMessage) (repositories.OrgRecord, error)
 	GetDeletedAt(context.Context, authorization.Info, string) (*time.Time, error)
 }
 
@@ -91,7 +91,7 @@ func (h *Org) update(r *http.Request) (*routing.Response, error) {
 		return nil, apierrors.LogAndReturn(logger, err, "failed to decode payload")
 	}
 
-	org, err := h.orgRepo.PatchOrgMetadata(r.Context(), authInfo, payload.ToMessage(orgGUID))
+	org, err := h.orgRepo.PatchOrg(r.Context(), authInfo, payload.ToMessage(orgGUID))
 	if err != nil {
 		return nil, apierrors.LogAndReturn(logger, err, "Failed to patch org metadata", "OrgGUID", orgGUID)
 	}

--- a/api/payloads/org.go
+++ b/api/payloads/org.go
@@ -30,18 +30,21 @@ func (p OrgCreate) ToMessage() repositories.CreateOrgMessage {
 }
 
 type OrgPatch struct {
+	Name     *string       `json:"name"`
 	Metadata MetadataPatch `json:"metadata"`
 }
 
 func (p OrgPatch) Validate() error {
 	return validation.ValidateStruct(&p,
 		validation.Field(&p.Metadata),
+		validation.Field(&p.Name, validation.NilOrNotEmpty),
 	)
 }
 
-func (p OrgPatch) ToMessage(orgGUID string) repositories.PatchOrgMetadataMessage {
-	return repositories.PatchOrgMetadataMessage{
+func (p OrgPatch) ToMessage(orgGUID string) repositories.PatchOrgMessage {
+	return repositories.PatchOrgMessage{
 		GUID: orgGUID,
+		Name: p.Name,
 		MetadataPatch: repositories.MetadataPatch{
 			Labels:      p.Metadata.Labels,
 			Annotations: p.Metadata.Annotations,

--- a/api/payloads/org_test.go
+++ b/api/payloads/org_test.go
@@ -64,6 +64,7 @@ var _ = Describe("Org", func() {
 
 		BeforeEach(func() {
 			payload = payloads.OrgPatch{
+				Name: tools.PtrTo("new-org-name"),
 				Metadata: payloads.MetadataPatch{
 					Annotations: map[string]*string{
 						"foo": tools.PtrTo("bar"),
@@ -95,6 +96,18 @@ var _ = Describe("Org", func() {
 				expectUnprocessableEntityError(
 					validatorErr,
 					"label/annotation key cannot use the cloudfoundry.org domain",
+				)
+			})
+		})
+		When("the name is invalid", func() {
+			BeforeEach(func() {
+				payload.Name = tools.PtrTo("")
+			})
+
+			It("returns an unprocessable entity error", func() {
+				expectUnprocessableEntityError(
+					validatorErr,
+					"name cannot be blank",
 				)
 			})
 		})

--- a/api/repositories/org_repository.go
+++ b/api/repositories/org_repository.go
@@ -46,9 +46,17 @@ type DeleteOrgMessage struct {
 	GUID string
 }
 
-type PatchOrgMetadataMessage struct {
+type PatchOrgMessage struct {
 	MetadataPatch
 	GUID string
+	Name *string
+}
+
+func (p *PatchOrgMessage) Apply(org *korifiv1alpha1.CFOrg) {
+	if p.Name != nil {
+		org.Spec.DisplayName = *p.Name
+	}
+	p.MetadataPatch.Apply(org)
 }
 
 type OrgRecord struct {
@@ -168,7 +176,7 @@ func (r *OrgRepo) DeleteOrg(ctx context.Context, info authorization.Info, messag
 	return apierrors.FromK8sError(err, OrgResourceType)
 }
 
-func (r *OrgRepo) PatchOrgMetadata(ctx context.Context, authInfo authorization.Info, message PatchOrgMetadataMessage) (OrgRecord, error) {
+func (r *OrgRepo) PatchOrg(ctx context.Context, authInfo authorization.Info, message PatchOrgMessage) (OrgRecord, error) {
 	userClient, err := r.userClientFactory.BuildClient(authInfo)
 	if err != nil {
 		return OrgRecord{}, fmt.Errorf("failed to build user client: %w", err)


### PR DESCRIPTION

## Is there a related GitHub Issue?
[Issue](https://github.com/cloudfoundry/korifi/issues/3852)

## What is this change about?
This change enables support for updating the organization name via the `PATCH /v3/organizations/:guid `API endpoint.

## Does this PR introduce a breaking change?
No
