### PR TITLE
Attempt to fix flake

### DIFF
--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -938,11 +938,6 @@ func appAction(appGUID, action string) {
 	Expect(resp).To(HaveRestyStatusCode(http.StatusOK))
 }
 
-func startApp(appGUID string) {
-	GinkgoHelper()
-	appAction(appGUID, "start")
-}
-
 func restartApp(appGUID string) {
 	GinkgoHelper()
 	appAction(appGUID, "restart")
@@ -1008,7 +1003,7 @@ func pushTestAppWithName(spaceGUID, appBitsFile string, appName string) string {
 	waitForDroplet(buildGUID)
 	setCurrentDroplet(appGUID, buildGUID)
 	waitAppStaged(appGUID)
-	startApp(appGUID)
+	restartApp(appGUID)
 
 	return appGUID
 }


### PR DESCRIPTION
## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Attempt to fix flake

https://ci.korifi.cf-app.com/teams/main/pipelines/main/jobs/run-e2es-periodic/builds/19981#L67d268f0:4690:4708

The test is re-pushing a started app and expects to see the new
response. Instead it sees the old response.

This could be happening because the pushTestAppWithName helper func does
an app start after setting the droplet. In this particular case the app
is already started, therefore the start action might return immediately,
thus not [waiting](https://github.com/cloudfoundry/korifi/blob/362054ce62c1a810ec226e4eeaf3250a084bd219/api/repositories/app_repository.go#L459-L470) for the app to become stopped, then started again.
Replacing the start action with a restart action should fix this flake.
<!-- _Please describe the change here._ -->

