### PR TITLE
Fix async service create/delete and and bind/unbind

### DIFF
--- a/api/handlers/job_test.go
+++ b/api/handlers/job_test.go
@@ -114,7 +114,7 @@ var _ = Describe("Job", func() {
 					MatchJSONPath("$.state", "FAILED"),
 					MatchJSONPath("$.errors", ConsistOf(map[string]interface{}{
 						"code":   float64(10008),
-						"detail": "Testing deletion timed out, check the remaining \"my-resource-guid\" resource",
+						"detail": "testing deletion timed out, check the remaining \"my-resource-guid\" resource",
 						"title":  "CF-UnprocessableEntity",
 					})),
 				)))
@@ -155,7 +155,7 @@ var _ = Describe("Job", func() {
 
 		BeforeEach(func() {
 			stateRepo = new(fake.StateRepository)
-			stateRepo.GetStateReturns(repositories.ResourceStateUnknown, nil)
+			stateRepo.GetStateReturns(repositories.ResourceStateReady, nil)
 			stateRepos["testing.state"] = stateRepo
 
 			jobGUID = "testing.state~my-resource-guid"
@@ -172,22 +172,9 @@ var _ = Describe("Job", func() {
 				MatchJSONPath("$.guid", jobGUID),
 				MatchJSONPath("$.links.self.href", defaultServerURL+"/v3/jobs/"+jobGUID),
 				MatchJSONPath("$.operation", "testing.state"),
-				MatchJSONPath("$.state", "PROCESSING"),
+				MatchJSONPath("$.state", "COMPLETE"),
 				MatchJSONPath("$.errors", BeEmpty()),
 			)))
-		})
-
-		When("the resource state is Ready", func() {
-			BeforeEach(func() {
-				stateRepo.GetStateReturns(repositories.ResourceStateReady, nil)
-			})
-
-			It("returns a complete status", func() {
-				Expect(rr).To(HaveHTTPBody(SatisfyAll(
-					MatchJSONPath("$.state", "COMPLETE"),
-					MatchJSONPath("$.errors", BeEmpty()),
-				)))
-			})
 		})
 
 		When("the user does not have permission to see the resource", func() {

--- a/api/repositories/service_instance_repository.go
+++ b/api/repositories/service_instance_repository.go
@@ -522,7 +522,8 @@ func (r *ServiceInstanceRepo) DeleteServiceInstance(ctx context.Context, authInf
 		}
 	}
 
-	if err := userClient.Delete(ctx, serviceInstance); err != nil {
+	err = userClient.Delete(ctx, serviceInstance)
+	if client.IgnoreNotFound(err) != nil {
 		return ServiceInstanceRecord{}, fmt.Errorf("failed to delete service instance: %w", apierrors.FromK8sError(err, ServiceInstanceResourceType))
 	}
 

--- a/controllers/controllers/workloads/apps/controller.go
+++ b/controllers/controllers/workloads/apps/controller.go
@@ -175,7 +175,9 @@ func (r *Reconciler) getServiceBindings(ctx context.Context, cfApp *korifiv1alph
 		return nil, err
 	}
 
-	return bindings.Items, nil
+	return slices.Collect(it.Exclude(slices.Values(bindings.Items), func(b korifiv1alpha1.CFServiceBinding) bool {
+		return b.DeletionTimestamp != nil
+	})), nil
 }
 
 func bindingsReady(bindings []korifiv1alpha1.CFServiceBinding) bool {


### PR DESCRIPTION
## Is there a related GitHub Issue?
#3856
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
- Return POLLING jobs state for async instance/bindings operations. This way the `--wait` flag of the cf cli behaves correctly
- Ignore NotFound error on deleting service instances. This prevents `cf purge-service-instance` from failing if invoked while the service is already being deprovisioned.
