### PR TITLE
Requeue instance finalization when bindings remaining

### DIFF
--- a/controllers/controllers/services/instances/managed/controller.go
+++ b/controllers/controllers/services/instances/managed/controller.go
@@ -278,6 +278,15 @@ func (r *Reconciler) finalizeCFServiceInstance(
 		return ctrl.Result{}, nil
 	}
 
+	bindings, err := r.getBindings(ctx, serviceInstance)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	if len(bindings) > 0 {
+		return ctrl.Result{}, k8s.NewNotReadyError().WithReason("BindingsAvailable").WithMessage(fmt.Sprintf("There are still %d bindings for the service instance", len(bindings)))
+	}
+
 	deprovisionResponse, err := r.deprovisionServiceInstance(ctx, serviceInstance, assets, osbapiClient)
 	if err != nil {
 		log.Error(err, "failed to deprovision service instance with broker")
@@ -297,6 +306,18 @@ func (r *Reconciler) finalizeCFServiceInstance(
 	log.V(1).Info("finalizer removed")
 
 	return ctrl.Result{}, nil
+}
+
+func (r *Reconciler) getBindings(ctx context.Context, serviceInstance *korifiv1alpha1.CFServiceInstance) ([]korifiv1alpha1.CFServiceBinding, error) {
+	serviceBindings := korifiv1alpha1.CFServiceBindingList{}
+	if err := r.k8sClient.List(ctx, &serviceBindings,
+		client.InNamespace(serviceInstance.Namespace),
+		client.MatchingFields{shared.IndexServiceBindingServiceInstanceGUID: serviceInstance.Name},
+	); err != nil {
+		return nil, fmt.Errorf("failed to list bindings: %w", err)
+	}
+
+	return serviceBindings.Items, nil
 }
 
 func (r *Reconciler) deprovisionServiceInstance(


### PR DESCRIPTION
## Is there a related GitHub Issue?
#3857
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
The CF API spec mandates that when a service instance is deleted, all
related bindings are deleted as well. On the other hand, OSBAPI brokers
may not accept unbind requests for bindings that have their service
instance already being deprovisioned.

In order to address this, the managed instance controller would ensure
that there are no more bindings remaining prior deprovisioning the
instance with the broker.

The actual binding deletion is taken care of by the OwnerReference from
the binding to the instance.
<!-- _Please describe the change here._ -->

