### PR TITLE
Wait for service instance/binding deletion in smoke tests

### DIFF
--- a/tests/smoke/services_test.go
+++ b/tests/smoke/services_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Services", func() {
 		})
 
 		It("deletes the managed service", func() {
-			session := helpers.Cf("delete-service", "-f", serviceName)
+			session := helpers.Cf("delete-service", "-f", serviceName, "--wait")
 			Expect(session).To(Exit(0))
 		})
 	})

--- a/tests/smoke/unbind_service_test.go
+++ b/tests/smoke/unbind_service_test.go
@@ -24,7 +24,7 @@ var _ = Describe("cf unbind-service", func() {
 	})
 
 	JustBeforeEach(func() {
-		unbindSession = helpers.Cf("unbind-service", appName, serviceName)
+		unbindSession = helpers.Cf("unbind-service", appName, serviceName, "--wait")
 	})
 
 	Describe("Unbinding from user-provided service instances", func() {


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
N/A
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
After the fix for issue #3856, plain `cf delete-service` returns
immediately and deletion takes place in the bacground. Our tests assume
that the execution is synchronous. To preserve this assumption, we add
the `--wait` flag to the delete instance/binding cli commands
<!-- _Please describe the change here._ -->

