### PR TITLE
Add debug info for flake

### DIFF
--- a/tests/smoke/list_test.go
+++ b/tests/smoke/list_test.go
@@ -1,6 +1,8 @@
 package smoke_test
 
 import (
+	"fmt"
+
 	"code.cloudfoundry.org/korifi/tests/helpers"
 	. "code.cloudfoundry.org/korifi/tests/matchers"
 	"github.com/google/uuid"
@@ -14,7 +16,7 @@ var _ = Describe("list", func() {
 	listResources := func(resourceType string, resourcesMatch types.GomegaMatcher) {
 		cfCurlOutput, err := sessionOutput(helpers.Cf("curl", "/v3/"+resourceType))
 		Expect(err).NotTo(HaveOccurred())
-		Expect(cfCurlOutput).To(MatchJSONPath("$.resources", resourcesMatch))
+		Expect(cfCurlOutput).To(MatchJSONPath("$.resources", resourcesMatch), fmt.Sprintf("JSON output: %s", cfCurlOutput))
 	}
 
 	BeforeEach(func() {

--- a/tests/smoke/suite_test.go
+++ b/tests/smoke/suite_test.go
@@ -180,6 +180,7 @@ func printCfApp(config *rest.Config) {
 		return
 	}
 
+	Expect(helpers.Cf("auth", sharedData.CfAdmin)).To(Exit(0))
 	cfAppNamespace, err := sessionOutput(helpers.Cf("space", sharedData.SpaceName, "--guid"))
 	if err != nil {
 		fmt.Fprintf(GinkgoWriter, "failed to run 'cf space %s --guid': %v\n", sharedData.SpaceName, err)


### PR DESCRIPTION
## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Debug info for flake

https://ci.korifi.cf-app.com/teams/main/pipelines/main/jobs/run-e2es-eks-periodic/builds/12882

- The build error logs says that cf curl /v3/packages returned invalid
  JSON. The JSON output is now logged in case of test failure
- Improve fail hander. It now makes sure it is authorized as cf-admin
  (in case the failing test swithed users)
