### PR TITLE
[Bug] Buildpacks does not appear correctly app  response

### DIFF
--- a/api/presenter/app_test.go
+++ b/api/presenter/app_test.go
@@ -156,8 +156,8 @@ var _ = Describe("App", func() {
 				record.Lifecycle.Data.Buildpacks = nil
 			})
 
-			It("does not render buildpacks", func() {
-				Expect(output).To(MatchJSONPathError("$.lifecycle.data.buildpacks", MatchError("unknown key buildpacks")))
+			It("renders the lifecycle with empty buildpacks", func() {
+				Expect(output).To(MatchJSONPath("$.lifecycle.data.buildpacks", BeEmpty()))
 			})
 		})
 
@@ -168,9 +168,9 @@ var _ = Describe("App", func() {
 				}
 			})
 
-			It("renders the docker lifecycle with empty data", func() {
+			It("renders the docker lifecycle with empty buildpacks", func() {
 				Expect(output).To(MatchJSONPath("$.lifecycle.type", Equal("docker")))
-				Expect(output).To(MatchJSONPath("$.lifecycle.data", BeEmpty()))
+				Expect(output).To(MatchJSONPath("$.lifecycle.data.buildpacks", BeEmpty()))
 			})
 		})
 	})

--- a/api/presenter/droplet_test.go
+++ b/api/presenter/droplet_test.go
@@ -59,7 +59,9 @@ var _ = Describe("Droplet", func() {
 			"error": null,
 			"lifecycle": {
 				"type": "buildpack",
-				"data": {}
+				"data": {
+					"buildpacks": []
+				}
 			},
 			"execution_metadata": "",
 			"process_types": {
@@ -122,7 +124,9 @@ var _ = Describe("Droplet", func() {
 			"error": null,
 			"lifecycle": {
 				"type": "docker",
-				"data": {}
+				"data": {
+					"buildpacks": []
+				}
 			},
 			"execution_metadata": "",
 			"process_types": {

--- a/api/presenter/shared.go
+++ b/api/presenter/shared.go
@@ -17,7 +17,7 @@ type Lifecycle struct {
 }
 
 type LifecycleData struct {
-	Buildpacks []string `json:"buildpacks,omitempty"`
+	Buildpacks []string `json:"buildpacks"`
 	Stack      string   `json:"stack,omitempty"`
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
<!-- _Please describe the change here._ -->

Currently if you push a cf app, without specifying the buildpack in the manifest, the lifecycle response will look like this: 
```
"lifecycle": {
    "type": "buildpack",
    "data": {}
  },
``` 

In such a scenario, we want the response to look like this: 
```
 "lifecycle": {
    "type": "buildpack",
    "data": {
      "buildpacks": []
    }
  },
```
This PR fixes this. 
## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->
No
## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
