### PR TITLE
Make sure a service instance is not deleted until all its bindings are gone

### DIFF
--- a/api/repositories/service_binding_repository_test.go
+++ b/api/repositories/service_binding_repository_test.go
@@ -803,7 +803,7 @@ var _ = Describe("ServiceBindingRepo", func() {
 						korifiv1alpha1.SpaceGUIDKey: space.Name,
 					},
 					Annotations: map[string]string{
-						korifiv1alpha1.ServiceInstanceTypeAnnotationKey: korifiv1alpha1.UserProvidedType,
+						korifiv1alpha1.ServiceInstanceTypeAnnotation: korifiv1alpha1.UserProvidedType,
 					},
 					Finalizers: []string{korifiv1alpha1.CFServiceBindingFinalizerName},
 				},

--- a/api/repositories/service_instance_repository.go
+++ b/api/repositories/service_instance_repository.go
@@ -512,7 +512,7 @@ func (r *ServiceInstanceRepo) DeleteServiceInstance(ctx context.Context, authInf
 
 	if message.Purge {
 		if err = k8s.PatchResource(ctx, userClient, serviceInstance, func() {
-			serviceInstance.Spec.NoopDeprovisioning = true
+			serviceInstance.Annotations = tools.SetMapValue(serviceInstance.Annotations, korifiv1alpha1.DeprovisionWithoutBrokerAnnotation, "true")
 		}); err != nil {
 			return ServiceInstanceRecord{}, fmt.Errorf("failed to remove finalizer for service instance: %s, %w", message.GUID, apierrors.FromK8sError(err, ServiceInstanceResourceType))
 		}

--- a/api/repositories/service_instance_repository.go
+++ b/api/repositories/service_instance_repository.go
@@ -512,13 +512,9 @@ func (r *ServiceInstanceRepo) DeleteServiceInstance(ctx context.Context, authInf
 
 	if message.Purge {
 		if err = k8s.PatchResource(ctx, userClient, serviceInstance, func() {
-			controllerutil.RemoveFinalizer(serviceInstance, korifiv1alpha1.CFServiceInstanceFinalizerName)
+			serviceInstance.Spec.NoopDeprovisioning = true
 		}); err != nil {
 			return ServiceInstanceRecord{}, fmt.Errorf("failed to remove finalizer for service instance: %s, %w", message.GUID, apierrors.FromK8sError(err, ServiceInstanceResourceType))
-		}
-
-		if err = r.removeBindingsFinalizer(ctx, userClient, namespace, message.GUID); err != nil {
-			return ServiceInstanceRecord{}, fmt.Errorf("failed delete related service bindings for instance: %s, %w", message.GUID, apierrors.FromK8sError(err, ServiceBindingResourceType))
 		}
 	}
 
@@ -553,28 +549,6 @@ func (r *ServiceInstanceRepo) GetDeletedAt(ctx context.Context, authInfo authori
 		return nil, err
 	}
 	return serviceInstance.DeletedAt, nil
-}
-
-func (r *ServiceInstanceRepo) removeBindingsFinalizer(ctx context.Context, userClient client.WithWatch, namespace, instanceGUID string) error {
-	serviceBindings := new(korifiv1alpha1.CFServiceBindingList)
-	if err := userClient.List(ctx, serviceBindings, client.InNamespace(namespace)); err != nil {
-		return fmt.Errorf("failed to get service bindings: %w", apierrors.FromK8sError(err, ServiceBindingResourceType))
-	}
-
-	filtered := itx.FromSlice(serviceBindings.Items).Filter(func(serviceBinding korifiv1alpha1.CFServiceBinding) bool {
-		return instanceGUID == serviceBinding.Spec.Service.Name
-	}).Collect()
-
-	for _, binding := range filtered {
-		err := k8s.PatchResource(ctx, userClient, &binding, func() {
-			controllerutil.RemoveFinalizer(&binding, korifiv1alpha1.CFServiceBindingFinalizerName)
-		})
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
 }
 
 func cfServiceInstanceToRecord(cfServiceInstance korifiv1alpha1.CFServiceInstance) ServiceInstanceRecord {

--- a/api/repositories/service_instance_repository_test.go
+++ b/api/repositories/service_instance_repository_test.go
@@ -1206,10 +1206,10 @@ var _ = Describe("ServiceInstanceRepository", func() {
 					})).To(Succeed())
 				})
 
-				It("requests noop deprovisioning", func() {
+				It("requests deprovisioning without broker", func() {
 					actualServiceInstance := &korifiv1alpha1.CFServiceInstance{}
 					Expect(k8sClient.Get(ctx, types.NamespacedName{Name: serviceInstance.Name, Namespace: space.Name}, actualServiceInstance)).To(Succeed())
-					Expect(actualServiceInstance.Spec.NoopDeprovisioning).To(BeTrue())
+					Expect(actualServiceInstance.Annotations).To(HaveKeyWithValue(korifiv1alpha1.DeprovisionWithoutBrokerAnnotation, "true"))
 				})
 
 				It("deletes the instance", func() {

--- a/api/repositories/service_instance_repository_test.go
+++ b/api/repositories/service_instance_repository_test.go
@@ -1196,73 +1196,34 @@ var _ = Describe("ServiceInstanceRepository", func() {
 					Expect(errors.As(deleteErr, &apierrors.NotFoundError{})).To(BeTrue())
 				})
 			})
+
+			When("purge parameter is set", func() {
+				BeforeEach(func() {
+					deleteMessage.Purge = true
+
+					Expect(k8s.Patch(ctx, k8sClient, serviceInstance, func() {
+						serviceInstance.Finalizers = []string{"do-not-delete-me"}
+					})).To(Succeed())
+				})
+
+				It("requests noop deprovisioning", func() {
+					actualServiceInstance := &korifiv1alpha1.CFServiceInstance{}
+					Expect(k8sClient.Get(ctx, types.NamespacedName{Name: serviceInstance.Name, Namespace: space.Name}, actualServiceInstance)).To(Succeed())
+					Expect(actualServiceInstance.Spec.NoopDeprovisioning).To(BeTrue())
+				})
+
+				It("deletes the instance", func() {
+					actualServiceInstance := &korifiv1alpha1.CFServiceInstance{}
+					Expect(k8sClient.Get(ctx, types.NamespacedName{Name: serviceInstance.Name, Namespace: space.Name}, actualServiceInstance)).To(Succeed())
+					Expect(actualServiceInstance.DeletionTimestamp).NotTo(BeZero())
+				})
+			})
 		})
 
 		When("there are no permissions on service instances", func() {
 			It("returns a forbidden error", func() {
 				Expect(errors.As(deleteErr, &apierrors.ForbiddenError{})).To(BeTrue())
 			})
-		})
-	})
-
-	Describe("PurgeServiceInstance", func() {
-		var (
-			serviceInstance *korifiv1alpha1.CFServiceInstance
-			serviceBinding  *korifiv1alpha1.CFServiceBinding
-			deleteMessage   repositories.DeleteServiceInstanceMessage
-			deleteErr       error
-		)
-
-		BeforeEach(func() {
-			serviceInstance = createServiceInstanceCR(ctx, k8sClient, prefixedGUID("service-instance"), space.Name, "the-service-instance", prefixedGUID("secret"))
-
-			serviceInstance.Finalizers = append(serviceInstance.Finalizers, korifiv1alpha1.CFServiceInstanceFinalizerName)
-			Expect(k8sClient.Update(ctx, serviceInstance)).To(Succeed())
-
-			serviceBinding = &korifiv1alpha1.CFServiceBinding{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      uuid.NewString(),
-					Namespace: space.Name,
-					Finalizers: []string{
-						korifiv1alpha1.CFServiceBindingFinalizerName,
-					},
-				},
-				Spec: korifiv1alpha1.CFServiceBindingSpec{
-					Service: corev1.ObjectReference{
-						Kind:       "CFServiceInstance",
-						APIVersion: korifiv1alpha1.SchemeGroupVersion.Identifier(),
-						Name:       serviceInstance.Name,
-					},
-					AppRef: corev1.LocalObjectReference{
-						Name: "some-app-guid",
-					},
-					Type: korifiv1alpha1.CFServiceBindingTypeApp,
-				},
-			}
-			Expect(k8sClient.Create(ctx, serviceBinding)).To(Succeed())
-
-			deleteMessage = repositories.DeleteServiceInstanceMessage{
-				GUID:  serviceInstance.Name,
-				Purge: true,
-			}
-			createRoleBinding(ctx, userName, spaceDeveloperRole.Name, space.Name)
-		})
-
-		JustBeforeEach(func() {
-			_, deleteErr = serviceInstanceRepo.DeleteServiceInstance(ctx, authInfo, deleteMessage)
-		})
-
-		It("purges the service instance", func() {
-			Expect(deleteErr).ToNot(HaveOccurred())
-
-			err := k8sClient.Get(ctx, types.NamespacedName{Name: serviceInstance.Name, Namespace: space.Name}, &korifiv1alpha1.CFServiceInstance{})
-			Expect(k8serrors.IsNotFound(err)).To(BeTrue(), fmt.Sprintf("error: %+v", err))
-
-			binding := new(korifiv1alpha1.CFServiceBinding)
-			err = k8sClient.Get(ctx, types.NamespacedName{Name: serviceBinding.Name, Namespace: space.Name}, binding)
-
-			Expect(err).ToNot(HaveOccurred())
-			Expect(binding.Finalizers).To(BeEmpty())
 		})
 	})
 })

--- a/controllers/api/v1alpha1/cfservicebinding_types.go
+++ b/controllers/api/v1alpha1/cfservicebinding_types.go
@@ -31,8 +31,8 @@ const (
 	CFServiceBindingTypeKey = "key"
 	CFServiceBindingTypeApp = "app"
 
-	ServiceInstanceTypeAnnotationKey = "korifi.cloudfoundry.org/service-instance-type"
-	PlanGUIDLabelKey                 = "korifi.cloudfoundry.org/plan-guid"
+	ServiceInstanceTypeAnnotation = "korifi.cloudfoundry.org/service-instance-type"
+	PlanGUIDLabelKey              = "korifi.cloudfoundry.org/plan-guid"
 
 	ServiceBindingGUIDLabel       = "korifi.cloudfoundry.org/service-binding-guid"
 	CFServiceBindingFinalizerName = "cfServiceBinding.korifi.cloudfoundry.org"

--- a/controllers/api/v1alpha1/cfserviceinstance_types.go
+++ b/controllers/api/v1alpha1/cfserviceinstance_types.go
@@ -29,6 +29,8 @@ const (
 
 	CFServiceInstanceFinalizerName = "cfServiceInstance.korifi.cloudfoundry.org"
 
+	DeprovisionWithoutBrokerAnnotation = "korifi.cloudfoundry.org/deprovision-without-broker"
+
 	ProvisioningFailedCondition   = "ProvisioningFailed"
 	DeprovisioningFailedCondition = "DeprovisioningFailed"
 )
@@ -56,11 +58,6 @@ type CFServiceInstanceSpec struct {
 	PlanGUID string `json:"planGuid"`
 
 	Parameters corev1.LocalObjectReference `json:"parameters,omitempty"`
-
-	// When set the service instance and its bindings are deleted
-	// without any interaction with the broker
-	// +optional
-	NoopDeprovisioning bool `json:"noopDeprovisioning"`
 }
 
 // InstanceType defines the type of the Service Instance

--- a/controllers/api/v1alpha1/cfserviceinstance_types.go
+++ b/controllers/api/v1alpha1/cfserviceinstance_types.go
@@ -56,6 +56,11 @@ type CFServiceInstanceSpec struct {
 	PlanGUID string `json:"planGuid"`
 
 	Parameters corev1.LocalObjectReference `json:"parameters,omitempty"`
+
+	// When set the service instance and its bindings are deleted
+	// without any interaction with the broker
+	// +optional
+	NoopDeprovisioning bool `json:"noopDeprovisioning"`
 }
 
 // InstanceType defines the type of the Service Instance

--- a/controllers/controllers/services/bindings/controller.go
+++ b/controllers/controllers/services/bindings/controller.go
@@ -113,7 +113,7 @@ func (r *Reconciler) ReconcileResource(ctx context.Context, cfServiceBinding *ko
 		return ctrl.Result{}, err
 	}
 
-	cfServiceBinding.Annotations = tools.SetMapValue(cfServiceBinding.Annotations, korifiv1alpha1.ServiceInstanceTypeAnnotationKey, string(cfServiceInstance.Spec.Type))
+	cfServiceBinding.Annotations = tools.SetMapValue(cfServiceBinding.Annotations, korifiv1alpha1.ServiceInstanceTypeAnnotation, string(cfServiceInstance.Spec.Type))
 
 	res, err := r.reconcileByType(ctx, cfServiceInstance, cfServiceBinding)
 	if needsRequeue(res, err) {

--- a/controllers/controllers/services/bindings/controller_test.go
+++ b/controllers/controllers/services/bindings/controller_test.go
@@ -121,7 +121,7 @@ var _ = Describe("CFServiceBinding", func() {
 			Eventually(func(g Gomega) {
 				g.Expect(adminClient.Get(ctx, client.ObjectKeyFromObject(binding), binding)).To(Succeed())
 				g.Expect(binding.Annotations).To(HaveKeyWithValue(
-					korifiv1alpha1.ServiceInstanceTypeAnnotationKey, "user-provided",
+					korifiv1alpha1.ServiceInstanceTypeAnnotation, "user-provided",
 				))
 			}).Should(Succeed())
 		})
@@ -407,7 +407,7 @@ var _ = Describe("CFServiceBinding", func() {
 			Eventually(func(g Gomega) {
 				g.Expect(adminClient.Get(ctx, client.ObjectKeyFromObject(binding), binding)).To(Succeed())
 				g.Expect(binding.Annotations).To(HaveKeyWithValue(
-					korifiv1alpha1.ServiceInstanceTypeAnnotationKey, "managed",
+					korifiv1alpha1.ServiceInstanceTypeAnnotation, "managed",
 				))
 			}).Should(Succeed())
 		})

--- a/controllers/controllers/services/bindings/controller_test.go
+++ b/controllers/controllers/services/bindings/controller_test.go
@@ -117,23 +117,6 @@ var _ = Describe("CFServiceBinding", func() {
 			}).Should(Succeed())
 		})
 
-		It("sets the foregroundDeletion finalizer on the service instance", func() {
-			Eventually(func(g Gomega) {
-				g.Expect(adminClient.Get(ctx, client.ObjectKeyFromObject(instance), instance)).To(Succeed())
-				g.Expect(instance.Finalizers).To(ContainElement(metav1.FinalizerDeleteDependents))
-			}).Should(Succeed())
-		})
-
-		It("sets an owner reference from the instance to the binding", func() {
-			Eventually(func(g Gomega) {
-				g.Expect(adminClient.Get(ctx, client.ObjectKeyFromObject(binding), binding)).To(Succeed())
-				g.Expect(binding.OwnerReferences).To(ConsistOf(MatchFields(IgnoreExtras, Fields{
-					"Name":               Equal(instance.Name),
-					"BlockOwnerDeletion": PointTo(BeTrue()),
-				})))
-			}).Should(Succeed())
-		})
-
 		It("sets the service-instance-type annotation to user-provided", func() {
 			Eventually(func(g Gomega) {
 				g.Expect(adminClient.Get(ctx, client.ObjectKeyFromObject(binding), binding)).To(Succeed())
@@ -417,15 +400,6 @@ var _ = Describe("CFServiceBinding", func() {
 			Eventually(func(g Gomega) {
 				g.Expect(adminClient.Get(ctx, client.ObjectKeyFromObject(binding), binding)).To(Succeed())
 				g.Expect(binding.Status.ObservedGeneration).To(Equal(binding.Generation))
-			}).Should(Succeed())
-		})
-
-		It("sets an owner reference from the instance to the binding", func() {
-			Eventually(func(g Gomega) {
-				g.Expect(adminClient.Get(ctx, client.ObjectKeyFromObject(binding), binding)).To(Succeed())
-				g.Expect(binding.OwnerReferences).To(ConsistOf(MatchFields(IgnoreExtras, Fields{
-					"Name": Equal(instance.Name),
-				})))
 			}).Should(Succeed())
 		})
 

--- a/controllers/controllers/services/bindings/managed/controller.go
+++ b/controllers/controllers/services/bindings/managed/controller.go
@@ -254,6 +254,13 @@ func (r *ManagedBindingsReconciler) finalizeCFServiceBinding(
 ) (ctrl.Result, error) {
 	log := logr.FromContextOrDiscard(ctx).WithName("finalize-managed-service-binding")
 
+	if assets.ServiceInstance.Spec.NoopDeprovisioning {
+		if controllerutil.RemoveFinalizer(serviceBinding, korifiv1alpha1.CFServiceBindingFinalizerName) {
+			log.V(1).Info("finalizer removed")
+		}
+		return ctrl.Result{}, nil
+	}
+
 	unbindResponse, err := r.deleteServiceBinding(ctx, serviceBinding, assets, osbapiClient)
 	if err != nil {
 		return ctrl.Result{}, err

--- a/controllers/controllers/services/instances/finalize.go
+++ b/controllers/controllers/services/instances/finalize.go
@@ -1,0 +1,46 @@
+package instances
+
+import (
+	"context"
+	"fmt"
+
+	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
+	"code.cloudfoundry.org/korifi/controllers/controllers/shared"
+	"code.cloudfoundry.org/korifi/tools/k8s"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func FinalizeServiceBindings(
+	ctx context.Context,
+	k8sClient client.Client,
+	serviceInstance *korifiv1alpha1.CFServiceInstance,
+) error {
+	bindings, err := getBindings(ctx, k8sClient, serviceInstance)
+	if err != nil {
+		return err
+	}
+
+	for _, binding := range bindings {
+		if err = client.IgnoreNotFound(k8sClient.Delete(ctx, &binding)); err != nil {
+			return err
+		}
+	}
+
+	if len(bindings) > 0 {
+		return k8s.NewNotReadyError().WithReason("BindingsAvailable").WithMessage(fmt.Sprintf("There are still %d bindings for the service instance", len(bindings)))
+	}
+
+	return nil
+}
+
+func getBindings(ctx context.Context, k8sClient client.Client, serviceInstance *korifiv1alpha1.CFServiceInstance) ([]korifiv1alpha1.CFServiceBinding, error) {
+	serviceBindings := korifiv1alpha1.CFServiceBindingList{}
+	if err := k8sClient.List(ctx, &serviceBindings,
+		client.InNamespace(serviceInstance.Namespace),
+		client.MatchingFields{shared.IndexServiceBindingServiceInstanceGUID: serviceInstance.Name},
+	); err != nil {
+		return nil, fmt.Errorf("failed to list bindings: %w", err)
+	}
+
+	return serviceBindings.Items, nil
+}

--- a/controllers/controllers/services/instances/finalize.go
+++ b/controllers/controllers/services/instances/finalize.go
@@ -3,6 +3,7 @@ package instances
 import (
 	"context"
 	"fmt"
+	"time"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"code.cloudfoundry.org/korifi/controllers/controllers/shared"
@@ -10,7 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func FinalizeServiceBindings(
+func EnsureNoServiceBindings(
 	ctx context.Context,
 	k8sClient client.Client,
 	serviceInstance *korifiv1alpha1.CFServiceInstance,
@@ -27,7 +28,10 @@ func FinalizeServiceBindings(
 	}
 
 	if len(bindings) > 0 {
-		return k8s.NewNotReadyError().WithReason("BindingsAvailable").WithMessage(fmt.Sprintf("There are still %d bindings for the service instance", len(bindings)))
+		return k8s.NewNotReadyError().
+			WithReason("BindingsAvailable").
+			WithMessage(fmt.Sprintf("There are still %d bindings for the service instance", len(bindings))).
+			WithRequeueAfter(time.Second)
 	}
 
 	return nil

--- a/controllers/controllers/services/instances/managed/controller_test.go
+++ b/controllers/controllers/services/instances/managed/controller_test.go
@@ -863,10 +863,10 @@ var _ = Describe("CFServiceInstance", func() {
 			})
 		})
 
-		When("noop deprovisioning is requested", func() {
+		When("deprovision without broker is is requested", func() {
 			BeforeEach(func() {
 				Expect(k8s.PatchResource(ctx, adminClient, instance, func() {
-					instance.Spec.NoopDeprovisioning = true
+					instance.Annotations = tools.SetMapValue(instance.Annotations, korifiv1alpha1.DeprovisionWithoutBrokerAnnotation, "true")
 				})).To(Succeed())
 			})
 

--- a/controllers/controllers/services/instances/upsi/controller.go
+++ b/controllers/controllers/services/instances/upsi/controller.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
+	"code.cloudfoundry.org/korifi/controllers/controllers/services/instances"
 	"code.cloudfoundry.org/korifi/controllers/controllers/shared"
 	"code.cloudfoundry.org/korifi/tools"
 	"code.cloudfoundry.org/korifi/tools/k8s"
@@ -111,10 +112,7 @@ func (r *Reconciler) ReconcileResource(ctx context.Context, cfServiceInstance *k
 	log.V(1).Info("set observed generation", "generation", cfServiceInstance.Status.ObservedGeneration)
 
 	if !cfServiceInstance.GetDeletionTimestamp().IsZero() {
-		controllerutil.RemoveFinalizer(cfServiceInstance, korifiv1alpha1.CFServiceInstanceFinalizerName)
-		log.V(1).Info("finalizer removed")
-
-		return ctrl.Result{}, nil
+		return r.finalizeCFServiceInstance(ctx, cfServiceInstance)
 	}
 
 	credentialsSecret := &corev1.Secret{
@@ -146,6 +144,26 @@ func (r *Reconciler) ReconcileResource(ctx context.Context, cfServiceInstance *k
 	cfServiceInstance.Status.LastOperation = reconcileLastOperation(cfServiceInstance, credentialsSecret)
 
 	cfServiceInstance.Status.CredentialsObservedVersion = credentialsSecret.ResourceVersion
+
+	return ctrl.Result{}, nil
+}
+
+func (r *Reconciler) finalizeCFServiceInstance(
+	ctx context.Context,
+	serviceInstance *korifiv1alpha1.CFServiceInstance,
+) (ctrl.Result, error) {
+	log := logr.FromContextOrDiscard(ctx).WithName("finalizeCFServiceInstance")
+
+	if !controllerutil.ContainsFinalizer(serviceInstance, korifiv1alpha1.CFServiceInstanceFinalizerName) {
+		return ctrl.Result{}, nil
+	}
+
+	if err := instances.FinalizeServiceBindings(ctx, r.k8sClient, serviceInstance); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	controllerutil.RemoveFinalizer(serviceInstance, korifiv1alpha1.CFServiceInstanceFinalizerName)
+	log.V(1).Info("finalizer removed")
 
 	return ctrl.Result{}, nil
 }

--- a/controllers/controllers/services/instances/upsi/controller.go
+++ b/controllers/controllers/services/instances/upsi/controller.go
@@ -158,7 +158,7 @@ func (r *Reconciler) finalizeCFServiceInstance(
 		return ctrl.Result{}, nil
 	}
 
-	if err := instances.FinalizeServiceBindings(ctx, r.k8sClient, serviceInstance); err != nil {
+	if err := instances.EnsureNoServiceBindings(ctx, r.k8sClient, serviceInstance); err != nil {
 		return ctrl.Result{}, err
 	}
 

--- a/controllers/controllers/services/instances/upsi/controller_test.go
+++ b/controllers/controllers/services/instances/upsi/controller_test.go
@@ -216,6 +216,43 @@ var _ = Describe("CFServiceInstance", func() {
 						g.Expect(k8serrors.IsNotFound(err)).To(BeTrue())
 					}).Should(Succeed())
 				})
+
+				When("the instance has bindings", func() {
+					var binding *korifiv1alpha1.CFServiceBinding
+
+					BeforeEach(func() {
+						binding = &korifiv1alpha1.CFServiceBinding{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      uuid.NewString(),
+								Namespace: instance.Namespace,
+							},
+							Spec: korifiv1alpha1.CFServiceBindingSpec{
+								Service: corev1.ObjectReference{
+									Kind:       "ServiceInstance",
+									Name:       instance.Name,
+									APIVersion: "korifi.cloudfoundry.org/v1alpha1",
+								},
+								Type: korifiv1alpha1.CFServiceBindingTypeApp,
+							},
+						}
+
+						Expect(adminClient.Create(ctx, binding)).To(Succeed())
+					})
+
+					It("deletes them", func() {
+						Eventually(func(g Gomega) {
+							err := adminClient.Get(ctx, client.ObjectKeyFromObject(binding), binding)
+							g.Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+						}).Should(Succeed())
+					})
+
+					It("is deleted", func() {
+						Eventually(func(g Gomega) {
+							err := adminClient.Get(ctx, client.ObjectKeyFromObject(instance), instance)
+							g.Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+						}).Should(Succeed())
+					})
+				})
 			})
 		})
 

--- a/controllers/controllers/workloads/env/vcap_services_builder.go
+++ b/controllers/controllers/workloads/env/vcap_services_builder.go
@@ -69,7 +69,7 @@ func buildSingleServiceEnv(ctx context.Context, k8sClient client.Client, service
 		return ServiceDetails{}, "", fmt.Errorf("credentials secret name not set for service binding %q", serviceBinding.Name)
 	}
 
-	serviceLabel := serviceBinding.Annotations[korifiv1alpha1.ServiceInstanceTypeAnnotationKey]
+	serviceLabel := serviceBinding.Annotations[korifiv1alpha1.ServiceInstanceTypeAnnotation]
 
 	serviceInstance := korifiv1alpha1.CFServiceInstance{}
 	err := k8sClient.Get(ctx, types.NamespacedName{Namespace: serviceBinding.Namespace, Name: serviceBinding.Spec.Service.Name}, &serviceInstance)

--- a/controllers/controllers/workloads/env/vcap_services_builder_test.go
+++ b/controllers/controllers/workloads/env/vcap_services_builder_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Builder", func() {
 				Namespace: cfSpace.Status.GUID,
 				Name:      "my-service-binding-guid",
 				Annotations: map[string]string{
-					korifiv1alpha1.ServiceInstanceTypeAnnotationKey: "sb-1-type",
+					korifiv1alpha1.ServiceInstanceTypeAnnotation: "sb-1-type",
 				},
 			},
 			Spec: korifiv1alpha1.CFServiceBindingSpec{
@@ -108,7 +108,7 @@ var _ = Describe("Builder", func() {
 				Namespace: cfSpace.Status.GUID,
 				Name:      "my-service-binding-guid-2",
 				Annotations: map[string]string{
-					korifiv1alpha1.ServiceInstanceTypeAnnotationKey: "sb-2-type",
+					korifiv1alpha1.ServiceInstanceTypeAnnotation: "sb-2-type",
 				},
 			},
 			Spec: korifiv1alpha1.CFServiceBindingSpec{

--- a/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfserviceinstances.yaml
+++ b/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfserviceinstances.yaml
@@ -50,6 +50,11 @@ spec:
                 description: The mutable, user-friendly name of the service instance.
                   Unlike metadata.name, the user can change this field
                 type: string
+              noopDeprovisioning:
+                description: |-
+                  When set the service instance and its bindings are deleted
+                  without any interaction with the broker
+                type: boolean
               parameters:
                 description: |-
                   LocalObjectReference contains enough information to let you locate the

--- a/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfserviceinstances.yaml
+++ b/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfserviceinstances.yaml
@@ -50,11 +50,6 @@ spec:
                 description: The mutable, user-friendly name of the service instance.
                   Unlike metadata.name, the user can change this field
                 type: string
-              noopDeprovisioning:
-                description: |-
-                  When set the service instance and its bindings are deleted
-                  without any interaction with the broker
-                type: boolean
               parameters:
                 description: |-
                   LocalObjectReference contains enough information to let you locate the


### PR DESCRIPTION
## Is there a related GitHub Issue?
#3876
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
- Do not set owner ref from instance to binding. Delete bindings in finalizer
  instead.
- Now that we handle binding cleanup in controllers finalizers instead of
  relying on owner references, we need to adapt the purge logic as follows:
    - Set noopDeprovisioning to true on the instance being purged
    - Delete the instance
    - The instance and biding controller will respect the noopDeprovisioning
      flag and will not call out to the broker while finalizing instances and
      bindings
- As the instance no longer owns the binding, we can simplify the app
  controller's finalizer by making the app the owner of the binding

