### PR TITLE
Remove `ObjectWithDeepCopy` interface

### DIFF
--- a/api/handlers/build_test.go
+++ b/api/handlers/build_test.go
@@ -119,9 +119,7 @@ var _ = Describe("Build", func() {
 	})
 
 	Describe("the GET /v3/builds endpoint", func() {
-		var (
-			buildGUID string
-		)
+		var buildGUID string
 
 		BeforeEach(func() {
 			buildGUID = uuid.NewString()

--- a/api/main.go
+++ b/api/main.go
@@ -141,14 +141,14 @@ func main() {
 		privilegedClient,
 		userClientFactoryUnfiltered,
 		nsPermissions,
-		conditions.NewConditionAwaiter[*korifiv1alpha1.CFOrg, korifiv1alpha1.CFOrg, korifiv1alpha1.CFOrgList](conditionTimeout),
+		conditions.NewConditionAwaiter[*korifiv1alpha1.CFOrg, korifiv1alpha1.CFOrgList](conditionTimeout),
 	)
 	spaceRepo := repositories.NewSpaceRepo(
 		namespaceRetriever,
 		orgRepo,
 		userClientFactoryUnfiltered,
 		nsPermissions,
-		conditions.NewConditionAwaiter[*korifiv1alpha1.CFSpace, korifiv1alpha1.CFSpace, korifiv1alpha1.CFSpaceList](conditionTimeout),
+		conditions.NewConditionAwaiter[*korifiv1alpha1.CFSpace, korifiv1alpha1.CFSpaceList](conditionTimeout),
 	)
 	processRepo := repositories.NewProcessRepo(
 		namespaceRetriever,
@@ -160,7 +160,7 @@ func main() {
 	appRepo := repositories.NewAppRepo(
 		namespaceRetriever,
 		userClientFactory,
-		conditions.NewConditionAwaiter[*korifiv1alpha1.CFApp, korifiv1alpha1.CFApp, korifiv1alpha1.CFAppList](conditionTimeout),
+		conditions.NewConditionAwaiter[*korifiv1alpha1.CFApp, korifiv1alpha1.CFAppList](conditionTimeout),
 		repositories.NewAppSorter(),
 	)
 	dropletRepo := repositories.NewDropletRepo(
@@ -200,21 +200,21 @@ func main() {
 		namespaceRetriever,
 		toolsregistry.NewRepositoryCreator(cfg.ContainerRegistryType),
 		cfg.ContainerRepositoryPrefix,
-		conditions.NewConditionAwaiter[*korifiv1alpha1.CFPackage, korifiv1alpha1.CFPackage, korifiv1alpha1.CFPackageList](conditionTimeout),
+		conditions.NewConditionAwaiter[*korifiv1alpha1.CFPackage, korifiv1alpha1.CFPackageList](conditionTimeout),
 		repositories.NewPackageSorter(),
 	)
 	serviceInstanceRepo := repositories.NewServiceInstanceRepo(
 		namespaceRetriever,
 		userClientFactory,
-		conditions.NewConditionAwaiter[*korifiv1alpha1.CFServiceInstance, korifiv1alpha1.CFServiceInstance, korifiv1alpha1.CFServiceInstanceList](conditionTimeout),
+		conditions.NewConditionAwaiter[*korifiv1alpha1.CFServiceInstance, korifiv1alpha1.CFServiceInstanceList](conditionTimeout),
 		repositories.NewServiceInstanceSorter(),
 		cfg.RootNamespace,
 	)
 	serviceBindingRepo := repositories.NewServiceBindingRepo(
 		namespaceRetriever,
 		userClientFactory,
-		conditions.NewConditionAwaiter[*korifiv1alpha1.CFServiceBinding, korifiv1alpha1.CFServiceBinding, korifiv1alpha1.CFServiceBindingList](conditionTimeout),
-		conditions.NewConditionAwaiter[*korifiv1alpha1.CFApp, korifiv1alpha1.CFApp, korifiv1alpha1.CFAppList](conditionTimeout),
+		conditions.NewConditionAwaiter[*korifiv1alpha1.CFServiceBinding, korifiv1alpha1.CFServiceBindingList](conditionTimeout),
+		conditions.NewConditionAwaiter[*korifiv1alpha1.CFApp, korifiv1alpha1.CFAppList](conditionTimeout),
 		paramsClient,
 	)
 	stackRepo := repositories.NewStackRepository(cfg.BuilderName,
@@ -246,7 +246,7 @@ func main() {
 	taskRepo := repositories.NewTaskRepo(
 		userClientFactory,
 		namespaceRetriever,
-		conditions.NewConditionAwaiter[*korifiv1alpha1.CFTask, korifiv1alpha1.CFTask, korifiv1alpha1.CFTaskList](conditionTimeout),
+		conditions.NewConditionAwaiter[*korifiv1alpha1.CFTask, korifiv1alpha1.CFTaskList](conditionTimeout),
 	)
 	metricsRepo := repositories.NewMetricsRepo(userClientFactoryUnfiltered)
 	serviceBrokerRepo := repositories.NewServiceBrokerRepo(userClientFactory, cfg.RootNamespace)

--- a/api/repositories/app_repository_test.go
+++ b/api/repositories/app_repository_test.go
@@ -37,7 +37,6 @@ var _ = Describe("AppRepository", func() {
 	var (
 		appAwaiter *fakeawaiter.FakeAwaiter[
 			*korifiv1alpha1.CFApp,
-			korifiv1alpha1.CFApp,
 			korifiv1alpha1.CFAppList,
 			*korifiv1alpha1.CFAppList,
 		]
@@ -51,7 +50,6 @@ var _ = Describe("AppRepository", func() {
 	BeforeEach(func() {
 		appAwaiter = &fakeawaiter.FakeAwaiter[
 			*korifiv1alpha1.CFApp,
-			korifiv1alpha1.CFApp,
 			korifiv1alpha1.CFAppList,
 			*korifiv1alpha1.CFAppList,
 		]{}

--- a/api/repositories/conditions/await_test.go
+++ b/api/repositories/conditions/await_test.go
@@ -17,7 +17,7 @@ import (
 
 var _ = Describe("ConditionAwaiter", func() {
 	var (
-		awaiter     *conditions.Awaiter[*korifiv1alpha1.CFTask, korifiv1alpha1.CFTask, korifiv1alpha1.CFTaskList, *korifiv1alpha1.CFTaskList]
+		awaiter     *conditions.Awaiter[*korifiv1alpha1.CFTask, korifiv1alpha1.CFTaskList, *korifiv1alpha1.CFTaskList]
 		task        *korifiv1alpha1.CFTask
 		awaitedTask *korifiv1alpha1.CFTask
 		awaitErr    error
@@ -43,7 +43,7 @@ var _ = Describe("ConditionAwaiter", func() {
 	}
 
 	BeforeEach(func() {
-		awaiter = conditions.NewConditionAwaiter[*korifiv1alpha1.CFTask, korifiv1alpha1.CFTask, korifiv1alpha1.CFTaskList](time.Second)
+		awaiter = conditions.NewConditionAwaiter[*korifiv1alpha1.CFTask, korifiv1alpha1.CFTaskList](time.Second)
 		awaitedTask = nil
 		awaitErr = nil
 

--- a/api/repositories/fakeawaiter/await.go
+++ b/api/repositories/fakeawaiter/await.go
@@ -8,7 +8,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-type FakeAwaiter[T k8s.RuntimeObjectWithStatusConditions[TT], TT any, L any, PL conditions.ObjectList[L]] struct {
+type FakeAwaiter[T k8s.RuntimeObjectWithStatusConditions, L any, PL conditions.ObjectList[L]] struct {
 	awaitConditionCalls []struct {
 		obj           client.Object
 		conditionType string
@@ -21,7 +21,7 @@ type FakeAwaiter[T k8s.RuntimeObjectWithStatusConditions[TT], TT any, L any, PL 
 	}
 }
 
-func (a *FakeAwaiter[T, TT, L, PL]) AwaitCondition(ctx context.Context, k8sClient client.WithWatch, object client.Object, conditionType string) (T, error) {
+func (a *FakeAwaiter[T, L, PL]) AwaitCondition(ctx context.Context, k8sClient client.WithWatch, object client.Object, conditionType string) (T, error) {
 	a.awaitConditionCalls = append(a.awaitConditionCalls, struct {
 		obj           client.Object
 		conditionType string
@@ -37,21 +37,21 @@ func (a *FakeAwaiter[T, TT, L, PL]) AwaitCondition(ctx context.Context, k8sClien
 	return a.AwaitConditionStub(ctx, k8sClient, object, conditionType)
 }
 
-func (a *FakeAwaiter[T, TT, L, PL]) AwaitConditionReturns(object T, err error) {
+func (a *FakeAwaiter[T, L, PL]) AwaitConditionReturns(object T, err error) {
 	a.AwaitConditionStub = func(ctx context.Context, k8sClient client.WithWatch, object client.Object, conditionType string) (T, error) {
 		return object.(T), err
 	}
 }
 
-func (a *FakeAwaiter[T, TT, L, PL]) AwaitConditionCallCount() int {
+func (a *FakeAwaiter[T, L, PL]) AwaitConditionCallCount() int {
 	return len(a.awaitConditionCalls)
 }
 
-func (a *FakeAwaiter[T, TT, L, PL]) AwaitConditionArgsForCall(i int) (client.Object, string) {
+func (a *FakeAwaiter[T, L, PL]) AwaitConditionArgsForCall(i int) (client.Object, string) {
 	return a.awaitConditionCalls[i].obj, a.awaitConditionCalls[i].conditionType
 }
 
-func (a *FakeAwaiter[T, TT, L, PL]) AwaitState(ctx context.Context, k8sClient client.WithWatch, object client.Object, checkState func(T) error) (T, error) {
+func (a *FakeAwaiter[T, L, PL]) AwaitState(ctx context.Context, k8sClient client.WithWatch, object client.Object, checkState func(T) error) (T, error) {
 	a.awaitStateCalls = append(a.awaitStateCalls, struct {
 		obj        client.Object
 		checkState func(T) error
@@ -67,16 +67,16 @@ func (a *FakeAwaiter[T, TT, L, PL]) AwaitState(ctx context.Context, k8sClient cl
 	return a.AwaitStateStub(ctx, k8sClient, object, checkState)
 }
 
-func (a *FakeAwaiter[T, TT, L, PL]) AwaitStateReturns(object T, err error) {
+func (a *FakeAwaiter[T, L, PL]) AwaitStateReturns(object T, err error) {
 	a.AwaitStateStub = func(ctx context.Context, k8sClient client.WithWatch, object client.Object, _ func(T) error) (T, error) {
 		return object.(T), err
 	}
 }
 
-func (a *FakeAwaiter[T, TT, L, PL]) AwaitStateCallCount() int {
+func (a *FakeAwaiter[T, L, PL]) AwaitStateCallCount() int {
 	return len(a.awaitStateCalls)
 }
 
-func (a *FakeAwaiter[T, TT, L, PL]) AwaitStateArgsForCall(i int) (client.Object, func(T) error) {
+func (a *FakeAwaiter[T, L, PL]) AwaitStateArgsForCall(i int) (client.Object, func(T) error) {
 	return a.awaitStateCalls[i].obj, a.awaitStateCalls[i].checkState
 }

--- a/api/repositories/org_repository_test.go
+++ b/api/repositories/org_repository_test.go
@@ -28,7 +28,6 @@ var _ = Describe("OrgRepository", func() {
 	var (
 		conditionAwaiter *fakeawaiter.FakeAwaiter[
 			*korifiv1alpha1.CFOrg,
-			korifiv1alpha1.CFOrg,
 			korifiv1alpha1.CFOrgList,
 			*korifiv1alpha1.CFOrgList,
 		]
@@ -38,7 +37,6 @@ var _ = Describe("OrgRepository", func() {
 	BeforeEach(func() {
 		conditionAwaiter = &fakeawaiter.FakeAwaiter[
 			*korifiv1alpha1.CFOrg,
-			korifiv1alpha1.CFOrg,
 			korifiv1alpha1.CFOrgList,
 			*korifiv1alpha1.CFOrgList,
 		]{}

--- a/api/repositories/package_repository_test.go
+++ b/api/repositories/package_repository_test.go
@@ -32,7 +32,6 @@ var _ = Describe("PackageRepository", func() {
 		repoCreator      *fake.RepositoryCreator
 		conditionAwaiter *fakeawaiter.FakeAwaiter[
 			*korifiv1alpha1.CFPackage,
-			korifiv1alpha1.CFPackage,
 			korifiv1alpha1.CFPackageList,
 			*korifiv1alpha1.CFPackageList,
 		]
@@ -48,7 +47,6 @@ var _ = Describe("PackageRepository", func() {
 		repoCreator = new(fake.RepositoryCreator)
 		conditionAwaiter = &fakeawaiter.FakeAwaiter[
 			*korifiv1alpha1.CFPackage,
-			korifiv1alpha1.CFPackage,
 			korifiv1alpha1.CFPackageList,
 			*korifiv1alpha1.CFPackageList,
 		]{}

--- a/api/repositories/patch.go
+++ b/api/repositories/patch.go
@@ -9,10 +9,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func PatchResource[T any, PT k8s.ObjectWithDeepCopy[T]](
+func PatchResource[T client.Object](
 	ctx context.Context,
 	k8sClient client.Client,
-	obj PT,
+	obj T,
 	modify func(),
 ) error {
 	err := k8sClient.Get(ctx, client.ObjectKeyFromObject(obj), obj)

--- a/api/repositories/role_repository_test.go
+++ b/api/repositories/role_repository_test.go
@@ -52,13 +52,11 @@ var _ = Describe("RoleRepository", func() {
 		}
 		orgRepo := repositories.NewOrgRepo(rootNamespace, k8sClient, userClientFactory, nsPerms, &fakeawaiter.FakeAwaiter[
 			*korifiv1alpha1.CFOrg,
-			korifiv1alpha1.CFOrg,
 			korifiv1alpha1.CFOrgList,
 			*korifiv1alpha1.CFOrgList,
 		]{})
 		spaceRepo := repositories.NewSpaceRepo(namespaceRetriever, orgRepo, userClientFactory, nsPerms, &fakeawaiter.FakeAwaiter[
 			*korifiv1alpha1.CFSpace,
-			korifiv1alpha1.CFSpace,
 			korifiv1alpha1.CFSpaceList,
 			*korifiv1alpha1.CFSpaceList,
 		]{})

--- a/api/repositories/service_binding_repository_test.go
+++ b/api/repositories/service_binding_repository_test.go
@@ -39,13 +39,11 @@ var _ = Describe("ServiceBindingRepo", func() {
 		bindingName             *string
 		bindingConditionAwaiter *fakeawaiter.FakeAwaiter[
 			*korifiv1alpha1.CFServiceBinding,
-			korifiv1alpha1.CFServiceBinding,
 			korifiv1alpha1.CFServiceBindingList,
 			*korifiv1alpha1.CFServiceBindingList,
 		]
 		appConditionAwaiter *fakeawaiter.FakeAwaiter[
 			*korifiv1alpha1.CFApp,
-			korifiv1alpha1.CFApp,
 			korifiv1alpha1.CFAppList,
 			*korifiv1alpha1.CFAppList,
 		]
@@ -55,13 +53,11 @@ var _ = Describe("ServiceBindingRepo", func() {
 	BeforeEach(func() {
 		bindingConditionAwaiter = &fakeawaiter.FakeAwaiter[
 			*korifiv1alpha1.CFServiceBinding,
-			korifiv1alpha1.CFServiceBinding,
 			korifiv1alpha1.CFServiceBindingList,
 			*korifiv1alpha1.CFServiceBindingList,
 		]{}
 		appConditionAwaiter = &fakeawaiter.FakeAwaiter[
 			*korifiv1alpha1.CFApp,
-			korifiv1alpha1.CFApp,
 			korifiv1alpha1.CFAppList,
 			*korifiv1alpha1.CFAppList,
 		]{}

--- a/api/repositories/service_instance_repository_test.go
+++ b/api/repositories/service_instance_repository_test.go
@@ -35,7 +35,6 @@ var _ = Describe("ServiceInstanceRepository", func() {
 		serviceInstanceRepo *repositories.ServiceInstanceRepo
 		conditionAwaiter    *fakeawaiter.FakeAwaiter[
 			*korifiv1alpha1.CFServiceInstance,
-			korifiv1alpha1.CFServiceInstance,
 			korifiv1alpha1.CFServiceInstanceList,
 			*korifiv1alpha1.CFServiceInstanceList,
 		]
@@ -49,7 +48,6 @@ var _ = Describe("ServiceInstanceRepository", func() {
 	BeforeEach(func() {
 		conditionAwaiter = &fakeawaiter.FakeAwaiter[
 			*korifiv1alpha1.CFServiceInstance,
-			korifiv1alpha1.CFServiceInstance,
 			korifiv1alpha1.CFServiceInstanceList,
 			*korifiv1alpha1.CFServiceInstanceList,
 		]{}

--- a/api/repositories/service_plan_repository_test.go
+++ b/api/repositories/service_plan_repository_test.go
@@ -32,7 +32,6 @@ var _ = Describe("ServicePlanRepo", func() {
 	BeforeEach(func() {
 		orgRepo := repositories.NewOrgRepo(rootNamespace, k8sClient, userClientFactory, nsPerms, &fakeawaiter.FakeAwaiter[
 			*korifiv1alpha1.CFOrg,
-			korifiv1alpha1.CFOrg,
 			korifiv1alpha1.CFOrgList,
 			*korifiv1alpha1.CFOrgList,
 		]{})

--- a/api/repositories/space_repository_test.go
+++ b/api/repositories/space_repository_test.go
@@ -27,7 +27,6 @@ var _ = Describe("SpaceRepository", func() {
 		orgRepo          *repositories.OrgRepo
 		conditionAwaiter *fakeawaiter.FakeAwaiter[
 			*korifiv1alpha1.CFSpace,
-			korifiv1alpha1.CFSpace,
 			korifiv1alpha1.CFSpaceList,
 			*korifiv1alpha1.CFSpaceList,
 		]
@@ -37,14 +36,12 @@ var _ = Describe("SpaceRepository", func() {
 	BeforeEach(func() {
 		orgRepo = repositories.NewOrgRepo(rootNamespace, k8sClient, userClientFactory, nsPerms, &fakeawaiter.FakeAwaiter[
 			*korifiv1alpha1.CFOrg,
-			korifiv1alpha1.CFOrg,
 			korifiv1alpha1.CFOrgList,
 			*korifiv1alpha1.CFOrgList,
 		]{})
 
 		conditionAwaiter = &fakeawaiter.FakeAwaiter[
 			*korifiv1alpha1.CFSpace,
-			korifiv1alpha1.CFSpace,
 			korifiv1alpha1.CFSpaceList,
 			*korifiv1alpha1.CFSpaceList,
 		]{}

--- a/api/repositories/task_repository_test.go
+++ b/api/repositories/task_repository_test.go
@@ -28,7 +28,6 @@ var _ = Describe("TaskRepository", func() {
 	var (
 		conditionAwaiter *fakeawaiter.FakeAwaiter[
 			*korifiv1alpha1.CFTask,
-			korifiv1alpha1.CFTask,
 			korifiv1alpha1.CFTaskList,
 			*korifiv1alpha1.CFTaskList,
 		]
@@ -41,7 +40,6 @@ var _ = Describe("TaskRepository", func() {
 	BeforeEach(func() {
 		conditionAwaiter = &fakeawaiter.FakeAwaiter[
 			*korifiv1alpha1.CFTask,
-			korifiv1alpha1.CFTask,
 			korifiv1alpha1.CFTaskList,
 			*korifiv1alpha1.CFTaskList,
 		]{}

--- a/controllers/controllers/networking/domains/controller.go
+++ b/controllers/controllers/networking/domains/controller.go
@@ -42,9 +42,9 @@ func NewReconciler(
 	client client.Client,
 	scheme *runtime.Scheme,
 	log logr.Logger,
-) *k8s.PatchingReconciler[korifiv1alpha1.CFDomain, *korifiv1alpha1.CFDomain] {
+) *k8s.PatchingReconciler[korifiv1alpha1.CFDomain] {
 	routeReconciler := Reconciler{client: client, scheme: scheme, log: log}
-	return k8s.NewPatchingReconciler[korifiv1alpha1.CFDomain, *korifiv1alpha1.CFDomain](log, client, &routeReconciler)
+	return k8s.NewPatchingReconciler[korifiv1alpha1.CFDomain](log, client, &routeReconciler)
 }
 
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) *builder.Builder {

--- a/controllers/controllers/networking/routes/controller.go
+++ b/controllers/controllers/networking/routes/controller.go
@@ -55,9 +55,9 @@ func NewReconciler(
 	scheme *runtime.Scheme,
 	log logr.Logger,
 	controllerConfig *config.ControllerConfig,
-) *k8s.PatchingReconciler[korifiv1alpha1.CFRoute, *korifiv1alpha1.CFRoute] {
+) *k8s.PatchingReconciler[korifiv1alpha1.CFRoute] {
 	routeReconciler := Reconciler{client: client, scheme: scheme, log: log, controllerConfig: controllerConfig}
-	return k8s.NewPatchingReconciler[korifiv1alpha1.CFRoute, *korifiv1alpha1.CFRoute](log, client, &routeReconciler)
+	return k8s.NewPatchingReconciler[korifiv1alpha1.CFRoute](log, client, &routeReconciler)
 }
 
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) *builder.Builder {

--- a/controllers/controllers/services/bindings/controller.go
+++ b/controllers/controllers/services/bindings/controller.go
@@ -52,7 +52,7 @@ func NewReconciler(
 	log logr.Logger,
 	upsiCredentialsReconciler DelegateReconciler,
 	managedCredentialsReconciler DelegateReconciler,
-) *k8s.PatchingReconciler[korifiv1alpha1.CFServiceBinding, *korifiv1alpha1.CFServiceBinding] {
+) *k8s.PatchingReconciler[korifiv1alpha1.CFServiceBinding] {
 	cfBindingReconciler := &Reconciler{
 		k8sClient:         k8sClient,
 		scheme:            scheme,

--- a/controllers/controllers/services/brokers/controller.go
+++ b/controllers/controllers/services/brokers/controller.go
@@ -53,7 +53,7 @@ func NewReconciler(
 	osbapiClientFactory osbapi.BrokerClientFactory,
 	scheme *runtime.Scheme,
 	log logr.Logger,
-) *k8s.PatchingReconciler[korifiv1alpha1.CFServiceBroker, *korifiv1alpha1.CFServiceBroker] {
+) *k8s.PatchingReconciler[korifiv1alpha1.CFServiceBroker] {
 	return k8s.NewPatchingReconciler(
 		log,
 		client,

--- a/controllers/controllers/services/instances/managed/controller.go
+++ b/controllers/controllers/services/instances/managed/controller.go
@@ -60,7 +60,7 @@ func NewReconciler(
 	scheme *runtime.Scheme,
 	rootNamespace string,
 	log logr.Logger,
-) *k8s.PatchingReconciler[korifiv1alpha1.CFServiceInstance, *korifiv1alpha1.CFServiceInstance] {
+) *k8s.PatchingReconciler[korifiv1alpha1.CFServiceInstance] {
 	return k8s.NewPatchingReconciler(log, client, &Reconciler{
 		k8sClient:           client,
 		osbapiClientFactory: brokerClientFactory,

--- a/controllers/controllers/services/instances/upsi/controller.go
+++ b/controllers/controllers/services/instances/upsi/controller.go
@@ -53,7 +53,7 @@ func NewReconciler(
 	client client.Client,
 	scheme *runtime.Scheme,
 	log logr.Logger,
-) *k8s.PatchingReconciler[korifiv1alpha1.CFServiceInstance, *korifiv1alpha1.CFServiceInstance] {
+) *k8s.PatchingReconciler[korifiv1alpha1.CFServiceInstance] {
 	serviceInstanceReconciler := Reconciler{k8sClient: client, scheme: scheme, log: log}
 	return k8s.NewPatchingReconciler(log, client, &serviceInstanceReconciler)
 }

--- a/controllers/controllers/workloads/apps/controller.go
+++ b/controllers/controllers/workloads/apps/controller.go
@@ -40,7 +40,7 @@ type Reconciler struct {
 	vcapApplicationEnvBuilder EnvValueBuilder
 }
 
-func NewReconciler(k8sClient client.Client, scheme *runtime.Scheme, log logr.Logger, vcapServicesBuilder, vcapApplicationBuilder EnvValueBuilder) *k8s.PatchingReconciler[korifiv1alpha1.CFApp, *korifiv1alpha1.CFApp] {
+func NewReconciler(k8sClient client.Client, scheme *runtime.Scheme, log logr.Logger, vcapServicesBuilder, vcapApplicationBuilder EnvValueBuilder) *k8s.PatchingReconciler[korifiv1alpha1.CFApp] {
 	appReconciler := Reconciler{
 		log:                       log,
 		k8sClient:                 k8sClient,

--- a/controllers/controllers/workloads/build/buildpack/controller.go
+++ b/controllers/controllers/workloads/build/buildpack/controller.go
@@ -54,8 +54,8 @@ func NewReconciler(
 	log logr.Logger,
 	controllerConfig *config.ControllerConfig,
 	envBuilder BuildpackEnvBuilder,
-) *k8s.PatchingReconciler[korifiv1alpha1.CFBuild, *korifiv1alpha1.CFBuild] {
-	return k8s.NewPatchingReconciler[korifiv1alpha1.CFBuild, *korifiv1alpha1.CFBuild](
+) *k8s.PatchingReconciler[korifiv1alpha1.CFBuild] {
+	return k8s.NewPatchingReconciler[korifiv1alpha1.CFBuild](
 		log,
 		k8sClient,
 		build.NewReconciler(

--- a/controllers/controllers/workloads/build/docker/controller.go
+++ b/controllers/controllers/workloads/build/docker/controller.go
@@ -45,8 +45,8 @@ func NewReconciler(
 	imageConfigGetter ImageConfigGetter,
 	scheme *runtime.Scheme,
 	log logr.Logger,
-) *k8s.PatchingReconciler[korifiv1alpha1.CFBuild, *korifiv1alpha1.CFBuild] {
-	return k8s.NewPatchingReconciler[korifiv1alpha1.CFBuild, *korifiv1alpha1.CFBuild](
+) *k8s.PatchingReconciler[korifiv1alpha1.CFBuild] {
+	return k8s.NewPatchingReconciler[korifiv1alpha1.CFBuild](
 		log,
 		k8sClient,
 		build.NewReconciler(

--- a/controllers/controllers/workloads/build/suite_test.go
+++ b/controllers/controllers/workloads/build/suite_test.go
@@ -119,7 +119,7 @@ var _ = BeforeSuite(func() {
 		return nil
 	}
 
-	Expect(k8s.NewPatchingReconciler[korifiv1alpha1.CFBuild, *korifiv1alpha1.CFBuild](
+	Expect(k8s.NewPatchingReconciler[korifiv1alpha1.CFBuild](
 		ctrl.Log.WithName("controllers").WithName("CFBuild"),
 		k8sManager.GetClient(),
 		build.NewReconciler(

--- a/controllers/controllers/workloads/orgs/controller.go
+++ b/controllers/controllers/workloads/orgs/controller.go
@@ -44,7 +44,7 @@ func NewReconciler(
 	log logr.Logger,
 	containerRegistrySecretNames []string,
 	labelCompiler labels.Compiler,
-) *k8s.PatchingReconciler[korifiv1alpha1.CFOrg, *korifiv1alpha1.CFOrg] {
+) *k8s.PatchingReconciler[korifiv1alpha1.CFOrg] {
 	namespaceController := k8sns.NewReconciler[korifiv1alpha1.CFOrg, *korifiv1alpha1.CFOrg](
 		client,
 		k8sns.NewNamespaceFinalizer[korifiv1alpha1.CFOrg, *korifiv1alpha1.CFOrg](
@@ -58,7 +58,7 @@ func NewReconciler(
 		containerRegistrySecretNames,
 	)
 
-	return k8s.NewPatchingReconciler[korifiv1alpha1.CFOrg, *korifiv1alpha1.CFOrg](log, client, &Reconciler{
+	return k8s.NewPatchingReconciler[korifiv1alpha1.CFOrg](log, client, &Reconciler{
 		client:              client,
 		namespaceReconciler: namespaceController,
 	})

--- a/controllers/controllers/workloads/packages/controller.go
+++ b/controllers/controllers/workloads/packages/controller.go
@@ -66,8 +66,8 @@ func NewReconciler(
 	imageDeleter ImageDeleter,
 	packageCleaner PackageCleaner,
 	packageRepoSecretNames []string,
-) *k8s.PatchingReconciler[korifiv1alpha1.CFPackage, *korifiv1alpha1.CFPackage] {
-	return k8s.NewPatchingReconciler[korifiv1alpha1.CFPackage, *korifiv1alpha1.CFPackage](log, client, &Reconciler{
+) *k8s.PatchingReconciler[korifiv1alpha1.CFPackage] {
+	return k8s.NewPatchingReconciler[korifiv1alpha1.CFPackage](log, client, &Reconciler{
 		k8sClient:              client,
 		scheme:                 scheme,
 		log:                    log,

--- a/controllers/controllers/workloads/processes/controller.go
+++ b/controllers/controllers/workloads/processes/controller.go
@@ -63,9 +63,9 @@ func NewReconciler(
 	log logr.Logger,
 	controllerConfig *config.ControllerConfig,
 	envBuilder ProcessEnvBuilder,
-) *k8s.PatchingReconciler[korifiv1alpha1.CFProcess, *korifiv1alpha1.CFProcess] {
+) *k8s.PatchingReconciler[korifiv1alpha1.CFProcess] {
 	processReconciler := Reconciler{k8sClient: client, scheme: scheme, log: log, controllerConfig: controllerConfig, envBuilder: envBuilder}
-	return k8s.NewPatchingReconciler[korifiv1alpha1.CFProcess, *korifiv1alpha1.CFProcess](log, client, &processReconciler)
+	return k8s.NewPatchingReconciler[korifiv1alpha1.CFProcess](log, client, &processReconciler)
 }
 
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) *builder.Builder {

--- a/controllers/controllers/workloads/spaces/controller.go
+++ b/controllers/controllers/workloads/spaces/controller.go
@@ -54,8 +54,8 @@ func NewReconciler(
 	rootNamespace string,
 	appDeletionTimeout int32,
 	labelCompiler labels.Compiler,
-) *k8s.PatchingReconciler[korifiv1alpha1.CFSpace, *korifiv1alpha1.CFSpace] {
-	namespaceController := k8sns.NewReconciler[korifiv1alpha1.CFSpace, *korifiv1alpha1.CFSpace](
+) *k8s.PatchingReconciler[korifiv1alpha1.CFSpace] {
+	namespaceController := k8sns.NewReconciler[korifiv1alpha1.CFSpace](
 		client,
 		k8sns.NewNamespaceFinalizer[korifiv1alpha1.CFSpace, *korifiv1alpha1.CFSpace](
 			client,
@@ -68,7 +68,7 @@ func NewReconciler(
 		containerRegistrySecretNames,
 	)
 
-	return k8s.NewPatchingReconciler[korifiv1alpha1.CFSpace, *korifiv1alpha1.CFSpace](log, client, &Reconciler{
+	return k8s.NewPatchingReconciler[korifiv1alpha1.CFSpace](log, client, &Reconciler{
 		client:                       client,
 		namespaceReconciler:          namespaceController,
 		rootNamespace:                rootNamespace,

--- a/controllers/controllers/workloads/tasks/controller.go
+++ b/controllers/controllers/workloads/tasks/controller.go
@@ -65,7 +65,7 @@ func NewReconciler(
 	log logr.Logger,
 	envBuilder TaskEnvBuilder,
 	taskTTLDuration time.Duration,
-) *k8s.PatchingReconciler[korifiv1alpha1.CFTask, *korifiv1alpha1.CFTask] {
+) *k8s.PatchingReconciler[korifiv1alpha1.CFTask] {
 	taskReconciler := Reconciler{
 		k8sClient:       client,
 		scheme:          scheme,
@@ -74,7 +74,7 @@ func NewReconciler(
 		envBuilder:      envBuilder,
 		taskTTLDuration: taskTTLDuration,
 	}
-	return k8s.NewPatchingReconciler[korifiv1alpha1.CFTask, *korifiv1alpha1.CFTask](log, client, &taskReconciler)
+	return k8s.NewPatchingReconciler[korifiv1alpha1.CFTask](log, client, &taskReconciler)
 }
 
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) *builder.Builder {

--- a/job-task-runner/controllers/taskworkload_controller.go
+++ b/job-task-runner/controllers/taskworkload_controller.go
@@ -64,7 +64,7 @@ func NewTaskWorkloadReconciler(
 	scheme *runtime.Scheme,
 	statusGetter TaskStatusGetter,
 	jobTTL time.Duration,
-) *k8s.PatchingReconciler[korifiv1alpha1.TaskWorkload, *korifiv1alpha1.TaskWorkload] {
+) *k8s.PatchingReconciler[korifiv1alpha1.TaskWorkload] {
 	taskReconciler := TaskWorkloadReconciler{
 		k8sClient:    k8sClient,
 		logger:       logger,
@@ -73,7 +73,7 @@ func NewTaskWorkloadReconciler(
 		jobTTL:       jobTTL,
 	}
 
-	return k8s.NewPatchingReconciler[korifiv1alpha1.TaskWorkload, *korifiv1alpha1.TaskWorkload](logger, k8sClient, &taskReconciler)
+	return k8s.NewPatchingReconciler[korifiv1alpha1.TaskWorkload](logger, k8sClient, &taskReconciler)
 }
 
 func (r *TaskWorkloadReconciler) SetupWithManager(mgr ctrl.Manager) *builder.Builder {

--- a/job-task-runner/controllers/taskworkload_controller_test.go
+++ b/job-task-runner/controllers/taskworkload_controller_test.go
@@ -27,7 +27,7 @@ var _ = Describe("TaskworkloadController", func() {
 	var (
 		statusGetter *fake.TaskStatusGetter
 
-		reconciler           *k8s.PatchingReconciler[korifiv1alpha1.TaskWorkload, *korifiv1alpha1.TaskWorkload]
+		reconciler           *k8s.PatchingReconciler[korifiv1alpha1.TaskWorkload]
 		reconcileResult      ctrl.Result
 		reconcileErr         error
 		req                  ctrl.Request

--- a/kpack-image-builder/controllers/builderinfo_controller.go
+++ b/kpack-image-builder/controllers/builderinfo_controller.go
@@ -47,7 +47,7 @@ func NewBuilderInfoReconciler(
 	log logr.Logger,
 	clusterBuilderName string,
 	rootNamespaceName string,
-) *k8s.PatchingReconciler[korifiv1alpha1.BuilderInfo, *korifiv1alpha1.BuilderInfo] {
+) *k8s.PatchingReconciler[korifiv1alpha1.BuilderInfo] {
 	builderInfoReconciler := BuilderInfoReconciler{
 		k8sClient:          c,
 		scheme:             scheme,
@@ -55,7 +55,7 @@ func NewBuilderInfoReconciler(
 		clusterBuilderName: clusterBuilderName,
 		rootNamespaceName:  rootNamespaceName,
 	}
-	return k8s.NewPatchingReconciler[korifiv1alpha1.BuilderInfo, *korifiv1alpha1.BuilderInfo](log, c, &builderInfoReconciler)
+	return k8s.NewPatchingReconciler[korifiv1alpha1.BuilderInfo](log, c, &builderInfoReconciler)
 }
 
 type BuilderInfoReconciler struct {

--- a/kpack-image-builder/controllers/buildworkload_controller.go
+++ b/kpack-image-builder/controllers/buildworkload_controller.go
@@ -81,7 +81,7 @@ func NewBuildWorkloadReconciler(
 	config *config.Config,
 	imageConfigGetter ImageConfigGetter,
 	imageRepoCreator RepositoryCreator,
-) *k8s.PatchingReconciler[korifiv1alpha1.BuildWorkload, *korifiv1alpha1.BuildWorkload] {
+) *k8s.PatchingReconciler[korifiv1alpha1.BuildWorkload] {
 	buildWorkloadReconciler := BuildWorkloadReconciler{
 		k8sClient:         c,
 		scheme:            scheme,
@@ -90,7 +90,7 @@ func NewBuildWorkloadReconciler(
 		imageConfigGetter: imageConfigGetter,
 		imageRepoCreator:  imageRepoCreator,
 	}
-	return k8s.NewPatchingReconciler[korifiv1alpha1.BuildWorkload, *korifiv1alpha1.BuildWorkload](log, c, &buildWorkloadReconciler)
+	return k8s.NewPatchingReconciler[korifiv1alpha1.BuildWorkload](log, c, &buildWorkloadReconciler)
 }
 
 // BuildWorkloadReconciler reconciles a BuildWorkload object

--- a/kpack-image-builder/controllers/suite_test.go
+++ b/kpack-image-builder/controllers/suite_test.go
@@ -60,7 +60,7 @@ var (
 	testEnv                 *envtest.Environment
 	fakeImageConfigGetter   *fake.ImageConfigGetter
 	fakeImageDeleter        *fake.ImageDeleter
-	buildWorkloadReconciler *k8s.PatchingReconciler[korifiv1alpha1.BuildWorkload, *korifiv1alpha1.BuildWorkload]
+	buildWorkloadReconciler *k8s.PatchingReconciler[korifiv1alpha1.BuildWorkload]
 	rootNamespace           *v1.Namespace
 	imageRepoCreator        *fake.RepositoryCreator
 	k8sManager              manager.Manager
@@ -182,6 +182,6 @@ var _ = BeforeEach(func() {
 })
 
 var _ = AfterEach(func() {
-	stopManager()
 	stopClientCache()
+	stopManager()
 })

--- a/statefulset-runner/controllers/appworkload/appworkload_controller.go
+++ b/statefulset-runner/controllers/appworkload/appworkload_controller.go
@@ -93,7 +93,7 @@ func NewAppWorkloadReconciler(
 	pdb PDB,
 	log logr.Logger,
 	stateCollector *state.AppWorkloadStateCollector,
-) *k8s.PatchingReconciler[korifiv1alpha1.AppWorkload, *korifiv1alpha1.AppWorkload] {
+) *k8s.PatchingReconciler[korifiv1alpha1.AppWorkload] {
 	appWorkloadReconciler := AppWorkloadReconciler{
 		k8sClient:        c,
 		scheme:           scheme,
@@ -102,7 +102,7 @@ func NewAppWorkloadReconciler(
 		log:              log,
 		stateCollector:   stateCollector,
 	}
-	return k8s.NewPatchingReconciler[korifiv1alpha1.AppWorkload, *korifiv1alpha1.AppWorkload](log, c, &appWorkloadReconciler)
+	return k8s.NewPatchingReconciler[korifiv1alpha1.AppWorkload](log, c, &appWorkloadReconciler)
 }
 
 func (r *AppWorkloadReconciler) SetupWithManager(mgr ctrl.Manager) *builder.Builder {

--- a/statefulset-runner/controllers/appworkload/appworkload_controller_test.go
+++ b/statefulset-runner/controllers/appworkload/appworkload_controller_test.go
@@ -28,7 +28,7 @@ import (
 
 var _ = Describe("AppWorkload Reconcile", func() {
 	var (
-		reconciler             *k8s.PatchingReconciler[korifiv1alpha1.AppWorkload, *korifiv1alpha1.AppWorkload]
+		reconciler             *k8s.PatchingReconciler[korifiv1alpha1.AppWorkload]
 		reconcileResult        ctrl.Result
 		reconcileErr           error
 		ctx                    context.Context

--- a/statefulset-runner/controllers/runnerinfo/runnerinfo_controller.go
+++ b/statefulset-runner/controllers/runnerinfo/runnerinfo_controller.go
@@ -42,13 +42,13 @@ func NewRunnerInfoReconciler(
 	c client.Client,
 	scheme *runtime.Scheme,
 	log logr.Logger,
-) *k8s.PatchingReconciler[korifiv1alpha1.RunnerInfo, *korifiv1alpha1.RunnerInfo] {
+) *k8s.PatchingReconciler[korifiv1alpha1.RunnerInfo] {
 	runnerInfoReconciler := RunnerInfoReconciler{
 		k8sClient: c,
 		scheme:    scheme,
 		log:       log,
 	}
-	return k8s.NewPatchingReconciler[korifiv1alpha1.RunnerInfo, *korifiv1alpha1.RunnerInfo](log, c, &runnerInfoReconciler)
+	return k8s.NewPatchingReconciler[korifiv1alpha1.RunnerInfo](log, c, &runnerInfoReconciler)
 }
 
 func (r *RunnerInfoReconciler) SetupWithManager(mgr ctrl.Manager) *builder.Builder {

--- a/statefulset-runner/controllers/runnerinfo/runnerinfo_controller_test.go
+++ b/statefulset-runner/controllers/runnerinfo/runnerinfo_controller_test.go
@@ -20,7 +20,7 @@ import (
 
 var _ = Describe("RunnerInfo Reconcile", func() {
 	var (
-		reconciler      *k8s.PatchingReconciler[korifiv1alpha1.RunnerInfo, *korifiv1alpha1.RunnerInfo]
+		reconciler      *k8s.PatchingReconciler[korifiv1alpha1.RunnerInfo]
 		reconcileResult ctrl.Result
 		reconcileErr    error
 		req             ctrl.Request

--- a/tests/helpers/broker/deleter.go
+++ b/tests/helpers/broker/deleter.go
@@ -153,7 +153,7 @@ func (d *Deleter) cleanupInsances(planName string) error {
 	return fmt.Errorf("failed to clean up service bindings for plan %q", planName)
 }
 
-func forceDelete[T any, PT k8s.ObjectWithDeepCopy[T]](ctx context.Context, k8sClient client.Client, obj PT) {
+func forceDelete[T client.Object](ctx context.Context, k8sClient client.Client, obj T) {
 	Expect(client.IgnoreNotFound(k8s.PatchResource(ctx, k8sClient, obj, func() {
 		obj.SetFinalizers(nil)
 	}))).To(Succeed())

--- a/tests/helpers/k8s.go
+++ b/tests/helpers/k8s.go
@@ -60,7 +60,7 @@ func EnsureCreate(k8sClient client.Client, obj client.Object) {
 	}).Should(Succeed())
 }
 
-func EnsurePatch[T any, PT k8s.ObjectWithDeepCopy[T]](k8sClient client.Client, obj PT, modifyFunc func(PT)) {
+func EnsurePatch[T client.Object](k8sClient client.Client, obj T, modifyFunc func(T)) {
 	GinkgoHelper()
 
 	Expect(k8s.Patch(context.Background(), k8sClient, obj, func() {
@@ -68,7 +68,7 @@ func EnsurePatch[T any, PT k8s.ObjectWithDeepCopy[T]](k8sClient client.Client, o
 	})).To(Succeed())
 	Eventually(func(g Gomega) {
 		g.Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(obj), obj)).To(Succeed())
-		objCopy := obj.DeepCopy()
+		objCopy := k8s.DeepCopy(obj)
 		modifyFunc(objCopy)
 		g.Expect(equality.Semantic.DeepEqual(objCopy, obj)).To(BeTrue())
 	}).Should(Succeed())

--- a/tools/k8s/reconcile_test.go
+++ b/tools/k8s/reconcile_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Reconcile", func() {
 		ctx                context.Context
 		fakeClient         *fake.Client
 		fakeStatusWriter   *fake.StatusWriter
-		patchingReconciler *k8s.PatchingReconciler[korifiv1alpha1.CFOrg, *korifiv1alpha1.CFOrg]
+		patchingReconciler *k8s.PatchingReconciler[korifiv1alpha1.CFOrg]
 		objectReconciler   *fakeObjectReconciler
 		org                *korifiv1alpha1.CFOrg
 		result             ctrl.Result
@@ -92,7 +92,7 @@ var _ = Describe("Reconcile", func() {
 			return nil
 		}
 
-		patchingReconciler = k8s.NewPatchingReconciler[korifiv1alpha1.CFOrg, *korifiv1alpha1.CFOrg](ctrl.Log, fakeClient, objectReconciler)
+		patchingReconciler = k8s.NewPatchingReconciler[korifiv1alpha1.CFOrg](ctrl.Log, fakeClient, objectReconciler)
 	})
 
 	JustBeforeEach(func() {


### PR DESCRIPTION
## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Remove the `ObjectWithDeepCopy` interface

We only had the interface in order to be able to call the `DeepCopy`
method generated by kuybebuilder. This seems not to be required as
`client.Object` already has a `DeepCopyObject` method.

Removing the interface simplifies generics on controllers, awaiters, etc.
<!-- _Please describe the change here._ -->
