### PR TITLE
Bump golang to 1.24.2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,36 @@ updates:
   schedule:
     interval: "daily"
 
+- package-ecosystem: "docker"
+  directory: "/job-task-runner"
+  schedule:
+    interval: "daily"
+
+- package-ecosystem: "docker"
+  directory: "/job-task-runner/remote-debug"
+  schedule:
+    interval: "daily"
+
+- package-ecosystem: "docker"
+  directory: "/kpack-image-builder"
+  schedule:
+    interval: "daily"
+
+- package-ecosystem: "docker"
+  directory: "/kpack-image-builder/remote-debug"
+  schedule:
+    interval: "daily"
+
+- package-ecosystem: "docker"
+  directory: "/statefulset-runner"
+  schedule:
+    interval: "daily"
+
+- package-ecosystem: "docker"
+  directory: "/statefulset-runner/remote-debug"
+  schedule:
+    interval: "daily"
+
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module code.cloudfoundry.org/korifi
 
-go 1.23.7
-
-toolchain go1.24.1
+go 1.24.2
 
 require (
 	code.cloudfoundry.org/bytefmt v0.36.0

--- a/job-task-runner/Dockerfile
+++ b/job-task-runner/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:experimental
-FROM golang:1.23 as builder
+FROM golang:1.24 as builder
 
 ARG version=dev
 

--- a/job-task-runner/remote-debug/Dockerfile
+++ b/job-task-runner/remote-debug/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:experimental
-FROM golang:1.23 as builder
+FROM golang:1.24 as builder
 
 ARG version=dev
 

--- a/kpack-image-builder/Dockerfile
+++ b/kpack-image-builder/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:experimental
-FROM golang:1.23 as builder
+FROM golang:1.24 as builder
 
 ARG version=dev
 

--- a/kpack-image-builder/remote-debug/Dockerfile
+++ b/kpack-image-builder/remote-debug/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:experimental
-FROM golang:1.23 as builder
+FROM golang:1.24 as builder
 
 ARG version=dev
 

--- a/statefulset-runner/Dockerfile
+++ b/statefulset-runner/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:experimental
-FROM golang:1.23 as builder
+FROM golang:1.24 as builder
 
 ARG version=dev
 

--- a/statefulset-runner/remote-debug/Dockerfile
+++ b/statefulset-runner/remote-debug/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:experimental
-FROM golang:1.23 as builder
+FROM golang:1.24 as builder
 
 ARG version=dev
 


### PR DESCRIPTION
## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
- **Configure dependabot to monitor runners Dockerfiles**
- **Bump golang to 1.24.2**
<!-- _Please describe the change here._ -->

