### PR TITLE
y

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module code.cloudfoundry.org/korifi
 
-go 1.24.2
+go 1.24.1
 
 require (
 	code.cloudfoundry.org/bytefmt v0.36.0


### PR DESCRIPTION
## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
This fixes `make lint` on Concourse. Concourse runs linters with the
`golangci-lint` image and the go version it brings is still 1.24.1. The
golang version mismatch causes staticcheck to fail
<!-- _Please describe the change here._ -->

