### PR TITLE
Do not create the `web` process in the app handler

### DIFF
--- a/api/handlers/app.go
+++ b/api/handlers/app.go
@@ -16,7 +16,6 @@ import (
 	"code.cloudfoundry.org/korifi/api/repositories"
 	"code.cloudfoundry.org/korifi/api/routing"
 	"code.cloudfoundry.org/korifi/api/tools/singleton"
-	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 
 	"github.com/go-logr/logr"
 )
@@ -145,15 +144,6 @@ func (h *App) create(r *http.Request) (*routing.Response, error) {
 	appRecord, err := h.appRepo.CreateApp(r.Context(), authInfo, payload.ToAppCreateMessage())
 	if err != nil {
 		return nil, apierrors.LogAndReturn(logger, err, "Failed to create app", "App Name", payload.Name)
-	}
-
-	err = h.processRepo.CreateProcess(r.Context(), authInfo, repositories.CreateProcessMessage{
-		AppGUID:   appRecord.GUID,
-		SpaceGUID: spaceGUID,
-		Type:      korifiv1alpha1.ProcessTypeWeb,
-	})
-	if err != nil {
-		return nil, apierrors.LogAndReturn(logger, err, "Failed to create web process", "App Name", payload.Name)
 	}
 
 	return routing.NewResponse(http.StatusCreated).WithBody(presenter.ForApp(appRecord, h.serverURL)), nil

--- a/api/handlers/app_test.go
+++ b/api/handlers/app_test.go
@@ -236,31 +236,10 @@ var _ = Describe("App", func() {
 			})
 		})
 
-		It("creates the `web` process", func() {
-			Expect(processRepo.CreateProcessCallCount()).To(Equal(1))
-			_, actualAuthInfo, actualMsg := processRepo.CreateProcessArgsForCall(0)
-			Expect(actualAuthInfo).To(Equal(authInfo))
-			Expect(actualMsg).To(Equal(repositories.CreateProcessMessage{
-				AppGUID:   appGUID,
-				SpaceGUID: spaceGUID,
-				Type:      "web",
-			}))
-		})
-
 		It("validates the payload", func() {
 			Expect(requestValidator.DecodeAndValidateJSONPayloadCallCount()).To(Equal(1))
 			actualReq, _ := requestValidator.DecodeAndValidateJSONPayloadArgsForCall(0)
 			Expect(bodyString(actualReq)).To(Equal("the-json-body"))
-		})
-
-		When("creating the process fails", func() {
-			BeforeEach(func() {
-				processRepo.CreateProcessReturns(errors.New("create-process-err"))
-			})
-
-			It("returns an error", func() {
-				expectUnknownError()
-			})
 		})
 
 		When("creating the app fails", func() {

--- a/tests/e2e/apps_test.go
+++ b/tests/e2e/apps_test.go
@@ -198,7 +198,7 @@ var _ = Describe("Apps", func() {
 		var result resourceList[typedResource]
 
 		BeforeEach(func() {
-			appGUID = createBuildpackApp(space1GUID, generateGUID("app"))
+			appGUID, _ = pushTestApp(space1GUID, defaultAppBitsFile)
 		})
 
 		JustBeforeEach(func() {


### PR DESCRIPTION
## Is there a related GitHub Issue?
#3621
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
The `web` process is created by the app controller anyway, therefore
creating the process from the API does not make sense

