### PR TITLE
Propagate the ready condition from workloads to apps

### DIFF
--- a/api/repositories/conditions/await.go
+++ b/api/repositories/conditions/await.go
@@ -6,9 +6,7 @@ import (
 	"time"
 
 	"code.cloudfoundry.org/korifi/api/repositories"
-	"code.cloudfoundry.org/korifi/tools/k8s"
-	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"code.cloudfoundry.org/korifi/tools/k8s/conditions"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -17,11 +15,11 @@ type ObjectList[L any] interface {
 	client.ObjectList
 }
 
-type Awaiter[T k8s.RuntimeObjectWithStatusConditions, L any, PL ObjectList[L]] struct {
+type Awaiter[T conditions.RuntimeObjectWithStatusConditions, L any, PL ObjectList[L]] struct {
 	timeout time.Duration
 }
 
-func NewConditionAwaiter[T k8s.RuntimeObjectWithStatusConditions, L any, PL ObjectList[L]](timeout time.Duration) *Awaiter[T, L, PL] {
+func NewConditionAwaiter[T conditions.RuntimeObjectWithStatusConditions, L any, PL ObjectList[L]](timeout time.Duration) *Awaiter[T, L, PL] {
 	return &Awaiter[T, L, PL]{
 		timeout: timeout,
 	}
@@ -29,7 +27,7 @@ func NewConditionAwaiter[T k8s.RuntimeObjectWithStatusConditions, L any, PL Obje
 
 func (a *Awaiter[T, L, PL]) AwaitCondition(ctx context.Context, k8sClient repositories.Klient, object client.Object, conditionType string) (T, error) {
 	return a.AwaitState(ctx, k8sClient, object, func(o T) error {
-		return checkConditionIsTrue[T, L](o, conditionType)
+		return conditions.CheckConditionIsTrue[T](o, conditionType)
 	})
 }
 
@@ -66,21 +64,4 @@ func (a *Awaiter[T, L, PL]) AwaitState(ctx context.Context, k8sClient repositori
 	return empty, fmt.Errorf("object %s/%s state has not been met in %.2f s: %s",
 		object.GetNamespace(), object.GetName(), a.timeout.Seconds(), checkStateErr.Error(),
 	)
-}
-
-func checkConditionIsTrue[T k8s.RuntimeObjectWithStatusConditions, L any](obj T, conditionType string) error {
-	condition := meta.FindStatusCondition(*obj.StatusConditions(), conditionType)
-
-	if condition == nil {
-		return fmt.Errorf("condition %s not set yet", conditionType)
-	}
-
-	if condition.ObservedGeneration != obj.GetGeneration() {
-		return fmt.Errorf("condition %s is outdated", conditionType)
-	}
-
-	if condition.Status == metav1.ConditionTrue {
-		return nil
-	}
-	return fmt.Errorf("expected the %s condition to be true", conditionType)
 }

--- a/api/repositories/conditions/await_test.go
+++ b/api/repositories/conditions/await_test.go
@@ -79,7 +79,7 @@ var _ = Describe("ConditionAwaiter", func() {
 			})
 
 			It("returns an error", func() {
-				Expect(awaitErr).To(MatchError(ContainSubstring("expected the Ready condition to be true")))
+				Expect(awaitErr).To(MatchError(ContainSubstring("Ready condition is not true")))
 			})
 		})
 

--- a/api/repositories/fakeawaiter/await.go
+++ b/api/repositories/fakeawaiter/await.go
@@ -4,12 +4,12 @@ import (
 	"context"
 
 	"code.cloudfoundry.org/korifi/api/repositories"
-	"code.cloudfoundry.org/korifi/api/repositories/conditions"
-	"code.cloudfoundry.org/korifi/tools/k8s"
+	repoconditions "code.cloudfoundry.org/korifi/api/repositories/conditions"
+	"code.cloudfoundry.org/korifi/tools/k8s/conditions"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-type FakeAwaiter[T k8s.RuntimeObjectWithStatusConditions, L any, PL conditions.ObjectList[L]] struct {
+type FakeAwaiter[T conditions.RuntimeObjectWithStatusConditions, L any, PL repoconditions.ObjectList[L]] struct {
 	awaitConditionCalls []struct {
 		obj           client.Object
 		conditionType string

--- a/controllers/controllers/workloads/apps/controller.go
+++ b/controllers/controllers/workloads/apps/controller.go
@@ -11,6 +11,7 @@ import (
 	"code.cloudfoundry.org/korifi/controllers/controllers/shared"
 	"code.cloudfoundry.org/korifi/tools"
 	"code.cloudfoundry.org/korifi/tools/k8s"
+	"code.cloudfoundry.org/korifi/tools/k8s/conditions"
 
 	"github.com/BooleanCat/go-functional/v2/it"
 	"github.com/go-logr/logr"
@@ -163,7 +164,17 @@ func (r *Reconciler) ReconcileResource(ctx context.Context, cfApp *korifiv1alpha
 		return ctrl.Result{}, k8s.NewNotReadyError().WithReason("DesiredStateNotReached")
 	}
 
+	if !allReady(reconciledProcesses) {
+		return ctrl.Result{}, k8s.NewNotReadyError().WithReason("ProcessesNotReady").WithRequeue()
+	}
+
 	return ctrl.Result{}, nil
+}
+
+func allReady(processes []*korifiv1alpha1.CFProcess) bool {
+	return it.All(it.Map(slices.Values(processes), func(p *korifiv1alpha1.CFProcess) bool {
+		return conditions.CheckConditionIsTrue(p, korifiv1alpha1.StatusConditionReady) == nil
+	}))
 }
 
 func (r *Reconciler) getServiceBindings(ctx context.Context, cfApp *korifiv1alpha1.CFApp) ([]korifiv1alpha1.CFServiceBinding, error) {

--- a/controllers/controllers/workloads/processes/controller.go
+++ b/controllers/controllers/workloads/processes/controller.go
@@ -21,6 +21,7 @@ import (
 	"crypto/sha1"
 	"errors"
 	"fmt"
+	"slices"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"code.cloudfoundry.org/korifi/controllers/config"
@@ -28,7 +29,9 @@ import (
 	"code.cloudfoundry.org/korifi/controllers/controllers/workloads/ports"
 	"code.cloudfoundry.org/korifi/tools"
 	"code.cloudfoundry.org/korifi/tools/k8s"
+	"code.cloudfoundry.org/korifi/tools/k8s/conditions"
 
+	"github.com/BooleanCat/go-functional/v2/it"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 
@@ -167,7 +170,17 @@ func (r *Reconciler) ReconcileResource(ctx context.Context, cfProcess *korifiv1a
 	cfProcess.Status.ActualInstances = getActualInstances(appWorkloads)
 	cfProcess.Status.InstancesStatus = getCurrentInstancesStatus(getDesiredAppWorkloadName(cfApp, cfProcess), appWorkloads)
 
+	if !allReady(appWorkloads) {
+		return ctrl.Result{}, k8s.NewNotReadyError().WithReason("AppWorkloadsNotReady").WithRequeue()
+	}
+
 	return ctrl.Result{}, nil
+}
+
+func allReady(appWorkloads []korifiv1alpha1.AppWorkload) bool {
+	return it.All(it.Map(slices.Values(appWorkloads), func(w korifiv1alpha1.AppWorkload) bool {
+		return conditions.CheckConditionIsTrue(&w, korifiv1alpha1.StatusConditionReady) == nil
+	}))
 }
 
 func getRevision(app *korifiv1alpha1.CFApp) string {
@@ -349,20 +362,15 @@ func getDesiredAppWorkloadName(cfApp *korifiv1alpha1.CFApp, cfProcess *korifiv1a
 }
 
 func (r *Reconciler) fetchAppWorkloadsForProcess(ctx context.Context, cfProcess *korifiv1alpha1.CFProcess) ([]korifiv1alpha1.AppWorkload, error) {
-	allAppWorkloads := &korifiv1alpha1.AppWorkloadList{}
-	err := r.k8sClient.List(ctx, allAppWorkloads, client.InNamespace(cfProcess.Namespace))
+	appWorkloadsForProcess := &korifiv1alpha1.AppWorkloadList{}
+	err := r.k8sClient.List(ctx, appWorkloadsForProcess, client.InNamespace(cfProcess.Namespace), client.MatchingLabels{
+		korifiv1alpha1.CFProcessGUIDLabelKey: cfProcess.Name,
+	})
 	if err != nil {
 		return []korifiv1alpha1.AppWorkload{}, err
 	}
 
-	var appWorkloadsForProcess []korifiv1alpha1.AppWorkload
-	for _, currentAppWorkload := range allAppWorkloads.Items {
-		if processGUID, has := currentAppWorkload.Labels[korifiv1alpha1.CFProcessGUIDLabelKey]; has && processGUID == cfProcess.Name {
-			appWorkloadsForProcess = append(appWorkloadsForProcess, currentAppWorkload)
-		}
-	}
-
-	return appWorkloadsForProcess, err
+	return appWorkloadsForProcess.Items, err
 }
 
 func commandForProcess(process *korifiv1alpha1.CFProcess, app *korifiv1alpha1.CFApp) []string {

--- a/controllers/controllers/workloads/tasks/controller_test.go
+++ b/controllers/controllers/workloads/tasks/controller_test.go
@@ -3,6 +3,7 @@ package tasks_test
 import (
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"code.cloudfoundry.org/korifi/tools/k8s"
+	"code.cloudfoundry.org/korifi/tools/k8s/conditions"
 
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
@@ -150,7 +151,7 @@ var _ = Describe("CFTaskReconciler Integration Tests", func() {
 		Expect(k8s.Patch(ctx, adminClient, cfApp, func() {
 			cfApp.Status.VCAPApplicationSecretName = vcapApplicationSecret.Name
 			cfApp.Status.VCAPServicesSecretName = vcapServicesSecret.Name
-			meta.SetStatusCondition(&cfApp.Status.Conditions, k8s.NewReadyConditionBuilder(cfApp).Ready().Build())
+			meta.SetStatusCondition(&cfApp.Status.Conditions, conditions.NewReadyConditionBuilder(cfApp).Ready().Build())
 		})).To(Succeed())
 
 		cfTask = &korifiv1alpha1.CFTask{

--- a/tools/k8s/conditions/builder.go
+++ b/tools/k8s/conditions/builder.go
@@ -1,4 +1,4 @@
-package k8s
+package conditions
 
 import (
 	"time"

--- a/tools/k8s/conditions/builder_test.go
+++ b/tools/k8s/conditions/builder_test.go
@@ -1,4 +1,4 @@
-package k8s_test
+package conditions_test
 
 import (
 	"errors"
@@ -9,17 +9,17 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
-	"code.cloudfoundry.org/korifi/tools/k8s"
+	"code.cloudfoundry.org/korifi/tools/k8s/conditions"
 )
 
 var _ = Describe("ReadyConditionBuilder", func() {
 	var (
-		builder   *k8s.ReadyConditionBuilder
+		builder   *conditions.ReadyConditionBuilder
 		condition metav1.Condition
 	)
 
 	BeforeEach(func() {
-		builder = k8s.NewReadyConditionBuilder(&corev1.Secret{
+		builder = conditions.NewReadyConditionBuilder(&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Generation: 4,
 			},

--- a/tools/k8s/conditions/checker.go
+++ b/tools/k8s/conditions/checker.go
@@ -1,0 +1,31 @@
+package conditions
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type RuntimeObjectWithStatusConditions interface {
+	client.Object
+	StatusConditions() *[]metav1.Condition
+}
+
+func CheckConditionIsTrue[T RuntimeObjectWithStatusConditions](obj T, conditionType string) error {
+	condition := meta.FindStatusCondition(*obj.StatusConditions(), conditionType)
+
+	if condition == nil {
+		return fmt.Errorf("condition %s not set yet", conditionType)
+	}
+
+	if condition.ObservedGeneration != obj.GetGeneration() {
+		return fmt.Errorf("condition %s is outdated", conditionType)
+	}
+
+	if condition.Status == metav1.ConditionTrue {
+		return nil
+	}
+	return fmt.Errorf("%s condition is not true", conditionType)
+}

--- a/tools/k8s/conditions/checker_test.go
+++ b/tools/k8s/conditions/checker_test.go
@@ -1,0 +1,69 @@
+package conditions_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
+	"code.cloudfoundry.org/korifi/tools/k8s/conditions"
+)
+
+var _ = Describe("CheckConditionIsTrue", func() {
+	var (
+		obj      *korifiv1alpha1.CFApp
+		checkErr error
+	)
+	BeforeEach(func() {
+		obj = &korifiv1alpha1.CFApp{}
+	})
+
+	JustBeforeEach(func() {
+		checkErr = conditions.CheckConditionIsTrue(obj, "TestCondition")
+	})
+
+	It("errors", func() {
+		Expect(checkErr).To(MatchError("condition TestCondition not set yet"))
+	})
+
+	When("the condition is false", func() {
+		BeforeEach(func() {
+			obj.Status.Conditions = []metav1.Condition{{
+				Type:   "TestCondition",
+				Status: metav1.ConditionFalse,
+			}}
+		})
+
+		It("errors", func() {
+			Expect(checkErr).To(MatchError("TestCondition condition is not true"))
+		})
+	})
+
+	When("the condition is true", func() {
+		BeforeEach(func() {
+			obj.Status.Conditions = []metav1.Condition{{
+				Type:   "TestCondition",
+				Status: metav1.ConditionTrue,
+			}}
+		})
+
+		It("succeeds", func() {
+			Expect(checkErr).NotTo(HaveOccurred())
+		})
+	})
+
+	When("the condition is outdated", func() {
+		BeforeEach(func() {
+			obj.SetGeneration(2)
+
+			obj.Status.Conditions = []metav1.Condition{{
+				Type:               "TestCondition",
+				ObservedGeneration: 1,
+			}}
+		})
+
+		It("errors", func() {
+			Expect(checkErr).To(MatchError("condition TestCondition is outdated"))
+		})
+	})
+})

--- a/tools/k8s/conditions/suite_test.go
+++ b/tools/k8s/conditions/suite_test.go
@@ -1,0 +1,13 @@
+package conditions_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestConditions(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Conditions Suite")
+}


### PR DESCRIPTION
## Is there a related GitHub Issue?
No, but the infamous bindings flake
https://ci.korifi.cf-app.com/teams/main/pipelines/main/jobs/run-e2es-eks-periodic/builds/13307

## What is this change about?
Applications, their processes and workloads represent a tree-like
logical structure. Each of the tree nodes have a `Ready` status
condition that is managed by the respective controllers.

When stopping/starting an app from the API, the API would await the
`CFApp` `Ready` condition. Therefore, it is important that whenever the
app becomes ready, it is guaranteed that its child nodes (processes and
workloads) are ready as well.

This change should address long ongoing flake of inconsistent service
bindings after app restart, for example https://ci.korifi.cf-app.com/teams/main/pipelines/main/jobs/run-e2es-eks-periodic/builds/13307
<!-- _Please describe the change here._ -->

## Tag your pair, your PM, and/or team
@georgethebeatle @uzabanov
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
