### PR TITLE
Fix flake in service binding repository

### DIFF
--- a/api/repositories/service_binding_repository_test.go
+++ b/api/repositories/service_binding_repository_test.go
@@ -498,7 +498,7 @@ var _ = Describe("ServiceBindingRepo", func() {
 			Expect(serviceBindingRecord.LastOperation.Type).To(Equal("create"))
 			Expect(serviceBindingRecord.LastOperation.State).To(Equal("initial"))
 			Expect(serviceBindingRecord.LastOperation.CreatedAt).To(Equal(serviceBindingRecord.CreatedAt))
-			Expect(serviceBindingRecord.LastOperation.UpdatedAt).To(PointTo(Equal(serviceBindingRecord.CreatedAt)))
+			Expect(serviceBindingRecord.LastOperation.UpdatedAt).To(PointTo(BeTemporally("~", serviceBindingRecord.CreatedAt, time.Second)))
 		})
 
 		When("the binding is being deleted", func() {


### PR DESCRIPTION
## Is there a related GitHub Issue?
Flake: https://ci.korifi.cf-app.com/teams/main/pipelines/main/jobs/run-tests-periodic/builds/23545
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Service binding's `UpdatedAt` is populated by the last modification
timestamp of managed fields. It could happen that it is a bit off
from the creation timestamp
<!-- _Please describe the change here._ -->

