### PR TITLE
Make the cert manager an optional dependency

### DIFF
--- a/README.helm.md
+++ b/README.helm.md
@@ -13,6 +13,7 @@ Here are all the values that can be set for the chart:
 - `adminUserName` (_String_): Name of the admin user that will be bound to the Cloud Foundry Admin role.
 - `api`:
   - `apiServer`:
+    - `ingressCertSecret` (_String_): The name of the secret containing the TLS certificate for the API ingress.
     - `internalPort` (_Integer_): Port used internally by the API container.
     - `port` (_Integer_): API external port. Defaults to `443`.
     - `timeouts`: HTTP timeouts.
@@ -70,6 +71,7 @@ Here are all the values that can be set for the chart:
       - `memory` (_String_): Memory request.
   - `taskTTL` (_String_): How long before the `CFTask` object is deleted after the task has completed. See [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration) for details on the format, an additional `d` suffix for days is supported.
   - `tolerations` (_Array_): Korifi-controllers pod tolerations for taints.
+  - `webhookCertSecret` (_String_): A secert containing the CA bundle and the certificate for the webhook server.
   - `workloadsTLSSecret` (_String_): TLS secret used when setting up an app routes.
 - `crds`:
   - `include` (_Boolean_): Install CRDs as part of the Helm installation.
@@ -93,6 +95,7 @@ Here are all the values that can be set for the chart:
     - `enabled` (_Boolean_): Enable UAA support
     - `url` (_String_): The url of a UAA instance
 - `generateIngressCertificates` (_Boolean_): Use `cert-manager` to generate self-signed certificates for the API and app endpoints.
+- `generateWebhookCertificates` (_Boolean_): Use `cert-manager` to generate self-signed certificates for the webhooks.
 - `helm`:
   - `hooksImage` (_String_): Image for the helm hooks containing kubectl
 - `jobTaskRunner`:
@@ -119,6 +122,7 @@ Here are all the values that can be set for the chart:
     - `requests`: Resource requests.
       - `cpu` (_String_): CPU request.
       - `memory` (_String_): Memory request.
+  - `webhookCertSecret` (_String_): A secert containing the CA bundle and the certificate for the webhook server.
 - `logLevel` (_String_): Sets level of logging for api and controllers components. Can be 'info' or 'debug'.
 - `networking`: Networking configuration
   - `gatewayClass` (_String_): The name of the GatewayClass Korifi Gateway references
@@ -144,4 +148,5 @@ Here are all the values that can be set for the chart:
     - `requests`: Resource requests.
       - `cpu` (_String_): CPU request.
       - `memory` (_String_): Memory request.
+  - `webhookCertSecret` (_String_): A secert containing the CA bundle and the certificate for the webhook server.
 - `systemImagePullSecrets` (_Array_): List of `Secret` names to be used when pulling Korifi system images from private registries

--- a/controllers/Makefile
+++ b/controllers/Makefile
@@ -42,9 +42,10 @@ manifests: bin/controller-gen bin/yq
 		output:rbac:artifacts:config=../helm/korifi/controllers \
 		output:webhook:artifacts:config=../helm/korifi/controllers
 
-	yq -i 'with(.metadata; .annotations["cert-manager.io/inject-ca-from"]="{{ .Release.Namespace }}/korifi-controllers-serving-cert")' $(webhooks-file)
+	yq -i 'with(.metadata; .annotations["cert-manager.io/inject-ca-from"]="{{ .Release.Namespace }}/{{ .Values.controllers.webhookCertSecret }}")' $(webhooks-file)
 	yq -i 'with(.metadata; .name="korifi-controllers-" + .name)' $(webhooks-file)
 	yq -i 'with(.webhooks[]; .clientConfig.service.namespace="{{ .Release.Namespace }}")' $(webhooks-file)
+	yq -i 'with(.webhooks[]; .clientConfig.caBundle="{{ include \"korifi.webhookCaBundle\" (set . \"component\" \"controllers\") }}")' $(webhooks-file)
 	yq -i 'with(.webhooks[]; .clientConfig.service.name="korifi-controllers-" + .clientConfig.service.name)' $(webhooks-file)
 
 generate: bin/controller-gen

--- a/helm/korifi/api/deployment.yaml
+++ b/helm/korifi/api/deployment.yaml
@@ -71,7 +71,7 @@ spec:
         name: korifi-api-config
       - name: korifi-tls-config
         secret:
-          secretName: korifi-api-ingress-cert
+          secretName: {{ .Values.api.apiServer.ingressCertSecret }}
 {{- if .Values.containerRegistryCACertSecret }}
       - name: korifi-registry-ca-cert
         secret:

--- a/helm/korifi/api/ingress-cert.yaml
+++ b/helm/korifi/api/ingress-cert.yaml
@@ -2,7 +2,7 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: korifi-api-ingress-cert
+  name: {{ .Values.api.apiServer.ingressCertSecret }}
   namespace: {{ .Release.Namespace }}
 spec:
   commonName: {{ .Values.api.apiServer.url }}
@@ -11,5 +11,5 @@ spec:
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer
-  secretName: korifi-api-ingress-cert
+  secretName: {{ .Values.api.apiServer.ingressCertSecret }}
 {{- end }}

--- a/helm/korifi/controllers/deployment.yaml
+++ b/helm/korifi/controllers/deployment.yaml
@@ -89,7 +89,7 @@ spec:
       - name: cert
         secret:
           defaultMode: 420
-          secretName: controllers-webhook-server-cert
+          secretName: {{ .Values.controllers.webhookCertSecret }}
       - configMap:
           name: korifi-controllers-config
         name: korifi-controllers-config

--- a/helm/korifi/controllers/ingress-cert.yaml
+++ b/helm/korifi/controllers/ingress-cert.yaml
@@ -2,7 +2,7 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: korifi-workloads-ingress-cert
+  name: {{ .Values.controllers.workloadsTLSSecret }}
   namespace: {{ .Release.Namespace }}
 spec:
   commonName: \*.{{ .Values.defaultAppDomainName }}

--- a/helm/korifi/controllers/manifests.yaml
+++ b/helm/korifi/controllers/manifests.yaml
@@ -4,7 +4,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: korifi-controllers-mutating-webhook-configuration
   annotations:
-    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/korifi-controllers-serving-cert'
+    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/{{ .Values.controllers.webhookCertSecret }}'
 webhooks:
   - admissionReviewVersions:
       - v1
@@ -14,6 +14,7 @@ webhooks:
         name: korifi-controllers-webhook-service
         namespace: '{{ .Release.Namespace }}'
         path: /mutate-korifi-cloudfoundry-org-v1alpha1-cfapp
+      caBundle: '{{ include "korifi.webhookCaBundle" (set . "component" "controllers") }}'
     failurePolicy: Fail
     name: mcfapp.korifi.cloudfoundry.org
     rules:
@@ -35,6 +36,7 @@ webhooks:
         name: korifi-controllers-webhook-service
         namespace: '{{ .Release.Namespace }}'
         path: /mutate-korifi-cloudfoundry-org-v1alpha1-cfbuild
+      caBundle: '{{ include "korifi.webhookCaBundle" (set . "component" "controllers") }}'
     failurePolicy: Fail
     name: mcfbuild.korifi.cloudfoundry.org
     rules:
@@ -56,6 +58,7 @@ webhooks:
         name: korifi-controllers-webhook-service
         namespace: '{{ .Release.Namespace }}'
         path: /mutate-korifi-cloudfoundry-org-v1alpha1-cfdomain
+      caBundle: '{{ include "korifi.webhookCaBundle" (set . "component" "controllers") }}'
     failurePolicy: Fail
     name: mcfdomain.korifi.cloudfoundry.org
     rules:
@@ -77,6 +80,7 @@ webhooks:
         name: korifi-controllers-webhook-service
         namespace: '{{ .Release.Namespace }}'
         path: /mutate-korifi-cloudfoundry-org-v1alpha1-cfpackage
+      caBundle: '{{ include "korifi.webhookCaBundle" (set . "component" "controllers") }}'
     failurePolicy: Fail
     name: mcfpackage.korifi.cloudfoundry.org
     rules:
@@ -98,6 +102,7 @@ webhooks:
         name: korifi-controllers-webhook-service
         namespace: '{{ .Release.Namespace }}'
         path: /mutate-korifi-cloudfoundry-org-v1alpha1-cfprocess
+      caBundle: '{{ include "korifi.webhookCaBundle" (set . "component" "controllers") }}'
     failurePolicy: Fail
     name: mcfprocess.korifi.cloudfoundry.org
     rules:
@@ -119,6 +124,7 @@ webhooks:
         name: korifi-controllers-webhook-service
         namespace: '{{ .Release.Namespace }}'
         path: /mutate-korifi-cloudfoundry-org-v1alpha1-cfroute
+      caBundle: '{{ include "korifi.webhookCaBundle" (set . "component" "controllers") }}'
     failurePolicy: Fail
     name: mcfroute.korifi.cloudfoundry.org
     rules:
@@ -140,6 +146,7 @@ webhooks:
         name: korifi-controllers-webhook-service
         namespace: '{{ .Release.Namespace }}'
         path: /mutate-korifi-cloudfoundry-org-v1alpha1-controllers-finalizer
+      caBundle: '{{ include "korifi.webhookCaBundle" (set . "component" "controllers") }}'
     failurePolicy: Fail
     name: mcffinalizer.korifi.cloudfoundry.org
     rules:
@@ -167,6 +174,7 @@ webhooks:
         name: korifi-controllers-webhook-service
         namespace: '{{ .Release.Namespace }}'
         path: /mutate-korifi-cloudfoundry-org-v1alpha1-controllers-space-guid
+      caBundle: '{{ include "korifi.webhookCaBundle" (set . "component" "controllers") }}'
     failurePolicy: Fail
     name: mcfspaceguid.korifi.cloudfoundry.org
     rules:
@@ -195,6 +203,7 @@ webhooks:
         name: korifi-controllers-webhook-service
         namespace: '{{ .Release.Namespace }}'
         path: /mutate-korifi-cloudfoundry-org-v1alpha1-all-version
+      caBundle: '{{ include "korifi.webhookCaBundle" (set . "component" "controllers") }}'
     failurePolicy: Fail
     name: mcfversion.korifi.cloudfoundry.org
     rules:
@@ -230,6 +239,7 @@ webhooks:
         name: korifi-controllers-webhook-service
         namespace: '{{ .Release.Namespace }}'
         path: /mutate-korifi-cloudfoundry-org-v1alpha1-cfapp-apprev
+      caBundle: '{{ include "korifi.webhookCaBundle" (set . "component" "controllers") }}'
     failurePolicy: Fail
     name: mcfapprev.korifi.cloudfoundry.org
     rules:
@@ -250,6 +260,7 @@ webhooks:
         name: korifi-controllers-webhook-service
         namespace: '{{ .Release.Namespace }}'
         path: /mutate-korifi-cloudfoundry-org-v1alpha1-cftask
+      caBundle: '{{ include "korifi.webhookCaBundle" (set . "component" "controllers") }}'
     failurePolicy: Fail
     name: mcftask.korifi.cloudfoundry.org
     rules:
@@ -269,7 +280,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: korifi-controllers-validating-webhook-configuration
   annotations:
-    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/korifi-controllers-serving-cert'
+    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/{{ .Values.controllers.webhookCertSecret }}'
 webhooks:
   - admissionReviewVersions:
       - v1
@@ -278,6 +289,7 @@ webhooks:
         name: korifi-controllers-webhook-service
         namespace: '{{ .Release.Namespace }}'
         path: /validate-korifi-cloudfoundry-org-v1alpha1-cfdomain
+      caBundle: '{{ include "korifi.webhookCaBundle" (set . "component" "controllers") }}'
     failurePolicy: Fail
     name: vcfdomain.korifi.cloudfoundry.org
     rules:
@@ -299,6 +311,7 @@ webhooks:
         name: korifi-controllers-webhook-service
         namespace: '{{ .Release.Namespace }}'
         path: /validate-korifi-cloudfoundry-org-v1alpha1-cfroute
+      caBundle: '{{ include "korifi.webhookCaBundle" (set . "component" "controllers") }}'
     failurePolicy: Fail
     name: vcfroute.korifi.cloudfoundry.org
     rules:
@@ -321,6 +334,7 @@ webhooks:
         name: korifi-controllers-webhook-service
         namespace: '{{ .Release.Namespace }}'
         path: /validate-korifi-cloudfoundry-org-v1alpha1-cfsecuritygroup
+      caBundle: '{{ include "korifi.webhookCaBundle" (set . "component" "controllers") }}'
     failurePolicy: Fail
     name: vcfsecuritygroup.korifi.cloudfoundry.org
     rules:
@@ -343,6 +357,7 @@ webhooks:
         name: korifi-controllers-webhook-service
         namespace: '{{ .Release.Namespace }}'
         path: /validate-korifi-cloudfoundry-org-v1alpha1-cfservicebinding
+      caBundle: '{{ include "korifi.webhookCaBundle" (set . "component" "controllers") }}'
     failurePolicy: Fail
     name: vcfservicebinding.korifi.cloudfoundry.org
     rules:
@@ -365,6 +380,7 @@ webhooks:
         name: korifi-controllers-webhook-service
         namespace: '{{ .Release.Namespace }}'
         path: /validate-korifi-cloudfoundry-org-v1alpha1-cfservicebroker
+      caBundle: '{{ include "korifi.webhookCaBundle" (set . "component" "controllers") }}'
     failurePolicy: Fail
     name: vcfservicebroker.korifi.cloudfoundry.org
     rules:
@@ -387,6 +403,7 @@ webhooks:
         name: korifi-controllers-webhook-service
         namespace: '{{ .Release.Namespace }}'
         path: /validate-korifi-cloudfoundry-org-v1alpha1-cfserviceinstance
+      caBundle: '{{ include "korifi.webhookCaBundle" (set . "component" "controllers") }}'
     failurePolicy: Fail
     name: vcfserviceinstance.korifi.cloudfoundry.org
     rules:
@@ -409,6 +426,7 @@ webhooks:
         name: korifi-controllers-webhook-service
         namespace: '{{ .Release.Namespace }}'
         path: /validate-korifi-cloudfoundry-org-v1alpha1-cfapp
+      caBundle: '{{ include "korifi.webhookCaBundle" (set . "component" "controllers") }}'
     failurePolicy: Fail
     name: vcfapp.korifi.cloudfoundry.org
     rules:
@@ -431,6 +449,7 @@ webhooks:
         name: korifi-controllers-webhook-service
         namespace: '{{ .Release.Namespace }}'
         path: /validate-korifi-cloudfoundry-org-v1alpha1-cforg
+      caBundle: '{{ include "korifi.webhookCaBundle" (set . "component" "controllers") }}'
     failurePolicy: Fail
     name: vcforg.korifi.cloudfoundry.org
     rules:
@@ -453,6 +472,7 @@ webhooks:
         name: korifi-controllers-webhook-service
         namespace: '{{ .Release.Namespace }}'
         path: /validate-korifi-cloudfoundry-org-v1alpha1-cfpackage
+      caBundle: '{{ include "korifi.webhookCaBundle" (set . "component" "controllers") }}'
     failurePolicy: Fail
     name: vcfpackage.korifi.cloudfoundry.org
     rules:
@@ -473,6 +493,7 @@ webhooks:
         name: korifi-controllers-webhook-service
         namespace: '{{ .Release.Namespace }}'
         path: /validate-korifi-cloudfoundry-org-v1alpha1-cfspace
+      caBundle: '{{ include "korifi.webhookCaBundle" (set . "component" "controllers") }}'
     failurePolicy: Fail
     name: vcfspace.korifi.cloudfoundry.org
     rules:
@@ -495,6 +516,7 @@ webhooks:
         name: korifi-controllers-webhook-service
         namespace: '{{ .Release.Namespace }}'
         path: /validate-korifi-cloudfoundry-org-v1alpha1-cftask
+      caBundle: '{{ include "korifi.webhookCaBundle" (set . "component" "controllers") }}'
     failurePolicy: Fail
     name: vcftask.korifi.cloudfoundry.org
     rules:

--- a/helm/korifi/controllers/webhook-cert.yaml
+++ b/helm/korifi/controllers/webhook-cert.yaml
@@ -1,7 +1,8 @@
+{{- if .Values.generateWebhookCertificates }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: korifi-controllers-serving-cert
+  name: {{ .Values.controllers.webhookCertSecret }}
   namespace: {{ .Release.Namespace }}
 spec:
   dnsNames:
@@ -10,4 +11,5 @@ spec:
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer
-  secretName: controllers-webhook-server-cert
+  secretName: {{ .Values.controllers.webhookCertSecret }}
+{{- end}}

--- a/helm/korifi/kpack-image-builder/deployment.yaml
+++ b/helm/korifi/kpack-image-builder/deployment.yaml
@@ -89,7 +89,7 @@ spec:
       - name: cert
         secret:
           defaultMode: 420
-          secretName: korifi-kpack-image-builder-webhook-cert
+          secretName: {{ .Values.kpackImageBuilder.webhookCertSecret }}
       - configMap:
           name: korifi-kpack-image-builder-config
         name: korifi-kpack-image-builder-config

--- a/helm/korifi/kpack-image-builder/manifests.yaml
+++ b/helm/korifi/kpack-image-builder/manifests.yaml
@@ -4,7 +4,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: korifi-kpack-image-builder-mutating-webhook-configuration
   annotations:
-    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/korifi-kpack-image-builder-serving-cert'
+    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/{{ .Values.kpackImageBuilder.webhookCertSecret }}'
 webhooks:
   - admissionReviewVersions:
       - v1
@@ -14,6 +14,7 @@ webhooks:
         name: korifi-kpack-image-builder-webhook-service
         namespace: '{{ .Release.Namespace }}'
         path: /mutate-korifi-cloudfoundry-org-v1alpha1-kpack-image-builder-finalizer
+      caBundle: '{{ include "korifi.webhookCaBundle" (set . "component" "kpackImageBuilder") }}'
     failurePolicy: Fail
     name: mcf-kib-finalizer.korifi.cloudfoundry.org
     rules:

--- a/helm/korifi/kpack-image-builder/webhook-cert.yaml
+++ b/helm/korifi/kpack-image-builder/webhook-cert.yaml
@@ -1,7 +1,8 @@
+{{- if .Values.generateWebhookCertificates }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: korifi-kpack-image-builder-serving-cert
+  name: {{ .Values.kpackImageBuilder.webhookCertSecret }}
   namespace: {{ .Release.Namespace }}
 spec:
   dnsNames:
@@ -10,4 +11,5 @@ spec:
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer
-  secretName: korifi-kpack-image-builder-webhook-cert
+  secretName: {{ .Values.kpackImageBuilder.webhookCertSecret }}
+{{- end}}

--- a/helm/korifi/statefulset-runner/deployment.yaml
+++ b/helm/korifi/statefulset-runner/deployment.yaml
@@ -74,4 +74,4 @@ spec:
       - name: cert
         secret:
           defaultMode: 420
-          secretName: korifi-statefulset-runner-webhook-server-cert
+          secretName: {{ .Values.statefulsetRunner.webhookCertSecret }}

--- a/helm/korifi/statefulset-runner/manifests.yaml
+++ b/helm/korifi/statefulset-runner/manifests.yaml
@@ -4,7 +4,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: korifi-statefulset-runner-mutating-webhook-configuration
   annotations:
-    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/korifi-statefulset-runner-serving-cert'
+    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/{{ .Values.statefulsetRunner.webhookCertSecret }}'
 webhooks:
   - admissionReviewVersions:
       - v1
@@ -14,6 +14,7 @@ webhooks:
         name: korifi-statefulset-runner-webhook-service
         namespace: '{{ .Release.Namespace }}'
         path: /mutate-korifi-cloudfoundry-org-v1alpha1-appworkload
+      caBundle: '{{ include "korifi.webhookCaBundle" (set . "component" "statefulsetRunner") }}'
     failurePolicy: Fail
     name: mappworkload.korifi.cloudfoundry.org
     rules:

--- a/helm/korifi/statefulset-runner/webhook-cert.yaml
+++ b/helm/korifi/statefulset-runner/webhook-cert.yaml
@@ -1,7 +1,8 @@
+{{- if .Values.generateWebhookCertificates }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: korifi-statefulset-runner-serving-cert
+  name: {{ .Values.statefulsetRunner.webhookCertSecret }}
   namespace: {{ .Release.Namespace }}
 spec:
   dnsNames:
@@ -10,4 +11,5 @@ spec:
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer
-  secretName: korifi-statefulset-runner-webhook-server-cert
+  secretName: {{ .Values.statefulsetRunner.webhookCertSecret }}
+{{- end}}

--- a/helm/korifi/templates/_helpers.yaml
+++ b/helm/korifi/templates/_helpers.yaml
@@ -43,3 +43,13 @@ securityContext:
   seccompProfile:
     type: RuntimeDefault
 {{- end }}
+
+{{- define "korifi.webhookCaBundle" -}}
+{{- $caBundle := "" -}}
+{{- if not .Values.generateWebhookCertificates -}}
+{{- $compValues := index .Values .component -}}
+{{- $webhookCertSecret := $compValues.webhookCertSecret -}}
+{{- $caBundle = index (lookup "v1" "Secret" .Release.Namespace $webhookCertSecret).data "ca.crt" -}}
+{{- end -}}
+{{ $caBundle }}
+{{- end -}}

--- a/helm/korifi/templates/cert-mgr-issuer.yaml
+++ b/helm/korifi/templates/cert-mgr-issuer.yaml
@@ -1,3 +1,4 @@
+{{- if or (eq .Values.generateIngressCertificates true) (eq .Values.generateWebhookCertificates true) }}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
@@ -5,3 +6,4 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   selfSigned: {}
+{{- end}}

--- a/helm/korifi/templates/gateway.yaml
+++ b/helm/korifi/templates/gateway.yaml
@@ -6,7 +6,7 @@ metadata:
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: ReferenceGrant
 metadata:
-  name: korifi-workloads-ingress-cert
+  name: {{ .Values.controllers.workloadsTLSSecret }}
   namespace: {{ .Release.Namespace }}
 spec:
   from:
@@ -16,7 +16,7 @@ spec:
   to:
   - group: ""
     kind: Secret
-    name: korifi-workloads-ingress-cert
+    name: {{ .Values.controllers.workloadsTLSSecret }}
 ---
 kind: Gateway
 apiVersion: gateway.networking.k8s.io/v1beta1
@@ -56,6 +56,6 @@ spec:
       certificateRefs:
       - group: ""
         kind: Secret
-        name: korifi-workloads-ingress-cert
+        name: {{ .Values.controllers.workloadsTLSSecret }}
         namespace: {{ .Release.Namespace }}
       mode: Terminate

--- a/helm/korifi/values.schema.json
+++ b/helm/korifi/values.schema.json
@@ -26,6 +26,10 @@
       "description": "Use `cert-manager` to generate self-signed certificates for the API and app endpoints.",
       "type": "boolean"
     },
+    "generateWebhookCertificates": {
+      "description": "Use `cert-manager` to generate self-signed certificates for the webhooks.",
+      "type": "boolean"
+    },
     "containerRepositoryPrefix": {
       "description": "The prefix of the container repository where package and droplet images will be pushed. This is suffixed with the app GUID and `-packages` or `-droplets`. For example, a value of `index.docker.io/korifi/` will result in `index.docker.io/korifi/<appGUID>-packages` and `index.docker.io/korifi/<appGUID>-droplets` being pushed.",
       "type": "string",
@@ -174,6 +178,10 @@
               "description": "Port used internally by the API container.",
               "type": "integer"
             },
+            "ingressCertSecret": {
+              "description": "The name of the secret containing the TLS certificate for the API ingress.",
+              "type": "string"
+            },
             "timeouts": {
               "type": "object",
               "description": "HTTP timeouts.",
@@ -198,7 +206,7 @@
               "required": ["read", "write", "idle", "readHeader"]
             }
           },
-          "required": ["url", "port", "internalPort", "timeouts"]
+          "required": ["url", "port", "internalPort", "ingressCertSecret", "timeouts"]
         },
         "image": {
           "description": "Reference to the API container image.",
@@ -350,6 +358,10 @@
           "description": "Reference to the controllers container image.",
           "type": "string"
         },
+        "webhookCertSecret": {
+          "description": "A secert containing the CA bundle and the certificate for the webhook server.",
+          "type": "string"
+        },
         "processDefaults": {
           "type": "object",
           "properties": {
@@ -393,7 +405,7 @@
           "minimum": 1
         }
       },
-      "required": ["image", "taskTTL", "workloadsTLSSecret"],
+      "required": ["image", "taskTTL", "workloadsTLSSecret", "webhookCertSecret"],
       "type": "object"
     },
     "kpackImageBuilder": {
@@ -452,9 +464,13 @@
           "description": "Container image repository to store the `ClusterBuilder` image. Required when `clusterBuilderName` is not provided.",
           "type": "string",
           "pattern": "^([a-z0-9]+([._-][a-z0-9]+)*(:[0-9]+)?(/[a-z0-9]+([._-][a-z0-9]+)*)*)?$"
+        },
+        "webhookCertSecret": {
+          "description": "A secert containing the CA bundle and the certificate for the webhook server.",
+          "type": "string"
         }
       },
-      "required": ["include", "builderReadinessTimeout"],
+      "required": ["include", "builderReadinessTimeout", "webhookCertSecret"],
       "type": "object"
     },
     "statefulsetRunner": {
@@ -466,6 +482,10 @@
         "replicas": {
           "description": "Number of replicas.",
           "type": "integer"
+        },
+        "webhookCertSecret": {
+          "description": "A secert containing the CA bundle and the certificate for the webhook server.",
+          "type": "string"
         },
         "resources": {
           "description": "[`ResourceRequirements`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#resourcerequirements-v1-core) for the API.",
@@ -502,7 +522,7 @@
           }
         }
       },
-      "required": ["include"],
+      "required": ["include", "webhookCertSecret"],
       "type": "object"
     },
     "jobTaskRunner": {

--- a/helm/korifi/values.yaml
+++ b/helm/korifi/values.yaml
@@ -3,12 +3,13 @@ rootNamespace: cf
 debug: false
 logLevel: info
 defaultAppDomainName:
-generateIngressCertificates: false
 containerRegistrySecrets:
 - image-registry-credentials
 eksContainerRegistryRoleARN: ""
 containerRegistryCACertSecret:
 systemImagePullSecrets: []
+generateIngressCertificates: false
+generateWebhookCertificates: true
 
 reconcilers:
   build: kpack-image-builder
@@ -43,6 +44,7 @@ api:
     # To override default port, set port to a non-zero value
     port: 0
     internalPort: 9000
+    ingressCertSecret: korifi-api-ingress-cert
     timeouts:
       read: 900
       write: 900
@@ -69,6 +71,7 @@ api:
 
 controllers:
   image: cloudfoundry/korifi-controllers:latest
+  webhookCertSecret: "korifi-controllers-webhook-cert"
 
   nodeSelector: {}
   tolerations: []
@@ -95,6 +98,8 @@ controllers:
 kpackImageBuilder:
   include: true
   image: cloudfoundry/korifi-kpack-image-builder:latest
+  webhookCertSecret: "korifi-kpack-image-builder-webhook-cert"
+
   replicas: 1
   resources:
     limits:
@@ -111,6 +116,8 @@ kpackImageBuilder:
 statefulsetRunner:
   include: true
   image: cloudfoundry/korifi-statefulset-runner:latest
+  webhookCertSecret: "korifi-statefulset-runner-webhook-cert"
+
   replicas: 1
   resources:
     limits:
@@ -161,5 +168,5 @@ experimental:
     k8sclient:
       qps: 0
       burst: 0
-  securityGroups: 
+  securityGroups:
     enabled: false

--- a/kpack-image-builder/Makefile
+++ b/kpack-image-builder/Makefile
@@ -42,9 +42,10 @@ manifests: bin/controller-gen
 		output:rbac:artifacts:config=../helm/korifi/kpack-image-builder \
 		output:webhook:artifacts:config=../helm/korifi/kpack-image-builder
 
-	yq -i 'with(.metadata; .annotations["cert-manager.io/inject-ca-from"]="{{ .Release.Namespace }}/korifi-kpack-image-builder-serving-cert")' $(webhooks-file)
+	yq -i 'with(.metadata; .annotations["cert-manager.io/inject-ca-from"]="{{ .Release.Namespace }}/{{ .Values.kpackImageBuilder.webhookCertSecret }}")' $(webhooks-file)
 	yq -i 'with(.metadata; .name="korifi-kpack-image-builder-" + .name)' $(webhooks-file)
 	yq -i 'with(.webhooks[]; .clientConfig.service.namespace="{{ .Release.Namespace }}")' $(webhooks-file)
+	yq -i 'with(.webhooks[]; .clientConfig.caBundle="{{ include \"korifi.webhookCaBundle\" (set . \"component\" \"kpackImageBuilder\") }}")' $(webhooks-file)
 	yq -i 'with(.webhooks[]; .clientConfig.service.name="korifi-kpack-image-builder-" + .clientConfig.service.name)' $(webhooks-file)
 
 

--- a/kpack-image-builder/controllers/suite_test.go
+++ b/kpack-image-builder/controllers/suite_test.go
@@ -18,6 +18,7 @@ package controllers_test
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -82,15 +83,19 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 	ctx = context.Background()
 
+	webhookManifestsPath := helpers.GenerateWebhookManifest(
+		"code.cloudfoundry.org/korifi/kpack-image-builder/controllers/webhooks/finalizer",
+	)
+	DeferCleanup(func() {
+		Expect(os.RemoveAll(filepath.Dir(webhookManifestsPath))).To(Succeed())
+	})
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths: []string{
 			filepath.Join("..", "..", "helm", "korifi", "controllers", "crds"),
 			filepath.Join("..", "..", "tests", "vendor", "kpack"),
 		},
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
-			Paths: []string{
-				filepath.Join("..", "..", "helm", "korifi", "kpack-image-builder", "manifests.yaml"),
-			},
+			Paths: []string{webhookManifestsPath},
 		},
 		ErrorIfCRDPathMissing: true,
 	}

--- a/statefulset-runner/Makefile
+++ b/statefulset-runner/Makefile
@@ -42,9 +42,10 @@ manifests: bin/controller-gen bin/yq
 		output:rbac:artifacts:config=../helm/korifi/statefulset-runner \
 		output:webhook:artifacts:config=../helm/korifi/statefulset-runner
 
-	yq -i 'with(.metadata; .annotations["cert-manager.io/inject-ca-from"]="{{ .Release.Namespace }}/korifi-statefulset-runner-serving-cert")' $(webhooks-file)
+	yq -i 'with(.metadata; .annotations["cert-manager.io/inject-ca-from"]="{{ .Release.Namespace }}/{{ .Values.statefulsetRunner.webhookCertSecret }}")' $(webhooks-file)
 	yq -i 'with(.metadata; .name="korifi-statefulset-runner-" + .name)' $(webhooks-file)
 	yq -i 'with(.webhooks[]; .clientConfig.service.namespace="{{ .Release.Namespace }}")' $(webhooks-file)
+	yq -i 'with(.webhooks[]; .clientConfig.caBundle="{{ include \"korifi.webhookCaBundle\" (set . \"component\" \"statefulsetRunner\") }}")' $(webhooks-file)
 	yq -i 'with(.webhooks[]; .clientConfig.service.name="korifi-statefulset-runner-" + .clientConfig.service.name)' $(webhooks-file)
 
 .PHONY: generate


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
#3931
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Make the cert manager an optional dependency

* Add a `generateWebhookCertificates` helm value similar to the
  existing `generateIngressCertificates`
* If neither `generateIngressCertificates` nor
  `generateIngressCertificates` values are set - do not create a cert
  manager issuer
* Generate ingress and webhook certificates only when the respective
  helm value is set.
* As a result the cert manager is not used when both
  `generateIngressCertificates` and `generateWebhookCertificates` are
  set to false, making it an optional dependency
* Add `webhookCertSecret` helm value for each component that runs webhooks
* Add template for reading the caBundle value from a webhook cert secret
* Insert the caBundle into the generated webhook manifest (if
  `generateWebhookCertificates` is set to `true`)
* Use a consistent convention for the names of the webhook and ingress secrets
* Add values for specifying custom cert secrets for both ingress and
  webhooks
* Update related documentation
<!-- _Please describe the change here._ -->

