### PR TITLE
Implementing GET service_plans/guid endpoint

### DIFF
--- a/api/handlers/service_plan_test.go
+++ b/api/handlers/service_plan_test.go
@@ -173,6 +173,41 @@ var _ = Describe("ServicePlan", func() {
 		})
 	})
 
+	Describe("GET /v3/service_plans/{guid}", func() {
+		BeforeEach(func() {
+			servicePlanRepo.GetPlanReturns(repositories.ServicePlanRecord{
+				GUID: "my-service-plan",
+			}, nil)
+		})
+
+		JustBeforeEach(func() {
+			req, err := http.NewRequestWithContext(ctx, "GET", "/v3/service_plans/my-service-plan", nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			routerBuilder.Build().ServeHTTP(rr, req)
+		})
+
+		It("returns the plan", func() {
+			Expect(servicePlanRepo.GetPlanCallCount()).To(Equal(1))
+			_, actualAuthInfo, actualPlanID := servicePlanRepo.GetPlanArgsForCall(0)
+			Expect(actualPlanID).To(Equal("my-service-plan"))
+			Expect(actualAuthInfo).To(Equal(authInfo))
+
+			Expect(rr).To(HaveHTTPStatus(http.StatusOK))
+			Expect(rr).To(HaveHTTPHeaderWithValue("Content-Type", "application/json"))
+		})
+
+		When("getting the plan fails", func() {
+			BeforeEach(func() {
+				servicePlanRepo.GetPlanReturns(repositories.ServicePlanRecord{}, errors.New("unkown-err"))
+			})
+
+			It("returns an error", func() {
+				expectUnknownError()
+			})
+		})
+	})
+
 	Describe("GET /v3/service_plans/{guid}/visibility", func() {
 		BeforeEach(func() {
 			servicePlanRepo.GetPlanReturns(repositories.ServicePlanRecord{

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -190,6 +190,11 @@ type serviceResource struct {
 	BindingName string `yaml:"binding_name"`
 }
 
+type servicePlanResource struct {
+	Name string `yaml:"name"`
+	GUID string `yaml:"guid"`
+}
+
 type manifestApplicationProcessResource struct {
 	Type    string  `yaml:"type"`
 	Command *string `yaml:"command"`

--- a/tests/e2e/service_plans_test.go
+++ b/tests/e2e/service_plans_test.go
@@ -46,6 +46,33 @@ var _ = Describe("Service Plans", func() {
 			})))
 		})
 	})
+	Describe("Get", func() {
+		var (
+			planGUID string
+			result   servicePlanResource
+		)
+
+		BeforeEach(func() {
+			plans := resourceList[resource]{}
+			resp, err = adminClient.R().SetResult(&plans).Get("/v3/service_plans")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp).To(HaveRestyStatusCode(http.StatusOK))
+
+			brokerPlans := itx.FromSlice(plans.Resources).Filter(func(r resource) bool {
+				return r.Metadata.Labels[korifiv1alpha1.RelServiceBrokerGUIDLabel] == brokerGUID
+			}).Collect()
+
+			Expect(brokerPlans).NotTo(BeEmpty())
+			planGUID = brokerPlans[0].GUID
+		})
+
+		It("returns the service plan", func() {
+			resp, err = adminClient.R().SetResult(&result).Get(fmt.Sprintf("/v3/service_plans/%s", planGUID))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp).To(HaveRestyStatusCode(http.StatusOK))
+			Expect(result.GUID).To(Equal(planGUID))
+		})
+	})
 
 	Describe("Visibility", func() {
 		var (


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

#2363

## What is this change about?
<!-- _Please describe the change here._ -->

Adding the `/v3/service_plans/<guid>` endpoint

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
