### PR TITLE
Configure helm version based on the github release

### DIFF
--- a/helm/korifi/Chart.yaml
+++ b/helm/korifi/Chart.yaml
@@ -2,5 +2,4 @@ apiVersion: v2
 name: korifi
 description: A Helm chart to deploy all Korifi components
 type: application
-version: 0.2.0
-appVersion: "dev"
+version: 0.0.0-dev

--- a/helm/korifi/migrations/post-upgrade-set-migrated-by.yaml
+++ b/helm/korifi/migrations/post-upgrade-set-migrated-by.yaml
@@ -4,20 +4,20 @@ metadata:
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
-    "helm.sh/hook": pre-upgrade
-    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-weight": "-9999"
     "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-  name: set-labels
+  name: post-upgrade-set-migrated-by-label
   namespace: {{ .Release.Namespace }}
 spec:
   template:
     metadata:
-      name: set-labels
+      name: post-upgrade-set-migrated-by-label
       labels:
         app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
         app.kubernetes.io/instance: {{ .Release.Name | quote }}
@@ -27,7 +27,10 @@ spec:
       restartPolicy: Never
       {{- include "korifi.podSecurityContext" . | indent 6 }}
       containers:
-      - name: pre-upgrade-set-labels
+      - name: post-upgrade-set-migrated-by-label
+        env:
+        - name: KORIFI_VERSION
+          value: "{{ .Chart.Version }}"
         image: {{ .Values.helm.hooksImage }}
         securityContext:
           allowPrivilegeEscalation: false
@@ -57,54 +60,25 @@ spec:
               "$kind" "$name"
           }
 
-          set-guid-label() {
+          set-migrated-by-label() {
             local resource_kinds=(cfapps cfdomains)
 
             for kind in "${resource_kinds[@]}"; do
               resources="$(kubectl get --all-namespaces "$kind" -o=custom-columns=NAMESPACE:.metadata.namespace,NAME:.metadata.name --no-headers)"
               if [[ -z "${resources}" ]]; then
                 echo "No resources of kind $kind. Nothing to do."
-                return
+                continue
               fi
 
               while IFS= read -r line; do
                 read -r namespace name <<<$line
-                set-label "$kind" $namespace $name "korifi.cloudfoundry.org/guid" "$name"
+                set-label "$kind" "$namespace" "$name" "korifi.cloudfoundry.org/migrated-by" "$KORIFI_VERSION"
               done <<<"$resources"
             done
           }
 
-          set-app-specific-labels() {
-            resources=$(kubectl get --all-namespaces cfapps -o=custom-columns=NAMESPACE:.metadata.namespace,NAME:.metadata.name,DISPLAY_NAME:.spec.displayName --no-headers)
-            if [[ -z "${resources}" ]]; then
-              echo "No resources of kind $kind. Nothing to do."
-              return
-            fi
-
-            while IFS= read -r line; do
-              read -r namespace name displayName <<<$line
-              set-label cfapps $namespace $name "korifi.cloudfoundry.org/display-name" "$displayName"
-            done <<<"$resources"
-          }
-
-          set-domain-specific-labels() {
-            resources=$(kubectl get --all-namespaces cfdomains -o=custom-columns=NAMESPACE:.metadata.namespace,NAME:.metadata.name,DOMAIN_NAME:.spec.name --no-headers)
-            if [[ -z "${resources}" ]]; then
-              echo "No resources of kind $kind. Nothing to do."
-              return
-            fi
-
-            while IFS= read -r line; do
-              read -r namespace name domainName <<<$line
-              set-label cfdomains $namespace $name "korifi.cloudfoundry.org/domain-name" "$domainName"
-            done <<<"$resources"
-          }
-
           main() {
-            set-guid-label
-
-            set-app-specific-labels
-            set-domain-specific-labels
+            set-migrated-by-label
           }
 
           main

--- a/scripts/installer/run-locally.sh
+++ b/scripts/installer/run-locally.sh
@@ -40,7 +40,9 @@ function build_korifi() {
     kbld_file="$SCRIPT_DIR/assets/korifi-kbld.yml"
     values_file="$HELM_CHART_SOURCE/values.yaml"
 
-    yq "with(.sources[]; .docker.buildx.rawOptions += [\"--build-arg\", \"version=dev\"])" $kbld_file |
+    export VERSION=$(git describe --tags | awk -F'[.-]' '{$3++; print $1 "." $2 "." $3 "-" $4 "-" $5}' | awk '{print substr($1,2)}')
+    yq -i 'with(.; .version=env(VERSION))' "$HELM_CHART_SOURCE/Chart.yaml"
+    yq "with(.sources[]; .docker.buildx.rawOptions += [\"--build-arg\", \"version=$VERSION\"])" $kbld_file |
       kbld \
         --images-annotation=false \
         -f "${ROOT_DIR}/helm/korifi/values.yaml" \


### PR DESCRIPTION
## Is there a related GitHub Issue?
#3949
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
* When building and deploying Korifi, the version on docker images and
  chart's `version` is derived from the latest git tag. Thus, when the
  helm chart is listed (`helm -n korifi list`), proper version is
  displayed
* The character `v` is stripped from the git tag when computing the
  version, as chart's `version` has to be a valid semver.
* The chart `appVersion` has been removed as it matches `version` anyway
* The migration job runs after upgrade and puts
  `korifi.cloudfoundry.org/migrated-by` on apps and domains. The value
  of the label is the chart version (see above). By "touching" those
  resources, their update webhooks kick in and populate the new
  filtering labels. There is no need to set them from within the
  migration job.
* The migration job has lowest hook weight (`-9999`) to ensure that it
  runs prior potential jobs that create new resources (and therefore do
  not need migration)
<!-- _Please describe the change here._ -->

## Tag your pair, your PM, and/or team
@georgethebeatle @uzabanov
