### PR TITLE
Set `migrated-by` label on `CFRoutes`

### DIFF
--- a/helm/korifi/migrations/post-upgrade-set-migrated-by.yaml
+++ b/helm/korifi/migrations/post-upgrade-set-migrated-by.yaml
@@ -81,7 +81,7 @@ spec:
           }
 
           main() {
-            set-migrated-by-label cfapps cfdomains
+            set-migrated-by-label cfapps cfdomains cfroutes
           }
 
           main


### PR DESCRIPTION
## Is there a related GitHub Issue?
#3920
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
With https://github.com/cloudfoundry/korifi/pull/3984, Korifi is now
setting labels related to filtering via a webhook. For existing routes
however this webhook would not kick in unless the route is updated.
<!-- _Please describe the change here._ -->

