### PR TITLE
List builds via label selectors

### DIFF
--- a/api/repositories/app_repository_test.go
+++ b/api/repositories/app_repository_test.go
@@ -665,7 +665,19 @@ var _ = Describe("AppRepository", func() {
 		BeforeEach(func() {
 			dropletGUID = uuid.NewString()
 			appGUID = cfApp.Name
-			createDropletCR(ctx, k8sClient, dropletGUID, cfApp.Name, cfSpace.Name)
+
+			Expect(k8sClient.Create(ctx, &korifiv1alpha1.CFBuild{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      dropletGUID,
+					Namespace: cfSpace.Name,
+				},
+				Spec: korifiv1alpha1.CFBuildSpec{
+					AppRef: corev1.LocalObjectReference{Name: appGUID},
+					Lifecycle: korifiv1alpha1.Lifecycle{
+						Type: "buildpack",
+					},
+				},
+			})).To(Succeed())
 		})
 
 		JustBeforeEach(func() {

--- a/api/repositories/build_repository_test.go
+++ b/api/repositories/build_repository_test.go
@@ -1,7 +1,6 @@
 package repositories_test
 
 import (
-	"context"
 	"time"
 
 	"code.cloudfoundry.org/korifi/tools/k8s"
@@ -12,7 +11,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	apierrors "code.cloudfoundry.org/korifi/api/errors"
 	"code.cloudfoundry.org/korifi/api/repositories"
@@ -25,6 +24,9 @@ var _ = Describe("BuildRepository", func() {
 	var (
 		buildRepo *repositories.BuildRepo
 		sorter    *fake.BuildSorter
+
+		cfSpace *korifiv1alpha1.CFSpace
+		build   *korifiv1alpha1.CFBuild
 	)
 
 	BeforeEach(func() {
@@ -32,546 +34,393 @@ var _ = Describe("BuildRepository", func() {
 		sorter.SortStub = func(records []repositories.BuildRecord, _ string) []repositories.BuildRecord {
 			return records
 		}
+
 		buildRepo = repositories.NewBuildRepo(
 			klient,
 			sorter,
 		)
+
+		org := createOrgWithCleanup(ctx, uuid.NewString())
+		cfSpace = createSpaceWithCleanup(ctx, org.Name, uuid.NewString())
+
+		appGUID := uuid.NewString()
+		packageGUID := uuid.NewString()
+		build = &korifiv1alpha1.CFBuild{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      uuid.NewString(),
+				Namespace: cfSpace.Name,
+				Labels: map[string]string{
+					korifiv1alpha1.SpaceGUIDKey:          cfSpace.Name,
+					korifiv1alpha1.CFAppGUIDLabelKey:     appGUID,
+					korifiv1alpha1.CFPackageGUIDLabelKey: packageGUID,
+				},
+			},
+			Spec: korifiv1alpha1.CFBuildSpec{
+				PackageRef: corev1.LocalObjectReference{
+					Name: packageGUID,
+				},
+				AppRef: corev1.LocalObjectReference{
+					Name: appGUID,
+				},
+				StagingMemoryMB: 123,
+				StagingDiskMB:   456,
+				Lifecycle: korifiv1alpha1.Lifecycle{
+					Type: "buildpack",
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, build)).To(Succeed())
 	})
 
 	Describe("GetBuild", func() {
-		const (
-			app1GUID      = "app-1-guid"
-			app2GUID      = "app-2-guid"
-			package1GUID  = "package-1-guid"
-			package2GUID  = "package-2-guid"
-			stagingMemory = 1024
-			stagingDisk   = 2048
-		)
-
 		var (
-			namespace1 *corev1.Namespace
-			namespace2 *corev1.Namespace
+			buildGUID string
+			record    repositories.BuildRecord
+			err       error
 		)
 
 		BeforeEach(func() {
-			namespace1Name := uuid.NewString()
-			namespace1 = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace1Name}}
-			Expect(k8sClient.Create(ctx, namespace1)).To(Succeed())
-
-			namespace2Name := uuid.NewString()
-			namespace2 = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace2Name}}
-			Expect(k8sClient.Create(ctx, namespace2)).To(Succeed())
+			buildGUID = build.Name
 		})
 
-		AfterEach(func() {
-			Expect(k8sClient.Delete(ctx, namespace1)).To(Succeed())
-			Expect(k8sClient.Delete(ctx, namespace2)).To(Succeed())
+		JustBeforeEach(func() {
+			record, err = buildRepo.GetBuild(ctx, authInfo, buildGUID)
 		})
 
-		makeBuild := func(namespace, buildGUID, packageGUID, appGUID string) *korifiv1alpha1.CFBuild {
-			return &korifiv1alpha1.CFBuild{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      buildGUID,
-					Namespace: namespace,
-					Labels: map[string]string{
-						korifiv1alpha1.SpaceGUIDKey: namespace,
-					},
-				},
-				Spec: korifiv1alpha1.CFBuildSpec{
-					PackageRef: corev1.LocalObjectReference{
-						Name: packageGUID,
-					},
-					AppRef: corev1.LocalObjectReference{
-						Name: appGUID,
-					},
-					StagingMemoryMB: stagingMemory,
-					StagingDiskMB:   stagingDisk,
-					Lifecycle: korifiv1alpha1.Lifecycle{
-						Type: "buildpack",
-						Data: korifiv1alpha1.LifecycleData{
-							Buildpacks: []string{},
-							Stack:      "",
-						},
-					},
-				},
-			}
-		}
+		It("returns a forbidden error", func() {
+			Expect(err).To(matchers.WrapErrorAssignableToTypeOf(apierrors.ForbiddenError{}))
+		})
 
-		When("on the happy path", func() {
-			var (
-				build1GUID string
-				build2GUID string
-				build1     *korifiv1alpha1.CFBuild
-				build2     *korifiv1alpha1.CFBuild
-			)
-
+		When("the user is a space developer", func() {
 			BeforeEach(func() {
-				build1GUID = uuid.NewString()
-				build2GUID = uuid.NewString()
-				build1 = makeBuild(namespace1.Name, build1GUID, package1GUID, app1GUID)
-				Expect(k8sClient.Create(ctx, build1)).To(Succeed())
-				build2 = makeBuild(namespace2.Name, build2GUID, package2GUID, app2GUID)
-				Expect(k8sClient.Create(ctx, build2)).To(Succeed())
-
-				createRoleBinding(ctx, userName, spaceDeveloperRole.Name, namespace1.Name)
-				createRoleBinding(ctx, userName, spaceDeveloperRole.Name, namespace2.Name)
+				createRoleBinding(ctx, userName, spaceDeveloperRole.Name, cfSpace.Name)
 			})
 
-			When("fetching a build", func() {
-				var (
-					buildRecord *repositories.BuildRecord
-					fetchError  error
-				)
-				When("no status.Conditions are set", func() {
-					BeforeEach(func() {
-						returnedBuildRecord, err := buildRepo.GetBuild(ctx, authInfo, build2GUID)
-						buildRecord = &returnedBuildRecord
-						fetchError = err
-					})
+			It("returns a build record", func() {
+				Expect(err).NotTo(HaveOccurred())
 
-					It("succeeds", func() {
-						Expect(fetchError).NotTo(HaveOccurred())
-					})
+				Expect(record.GUID).To(Equal(build.Name))
+				Expect(record.State).To(Equal(repositories.BuildStateStaging))
+				Expect(record.StagingErrorMsg).To(BeEmpty())
+				Expect(record.DropletGUID).To(BeEmpty())
+				Expect(record.CreatedAt).To(BeTemporally("~", time.Now(), timeCheckThreshold))
+				Expect(record.UpdatedAt).To(gstruct.PointTo(BeTemporally("~", time.Now(), timeCheckThreshold)))
+				Expect(record.StagingMemoryMB).To(Equal(123))
+				Expect(record.StagingDiskMB).To(Equal(456))
+				Expect(record.Lifecycle.Type).To(Equal("buildpack"))
+				Expect(record.Lifecycle.Data.Buildpacks).To(BeEmpty())
+				Expect(record.Lifecycle.Data.Stack).To(BeEmpty())
+				Expect(record.PackageGUID).To(Equal(build.Spec.PackageRef.Name))
+				Expect(record.AppGUID).To(Equal(build.Spec.AppRef.Name))
+				Expect(record.SpaceGUID).To(Equal(cfSpace.Name))
+				Expect(record.Relationships()).To(Equal(map[string]string{
+					"app": build.Spec.AppRef.Name,
+				}))
+			})
 
-					It("returns a record with a matching GUID", func() {
-						Expect(buildRecord.GUID).To(Equal(build2GUID))
-					})
-
-					It("returns a record with state \"STAGING\" and no StagingErrorMsg", func() {
-						Expect(buildRecord.State).To(Equal("STAGING"))
-						Expect(buildRecord.StagingErrorMsg).To(BeEmpty(), "record staging error message was supposed to be empty")
-					})
-
-					It("returns a record with no DropletGUID", func() {
-						Expect(buildRecord.DropletGUID).To(BeEmpty())
-					})
-
-					It("returns a record with a CreatedAt field from the CR", func() {
-						Expect(buildRecord.CreatedAt).To(BeTemporally("~", time.Now(), timeCheckThreshold))
-					})
-
-					It("returns a record with a UpdatedAt field from the CR", func() {
-						Expect(buildRecord.UpdatedAt).To(gstruct.PointTo(BeTemporally("~", time.Now(), timeCheckThreshold)))
-					})
-
-					It("returns a record with a StagingMemoryMB field matching the CR", func() {
-						Expect(buildRecord.StagingMemoryMB).To(Equal(build2.Spec.StagingMemoryMB))
-					})
-
-					It("returns a record with a StagingDiskMB field matching the CR", func() {
-						Expect(buildRecord.StagingDiskMB).To(Equal(build2.Spec.StagingDiskMB))
-					})
-
-					It("returns a record with Lifecycle fields matching the CR", func() {
-						Expect(buildRecord.Lifecycle.Type).To(Equal(string(build2.Spec.Lifecycle.Type)), "returned record lifecycle.type did not match CR")
-						Expect(buildRecord.Lifecycle.Data.Buildpacks).To(BeEmpty(), "returned record lifecycle.data.buildpacks did not match CR")
-						Expect(buildRecord.Lifecycle.Data.Stack).To(Equal(build2.Spec.Lifecycle.Data.Stack), "returned record lifecycle.data.stack did not match CR")
-					})
-
-					It("returns a record with a PackageGUID field matching the CR", func() {
-						Expect(buildRecord.PackageGUID).To(Equal(build2.Spec.PackageRef.Name))
-					})
-
-					It("returns a record with an AppGUID field matching the CR", func() {
-						Expect(buildRecord.AppGUID).To(Equal(build2.Spec.AppRef.Name))
-					})
-
-					It("sets the space guid on the record", func() {
-						Expect(buildRecord.SpaceGUID).To(Equal(namespace2.Name))
-					})
-
-					It("returns record with relationships", func() {
-						Expect(buildRecord.Relationships()).To(Equal(map[string]string{
-							"app": build2.Spec.AppRef.Name,
-						}))
-					})
-				})
-
-				When("status.Conditions \"Staging\": False, \"Succeeded\": True, is set", func() {
-					BeforeEach(func() {
-						meta.SetStatusCondition(&build2.Status.Conditions, metav1.Condition{
-							Type:    korifiv1alpha1.StagingConditionType,
-							Status:  metav1.ConditionFalse,
-							Reason:  "kpack",
-							Message: "kpack",
-						})
-						meta.SetStatusCondition(&build2.Status.Conditions, metav1.Condition{
+			When("the build is staged", func() {
+				BeforeEach(func() {
+					Expect(k8s.Patch(ctx, k8sClient, build, func() {
+						meta.SetStatusCondition(&build.Status.Conditions, metav1.Condition{
 							Type:    korifiv1alpha1.SucceededConditionType,
 							Status:  metav1.ConditionTrue,
-							Reason:  "Unknown",
-							Message: "Unknown",
+							Message: "Succeeded",
+							Reason:  "Succeeded",
 						})
-						Expect(k8sClient.Status().Update(ctx, build2)).To(Succeed())
-					})
-
-					It("should return a record with State: \"STAGED\", no StagingErrorMsg, and a DropletGUID that matches the BuildGUID", func() {
-						buildRecord, err := buildRepo.GetBuild(ctx, authInfo, build2GUID)
-						Expect(err).NotTo(HaveOccurred())
-						Expect(buildRecord.State).To(Equal("STAGED"))
-						Expect(buildRecord.DropletGUID).To(Equal(build2.Name))
-						Expect(buildRecord.StagingErrorMsg).To(BeEmpty())
-					})
-				})
-
-				When("status.Conditions \"Staging\": False, \"Succeeded\": False, is set", func() {
-					const (
-						StagingError        = "StagingError"
-						StagingErrorMessage = "Staging failed for some reason"
-					)
-
-					BeforeEach(func() {
-						meta.SetStatusCondition(&build2.Status.Conditions, metav1.Condition{
+						meta.SetStatusCondition(&build.Status.Conditions, metav1.Condition{
 							Type:    korifiv1alpha1.StagingConditionType,
 							Status:  metav1.ConditionFalse,
-							Reason:  "kpack",
-							Message: "kpack",
+							Message: "StatingDone",
+							Reason:  "Succeeded",
 						})
-						meta.SetStatusCondition(&build2.Status.Conditions, metav1.Condition{
+					})).To(Succeed())
+				})
+
+				It("it returns a staged build record", func() {
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(record.State).To(Equal(repositories.BuildStateStaged))
+					Expect(record.DropletGUID).To(Equal(build.Name))
+					Expect(record.StagingErrorMsg).To(BeEmpty())
+				})
+			})
+
+			When("the build has failed", func() {
+				BeforeEach(func() {
+					Expect(k8s.Patch(ctx, k8sClient, build, func() {
+						meta.SetStatusCondition(&build.Status.Conditions, metav1.Condition{
+							Type:    korifiv1alpha1.StagingConditionType,
+							Status:  metav1.ConditionFalse,
+							Message: "StatingFailed",
+							Reason:  "Failed",
+						})
+						meta.SetStatusCondition(&build.Status.Conditions, metav1.Condition{
 							Type:    korifiv1alpha1.SucceededConditionType,
 							Status:  metav1.ConditionFalse,
 							Reason:  "StagingError",
-							Message: StagingErrorMessage,
+							Message: "because it failed",
 						})
-						Expect(k8sClient.Status().Update(ctx, build2)).To(Succeed())
-					})
+					})).To(Succeed())
+				})
 
-					It("should return a record with State: \"FAILED\", no DropletGUID, and a Staging Error Message", func() {
-						buildRecord, err := buildRepo.GetBuild(ctx, authInfo, build2GUID)
-						Expect(err).NotTo(HaveOccurred())
-						Expect(buildRecord.State).To(Equal("FAILED"))
-						Expect(buildRecord.DropletGUID).To(BeEmpty())
-						Expect(buildRecord.StagingErrorMsg).To(Equal(StagingErrorMessage))
-					})
+				It("returns a failed build record", func() {
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(record.State).To(Equal(repositories.BuildStateFailed))
+					Expect(record.DropletGUID).To(BeEmpty())
+					Expect(record.StagingErrorMsg).To(Equal("because it failed"))
 				})
 			})
-		})
 
-		When("duplicate Builds exist across namespaces with the same GUID", func() {
-			var buildGUID string
+			When("duplicate Builds exist across namespaces with the same GUID", func() {
+				BeforeEach(func() {
+					anotherOrg := createOrgWithCleanup(ctx, uuid.NewString())
+					anotherSpace := createSpaceWithCleanup(ctx, anotherOrg.Name, uuid.NewString())
 
-			BeforeEach(func() {
-				buildGUID = uuid.NewString()
-				build1 := makeBuild(namespace1.Name, buildGUID, package1GUID, app1GUID)
-				Expect(k8sClient.Create(ctx, build1)).To(Succeed())
-				build2 := makeBuild(namespace2.Name, buildGUID, package2GUID, app2GUID)
-				Expect(k8sClient.Create(ctx, build2)).To(Succeed())
+					createRoleBinding(ctx, userName, spaceDeveloperRole.Name, anotherSpace.Name)
+
+					Expect(k8sClient.Create(ctx, &korifiv1alpha1.CFBuild{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      build.Name,
+							Namespace: anotherSpace.Name,
+							Labels: map[string]string{
+								korifiv1alpha1.SpaceGUIDKey: anotherSpace.Name,
+							},
+						},
+						Spec: korifiv1alpha1.CFBuildSpec{
+							Lifecycle: korifiv1alpha1.Lifecycle{
+								Type: "buildpack",
+							},
+						},
+					})).To(Succeed())
+				})
+
+				It("returns an error", func() {
+					Expect(err).To(MatchError(ContainSubstring("get-build duplicate records exist")))
+				})
 			})
 
-			It("returns an error", func() {
-				_, err := buildRepo.GetBuild(ctx, authInfo, buildGUID)
-				Expect(err).To(HaveOccurred())
-				Expect(err).To(MatchError(ContainSubstring("get-build duplicate records exist")))
-			})
-		})
+			When("the build does not exist", func() {
+				BeforeEach(func() {
+					buildGUID = "i do not exist"
+				})
 
-		When("no builds exist", func() {
-			It("returns an error", func() {
-				_, err := buildRepo.GetBuild(ctx, authInfo, "i don't exist")
-				Expect(err).To(HaveOccurred())
-				Expect(err).To(matchers.WrapErrorAssignableToTypeOf(apierrors.NotFoundError{}))
-			})
-		})
-
-		When("the user is not authorized for builds in the namespace", func() {
-			var buildGUID string
-
-			BeforeEach(func() {
-				buildGUID = uuid.NewString()
-				build1 := makeBuild(namespace1.Name, buildGUID, package1GUID, app1GUID)
-				Expect(k8sClient.Create(ctx, build1)).To(Succeed())
-			})
-
-			It("returns a forbidden error", func() {
-				_, err := buildRepo.GetBuild(ctx, authInfo, buildGUID)
-				Expect(err).To(HaveOccurred())
-				Expect(err).To(matchers.WrapErrorAssignableToTypeOf(apierrors.ForbiddenError{}))
+				It("returns an error", func() {
+					Expect(err).To(matchers.WrapErrorAssignableToTypeOf(apierrors.NotFoundError{}))
+				})
 			})
 		})
 	})
 
 	Describe("GetLatestBuildByAppGUID", func() {
-		const (
-			packageGUID = "package-guid"
-		)
-
 		var (
-			space       *korifiv1alpha1.CFSpace
-			appGUID     string
-			checkSpace  string
-			buildRecord repositories.BuildRecord
-			fetchError  error
+			appGUID   string
+			spaceGUID string
+			record    repositories.BuildRecord
+			err       error
 		)
 
 		BeforeEach(func() {
-			orgGUID := prefixedGUID("get-latest-build-org")
-			org := createOrgWithCleanup(ctx, orgGUID)
-			space = createSpaceWithCleanup(ctx, org.Name, prefixedGUID("get-latest-build-space"))
-			checkSpace = space.Name
-			appGUID = prefixedGUID("get-latest-build-app")
+			appGUID = uuid.NewString()
+			spaceGUID = cfSpace.Name
 		})
 
 		JustBeforeEach(func() {
-			buildRecord, fetchError = buildRepo.GetLatestBuildByAppGUID(ctx, authInfo, checkSpace, appGUID)
+			record, err = buildRepo.GetLatestBuildByAppGUID(ctx, authInfo, spaceGUID, appGUID)
 		})
 
-		When("the user has space developer role", func() {
+		It("returns a forbidden error", func() {
+			Expect(err).To(BeAssignableToTypeOf(apierrors.ForbiddenError{}))
+		})
+
+		When("the user is a space developer", func() {
+			var newerBuild *korifiv1alpha1.CFBuild
+
 			BeforeEach(func() {
-				createRoleBinding(ctx, userName, spaceDeveloperRole.Name, space.Name)
+				createRoleBinding(ctx, userName, spaceDeveloperRole.Name, cfSpace.Name)
+				time.Sleep(1001 * time.Millisecond)
+
+				newerBuild = &korifiv1alpha1.CFBuild{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      uuid.NewString(),
+						Namespace: cfSpace.Name,
+						Labels: map[string]string{
+							korifiv1alpha1.SpaceGUIDKey:      cfSpace.Name,
+							korifiv1alpha1.CFAppGUIDLabelKey: appGUID,
+						},
+					},
+					Spec: korifiv1alpha1.CFBuildSpec{
+						AppRef: corev1.LocalObjectReference{
+							Name: appGUID,
+						},
+						Lifecycle: korifiv1alpha1.Lifecycle{
+							Type: "buildpack",
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, newerBuild)).To(Succeed())
 			})
 
-			When("on the happy path", func() {
-				var build3 *korifiv1alpha1.CFBuild
-
-				BeforeEach(func() {
-					_ = createBuild(ctx, k8sClient, space.Name, prefixedGUID("first"), packageGUID, appGUID)
-					_ = createBuild(ctx, k8sClient, space.Name, prefixedGUID("second"), packageGUID, appGUID)
-					time.Sleep(1001 * time.Millisecond)
-					build3 = createBuild(ctx, k8sClient, space.Name, prefixedGUID("third"), packageGUID, appGUID)
-				})
-
-				When("fetching builds for an app", func() {
-					It("it returns a record that matches the last created build and no error", func() {
-						Expect(fetchError).NotTo(HaveOccurred())
-						Expect(buildRecord.GUID).To(Equal(build3.Name))
-						Expect(buildRecord.AppGUID).To(Equal(appGUID))
-					})
-				})
+			It("returns a record for the lastet build for the app", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(record.GUID).To(Equal(newerBuild.Name))
 			})
 
 			When("the app has no builds", func() {
 				BeforeEach(func() {
 					appGUID = "i-dont-exist"
 				})
-				It("returns an empty record and a not found error", func() {
-					Expect(fetchError).To(HaveOccurred())
-					Expect(fetchError).To(matchers.WrapErrorAssignableToTypeOf(apierrors.NotFoundError{}))
-					Expect(buildRecord).To(Equal(repositories.BuildRecord{}))
-				})
-			})
-		})
 
-		When("the user has no role in the space", func() {
-			It("returns a forbidden error", func() {
-				Expect(fetchError).To(HaveOccurred())
-				Expect(fetchError).To(BeAssignableToTypeOf(apierrors.ForbiddenError{}))
-				Expect(buildRecord).To(Equal(repositories.BuildRecord{}))
+				It("returns a not found error", func() {
+					Expect(err).To(matchers.WrapErrorAssignableToTypeOf(apierrors.NotFoundError{}))
+				})
 			})
 		})
 
 		When("the namespace doesn't exist", func() {
 			BeforeEach(func() {
-				checkSpace = "i-dont-exist"
+				spaceGUID = "i-dont-exist"
 			})
 
 			It("returns a forbidden error", func() {
-				Expect(fetchError).To(HaveOccurred())
-				Expect(fetchError).To(BeAssignableToTypeOf(apierrors.ForbiddenError{}))
-				Expect(buildRecord).To(Equal(repositories.BuildRecord{}))
+				Expect(err).To(BeAssignableToTypeOf(apierrors.ForbiddenError{}))
 			})
 		})
 	})
 
 	Describe("CreateBuild", func() {
-		const (
-			appGUID     = "the-app-guid"
-			packageGUID = "the-package-guid"
-
-			buildStagingState = "STAGING"
-
-			buildpackLifecycleType = "buildpack"
-			buildStack             = "cflinuxfs3"
-
-			stagingMemory = 1024
-			stagingDisk   = 2048
-		)
-
 		var (
-			buildCreateLabels      map[string]string
-			buildCreateAnnotations map[string]string
-			buildCreateMsg         repositories.CreateBuildMessage
-			spaceGUID              string
+			createMsg repositories.CreateBuildMessage
+			record    repositories.BuildRecord
+			err       error
 		)
 
 		BeforeEach(func() {
-			spaceGUID = uuid.NewString()
-			Expect(
-				k8sClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: spaceGUID}}),
-			).To(Succeed())
-
-			buildCreateLabels = nil
-			buildCreateAnnotations = nil
-			buildCreateMsg = repositories.CreateBuildMessage{
-				AppGUID:         appGUID,
-				PackageGUID:     packageGUID,
-				SpaceGUID:       spaceGUID,
-				StagingMemoryMB: stagingMemory,
-				StagingDiskMB:   stagingDisk,
+			createMsg = repositories.CreateBuildMessage{
+				AppGUID:         uuid.NewString(),
+				PackageGUID:     uuid.NewString(),
+				SpaceGUID:       cfSpace.Name,
+				StagingMemoryMB: 123,
+				StagingDiskMB:   456,
 				Lifecycle: repositories.Lifecycle{
-					Type: buildpackLifecycleType,
+					Type: "buildpack",
 					Data: repositories.LifecycleData{
-						Buildpacks: []string{},
-						Stack:      buildStack,
+						Stack: "my-build-stack",
 					},
 				},
-				Labels:      buildCreateLabels,
-				Annotations: buildCreateAnnotations,
+				Labels:      map[string]string{"label-key": "label-value"},
+				Annotations: map[string]string{"annotation-key": "annotation-value"},
 			}
 		})
 
-		When("the user is authorized to create a Build", func() {
-			var (
-				buildCreateRecord repositories.BuildRecord
-				buildCreateErr    error
-			)
+		JustBeforeEach(func() {
+			record, err = buildRepo.CreateBuild(ctx, authInfo, createMsg)
+		})
 
+		It("returns a forbidden error", func() {
+			Expect(err).To(matchers.WrapErrorAssignableToTypeOf(apierrors.ForbiddenError{}))
+		})
+
+		When("the user is a space developer", func() {
 			BeforeEach(func() {
-				createRoleBinding(ctx, userName, spaceDeveloperRole.Name, spaceGUID)
-			})
-
-			JustBeforeEach(func() {
-				buildCreateRecord, buildCreateErr = buildRepo.CreateBuild(ctx, authInfo, buildCreateMsg)
-			})
-
-			AfterEach(func() {
-				if buildCreateErr == nil {
-					Expect(cleanupBuild(ctx, buildCreateRecord.GUID, spaceGUID)).To(Succeed())
-				}
+				createRoleBinding(ctx, userName, spaceDeveloperRole.Name, cfSpace.Name)
 			})
 
 			It("returns correct build record", func() {
-				Expect(buildCreateErr).NotTo(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 
-				Expect(buildCreateRecord.GUID).To(MatchRegexp("^[-0-9a-f]{36}$"), "record GUID was not a 36 character guid")
-				Expect(buildCreateRecord.State).To(Equal(buildStagingState))
-				Expect(buildCreateRecord.CreatedAt).To(BeTemporally("~", time.Now(), timeCheckThreshold))
-				Expect(buildCreateRecord.UpdatedAt).To(gstruct.PointTo(BeTemporally("~", time.Now(), timeCheckThreshold)))
-				Expect(buildCreateRecord.StagingErrorMsg).To(BeEmpty())
-				Expect(buildCreateRecord.StagingMemoryMB).To(Equal(stagingMemory))
-				Expect(buildCreateRecord.StagingDiskMB).To(Equal(stagingDisk))
-				Expect(buildCreateRecord.Lifecycle.Type).To(Equal(buildpackLifecycleType))
-				Expect(buildCreateRecord.Lifecycle.Data.Stack).To(Equal(buildStack))
-				Expect(buildCreateRecord.PackageGUID).To(Equal(packageGUID))
-				Expect(buildCreateRecord.DropletGUID).To(BeEmpty())
-				Expect(buildCreateRecord.AppGUID).To(Equal(appGUID))
-				Expect(buildCreateRecord.Labels).To(Equal(buildCreateLabels))
-				Expect(buildCreateRecord.Annotations).To(Equal(buildCreateAnnotations))
-				Expect(buildCreateRecord.Annotations).To(Equal(buildCreateAnnotations))
+				Expect(record.GUID).To(MatchRegexp("^[-0-9a-f]{36}$"), "record GUID was not a 36 character guid")
+				Expect(record.State).To(Equal(repositories.BuildStateStaging))
+				Expect(record.CreatedAt).To(BeTemporally("~", time.Now(), timeCheckThreshold))
+				Expect(record.UpdatedAt).To(gstruct.PointTo(BeTemporally("~", time.Now(), timeCheckThreshold)))
+				Expect(record.StagingErrorMsg).To(BeEmpty())
+				Expect(record.StagingMemoryMB).To(Equal(123))
+				Expect(record.StagingDiskMB).To(Equal(456))
+				Expect(record.Lifecycle.Type).To(Equal("buildpack"))
+				Expect(record.Lifecycle.Data.Stack).To(Equal("my-build-stack"))
+				Expect(record.PackageGUID).To(Equal(createMsg.PackageGUID))
+				Expect(record.DropletGUID).To(BeEmpty())
+				Expect(record.AppGUID).To(Equal(createMsg.AppGUID))
+				Expect(record.Labels).To(HaveKeyWithValue("label-key", "label-value"))
+				Expect(record.Annotations).To(HaveKeyWithValue("annotation-key", "annotation-value"))
 			})
 
 			It("creates a new Build CR", func() {
-				cfBuildLookupKey := types.NamespacedName{Name: buildCreateRecord.GUID, Namespace: spaceGUID}
+				Expect(err).NotTo(HaveOccurred())
 
-				cfBuild := korifiv1alpha1.CFBuild{}
-				Expect(k8sClient.Get(ctx, cfBuildLookupKey, &cfBuild)).To(Succeed())
+				cfBuild := &korifiv1alpha1.CFBuild{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: cfSpace.Name,
+						Name:      record.GUID,
+					},
+				}
+				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cfBuild), cfBuild)).To(Succeed())
 
-				Expect(cfBuild.Name).To(MatchRegexp("^[-0-9a-f]{36}$"), "record GUID was not a 36 character guid")
-				Expect(cfBuild.Labels).To(Equal(buildCreateLabels))
-				Expect(cfBuild.Annotations).To(Equal(buildCreateAnnotations))
-				Expect(cfBuild.Annotations).To(Equal(buildCreateAnnotations))
-				Expect(cfBuild.Spec.PackageRef.Name).To(Equal(packageGUID))
-				Expect(cfBuild.Spec.AppRef.Name).To(Equal(appGUID))
-				Expect(cfBuild.Spec.StagingMemoryMB).To(Equal(stagingMemory))
-				Expect(cfBuild.Spec.StagingDiskMB).To(Equal(stagingDisk))
-				Expect(cfBuild.Spec.Lifecycle.Type).To(Equal(korifiv1alpha1.LifecycleType(buildpackLifecycleType)))
-				Expect(cfBuild.Spec.Lifecycle.Data.Stack).To(Equal(buildStack))
+				Expect(cfBuild.Labels).To(HaveKeyWithValue("label-key", "label-value"))
+				Expect(cfBuild.Annotations).To(HaveKeyWithValue("annotation-key", "annotation-value"))
+				Expect(cfBuild.Spec.PackageRef.Name).To(Equal(createMsg.PackageGUID))
+				Expect(cfBuild.Spec.AppRef.Name).To(Equal(createMsg.AppGUID))
+				Expect(cfBuild.Spec.StagingMemoryMB).To(Equal(123))
+				Expect(cfBuild.Spec.StagingDiskMB).To(Equal(456))
+				Expect(cfBuild.Spec.Lifecycle.Type).To(BeEquivalentTo("buildpack"))
+				Expect(cfBuild.Spec.Lifecycle.Data.Stack).To(Equal("my-build-stack"))
 			})
 
 			When("the lifecycle type is docker", func() {
 				BeforeEach(func() {
-					buildCreateMsg.Lifecycle = repositories.Lifecycle{
+					createMsg.Lifecycle = repositories.Lifecycle{
 						Type: "docker",
 					}
 				})
 
 				It("returns correct build record", func() {
-					Expect(buildCreateErr).NotTo(HaveOccurred())
+					Expect(err).NotTo(HaveOccurred())
 
-					Expect(buildCreateRecord.GUID).To(matchers.BeValidUUID())
-					Expect(buildCreateRecord.Lifecycle.Type).To(Equal("docker"))
-					Expect(buildCreateRecord.Lifecycle.Data).To(Equal(repositories.LifecycleData{}))
+					Expect(record.GUID).To(matchers.BeValidUUID())
+					Expect(record.Lifecycle.Type).To(Equal("docker"))
+					Expect(record.Lifecycle.Data).To(Equal(repositories.LifecycleData{}))
 				})
 
 				It("creates a new Build CR", func() {
-					cfBuildLookupKey := types.NamespacedName{Name: buildCreateRecord.GUID, Namespace: spaceGUID}
+					Expect(err).NotTo(HaveOccurred())
 
-					cfBuild := korifiv1alpha1.CFBuild{}
-					Expect(k8sClient.Get(ctx, cfBuildLookupKey, &cfBuild)).To(Succeed())
+					cfBuild := &korifiv1alpha1.CFBuild{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: cfSpace.Name,
+							Name:      record.GUID,
+						},
+					}
+					Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cfBuild), cfBuild)).To(Succeed())
 
 					Expect(cfBuild.Spec.Lifecycle.Type).To(Equal(korifiv1alpha1.LifecycleType("docker")))
 					Expect(cfBuild.Spec.Lifecycle.Data).To(Equal(korifiv1alpha1.LifecycleData{}))
 				})
 			})
 		})
-
-		When("the user is not authorized for builds in the namespace", func() {
-			It("returns a forbidden error", func() {
-				_, err := buildRepo.CreateBuild(ctx, authInfo, buildCreateMsg)
-				Expect(err).To(HaveOccurred())
-				Expect(err).To(matchers.WrapErrorAssignableToTypeOf(apierrors.ForbiddenError{}))
-			})
-		})
 	})
 
 	Describe("ListBuilds", func() {
 		var (
-			app1GUID     string
-			app2GUID     string
-			package1GUID string
-			package2GUID string
-			namespace1   *korifiv1alpha1.CFSpace
-			namespace2   *korifiv1alpha1.CFSpace
-			cfOrg        *korifiv1alpha1.CFOrg
-			build1GUID   string
-			build2GUID   string
-			build1       *korifiv1alpha1.CFBuild
-			build2       *korifiv1alpha1.CFBuild
+			anotherBuild *korifiv1alpha1.CFBuild
 			buildRecords []repositories.BuildRecord
 			fetchError   error
 			listMessage  repositories.ListBuildsMessage
 		)
 
 		BeforeEach(func() {
-			build1GUID = uuid.NewString()
-			build2GUID = uuid.NewString()
-			app1GUID = uuid.NewString()
-			app2GUID = uuid.NewString()
-			package1GUID = uuid.NewString()
-			package2GUID = uuid.NewString()
 			listMessage = repositories.ListBuildsMessage{}
-			cfOrg = createOrgWithCleanup(ctx, prefixedGUID("org"))
-			namespace1 = createSpaceWithCleanup(ctx, cfOrg.Name, prefixedGUID("space2"))
-			namespace2 = createSpaceWithCleanup(ctx, cfOrg.Name, prefixedGUID("space3"))
-			build1 = &korifiv1alpha1.CFBuild{
+
+			app2GUID := uuid.NewString()
+			package2GUID := uuid.NewString()
+
+			anotherBuild = &korifiv1alpha1.CFBuild{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      build1GUID,
-					Namespace: namespace1.Name,
+					Name:      uuid.NewString(),
+					Namespace: cfSpace.Name,
 					Labels: map[string]string{
-						korifiv1alpha1.SpaceGUIDKey: namespace1.Name,
-					},
-				},
-				Spec: korifiv1alpha1.CFBuildSpec{
-					PackageRef: corev1.LocalObjectReference{
-						Name: package1GUID,
-					},
-					AppRef: corev1.LocalObjectReference{
-						Name: app1GUID,
-					},
-					Lifecycle: korifiv1alpha1.Lifecycle{
-						Type: "buildpack",
-						Data: korifiv1alpha1.LifecycleData{
-							Buildpacks: []string{},
-							Stack:      "",
-						},
-					},
-				},
-			}
-			Expect(k8sClient.Create(ctx, build1)).To(Succeed())
-			build2 = &korifiv1alpha1.CFBuild{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      build2GUID,
-					Namespace: namespace2.Name,
-					Labels: map[string]string{
-						korifiv1alpha1.SpaceGUIDKey: namespace2.Name,
+						korifiv1alpha1.SpaceGUIDKey:          cfSpace.Name,
+						korifiv1alpha1.CFAppGUIDLabelKey:     app2GUID,
+						korifiv1alpha1.CFPackageGUIDLabelKey: package2GUID,
 					},
 				},
 				Spec: korifiv1alpha1.CFBuildSpec{
@@ -583,15 +432,12 @@ var _ = Describe("BuildRepository", func() {
 					},
 					Lifecycle: korifiv1alpha1.Lifecycle{
 						Type: "buildpack",
-						Data: korifiv1alpha1.LifecycleData{
-							Buildpacks: []string{},
-							Stack:      "",
-						},
 					},
 				},
 			}
-			Expect(k8sClient.Create(ctx, build2)).To(Succeed())
+			Expect(k8sClient.Create(ctx, anotherBuild)).To(Succeed())
 		})
+
 		JustBeforeEach(func() {
 			buildRecords, fetchError = buildRepo.ListBuilds(ctx, authInfo, listMessage)
 		})
@@ -603,68 +449,91 @@ var _ = Describe("BuildRepository", func() {
 
 		When("the user is a space developer", func() {
 			BeforeEach(func() {
-				createRoleBinding(ctx, userName, spaceDeveloperRole.Name, namespace1.Name)
+				createRoleBinding(ctx, userName, spaceDeveloperRole.Name, cfSpace.Name)
 			})
-			It("if user is a Space Developer it returns a list with one element", func() {
+
+			It("returns records for all builds", func() {
 				Expect(fetchError).NotTo(HaveOccurred())
-				Expect(buildRecords).To(HaveLen(1))
-				Expect(buildRecords[0].GUID).To(Equal(build1GUID))
+
+				Expect(buildRecords).To(ConsistOf(
+					gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+						"GUID": Equal(build.Name),
+					}),
+					gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+						"GUID": Equal(anotherBuild.Name),
+					}),
+				))
 			})
+
 			When("the app_guids filter is provided", func() {
 				BeforeEach(func() {
-					listMessage = repositories.ListBuildsMessage{AppGUIDs: []string{app1GUID}}
+					listMessage = repositories.ListBuildsMessage{AppGUIDs: []string{build.Spec.AppRef.Name}}
 				})
+
 				It("fetches all BuildRecords for that app", func() {
 					Expect(fetchError).NotTo(HaveOccurred())
+
 					Expect(buildRecords).To(ConsistOf(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
-						"AppGUID": Equal(app1GUID),
-					}),
-					))
+						"GUID": Equal(build.Name),
+					})))
 				})
 			})
+
 			When("the package_guids filter is provided", func() {
 				BeforeEach(func() {
-					listMessage = repositories.ListBuildsMessage{PackageGUIDs: []string{package1GUID}}
+					listMessage = repositories.ListBuildsMessage{PackageGUIDs: []string{build.Spec.PackageRef.Name}}
 				})
+
 				It("fetches all BuildRecords for that package", func() {
 					Expect(fetchError).NotTo(HaveOccurred())
 					Expect(buildRecords).To(ConsistOf(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
-						"PackageGUID": Equal(package1GUID),
-					}),
-					))
+						"GUID": Equal(build.Name),
+					})))
 				})
 			})
+
 			When("the state filter is provided", func() {
 				When("filtering by State=STAGING", func() {
 					BeforeEach(func() {
-						Expect(k8s.Patch(ctx, k8sClient, build1, func() {
-							meta.SetStatusCondition(&build1.Status.Conditions, metav1.Condition{
+						Expect(k8s.Patch(ctx, k8sClient, build, func() {
+							meta.SetStatusCondition(&build.Status.Conditions, metav1.Condition{
 								Type:    korifiv1alpha1.StagingConditionType,
 								Status:  metav1.ConditionTrue,
 								Reason:  "kpack",
 								Message: "kpack",
 							})
 						})).To(Succeed())
+
+						Expect(k8s.Patch(ctx, k8sClient, anotherBuild, func() {
+							meta.SetStatusCondition(&anotherBuild.Status.Conditions, metav1.Condition{
+								Type:    korifiv1alpha1.StagingConditionType,
+								Status:  metav1.ConditionFalse,
+								Reason:  "kpack",
+								Message: "kpack",
+							})
+						})).To(Succeed())
+
 						listMessage = repositories.ListBuildsMessage{States: []string{"STAGING"}}
 					})
 
 					It("filters the builds", func() {
 						Expect(fetchError).NotTo(HaveOccurred())
 						Expect(buildRecords).To(ConsistOf(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
-							"State": Equal("STAGING"),
+							"GUID": Equal(build.Name),
 						})))
 					})
 				})
+
 				When("filtering by State=STAGED", func() {
 					BeforeEach(func() {
-						Expect(k8s.Patch(ctx, k8sClient, build1, func() {
-							meta.SetStatusCondition(&build1.Status.Conditions, metav1.Condition{
+						Expect(k8s.Patch(ctx, k8sClient, build, func() {
+							meta.SetStatusCondition(&build.Status.Conditions, metav1.Condition{
 								Type:    korifiv1alpha1.StagingConditionType,
 								Status:  metav1.ConditionFalse,
 								Reason:  "Unknown",
 								Message: "Unknown",
 							})
-							meta.SetStatusCondition(&build1.Status.Conditions, metav1.Condition{
+							meta.SetStatusCondition(&build.Status.Conditions, metav1.Condition{
 								Type:    korifiv1alpha1.SucceededConditionType,
 								Status:  metav1.ConditionTrue,
 								Reason:  "Unknown",
@@ -678,20 +547,21 @@ var _ = Describe("BuildRepository", func() {
 					It("filters the builds", func() {
 						Expect(fetchError).NotTo(HaveOccurred())
 						Expect(buildRecords).To(ConsistOf(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
-							"State": Equal("STAGED"),
+							"GUID": Equal(build.Name),
 						})))
 					})
 				})
+
 				When("filtering by State=FAILED", func() {
 					BeforeEach(func() {
-						Expect(k8s.Patch(ctx, k8sClient, build1, func() {
-							meta.SetStatusCondition(&build1.Status.Conditions, metav1.Condition{
+						Expect(k8s.Patch(ctx, k8sClient, build, func() {
+							meta.SetStatusCondition(&build.Status.Conditions, metav1.Condition{
 								Type:    korifiv1alpha1.StagingConditionType,
 								Status:  metav1.ConditionFalse,
 								Reason:  "Unknown",
 								Message: "Unknown",
 							})
-							meta.SetStatusCondition(&build1.Status.Conditions, metav1.Condition{
+							meta.SetStatusCondition(&build.Status.Conditions, metav1.Condition{
 								Type:    korifiv1alpha1.SucceededConditionType,
 								Status:  metav1.ConditionFalse,
 								Reason:  "Unknown",
@@ -705,8 +575,7 @@ var _ = Describe("BuildRepository", func() {
 					It("filters the builds", func() {
 						Expect(fetchError).NotTo(HaveOccurred())
 						Expect(buildRecords).To(ConsistOf(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
-							"GUID":  Equal(build1.Name),
-							"State": Equal("FAILED"),
+							"GUID": Equal(build.Name),
 						})))
 					})
 				})
@@ -714,13 +583,3 @@ var _ = Describe("BuildRepository", func() {
 		})
 	})
 })
-
-func cleanupBuild(ctx context.Context, buildGUID, namespace string) error {
-	cfBuild := korifiv1alpha1.CFBuild{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      buildGUID,
-			Namespace: namespace,
-		},
-	}
-	return k8sClient.Delete(ctx, &cfBuild)
-}

--- a/api/repositories/droplet_repository_test.go
+++ b/api/repositories/droplet_repository_test.go
@@ -16,16 +16,12 @@ import (
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("DropletRepository", func() {
 	const (
-		appGUID             = "app-1-guid"
-		stagingMemory       = 1024
-		stagingDisk         = 2048
 		dropletStack        = "cflinuxfs3"
 		registryImage       = "registry/image:tag"
 		registryImageSecret = "secret-key"
@@ -33,26 +29,20 @@ var _ = Describe("DropletRepository", func() {
 
 	var (
 		dropletRepo *repositories.DropletRepo
-		org         *korifiv1alpha1.CFOrg
-		space       *korifiv1alpha1.CFSpace
 		build       *korifiv1alpha1.CFBuild
-		packageGUID string
-		buildGUID   string
 	)
 
 	BeforeEach(func() {
-		orgName := prefixedGUID("org-")
-		spaceName := prefixedGUID("space-")
-		packageGUID = prefixedGUID("package-")
-		buildGUID = prefixedGUID("build-")
-		org = createOrgWithCleanup(ctx, orgName)
-		space = createSpaceWithCleanup(ctx, org.Name, spaceName)
+		org := createOrgWithCleanup(ctx, uuid.NewString())
+		space := createSpaceWithCleanup(ctx, org.Name, uuid.NewString())
 
 		dropletRepo = repositories.NewDropletRepo(klient)
 
+		packageGUID := uuid.NewString()
+		appGUID := uuid.NewString()
 		build = &korifiv1alpha1.CFBuild{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      buildGUID,
+				Name:      uuid.NewString(),
 				Namespace: space.Name,
 				Labels: map[string]string{
 					"key1":                               "val1",
@@ -73,8 +63,6 @@ var _ = Describe("DropletRepository", func() {
 				AppRef: corev1.LocalObjectReference{
 					Name: appGUID,
 				},
-				StagingMemoryMB: stagingMemory,
-				StagingDiskMB:   stagingDisk,
 				Lifecycle: korifiv1alpha1.Lifecycle{
 					Type: "buildpack",
 				},
@@ -91,33 +79,30 @@ var _ = Describe("DropletRepository", func() {
 		)
 
 		BeforeEach(func() {
-			fetchBuildGUID = buildGUID
+			fetchBuildGUID = build.Name
 		})
 
 		JustBeforeEach(func() {
 			dropletRecord, fetchErr = dropletRepo.GetDroplet(ctx, authInfo, fetchBuildGUID)
 		})
 
+		It("returns a forbidden error", func() {
+			Expect(fetchErr).To(BeAssignableToTypeOf(apierrors.ForbiddenError{}))
+		})
+
 		When("the user is authorized to get the droplet", func() {
 			BeforeEach(func() {
-				createRoleBinding(ctx, userName, spaceDeveloperRole.Name, space.Name)
+				createRoleBinding(ctx, userName, spaceDeveloperRole.Name, build.Namespace)
 			})
 
-			When("status.Droplet is set", func() {
+			It("returns a NotFound error", func() {
+				Expect(fetchErr).To(MatchError(apierrors.NewNotFoundError(nil, repositories.DropletResourceType)))
+			})
+
+			When("the build is staged", func() {
 				BeforeEach(func() {
 					Expect(k8s.Patch(ctx, k8sClient, build, func() {
-						meta.SetStatusCondition(&build.Status.Conditions, metav1.Condition{
-							Type:    "Staging",
-							Status:  metav1.ConditionFalse,
-							Reason:  "kpack",
-							Message: "kpack",
-						})
-						meta.SetStatusCondition(&build.Status.Conditions, metav1.Condition{
-							Type:    "Succeeded",
-							Status:  metav1.ConditionTrue,
-							Reason:  "Unknown",
-							Message: "Unknown",
-						})
+						build.Status.State = korifiv1alpha1.BuildStateStaged
 						build.Status.Droplet = &korifiv1alpha1.BuildDropletStatus{
 							Stack: dropletStack,
 							Registry: korifiv1alpha1.Registry{
@@ -128,28 +113,18 @@ var _ = Describe("DropletRepository", func() {
 									},
 								},
 							},
-							ProcessTypes: []korifiv1alpha1.ProcessType{
-								{
-									Type:    "rake",
-									Command: "bundle exec rake",
-								},
-								{
-									Type:    "web",
-									Command: "bundle exec rackup config.ru -p $PORT",
-								},
-							},
 							Ports: []int32{1234, 2345},
 						}
 					})).To(Succeed())
 				})
 
-				It("should eventually return a droplet record with fields set to expected values", func() {
+				It("returns a droplet record with fields set to expected values", func() {
 					Expect(fetchErr).NotTo(HaveOccurred())
 
 					Expect(dropletRecord.State).To(Equal("STAGED"))
 					Expect(dropletRecord.CreatedAt).To(BeTemporally("~", time.Now(), timeCheckThreshold))
 					Expect(dropletRecord.UpdatedAt).To(PointTo(BeTemporally("~", time.Now(), timeCheckThreshold)))
-					Expect(dropletRecord.Stack).To(Equal(build.Status.Droplet.Stack))
+					Expect(dropletRecord.Stack).To(Equal(dropletStack))
 					Expect(dropletRecord.Lifecycle.Type).To(Equal(string(build.Spec.Lifecycle.Type)))
 					Expect(dropletRecord.Lifecycle.Data.Buildpacks).To(BeEmpty())
 					Expect(dropletRecord.Lifecycle.Data.Stack).To(Equal(build.Spec.Lifecycle.Data.Stack))
@@ -157,17 +132,14 @@ var _ = Describe("DropletRepository", func() {
 					Expect(dropletRecord.Ports).To(ConsistOf(int32(1234), int32(2345)))
 					Expect(dropletRecord.AppGUID).To(Equal(build.Spec.AppRef.Name))
 					Expect(dropletRecord.PackageGUID).To(Equal(build.Spec.PackageRef.Name))
-					Expect(dropletRecord.Labels).To(Equal(map[string]string{
-						"key1":                               "val1",
-						"key2":                               "val2",
-						korifiv1alpha1.CFPackageGUIDLabelKey: packageGUID,
-						korifiv1alpha1.CFAppGUIDLabelKey:     appGUID,
-						korifiv1alpha1.SpaceGUIDKey:          space.Name,
-					}))
-					Expect(dropletRecord.Annotations).To(Equal(map[string]string{
-						"key1": "val1",
-						"key2": "val2",
-					}))
+					Expect(dropletRecord.Labels).To(SatisfyAll(
+						HaveKeyWithValue("key1", "val1"),
+						HaveKeyWithValue("key2", "val2"),
+					))
+					Expect(dropletRecord.Annotations).To(SatisfyAll(
+						HaveKeyWithValue("key1", "val1"),
+						HaveKeyWithValue("key2", "val2"),
+					))
 
 					processTypesArray := build.Status.Droplet.ProcessTypes
 					for index := range processTypesArray {
@@ -195,112 +167,8 @@ var _ = Describe("DropletRepository", func() {
 				})
 			})
 
-			When("status.Droplet is not set", func() {
-				When("status.Conditions \"Staging\": Unknown, \"Succeeded\": Unknown, is set", func() {
-					BeforeEach(func() {
-						meta.SetStatusCondition(&build.Status.Conditions, metav1.Condition{
-							Type:    "Staging",
-							Status:  metav1.ConditionUnknown,
-							Reason:  "kpack",
-							Message: "kpack",
-						})
-						meta.SetStatusCondition(&build.Status.Conditions, metav1.Condition{
-							Type:    "Succeeded",
-							Status:  metav1.ConditionUnknown,
-							Reason:  "Unknown",
-							Message: "Unknown",
-						})
-						Expect(k8sClient.Status().Update(ctx, build)).To(Succeed())
-					})
-
-					It("should return a NotFound error", func() {
-						Expect(fetchErr).To(MatchError(apierrors.NewNotFoundError(nil, repositories.DropletResourceType)))
-					})
-				})
-
-				When("status.Conditions \"Staging\": True, \"Succeeded\": Unknown, is set", func() {
-					BeforeEach(func() {
-						meta.SetStatusCondition(&build.Status.Conditions, metav1.Condition{
-							Type:    "Staging",
-							Status:  metav1.ConditionTrue,
-							Reason:  "kpack",
-							Message: "kpack",
-						})
-						meta.SetStatusCondition(&build.Status.Conditions, metav1.Condition{
-							Type:    "Succeeded",
-							Status:  metav1.ConditionUnknown,
-							Reason:  "Unknown",
-							Message: "Unknown",
-						})
-						Expect(k8sClient.Status().Update(ctx, build)).To(Succeed())
-					})
-
-					It("should return a NotFound error", func() {
-						Expect(fetchErr).To(MatchError(apierrors.NewNotFoundError(nil, repositories.DropletResourceType)))
-					})
-				})
-
-				When("status.Conditions \"Staging\": False, \"Succeeded\": False, is set", func() {
-					BeforeEach(func() {
-						meta.SetStatusCondition(&build.Status.Conditions, metav1.Condition{
-							Type:    "Staging",
-							Status:  metav1.ConditionTrue,
-							Reason:  "kpack",
-							Message: "kpack",
-						})
-						meta.SetStatusCondition(&build.Status.Conditions, metav1.Condition{
-							Type:    "Succeeded",
-							Status:  metav1.ConditionUnknown,
-							Reason:  "Unknown",
-							Message: "Unknown",
-						})
-						Expect(k8sClient.Status().Update(ctx, build)).To(Succeed())
-					})
-
-					It("should return a NotFound error", func() {
-						Expect(fetchErr).To(MatchError(apierrors.NewNotFoundError(nil, repositories.DropletResourceType)))
-					})
-				})
-			})
-
 			When("build does not exist", func() {
 				BeforeEach(func() {
-					meta.SetStatusCondition(&build.Status.Conditions, metav1.Condition{
-						Type:    "Staging",
-						Status:  metav1.ConditionFalse,
-						Reason:  "kpack",
-						Message: "kpack",
-					})
-					meta.SetStatusCondition(&build.Status.Conditions, metav1.Condition{
-						Type:    "Succeeded",
-						Status:  metav1.ConditionTrue,
-						Reason:  "Unknown",
-						Message: "Unknown",
-					})
-					build.Status.Droplet = &korifiv1alpha1.BuildDropletStatus{
-						Stack: dropletStack,
-						Registry: korifiv1alpha1.Registry{
-							Image: registryImage,
-							ImagePullSecrets: []corev1.LocalObjectReference{
-								{
-									Name: registryImageSecret,
-								},
-							},
-						},
-						ProcessTypes: []korifiv1alpha1.ProcessType{
-							{
-								Type:    "rake",
-								Command: "bundle exec rake",
-							},
-							{
-								Type:    "web",
-								Command: "bundle exec rackup config.ru -p $PORT",
-							},
-						},
-						Ports: []int32{8080, 443},
-					}
-					// Update Build Status based on changes made to local copy
-					Expect(k8sClient.Status().Update(ctx, build)).To(Succeed())
 					fetchBuildGUID = "i don't exist"
 				})
 
@@ -308,12 +176,6 @@ var _ = Describe("DropletRepository", func() {
 					Expect(fetchErr).To(HaveOccurred())
 					Expect(fetchErr).To(matchers.WrapErrorAssignableToTypeOf(apierrors.NotFoundError{}))
 				})
-			})
-		})
-
-		When("the user is not authorized to get the droplet", func() {
-			It("returns a forbidden error", func() {
-				Expect(fetchErr).To(BeAssignableToTypeOf(apierrors.ForbiddenError{}))
 			})
 		})
 	})
@@ -335,11 +197,11 @@ var _ = Describe("DropletRepository", func() {
 			anotherBuild := &korifiv1alpha1.CFBuild{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      uuid.NewString(),
-					Namespace: space.Name,
+					Namespace: build.Namespace,
 					Labels: map[string]string{
 						korifiv1alpha1.CFPackageGUIDLabelKey: uuid.NewString(),
 						korifiv1alpha1.CFAppGUIDLabelKey:     uuid.NewString(),
-						korifiv1alpha1.SpaceGUIDKey:          space.Name,
+						korifiv1alpha1.SpaceGUIDKey:          build.Namespace,
 					},
 				},
 				Spec: korifiv1alpha1.CFBuildSpec{
@@ -365,7 +227,7 @@ var _ = Describe("DropletRepository", func() {
 
 		When("the user is a space developer", func() {
 			BeforeEach(func() {
-				createRoleBinding(ctx, userName, spaceDeveloperRole.Name, space.Name)
+				createRoleBinding(ctx, userName, spaceDeveloperRole.Name, build.Namespace)
 			})
 
 			It("returns the droplets", func() {
@@ -376,14 +238,14 @@ var _ = Describe("DropletRepository", func() {
 			Describe("filtering", func() {
 				BeforeEach(func() {
 					message = repositories.ListDropletsMessage{
-						PackageGUIDs: []string{packageGUID},
+						PackageGUIDs: []string{build.Spec.PackageRef.Name},
 					}
 				})
 
 				It("returns the builds matching the filter parameters", func() {
 					Expect(listErr).NotTo(HaveOccurred())
 					Expect(dropletRecords).To(ConsistOf(MatchFields(IgnoreExtras, Fields{
-						"PackageGUID": Equal(packageGUID),
+						"PackageGUID": Equal(build.Spec.PackageRef.Name),
 					})))
 				})
 
@@ -423,7 +285,7 @@ var _ = Describe("DropletRepository", func() {
 
 		BeforeEach(func() {
 			dropletUpdateMsg = repositories.UpdateDropletMessage{
-				GUID: buildGUID,
+				GUID: build.Name,
 				MetadataPatch: repositories.MetadataPatch{
 					Labels: map[string]*string{
 						"key1": tools.PtrTo("val1edit"),
@@ -443,230 +305,61 @@ var _ = Describe("DropletRepository", func() {
 			dropletRecord, updateError = dropletRepo.UpdateDroplet(ctx, authInfo, dropletUpdateMsg)
 		})
 
-		When("the user is authorized to get the droplet", func() {
+		It("returns a forbidden error", func() {
+			Expect(updateError).To(BeAssignableToTypeOf(apierrors.ForbiddenError{}))
+		})
+
+		When("the user is authorized to update the droplet", func() {
 			BeforeEach(func() {
-				createRoleBinding(ctx, userName, spaceDeveloperRole.Name, space.Name)
+				createRoleBinding(ctx, userName, spaceDeveloperRole.Name, build.Namespace)
 			})
 
-			When("status.Droplet is set", func() {
+			It("returns a NotFound error", func() {
+				Expect(updateError).To(MatchError(apierrors.NewNotFoundError(nil, repositories.DropletResourceType)))
+			})
+
+			When("the build is staged", func() {
 				BeforeEach(func() {
-					meta.SetStatusCondition(&build.Status.Conditions, metav1.Condition{
-						Type:    "Staging",
-						Status:  metav1.ConditionFalse,
-						Reason:  "kpack",
-						Message: "kpack",
-					})
-					meta.SetStatusCondition(&build.Status.Conditions, metav1.Condition{
-						Type:    "Succeeded",
-						Status:  metav1.ConditionTrue,
-						Reason:  "Unknown",
-						Message: "Unknown",
-					})
-					build.Status.Droplet = &korifiv1alpha1.BuildDropletStatus{
-						Stack: dropletStack,
-						Registry: korifiv1alpha1.Registry{
-							Image: registryImage,
-							ImagePullSecrets: []corev1.LocalObjectReference{
-								{
-									Name: registryImageSecret,
-								},
-							},
-						},
-						ProcessTypes: []korifiv1alpha1.ProcessType{
-							{
-								Type:    "rake",
-								Command: "bundle exec rake",
-							},
-							{
-								Type:    "web",
-								Command: "bundle exec rackup config.ru -p $PORT",
-							},
-						},
-						Ports: []int32{8080, 443},
-					}
-					// Update Build Status based on changes made to local copy
-					Expect(k8sClient.Status().Update(ctx, build)).To(Succeed())
+					Expect(k8s.Patch(ctx, k8sClient, build, func() {
+						build.Status.State = korifiv1alpha1.BuildStateStaged
+						build.Status.Droplet = &korifiv1alpha1.BuildDropletStatus{}
+					})).To(Succeed())
 				})
 
 				It("updates the build metadata in kubernetes", func() {
-					updatedBuild := new(korifiv1alpha1.CFBuild)
-					Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(build), updatedBuild)).To(Succeed())
-
-					Expect(updatedBuild.Labels).To(SatisfyAll(
-						HaveKeyWithValue("key1", "val1edit"),
-						HaveKeyWithValue("key3", "val3")))
-					Expect(updatedBuild.Annotations).To(SatisfyAll(
-						HaveKeyWithValue("key1", "val1edit"),
-						HaveKeyWithValue("key3", "val3")))
-				})
-
-				It("should eventually return a droplet record with fields set to expected values", func() {
 					Expect(updateError).NotTo(HaveOccurred())
 
-					Expect(dropletRecord.State).To(Equal("STAGED"))
+					Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(build), build)).To(Succeed())
 
-					By("returning a record with a CreatedAt field from the CR", func() {
-						Expect(dropletRecord.CreatedAt).To(BeTemporally("~", time.Now(), timeCheckThreshold))
-					})
-
-					By("returning a record with a UpdatedAt field from the CR", func() {
-						Expect(dropletRecord.UpdatedAt).To(PointTo(BeTemporally("~", time.Now(), timeCheckThreshold)))
-					})
-
-					By("returning a record with stack field matching the CR", func() {
-						Expect(dropletRecord.Stack).To(Equal(build.Status.Droplet.Stack))
-					})
-
-					By("returning a record with Lifecycle fields matching the CR", func() {
-						Expect(dropletRecord.Lifecycle.Type).To(Equal(string(build.Spec.Lifecycle.Type)), "returned record lifecycle.type did not match CR")
-						Expect(dropletRecord.Lifecycle.Data.Buildpacks).To(BeEmpty(), "returned record lifecycle.data.buildpacks did not match CR")
-						Expect(dropletRecord.Lifecycle.Data.Stack).To(Equal(build.Spec.Lifecycle.Data.Stack), "returned record lifecycle.data.stack did not match CR")
-					})
-
-					By("returning a record with an AppGUID field matching the CR", func() {
-						Expect(dropletRecord.AppGUID).To(Equal(build.Spec.AppRef.Name))
-					})
-
-					By("returning a record with a PackageGUID field matching the CR", func() {
-						Expect(dropletRecord.PackageGUID).To(Equal(build.Spec.PackageRef.Name))
-					})
-
-					By("returning a record with all process types and commands matching the CR", func() {
-						processTypesArray := build.Status.Droplet.ProcessTypes
-						for index := range processTypesArray {
-							Expect(dropletRecord.ProcessTypes).To(HaveKeyWithValue(processTypesArray[index].Type, processTypesArray[index].Command))
-						}
-					})
-
-					By("returning a record with a GUID matching the build", func() {
-						Expect(dropletRecord.GUID).To(Equal(buildGUID))
-					})
-
-					By("returns a record with a Label field matching the CR", func() {
-						Expect(dropletRecord.Labels).To(Equal(map[string]string{
-							"key1":                               "val1edit",
-							"key3":                               "val3",
-							korifiv1alpha1.CFPackageGUIDLabelKey: packageGUID,
-							korifiv1alpha1.CFAppGUIDLabelKey:     appGUID,
-							korifiv1alpha1.SpaceGUIDKey:          space.Name,
-						}))
-					})
-
-					By("returns a record with an Annotation field matching the CR", func() {
-						Expect(dropletRecord.Annotations).To(Equal(map[string]string{
-							"key1": "val1edit",
-							"key3": "val3",
-						}))
-					})
-				})
-			})
-
-			When("status.Droplet is not set", func() {
-				When("status.Conditions \"Staging\": Unknown, \"Succeeded\": Unknown, is set", func() {
-					BeforeEach(func() {
-						meta.SetStatusCondition(&build.Status.Conditions, metav1.Condition{
-							Type:    "Staging",
-							Status:  metav1.ConditionUnknown,
-							Reason:  "kpack",
-							Message: "kpack",
-						})
-						meta.SetStatusCondition(&build.Status.Conditions, metav1.Condition{
-							Type:    "Succeeded",
-							Status:  metav1.ConditionUnknown,
-							Reason:  "Unknown",
-							Message: "Unknown",
-						})
-						Expect(k8sClient.Status().Update(ctx, build)).To(Succeed())
-					})
-
-					It("should return a NotFound error", func() {
-						Expect(updateError).To(MatchError(apierrors.NewNotFoundError(nil, repositories.DropletResourceType)))
-					})
+					Expect(build.Labels).To(SatisfyAll(
+						HaveKeyWithValue("key1", "val1edit"),
+						Not(HaveKey("key2")),
+						HaveKeyWithValue("key3", "val3")))
+					Expect(build.Annotations).To(SatisfyAll(
+						HaveKeyWithValue("key1", "val1edit"),
+						Not(HaveKey("key2")),
+						HaveKeyWithValue("key3", "val3")))
 				})
 
-				When("status.Conditions \"Staging\": True, \"Succeeded\": Unknown, is set", func() {
-					BeforeEach(func() {
-						meta.SetStatusCondition(&build.Status.Conditions, metav1.Condition{
-							Type:    "Staging",
-							Status:  metav1.ConditionTrue,
-							Reason:  "kpack",
-							Message: "kpack",
-						})
-						meta.SetStatusCondition(&build.Status.Conditions, metav1.Condition{
-							Type:    "Succeeded",
-							Status:  metav1.ConditionUnknown,
-							Reason:  "Unknown",
-							Message: "Unknown",
-						})
-						Expect(k8sClient.Status().Update(ctx, build)).To(Succeed())
-					})
+				It("returns a droplet record with updated metadata", func() {
+					Expect(updateError).NotTo(HaveOccurred())
 
-					It("should return a NotFound error", func() {
-						Expect(updateError).To(MatchError(apierrors.NewNotFoundError(nil, repositories.DropletResourceType)))
-					})
-				})
+					Expect(dropletRecord.Labels).To(SatisfyAll(
+						HaveKeyWithValue("key1", "val1edit"),
+						Not(HaveKey("key2")),
+						HaveKeyWithValue("key3", "val3"),
+					))
 
-				When("status.Conditions \"Staging\": False, \"Succeeded\": False, is set", func() {
-					BeforeEach(func() {
-						meta.SetStatusCondition(&build.Status.Conditions, metav1.Condition{
-							Type:    "Staging",
-							Status:  metav1.ConditionTrue,
-							Reason:  "kpack",
-							Message: "kpack",
-						})
-						meta.SetStatusCondition(&build.Status.Conditions, metav1.Condition{
-							Type:    "Succeeded",
-							Status:  metav1.ConditionUnknown,
-							Reason:  "Unknown",
-							Message: "Unknown",
-						})
-						Expect(k8sClient.Status().Update(ctx, build)).To(Succeed())
-					})
-
-					It("should return a NotFound error", func() {
-						Expect(updateError).To(MatchError(apierrors.NewNotFoundError(nil, repositories.DropletResourceType)))
-					})
+					Expect(dropletRecord.Annotations).To(SatisfyAll(
+						HaveKeyWithValue("key1", "val1edit"),
+						Not(HaveKey("key2")),
+						HaveKeyWithValue("key3", "val3"),
+					))
 				})
 			})
 
 			When("build does not exist", func() {
 				BeforeEach(func() {
-					meta.SetStatusCondition(&build.Status.Conditions, metav1.Condition{
-						Type:    "Staging",
-						Status:  metav1.ConditionFalse,
-						Reason:  "kpack",
-						Message: "kpack",
-					})
-					meta.SetStatusCondition(&build.Status.Conditions, metav1.Condition{
-						Type:    "Succeeded",
-						Status:  metav1.ConditionTrue,
-						Reason:  "Unknown",
-						Message: "Unknown",
-					})
-					build.Status.Droplet = &korifiv1alpha1.BuildDropletStatus{
-						Stack: dropletStack,
-						Registry: korifiv1alpha1.Registry{
-							Image: registryImage,
-							ImagePullSecrets: []corev1.LocalObjectReference{
-								{
-									Name: registryImageSecret,
-								},
-							},
-						},
-						ProcessTypes: []korifiv1alpha1.ProcessType{
-							{
-								Type:    "rake",
-								Command: "bundle exec rake",
-							},
-							{
-								Type:    "web",
-								Command: "bundle exec rackup config.ru -p $PORT",
-							},
-						},
-						Ports: []int32{8080, 443},
-					}
-					// Update Build Status based on changes made to local copy
-					Expect(k8sClient.Status().Update(ctx, build)).To(Succeed())
 					dropletUpdateMsg.GUID = "i don't exist"
 				})
 
@@ -674,12 +367,6 @@ var _ = Describe("DropletRepository", func() {
 					Expect(updateError).To(HaveOccurred())
 					Expect(updateError).To(matchers.WrapErrorAssignableToTypeOf(apierrors.NotFoundError{}))
 				})
-			})
-		})
-
-		When("the user is not authorized to get the droplet", func() {
-			It("returns a forbidden error", func() {
-				Expect(updateError).To(BeAssignableToTypeOf(apierrors.ForbiddenError{}))
 			})
 		})
 	})

--- a/api/repositories/repositories_suite_test.go
+++ b/api/repositories/repositories_suite_test.go
@@ -303,64 +303,6 @@ func createAppCR(ctx context.Context, k8sClient client.Client, appName, appGUID,
 	return toReturn
 }
 
-func createBuild(ctx context.Context, k8sClient client.Client, namespace, buildGUID, packageGUID, appGUID string) *korifiv1alpha1.CFBuild {
-	const (
-		stagingMemory = 1024
-		stagingDisk   = 2048
-	)
-
-	record := &korifiv1alpha1.CFBuild{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      buildGUID,
-			Namespace: namespace,
-			Labels: map[string]string{
-				korifiv1alpha1.SpaceGUIDKey:      namespace,
-				korifiv1alpha1.CFAppGUIDLabelKey: appGUID,
-			},
-		},
-		Spec: korifiv1alpha1.CFBuildSpec{
-			PackageRef: corev1.LocalObjectReference{
-				Name: packageGUID,
-			},
-			AppRef: corev1.LocalObjectReference{
-				Name: appGUID,
-			},
-			StagingMemoryMB: stagingMemory,
-			StagingDiskMB:   stagingDisk,
-			Lifecycle: korifiv1alpha1.Lifecycle{
-				Type: "buildpack",
-				Data: korifiv1alpha1.LifecycleData{
-					Buildpacks: []string{},
-					Stack:      "",
-				},
-			},
-		},
-	}
-	Expect(
-		k8sClient.Create(ctx, record),
-	).To(Succeed())
-	return record
-}
-
-func createDropletCR(ctx context.Context, k8sClient client.Client, dropletGUID, appGUID, spaceGUID string) *korifiv1alpha1.CFBuild {
-	toReturn := &korifiv1alpha1.CFBuild{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      dropletGUID,
-			Namespace: spaceGUID,
-		},
-		Spec: korifiv1alpha1.CFBuildSpec{
-			AppRef: corev1.LocalObjectReference{Name: appGUID},
-			Lifecycle: korifiv1alpha1.Lifecycle{
-				Type: "buildpack",
-			},
-		},
-	}
-	Expect(
-		k8sClient.Create(ctx, toReturn),
-	).To(Succeed())
-	return toReturn
-}
-
 func createServiceInstanceCR(ctx context.Context, k8sClient client.Client, serviceInstanceGUID, spaceGUID, name, secretName string) *korifiv1alpha1.CFServiceInstance {
 	serviceInstance := &korifiv1alpha1.CFServiceInstance{
 		ObjectMeta: metav1.ObjectMeta{

--- a/api/repositories/shared.go
+++ b/api/repositories/shared.go
@@ -8,7 +8,6 @@ import (
 
 	"code.cloudfoundry.org/korifi/api/authorization"
 	"github.com/BooleanCat/go-functional/v2/it/itx"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -58,17 +57,6 @@ func golangTime(t *metav1.Time) *time.Time {
 		return nil
 	}
 	return &t.Time
-}
-
-// getConditionValue is a helper function that retrieves the value of the provided conditionType, like "Succeeded" and returns the value: "True", "False", or "Unknown"
-// If the value is not present, returns Unknown
-func getConditionValue(conditions *[]metav1.Condition, conditionType string) metav1.ConditionStatus {
-	conditionStatusValue := metav1.ConditionUnknown
-	conditionStatus := meta.FindStatusCondition(*conditions, conditionType)
-	if conditionStatus != nil {
-		conditionStatusValue = conditionStatus.Status
-	}
-	return conditionStatusValue
 }
 
 func getLabelOrAnnotation(mapObj map[string]string, key string) string {

--- a/controllers/api/v1alpha1/cfbuild_types.go
+++ b/controllers/api/v1alpha1/cfbuild_types.go
@@ -21,6 +21,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	BuildStateStaging = "STAGING"
+	BuildStateStaged  = "STAGED"
+	BuildStateFailed  = "FAILED"
+)
+
 // CFBuildSpec defines the desired state of CFBuild
 type CFBuildSpec struct {
 	// The CFPackage associated with this build. Must be in the same namespace
@@ -45,6 +51,10 @@ type CFBuildStatus struct {
 
 	// ObservedGeneration captures the latest generation of the CFBuild that has been reconciled
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
+	//+kubebuilder:validation:Optional
+	//+kubebuilder:validation:Enum=STAGING;STAGED;FAILED
+	State string `json:"state,omitempty"`
 }
 
 // BuildDropletStatus defines the observed state of the CFBuild's Droplet or runnable image
@@ -74,7 +84,7 @@ type ProcessType struct {
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 //+kubebuilder:printcolumn:name="AppGUID",type=string,JSONPath=`.spec.appRef.name`
-//+kubebuilder:printcolumn:name="Staged",type=string,JSONPath=`.status.conditions[?(@.type=='Succeeded')].status`
+//+kubebuilder:printcolumn:name="State",type=string,JSONPath=`.status.state`
 //+kubebuilder:printcolumn:name="Age",type="date",JSONPath=`.metadata.creationTimestamp`
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 

--- a/controllers/api/v1alpha1/cfbuild_types.go
+++ b/controllers/api/v1alpha1/cfbuild_types.go
@@ -22,6 +22,8 @@ import (
 )
 
 const (
+	CFBuildStateLabelKey = "korifi.cloudfoundry.org/build-state"
+
 	BuildStateStaging = "STAGING"
 	BuildStateStaged  = "STAGED"
 	BuildStateFailed  = "FAILED"

--- a/controllers/controllers/workloads/build/buildpack/controller.go
+++ b/controllers/controllers/workloads/build/buildpack/controller.go
@@ -147,6 +147,7 @@ func (r *buildpackBuildReconciler) ReconcileBuild(
 			Reason:             "BuildRunning",
 			ObservedGeneration: cfBuild.Generation,
 		})
+		cfBuild.Status.State = korifiv1alpha1.BuildStateStaging
 
 		return ctrl.Result{}, nil
 	}
@@ -183,6 +184,8 @@ func (r *buildpackBuildReconciler) ReconcileBuild(
 			Message:            fmt.Sprintf("%s: %s", workloadSucceededStatus.Reason, workloadSucceededStatus.Message),
 			ObservedGeneration: cfBuild.Generation,
 		})
+
+		cfBuild.Status.State = korifiv1alpha1.BuildStateFailed
 	case metav1.ConditionTrue:
 		meta.SetStatusCondition(&cfBuild.Status.Conditions, metav1.Condition{
 			Type:               korifiv1alpha1.StagingConditionType,
@@ -198,6 +201,7 @@ func (r *buildpackBuildReconciler) ReconcileBuild(
 			ObservedGeneration: cfBuild.Generation,
 		})
 
+		cfBuild.Status.State = korifiv1alpha1.BuildStateStaged
 		cfBuild.Status.Droplet = buildWorkload.Status.Droplet
 	default:
 		return ctrl.Result{}, nil

--- a/controllers/controllers/workloads/build/buildpack/controller_test.go
+++ b/controllers/controllers/workloads/build/buildpack/controller_test.go
@@ -209,6 +209,8 @@ var _ = Describe("CFBuildpackBuildReconciler Integration Tests", func() {
 			g.Expect(stagingCondition.Status).To(Equal(metav1.ConditionTrue))
 			g.Expect(stagingCondition.Reason).To(Equal("BuildRunning"))
 			g.Expect(stagingCondition.ObservedGeneration).To(Equal(cfBuild.Generation))
+
+			g.Expect(cfBuild.Status.State).To(Equal(korifiv1alpha1.BuildStateStaging))
 		}).Should(Succeed())
 	})
 
@@ -264,6 +266,8 @@ var _ = Describe("CFBuildpackBuildReconciler Integration Tests", func() {
 				g.Expect(stagingCondition.Status).To(Equal(metav1.ConditionTrue))
 				g.Expect(stagingCondition.Reason).To(Equal("BuildRunning"))
 				g.Expect(stagingCondition.ObservedGeneration).To(Equal(cfBuild.Generation))
+
+				g.Expect(cfBuild.Status.State).To(Equal(korifiv1alpha1.BuildStateStaging))
 			}).Should(Succeed())
 		})
 	})
@@ -299,6 +303,8 @@ var _ = Describe("CFBuildpackBuildReconciler Integration Tests", func() {
 				g.Expect(succeededStatusCondition.Status).To(Equal(metav1.ConditionFalse))
 				g.Expect(succeededStatusCondition.Reason).To(Equal("BuildFailed"))
 				g.Expect(succeededStatusCondition.ObservedGeneration).To(Equal(cfBuild.Generation))
+
+				g.Expect(cfBuild.Status.State).To(Equal(korifiv1alpha1.BuildStateFailed))
 			}).Should(Succeed())
 		})
 	})
@@ -351,6 +357,8 @@ var _ = Describe("CFBuildpackBuildReconciler Integration Tests", func() {
 				g.Expect(succeededStatusCondition.Status).To(Equal(metav1.ConditionTrue))
 				g.Expect(succeededStatusCondition.Reason).To(Equal("BuildSucceeded"))
 				g.Expect(succeededStatusCondition.ObservedGeneration).To(Equal(cfBuild.Generation))
+
+				g.Expect(cfBuild.Status.State).To(Equal(korifiv1alpha1.BuildStateStaged))
 			}).Should(Succeed())
 		})
 

--- a/controllers/controllers/workloads/build/docker/controller.go
+++ b/controllers/controllers/workloads/build/docker/controller.go
@@ -128,6 +128,7 @@ func (r *dockerBuildReconciler) ReconcileBuild(
 			Message:            fmt.Sprintf("Failed to fetch image %q", cfPackage.Spec.Source.Registry.Image),
 			ObservedGeneration: cfBuild.Generation,
 		})
+		cfBuild.Status.State = korifiv1alpha1.BuildStateFailed
 
 		return ctrl.Result{}, nil
 	}
@@ -150,6 +151,7 @@ func (r *dockerBuildReconciler) ReconcileBuild(
 			),
 			ObservedGeneration: cfBuild.Generation,
 		})
+		cfBuild.Status.State = korifiv1alpha1.BuildStateFailed
 
 		return ctrl.Result{}, nil
 	}
@@ -160,6 +162,7 @@ func (r *dockerBuildReconciler) ReconcileBuild(
 		Reason:             "BuildSucceeded",
 		ObservedGeneration: cfBuild.Generation,
 	})
+	cfBuild.Status.State = korifiv1alpha1.BuildStateStaged
 
 	cfBuild.Status.Droplet = &korifiv1alpha1.BuildDropletStatus{
 		Registry: cfPackage.Spec.Source.Registry,

--- a/controllers/webhooks/label_indexer/webhook.go
+++ b/controllers/webhooks/label_indexer/webhook.go
@@ -45,6 +45,7 @@ func NewWebhook() *LabelIndexerWebhook {
 				LabelRule{Label: korifiv1alpha1.SpaceGUIDKey, IndexingFunc: Unquote(JSONValue("$.metadata.namespace"))},
 				LabelRule{Label: korifiv1alpha1.CFAppGUIDLabelKey, IndexingFunc: Unquote(JSONValue("$.spec.appRef.name"))},
 				LabelRule{Label: korifiv1alpha1.CFPackageGUIDLabelKey, IndexingFunc: Unquote(JSONValue("$.spec.packageRef.name"))},
+				LabelRule{Label: korifiv1alpha1.CFBuildStateLabelKey, IndexingFunc: Unquote(JSONValue("$.status.state"))},
 			},
 			"CFDomain": {
 				LabelRule{Label: korifiv1alpha1.CFEncodedDomainNameLabelKey, IndexingFunc: SHA224(Unquote(JSONValue("$.spec.name")))},

--- a/controllers/webhooks/label_indexer/webhook_test.go
+++ b/controllers/webhooks/label_indexer/webhook_test.go
@@ -4,6 +4,7 @@ import (
 	"maps"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
+	"code.cloudfoundry.org/korifi/tools/k8s"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -147,6 +148,9 @@ var _ = Describe("LabelIndexerWebhook", func() {
 
 		JustBeforeEach(func() {
 			Expect(adminClient.Create(ctx, build)).To(Succeed())
+			Expect(k8s.Patch(ctx, adminClient, build, func() {
+				build.Status.State = korifiv1alpha1.BuildStateStaged
+			})).To(Succeed())
 		})
 
 		It("labels the CFBuild with the expected index labels", func() {
@@ -156,6 +160,7 @@ var _ = Describe("LabelIndexerWebhook", func() {
 					korifiv1alpha1.SpaceGUIDKey:          Equal(build.Namespace),
 					korifiv1alpha1.CFAppGUIDLabelKey:     Equal(build.Spec.AppRef.Name),
 					korifiv1alpha1.CFPackageGUIDLabelKey: Equal(build.Spec.PackageRef.Name),
+					korifiv1alpha1.CFBuildStateLabelKey:  Equal(korifiv1alpha1.BuildStateStaged),
 				}))
 			}).Should(Succeed())
 		})

--- a/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfbuilds.yaml
+++ b/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfbuilds.yaml
@@ -18,8 +18,8 @@ spec:
     - jsonPath: .spec.appRef.name
       name: AppGUID
       type: string
-    - jsonPath: .status.conditions[?(@.type=='Succeeded')].status
-      name: Staged
+    - jsonPath: .status.state
+      name: State
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
@@ -249,6 +249,12 @@ spec:
                   the CFBuild that has been reconciled
                 format: int64
                 type: integer
+              state:
+                enum:
+                - STAGING
+                - STAGED
+                - FAILED
+                type: string
             type: object
         type: object
     served: true

--- a/helm/korifi/migrations/post-upgrade-set-migrated-by.yaml
+++ b/helm/korifi/migrations/post-upgrade-set-migrated-by.yaml
@@ -81,7 +81,7 @@ spec:
           }
 
           main() {
-            set-migrated-by-label cfapps cfdomains cfroutes
+            set-migrated-by-label cfapps cfdomains cfroutes cfbuilds
           }
 
           main


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
#3988
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Use label selectors to filter CFBuilds

* Introduce a `CFBuild.Status.State` field to reflect the build state, populated by the build controller
* The build and droplet repositories just use the `CFBuild.Status.State` field when setting the record state; they no longer interet the CFBuild statuses
* The indexer webhook sets the `build-state` label on CFBuilds with the value from `CFBuild.Status.State`
* The migration job sets the `migrated-by` label on CFBuilds in order to force the indexer webhook on existing builds during upgrade
* The build repository uses label selector to filter builds when listing

The PR has been split into several commits to make it easier to review. Feel free to squash them when merging.


