### PR TITLE
Filter orgs when listing via label selectors

### DIFF
--- a/api/authorization/namespace_permissions.go
+++ b/api/authorization/namespace_permissions.go
@@ -35,7 +35,7 @@ func NewNamespacePermissions(privilegedClient client.Client, identityProvider Id
 }
 
 func (o *NamespacePermissions) GetAuthorizedOrgNamespaces(ctx context.Context, info Info) (map[string]bool, error) {
-	return o.getAuthorizedNamespaces(ctx, info, korifiv1alpha1.OrgNameKey, "Org")
+	return o.getAuthorizedNamespaces(ctx, info, korifiv1alpha1.CFOrgDisplayNameKey, "Org")
 }
 
 func (o *NamespacePermissions) GetAuthorizedSpaceNamespaces(ctx context.Context, info Info) (map[string]bool, error) {

--- a/api/authorization/namespace_permissions_test.go
+++ b/api/authorization/namespace_permissions_test.go
@@ -130,8 +130,8 @@ var _ = Describe("Namespace Permissions", func() {
 
 	Describe("Get Authorized Org Namespaces", func() {
 		BeforeEach(func() {
-			org1NS = createNamespace("org1", map[string]string{korifiv1alpha1.OrgNameKey: "org1"})
-			org2NS = createNamespace("org2", map[string]string{korifiv1alpha1.OrgNameKey: "org2"})
+			org1NS = createNamespace("org1", map[string]string{korifiv1alpha1.CFOrgDisplayNameKey: "org1"})
+			org2NS = createNamespace("org2", map[string]string{korifiv1alpha1.CFOrgDisplayNameKey: "org2"})
 		})
 
 		AfterEach(func() {
@@ -339,8 +339,8 @@ var _ = Describe("Namespace Permissions", func() {
 
 	Describe("Authorized In", func() {
 		BeforeEach(func() {
-			org1NS = createNamespace("org1", map[string]string{korifiv1alpha1.OrgNameKey: "org1"})
-			org2NS = createNamespace("org2", map[string]string{korifiv1alpha1.OrgNameKey: "org2"})
+			org1NS = createNamespace("org1", map[string]string{korifiv1alpha1.CFOrgDisplayNameKey: "org1"})
+			org2NS = createNamespace("org2", map[string]string{korifiv1alpha1.CFOrgDisplayNameKey: "org2"})
 		})
 
 		AfterEach(func() {

--- a/api/repositories/klient.go
+++ b/api/repositories/klient.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"code.cloudfoundry.org/korifi/tools/k8s"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
@@ -125,4 +126,21 @@ func (m MatchingFields) ApplyToList(opts *ListOptions) error {
 	sel := fields.Set(m).AsSelector()
 	opts.FieldSelector = sel
 	return nil
+}
+
+type Nothing struct{}
+
+func (o Nothing) ApplyToList(opts *ListOptions) error {
+	matchNothingRequirements, _ := k8s.MatchNotingSelector().Requirements()
+	opts.Requrements = append(opts.Requrements, matchNothingRequirements...)
+
+	return nil
+}
+
+func WithLabelStrictlyIn(key string, values []string) ListOption {
+	if len(values) == 0 {
+		return Nothing{}
+	}
+
+	return WithLabelIn(key, values)
 }

--- a/api/repositories/klient_test.go
+++ b/api/repositories/klient_test.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/selection"
 
 	"code.cloudfoundry.org/korifi/api/repositories"
+	"code.cloudfoundry.org/korifi/tools/k8s"
 )
 
 var _ = Describe("Klient", func() {
@@ -163,6 +164,30 @@ var _ = Describe("Klient", func() {
 
 				It("returns an error", func() {
 					Expect(applyToListErr).To(MatchError(ContainSubstring("invalid label selector")))
+				})
+			})
+		})
+
+		Describe("WithLabelStrictlyIn", func() {
+			BeforeEach(func() {
+				option = repositories.WithLabelStrictlyIn("foo", []string{"bar"})
+			})
+
+			It("adds the label selector requirements to the list options", func() {
+				expectedReq, err := labels.NewRequirement("foo", selection.In, []string{"bar"})
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(listOptions.Requrements).To(ConsistOf(*expectedReq))
+			})
+
+			When("the values are empty", func() {
+				BeforeEach(func() {
+					option = repositories.WithLabelStrictlyIn("foo", []string{})
+				})
+
+				It("adds match nothing requirements to the list options", func() {
+					expectedReqs, _ := k8s.MatchNotingSelector().Requirements()
+					Expect(listOptions.Requrements).To(ConsistOf(expectedReqs))
 				})
 			})
 		})

--- a/api/repositories/org_repository_test.go
+++ b/api/repositories/org_repository_test.go
@@ -8,6 +8,7 @@ import (
 	"code.cloudfoundry.org/korifi/api/authorization"
 	apierrors "code.cloudfoundry.org/korifi/api/errors"
 	"code.cloudfoundry.org/korifi/api/repositories"
+	"code.cloudfoundry.org/korifi/api/repositories/fake"
 	"code.cloudfoundry.org/korifi/api/repositories/fakeawaiter"
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"code.cloudfoundry.org/korifi/tests/matchers"
@@ -60,7 +61,7 @@ var _ = Describe("OrgRepository", func() {
 				namespace := &corev1.Namespace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   cfOrg.Name,
-						Labels: map[string]string{korifiv1alpha1.OrgNameKey: cfOrg.Spec.DisplayName},
+						Labels: map[string]string{korifiv1alpha1.CFOrgDisplayNameKey: cfOrg.Spec.DisplayName},
 					},
 				}
 				Expect(k8sClient.Create(ctx, namespace)).To(Succeed())
@@ -163,101 +164,49 @@ var _ = Describe("OrgRepository", func() {
 	})
 
 	Describe("ListOrgs", func() {
-		var cfOrg1, cfOrg2, cfOrg3 *korifiv1alpha1.CFOrg
+		var (
+			cfOrg1, cfOrg2, cfOrg3 *korifiv1alpha1.CFOrg
+			listMessage            repositories.ListOrgsMessage
+			orgs                   []repositories.OrgRecord
+			listErr                error
+		)
 
 		BeforeEach(func() {
 			cfOrg1 = createOrgWithCleanup(ctx, prefixedGUID("org1"))
-			createRoleBinding(ctx, userName, orgUserRole.Name, cfOrg1.Name)
 			cfOrg2 = createOrgWithCleanup(ctx, prefixedGUID("org2"))
-			createRoleBinding(ctx, userName, orgUserRole.Name, cfOrg2.Name)
 			cfOrg3 = createOrgWithCleanup(ctx, prefixedGUID("org3"))
-			createRoleBinding(ctx, userName, orgUserRole.Name, cfOrg3.Name)
 			createOrgWithCleanup(ctx, prefixedGUID("org4"))
+			listMessage = repositories.ListOrgsMessage{}
 		})
 
-		It("returns the 3 orgs", func() {
-			orgs, err := orgRepo.ListOrgs(ctx, authInfo, repositories.ListOrgsMessage{})
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(orgs).To(ConsistOf(
-				MatchFields(IgnoreExtras, Fields{
-					"Name": Equal(cfOrg1.Spec.DisplayName),
-					"GUID": Equal(cfOrg1.Name),
-				}),
-				MatchFields(IgnoreExtras, Fields{
-					"Name": Equal(cfOrg2.Spec.DisplayName),
-					"GUID": Equal(cfOrg2.Name),
-				}),
-				MatchFields(IgnoreExtras, Fields{
-					"Name": Equal(cfOrg3.Spec.DisplayName),
-					"GUID": Equal(cfOrg3.Name),
-				}),
-			))
+		JustBeforeEach(func() {
+			orgs, listErr = orgRepo.ListOrgs(ctx, authInfo, listMessage)
 		})
 
-		When("the org is not ready", func() {
+		It("returns an empty list (as no roles assigned)", func() {
+			Expect(listErr).NotTo(HaveOccurred())
+			Expect(orgs).To(BeEmpty())
+		})
+
+		When("fetching authorized namespaces fails", func() {
 			BeforeEach(func() {
-				meta.SetStatusCondition(&(cfOrg1.Status.Conditions), metav1.Condition{
-					Type:    korifiv1alpha1.StatusConditionReady,
-					Status:  metav1.ConditionFalse,
-					Reason:  "because",
-					Message: "because",
-				})
-				Expect(k8sClient.Status().Update(ctx, cfOrg1)).To(Succeed())
-
-				meta.SetStatusCondition(&(cfOrg2.Status.Conditions), metav1.Condition{
-					Type:    korifiv1alpha1.StatusConditionReady,
-					Status:  metav1.ConditionUnknown,
-					Reason:  "because",
-					Message: "because",
-				})
-				Expect(k8sClient.Status().Update(ctx, cfOrg2)).To(Succeed())
+				authInfo = authorization.Info{}
 			})
 
-			It("does not list it", func() {
-				orgs, err := orgRepo.ListOrgs(ctx, authInfo, repositories.ListOrgsMessage{})
-				Expect(err).NotTo(HaveOccurred())
-
-				Expect(orgs).NotTo(ContainElement(
-					MatchFields(IgnoreExtras, Fields{
-						"GUID": Equal(cfOrg1.Name),
-					}),
-				))
-				Expect(orgs).NotTo(ContainElement(
-					MatchFields(IgnoreExtras, Fields{
-						"GUID": Equal(cfOrg2.Name),
-					}),
-				))
-				Expect(orgs).To(ContainElement(
-					MatchFields(IgnoreExtras, Fields{
-						"GUID": Equal(cfOrg3.Name),
-					}),
-				))
+			It("returns the error", func() {
+				Expect(listErr).To(MatchError(ContainSubstring("failed to get identity")))
 			})
 		})
 
-		When("we filter for names org1 and org3", func() {
-			It("returns just those", func() {
-				orgs, err := orgRepo.ListOrgs(ctx, authInfo, repositories.ListOrgsMessage{Names: []string{cfOrg1.Spec.DisplayName, cfOrg3.Spec.DisplayName}})
-				Expect(err).NotTo(HaveOccurred())
-
-				Expect(orgs).To(ConsistOf(
-					MatchFields(IgnoreExtras, Fields{
-						"Name": Equal(cfOrg1.Spec.DisplayName),
-						"GUID": Equal(cfOrg1.Name),
-					}),
-					MatchFields(IgnoreExtras, Fields{
-						"Name": Equal(cfOrg3.Spec.DisplayName),
-						"GUID": Equal(cfOrg3.Name),
-					}),
-				))
+		When("the user is an org user", func() {
+			BeforeEach(func() {
+				createRoleBinding(ctx, userName, orgUserRole.Name, cfOrg1.Name)
+				createRoleBinding(ctx, userName, orgUserRole.Name, cfOrg2.Name)
+				createRoleBinding(ctx, userName, orgUserRole.Name, cfOrg3.Name)
 			})
-		})
 
-		When("we filter for guids org1 and org2", func() {
-			It("returns just those", func() {
-				orgs, err := orgRepo.ListOrgs(ctx, authInfo, repositories.ListOrgsMessage{GUIDs: []string{cfOrg1.Name, cfOrg2.Name}})
-				Expect(err).NotTo(HaveOccurred())
+			It("returns the orgs", func() {
+				Expect(listErr).NotTo(HaveOccurred())
 
 				Expect(orgs).To(ConsistOf(
 					MatchFields(IgnoreExtras, Fields{
@@ -268,19 +217,71 @@ var _ = Describe("OrgRepository", func() {
 						"Name": Equal(cfOrg2.Spec.DisplayName),
 						"GUID": Equal(cfOrg2.Name),
 					}),
+					MatchFields(IgnoreExtras, Fields{
+						"Name": Equal(cfOrg3.Spec.DisplayName),
+						"GUID": Equal(cfOrg3.Name),
+					}),
 				))
 			})
-		})
 
-		When("fetching authorized namespaces fails", func() {
-			var listErr error
+			When("listing by names", func() {
+				BeforeEach(func() {
+					listMessage = repositories.ListOrgsMessage{
+						Names: []string{cfOrg2.Spec.DisplayName},
+					}
+				})
 
-			BeforeEach(func() {
-				_, listErr = orgRepo.ListOrgs(ctx, authorization.Info{}, repositories.ListOrgsMessage{Names: []string{cfOrg1.Spec.DisplayName, cfOrg3.Spec.DisplayName}})
+				It("returns the orgs with matching names", func() {
+					Expect(listErr).NotTo(HaveOccurred())
+
+					Expect(orgs).To(ConsistOf(
+						MatchFields(IgnoreExtras, Fields{
+							"GUID": Equal(cfOrg2.Name),
+						}),
+					))
+				})
 			})
 
-			It("returns the error", func() {
-				Expect(listErr).To(MatchError(ContainSubstring("failed to get identity")))
+			Describe("filter parameters to list options", func() {
+				var fakeKlient *fake.Klient
+
+				BeforeEach(func() {
+					fakeKlient = new(fake.Klient)
+					orgRepo = repositories.NewOrgRepo(fakeKlient, rootNamespace, nsPerms, conditionAwaiter)
+
+					listMessage = repositories.ListOrgsMessage{
+						GUIDs: []string{cfOrg2.Name},
+						Names: []string{"a1", "a2"},
+					}
+				})
+
+				It("translates filter parameters to klient list options", func() {
+					Expect(fakeKlient.ListCallCount()).To(Equal(1))
+					_, _, listOptions := fakeKlient.ListArgsForCall(0)
+					Expect(listOptions).To(ConsistOf(
+						repositories.WithLabelIn(korifiv1alpha1.GUIDLabelKey, []string{cfOrg2.Name}),
+						repositories.WithLabelIn(korifiv1alpha1.CFOrgDisplayNameKey, tools.EncodeValuesToSha224("a1", "a2")),
+						repositories.WithLabel(korifiv1alpha1.ReadyLabelKey, string(metav1.ConditionTrue)),
+						repositories.InNamespace(rootNamespace),
+					))
+				})
+
+				When("the list message does not filter by org GUIDs", func() {
+					BeforeEach(func() {
+						listMessage.GUIDs = nil
+					})
+
+					It("filters orgs authorised orgs only", func() {
+						Expect(fakeKlient.ListCallCount()).To(Equal(1))
+						_, _, listOptions := fakeKlient.ListArgsForCall(0)
+						Expect(listOptions).To(ContainElement(
+							MatchAllFields(Fields{
+								"Key":    Equal(korifiv1alpha1.GUIDLabelKey),
+								"Values": ConsistOf(cfOrg1.Name, cfOrg2.Name, cfOrg3.Name),
+							}),
+						))
+					})
+				})
 			})
 		})
 	})
@@ -291,9 +292,7 @@ var _ = Describe("OrgRepository", func() {
 		BeforeEach(func() {
 			cfOrg = createOrgWithCleanup(ctx, prefixedGUID("the-org"))
 			Expect(k8s.PatchResource(ctx, k8sClient, cfOrg, func() {
-				cfOrg.Labels = map[string]string{
-					"test-label-key": "test-label-val",
-				}
+				cfOrg.Labels["test-label-key"] = "test-label-val"
 				cfOrg.Annotations = map[string]string{
 					"test-annotation-key": "test-annotation-val",
 				}
@@ -309,8 +308,8 @@ var _ = Describe("OrgRepository", func() {
 				orgRecord, err := orgRepo.GetOrg(ctx, authInfo, cfOrg.Name)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(orgRecord.Name).To(Equal(cfOrg.Spec.DisplayName))
-				Expect(orgRecord.Labels).To(Equal(map[string]string{"test-label-key": "test-label-val"}))
-				Expect(orgRecord.Annotations).To(Equal(map[string]string{"test-annotation-key": "test-annotation-val"}))
+				Expect(orgRecord.Labels).To(HaveKeyWithValue("test-label-key", "test-label-val"))
+				Expect(orgRecord.Annotations).To(HaveKeyWithValue("test-annotation-key", "test-annotation-val"))
 			})
 		})
 

--- a/controllers/api/v1alpha1/cforg_types.go
+++ b/controllers/api/v1alpha1/cforg_types.go
@@ -27,9 +27,7 @@ import (
 const (
 	CFOrgFinalizerName = "cfOrg.korifi.cloudfoundry.org"
 
-	OrgNameKey             = "cloudfoundry.org/org-name"
-	OrgGUIDKey             = "cloudfoundry.org/org-guid"
-	OrgSpaceDeprecatedName = "XXX-deprecated-XXX"
+	CFOrgDisplayNameKey = "korifi.cloudfoundry.org/org-name"
 )
 
 // CFOrgSpec defines the desired state of CFOrg

--- a/controllers/api/v1alpha1/shared_types.go
+++ b/controllers/api/v1alpha1/shared_types.go
@@ -11,6 +11,7 @@ import (
 const (
 	VersionLabelKey = "korifi.cloudfoundry.org/version"
 
+	CFOrgGUIDKey                = "korifi.cloudfoundry.org/org-guid"
 	CFAppGUIDLabelKey           = "korifi.cloudfoundry.org/app-guid"
 	CFAppRevisionKey            = "korifi.cloudfoundry.org/app-rev"
 	CFAppDisplayNameKey         = "korifi.cloudfoundry.org/display-name"
@@ -27,6 +28,7 @@ const (
 	CFRoutePathLabelKey         = "korifi.cloudfoundry.org/route-path"
 	CFTaskGUIDLabelKey          = "korifi.cloudfoundry.org/task-guid"
 
+	ReadyLabelKey           = "korifi.cloudfoundry.org/ready"
 	GUIDLabelKey            = "korifi.cloudfoundry.org/guid"
 	SpaceGUIDKey            = "korifi.cloudfoundry.org/space-guid"
 	ServiceBindingTypeLabel = "korifi.cloudfoundry.org/service-binding-type"

--- a/controllers/controllers/services/instances/managed/controller.go
+++ b/controllers/controllers/services/instances/managed/controller.go
@@ -217,7 +217,7 @@ func (r *Reconciler) provisionServiceInstance(
 			ServiceId:  assets.ServiceOffering.Spec.BrokerCatalog.ID,
 			PlanID:     assets.ServicePlan.Spec.BrokerCatalog.ID,
 			SpaceGUID:  namespace.Labels[korifiv1alpha1.SpaceGUIDKey],
-			OrgGUID:    namespace.Labels[korifiv1alpha1.OrgGUIDKey],
+			OrgGUID:    namespace.Labels[korifiv1alpha1.CFOrgGUIDKey],
 			Parameters: parametersMap,
 		},
 	})
@@ -454,7 +454,7 @@ func (r *Reconciler) isServicePlanVisible(
 		return false, err
 	}
 
-	return slices.Contains(servicePlan.Spec.Visibility.Organizations, namespace.Labels[korifiv1alpha1.OrgGUIDKey]), nil
+	return slices.Contains(servicePlan.Spec.Visibility.Organizations, namespace.Labels[korifiv1alpha1.CFOrgGUIDKey]), nil
 }
 
 func (r *Reconciler) getNamespace(ctx context.Context, namespaceName string) (*corev1.Namespace, error) {

--- a/controllers/controllers/services/instances/managed/controller_test.go
+++ b/controllers/controllers/services/instances/managed/controller_test.go
@@ -56,7 +56,7 @@ var _ = Describe("CFServiceInstance", func() {
 				Name: uuid.NewString(),
 				Labels: map[string]string{
 					korifiv1alpha1.SpaceGUIDKey: "space-guid",
-					korifiv1alpha1.OrgGUIDKey:   "org-guid",
+					korifiv1alpha1.CFOrgGUIDKey: "org-guid",
 				},
 			},
 		}

--- a/controllers/controllers/workloads/orgs/controller.go
+++ b/controllers/controllers/workloads/orgs/controller.go
@@ -136,13 +136,13 @@ type cfOrgMetadataCompiler struct {
 
 func (c *cfOrgMetadataCompiler) CompileLabels(cfOrg *korifiv1alpha1.CFOrg) map[string]string {
 	return c.labelCompiler.Compile(map[string]string{
-		korifiv1alpha1.OrgNameKey: korifiv1alpha1.OrgSpaceDeprecatedName,
-		korifiv1alpha1.OrgGUIDKey: cfOrg.Name,
+		korifiv1alpha1.CFOrgDisplayNameKey: cfOrg.Labels[korifiv1alpha1.CFOrgDisplayNameKey],
+		korifiv1alpha1.CFOrgGUIDKey:        cfOrg.Name,
 	})
 }
 
 func (c *cfOrgMetadataCompiler) CompileAnnotations(cfOrg *korifiv1alpha1.CFOrg) map[string]string {
 	return map[string]string{
-		korifiv1alpha1.OrgNameKey: cfOrg.Spec.DisplayName,
+		korifiv1alpha1.CFOrgDisplayNameKey: cfOrg.Spec.DisplayName,
 	}
 }

--- a/controllers/controllers/workloads/orgs/controller_test.go
+++ b/controllers/controllers/workloads/orgs/controller_test.go
@@ -25,9 +25,12 @@ var _ = Describe("CFOrgReconciler Integration Tests", func() {
 				Finalizers: []string{
 					korifiv1alpha1.CFOrgFinalizerName,
 				},
+				Labels: map[string]string{
+					korifiv1alpha1.CFOrgDisplayNameKey: "my-test-org",
+				},
 			},
 			Spec: korifiv1alpha1.CFOrgSpec{
-				DisplayName: uuid.NewString(),
+				DisplayName: "my-test-org",
 			},
 		}
 		Expect(adminClient.Create(ctx, cfOrg)).To(Succeed())
@@ -39,11 +42,11 @@ var _ = Describe("CFOrgReconciler Integration Tests", func() {
 			g.Expect(adminClient.Get(ctx, types.NamespacedName{Name: cfOrg.Name}, &orgNamespace)).To(Succeed())
 
 			g.Expect(orgNamespace.Labels).To(SatisfyAll(
-				HaveKeyWithValue(korifiv1alpha1.OrgNameKey, korifiv1alpha1.OrgSpaceDeprecatedName),
-				HaveKeyWithValue(korifiv1alpha1.OrgGUIDKey, cfOrg.Name),
+				HaveKeyWithValue(korifiv1alpha1.CFOrgDisplayNameKey, "my-test-org"),
+				HaveKeyWithValue(korifiv1alpha1.CFOrgGUIDKey, cfOrg.Name),
 				HaveKeyWithValue(api.EnforceLevelLabel, string(api.LevelRestricted)),
 			))
-			g.Expect(orgNamespace.Annotations).To(HaveKeyWithValue(korifiv1alpha1.OrgNameKey, cfOrg.Spec.DisplayName))
+			g.Expect(orgNamespace.Annotations).To(HaveKeyWithValue(korifiv1alpha1.CFOrgDisplayNameKey, cfOrg.Spec.DisplayName))
 		}).Should(Succeed())
 	})
 

--- a/controllers/controllers/workloads/spaces/controller.go
+++ b/controllers/controllers/workloads/spaces/controller.go
@@ -284,9 +284,9 @@ type cfSpaceMetadataCompiler struct {
 
 func (c *cfSpaceMetadataCompiler) CompileLabels(cfSpace *korifiv1alpha1.CFSpace) map[string]string {
 	return c.labelCompiler.Compile(map[string]string{
-		korifiv1alpha1.SpaceNameKey: korifiv1alpha1.OrgSpaceDeprecatedName,
+		korifiv1alpha1.SpaceNameKey: "XXX-deprecated-XXX",
 		korifiv1alpha1.SpaceGUIDKey: cfSpace.Name,
-		korifiv1alpha1.OrgGUIDKey:   cfSpace.Namespace,
+		korifiv1alpha1.CFOrgGUIDKey: cfSpace.Namespace,
 	})
 }
 

--- a/controllers/controllers/workloads/spaces/controller_test.go
+++ b/controllers/controllers/workloads/spaces/controller_test.go
@@ -43,9 +43,9 @@ var _ = Describe("CFSpaceReconciler Integration Tests", func() {
 			g.Expect(adminClient.Get(ctx, types.NamespacedName{Name: cfSpace.Name}, &ns)).To(Succeed())
 
 			g.Expect(ns.Labels).To(SatisfyAll(
-				HaveKeyWithValue(korifiv1alpha1.SpaceNameKey, korifiv1alpha1.OrgSpaceDeprecatedName),
+				HaveKeyWithValue(korifiv1alpha1.SpaceNameKey, "XXX-deprecated-XXX"),
 				HaveKeyWithValue(korifiv1alpha1.SpaceGUIDKey, cfSpace.Name),
-				HaveKeyWithValue(korifiv1alpha1.OrgGUIDKey, cfSpace.Namespace),
+				HaveKeyWithValue(korifiv1alpha1.CFOrgGUIDKey, cfSpace.Namespace),
 				HaveKeyWithValue(api.EnforceLevelLabel, string(api.LevelRestricted)),
 			))
 			g.Expect(ns.Annotations).To(HaveKeyWithValue(korifiv1alpha1.SpaceNameKey, cfSpace.Spec.DisplayName))

--- a/controllers/webhooks/finalizer/webhook_test.go
+++ b/controllers/webhooks/finalizer/webhook_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Controllers Finalizers Webhook", func() {
 				Expect(adminClient.Create(context.Background(), &corev1.Namespace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   obj.GetNamespace(),
-						Labels: map[string]string{korifiv1alpha1.OrgNameKey: obj.GetNamespace()},
+						Labels: map[string]string{korifiv1alpha1.CFOrgDisplayNameKey: obj.GetNamespace()},
 					},
 				})).To(Succeed())
 			}

--- a/controllers/webhooks/label_indexer/webhook.go
+++ b/controllers/webhooks/label_indexer/webhook.go
@@ -1,6 +1,6 @@
 package label_indexer
 
-//+kubebuilder:webhook:path=/mutate-korifi-cloudfoundry-org-v1alpha1-controllers-label-indexer,mutating=true,failurePolicy=fail,sideEffects=None,groups=korifi.cloudfoundry.org,resources=cfroutes;cfapps;cfbuilds;cfdomains;cfpackages;cfprocesses;cfservicebindings;cfserviceinstances;cftasks,verbs=create;update,versions=v1alpha1,name=mcflabelindexer.korifi.cloudfoundry.org,admissionReviewVersions={v1,v1beta1}
+//+kubebuilder:webhook:path=/mutate-korifi-cloudfoundry-org-v1alpha1-controllers-label-indexer,mutating=true,failurePolicy=fail,sideEffects=None,groups=korifi.cloudfoundry.org,resources=cfroutes;cfapps;cfbuilds;cfdomains;cfpackages;cfprocesses;cfservicebindings;cfserviceinstances;cftasks;cforgs,verbs=create;update,versions=v1alpha1,name=mcflabelindexer.korifi.cloudfoundry.org,admissionReviewVersions={v1,v1beta1}
 
 import (
 	"context"
@@ -65,6 +65,11 @@ func NewWebhook() *LabelIndexerWebhook {
 			},
 			"CFTask": {
 				LabelRule{Label: korifiv1alpha1.SpaceGUIDKey, IndexingFunc: Unquote(JSONValue("$.metadata.namespace"))},
+			},
+			"CFOrg": {
+				LabelRule{Label: korifiv1alpha1.CFOrgDisplayNameKey, IndexingFunc: SHA224(Unquote(JSONValue("$.spec.displayName")))},
+				LabelRule{Label: korifiv1alpha1.GUIDLabelKey, IndexingFunc: Unquote(JSONValue("$.metadata.name"))},
+				LabelRule{Label: korifiv1alpha1.ReadyLabelKey, IndexingFunc: Unquote(SingleValue(JSONValue("$.status.conditions[?@.type == \"Ready\"].status")))},
 			},
 		},
 	}

--- a/controllers/webhooks/version/version_test.go
+++ b/controllers/webhooks/version/version_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Setting the version annotation", func() {
 			Expect(adminClient.Create(context.Background(), &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   orgNamespace,
-					Labels: map[string]string{korifiv1alpha1.OrgNameKey: orgNamespace},
+					Labels: map[string]string{korifiv1alpha1.CFOrgDisplayNameKey: orgNamespace},
 				},
 			})).To(Succeed())
 

--- a/helm/korifi/controllers/manifests.yaml
+++ b/helm/korifi/controllers/manifests.yaml
@@ -107,6 +107,7 @@ webhooks:
           - cfservicebindings
           - cfserviceinstances
           - cftasks
+          - cforgs
     sideEffects: None
   - admissionReviewVersions:
       - v1

--- a/helm/korifi/migrations/post-upgrade-set-migrated-by.yaml
+++ b/helm/korifi/migrations/post-upgrade-set-migrated-by.yaml
@@ -81,7 +81,7 @@ spec:
           }
 
           main() {
-            set-migrated-by-label cfapps cfdomains cfroutes cfbuilds
+            set-migrated-by-label cfapps cfdomains cfroutes cfbuilds cforgs
           }
 
           main

--- a/tools/k8s/k8s_suite_test.go
+++ b/tools/k8s/k8s_suite_test.go
@@ -23,6 +23,7 @@ var (
 	k8sClient     client.Client
 	testEnv       *envtest.Environment
 	testNamespace *corev1.Namespace
+	ctx           context.Context
 )
 
 var _ = BeforeSuite(func() {
@@ -43,7 +44,8 @@ var _ = AfterSuite(func() {
 })
 
 var _ = BeforeEach(func() {
-	testNamespace = createNamespace(context.Background(), k8sClient, prefixedGUID("testns"))
+	ctx = context.Background()
+	testNamespace = createNamespace(ctx, k8sClient, prefixedGUID("testns"))
 })
 
 func prefixedGUID(prefix string) string {

--- a/tools/k8s/patch_test.go
+++ b/tools/k8s/patch_test.go
@@ -16,12 +16,6 @@ import (
 )
 
 var _ = Describe("Kubernetes Patch", func() {
-	var ctx context.Context
-
-	BeforeEach(func() {
-		ctx = context.Background()
-	})
-
 	Describe("Patch", func() {
 		Describe("objects with Status", func() {
 			var (

--- a/tools/k8s/reconcile_test.go
+++ b/tools/k8s/reconcile_test.go
@@ -53,7 +53,6 @@ func (f *fakeObjectReconciler) SetupWithManager(mgr ctrl.Manager) *builder.Build
 
 var _ = Describe("Reconcile", func() {
 	var (
-		ctx                context.Context
 		fakeClient         *fake.Client
 		fakeStatusWriter   *fake.StatusWriter
 		patchingReconciler *k8s.PatchingReconciler[korifiv1alpha1.CFOrg]
@@ -69,7 +68,6 @@ var _ = Describe("Reconcile", func() {
 		fakeStatusWriter = new(fake.StatusWriter)
 		fakeClient.StatusReturns(fakeStatusWriter)
 
-		ctx = context.Background()
 		org = &korifiv1alpha1.CFOrg{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: uuid.NewString(),

--- a/tools/k8s/retrying_client_test.go
+++ b/tools/k8s/retrying_client_test.go
@@ -1,7 +1,6 @@
 package k8s_test
 
 import (
-	"context"
 	"errors"
 
 	"code.cloudfoundry.org/korifi/tools/k8s"
@@ -22,7 +21,6 @@ var _ = Describe("RetryingK8sClient", func() {
 		retriableError error
 		retryingClient client.WithWatch
 		k8sClient      *fake.WithWatch
-		ctx            context.Context
 		backoff        wait.Backoff
 	)
 
@@ -34,7 +32,6 @@ var _ = Describe("RetryingK8sClient", func() {
 		}
 
 		retryingClient = k8s.NewRetryingClient(k8sClient, func(err error) bool { return err == retriableError }, backoff)
-		ctx = context.Background()
 	})
 
 	Describe("get", func() {

--- a/tools/k8s/selectors.go
+++ b/tools/k8s/selectors.go
@@ -1,0 +1,13 @@
+package k8s
+
+import (
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+)
+
+func MatchNotingSelector() labels.Selector {
+	r1, _ := labels.NewRequirement("whatever", selection.Exists, []string{})
+	r2, _ := labels.NewRequirement("whatever", selection.DoesNotExist, []string{})
+
+	return labels.NewSelector().Add(*r1, *r2)
+}

--- a/tools/k8s/selectors_test.go
+++ b/tools/k8s/selectors_test.go
@@ -1,0 +1,17 @@
+package k8s_test
+
+import (
+	"code.cloudfoundry.org/korifi/tools/k8s"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("MatchNothingSelector", func() {
+	It("mathes nothing", func() {
+		nsList := &corev1.NamespaceList{}
+		Expect(k8sClient.List(ctx, nsList, client.MatchingLabelsSelector{Selector: k8s.MatchNotingSelector()})).To(Succeed())
+		Expect(nsList.Items).To(BeEmpty())
+	})
+})


### PR DESCRIPTION
## Is there a related GitHub Issue?
#3988
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
* Introduce `org-name`, `guid` and `ready` labels on CFOrgs
* Use label selectors when listing orgs in the repository instead of
  filtering them on the client side

