### PR TITLE
Filter offering and plans via label selector when listing

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -236,7 +236,7 @@ func main() {
 	)
 	metricsRepo := repositories.NewMetricsRepo(klientUnfiltered)
 	serviceBrokerRepo := repositories.NewServiceBrokerRepo(klient, cfg.RootNamespace)
-	serviceOfferingRepo := repositories.NewServiceOfferingRepo(klient, cfg.RootNamespace, serviceBrokerRepo, nsPermissions)
+	serviceOfferingRepo := repositories.NewServiceOfferingRepo(klient, cfg.RootNamespace, nsPermissions)
 	servicePlanRepo := repositories.NewServicePlanRepo(klient, cfg.RootNamespace, orgRepo)
 	securityGroupRepo := repositories.NewSecurityGroupRepo(klient, cfg.RootNamespace)
 

--- a/api/repositories/klient.go
+++ b/api/repositories/klient.go
@@ -144,3 +144,9 @@ func WithLabelStrictlyIn(key string, values []string) ListOption {
 
 	return WithLabelIn(key, values)
 }
+
+type NoopListOption struct{}
+
+func (o NoopListOption) ApplyToList(opts *ListOptions) error {
+	return nil
+}

--- a/controllers/api/v1alpha1/cfservice_offering_types.go
+++ b/controllers/api/v1alpha1/cfservice_offering_types.go
@@ -5,6 +5,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+const (
+	CFServiceOfferingNameKey = "korifi.cloudfoundry.org/service-offering-name"
+)
+
 // CFServiceOfferingSpec defines the desired state of CFServiceOffering
 type CFServiceOfferingSpec struct {
 	Name        string   `json:"name"`

--- a/controllers/api/v1alpha1/cfservice_plan_types.go
+++ b/controllers/api/v1alpha1/cfservice_plan_types.go
@@ -5,6 +5,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+const (
+	CFServicePlanNameKey      = "korifi.cloudfoundry.org/service-plan-name"
+	CFServicePlanAvailableKey = "korifi.cloudfoundry.org/service-plan-available"
+)
+
 type CFServicePlanSpec struct {
 	Name            string                   `json:"name"`
 	Free            bool                     `json:"free"`

--- a/controllers/controllers/services/brokers/controller.go
+++ b/controllers/controllers/services/brokers/controller.go
@@ -171,7 +171,7 @@ func (r *Reconciler) reconcileCatalogService(ctx context.Context, cfServiceBroke
 			serviceOffering.Labels = map[string]string{}
 		}
 		serviceOffering.Labels[korifiv1alpha1.RelServiceBrokerGUIDLabel] = cfServiceBroker.Name
-		serviceOffering.Labels[korifiv1alpha1.RelServiceBrokerNameLabel] = cfServiceBroker.Spec.Name
+		serviceOffering.Labels[korifiv1alpha1.RelServiceBrokerNameLabel] = tools.EncodeValueToSha224(cfServiceBroker.Spec.Name)
 
 		var err error
 		serviceOffering.Spec, err = toServiceOfferingSpec(catalogService)
@@ -206,7 +206,7 @@ func (r *Reconciler) reconcileCatalogPlan(ctx context.Context, serviceOffering *
 		servicePlan.Labels[korifiv1alpha1.RelServiceBrokerGUIDLabel] = serviceOffering.Labels[korifiv1alpha1.RelServiceBrokerGUIDLabel]
 		servicePlan.Labels[korifiv1alpha1.RelServiceBrokerNameLabel] = serviceOffering.Labels[korifiv1alpha1.RelServiceBrokerNameLabel]
 		servicePlan.Labels[korifiv1alpha1.RelServiceOfferingGUIDLabel] = serviceOffering.Name
-		servicePlan.Labels[korifiv1alpha1.RelServiceOfferingNameLabel] = serviceOffering.Spec.Name
+		servicePlan.Labels[korifiv1alpha1.RelServiceOfferingNameLabel] = tools.EncodeValueToSha224(serviceOffering.Spec.Name)
 
 		visibilityType := korifiv1alpha1.AdminServicePlanVisibilityType
 		if servicePlan.Spec.Visibility.Type != "" {

--- a/controllers/controllers/services/brokers/controller_test.go
+++ b/controllers/controllers/services/brokers/controller_test.go
@@ -13,6 +13,7 @@ import (
 	"code.cloudfoundry.org/korifi/controllers/controllers/services/osbapi"
 	"code.cloudfoundry.org/korifi/controllers/controllers/services/osbapi/fake"
 	. "code.cloudfoundry.org/korifi/tests/matchers"
+	"code.cloudfoundry.org/korifi/tools"
 	"code.cloudfoundry.org/korifi/tools/k8s"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -140,7 +141,7 @@ var _ = Describe("CFServiceBroker", func() {
 			offering := offerings.Items[0]
 			g.Expect(offering.Labels).To(SatisfyAll(
 				HaveKeyWithValue(korifiv1alpha1.RelServiceBrokerGUIDLabel, serviceBroker.Name),
-				HaveKeyWithValue(korifiv1alpha1.RelServiceBrokerNameLabel, serviceBroker.Spec.Name),
+				HaveKeyWithValue(korifiv1alpha1.RelServiceBrokerNameLabel, tools.EncodeValueToSha224(serviceBroker.Spec.Name)),
 			))
 			g.Expect(offering.Spec).To(MatchAllFields(Fields{
 				"Name":             Equal("service-name"),
@@ -186,12 +187,12 @@ var _ = Describe("CFServiceBroker", func() {
 
 			plan := plans.Items[0]
 
-			g.Expect(plan.Labels).To(SatisfyAll(
-				HaveKeyWithValue(korifiv1alpha1.RelServiceBrokerGUIDLabel, serviceBroker.Name),
-				HaveKeyWithValue(korifiv1alpha1.RelServiceBrokerNameLabel, "my-service-broker"),
-				HaveKeyWithValue(korifiv1alpha1.RelServiceOfferingGUIDLabel, offerings.Items[0].Name),
-				HaveKeyWithValue(korifiv1alpha1.RelServiceOfferingNameLabel, "service-name"),
-			))
+			g.Expect(plan.Labels).To(MatchKeys(IgnoreExtras, Keys{
+				korifiv1alpha1.RelServiceBrokerGUIDLabel:   Equal(serviceBroker.Name),
+				korifiv1alpha1.RelServiceBrokerNameLabel:   Equal(tools.EncodeValueToSha224("my-service-broker")),
+				korifiv1alpha1.RelServiceOfferingGUIDLabel: Equal(offerings.Items[0].Name),
+				korifiv1alpha1.RelServiceOfferingNameLabel: Equal(tools.EncodeValueToSha224("service-name")),
+			}))
 			g.Expect(plan.Spec).To(MatchAllFields(Fields{
 				"Name":        Equal("plan-name"),
 				"Free":        BeTrue(),

--- a/helm/korifi/controllers/manifests.yaml
+++ b/helm/korifi/controllers/manifests.yaml
@@ -109,6 +109,8 @@ webhooks:
           - cftasks
           - cforgs
           - cfspaces
+          - cfserviceofferings
+          - cfserviceplans
     sideEffects: None
   - admissionReviewVersions:
       - v1

--- a/helm/korifi/migrations/post-upgrade-set-migrated-by.yaml
+++ b/helm/korifi/migrations/post-upgrade-set-migrated-by.yaml
@@ -81,7 +81,7 @@ spec:
           }
 
           main() {
-            set-migrated-by-label cfapps cfdomains cfroutes cfbuilds cforgs cfspaces
+            set-migrated-by-label cfapps cfdomains cfroutes cfbuilds cforgs cfspaces cfserviceofferings cfserviceplans cfservicebrokers
           }
 
           main

--- a/tests/helpers/broker/deleter.go
+++ b/tests/helpers/broker/deleter.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
+	"code.cloudfoundry.org/korifi/tools"
 	"code.cloudfoundry.org/korifi/tools/k8s"
 	"github.com/BooleanCat/go-functional/v2/it/itx"
 	. "github.com/onsi/ginkgo/v2" //lint:ignore ST1001 this is a test file
@@ -62,7 +63,7 @@ func (d *Deleter) ForBrokerGUID(brokerGUID string) *Deleter {
 
 func (d *Deleter) ForBrokerName(brokerName string) *Deleter {
 	d.catalogLabelSelector = client.MatchingLabels{
-		korifiv1alpha1.RelServiceBrokerNameLabel: brokerName,
+		korifiv1alpha1.RelServiceBrokerNameLabel: tools.EncodeValueToSha224(brokerName),
 	}
 
 	d.deleteCFServiceBroker = func() {


### PR DESCRIPTION
## Is there a related GitHub Issue?
#3988
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Filter offering and plans via label selector when listing

* `RelServiceBrokerNameLabel` and `RelServiceOfferingNameLabel` are now
  populated with their respective sha224 value (as the broker/offering
  name could not be a valid label value)
* `cfservicebrokers`, `cfserviceplans` and `cfserviceofferings` are
  "touched" during migration to ensure proper values for the new/rel labels
<!-- _Please describe the change here._ -->

