### PR TITLE
Use label selectors to filter processes

### DIFF
--- a/api/actions/manifest/state_collector.go
+++ b/api/actions/manifest/state_collector.go
@@ -92,8 +92,8 @@ func (s StateCollector) CollectState(ctx context.Context, authInfo authorization
 func (s StateCollector) collectProcesses(ctx context.Context, authInfo authorization.Info, appGUID, spaceGUID string) (map[string]repositories.ProcessRecord, error) {
 	existingProcesses := map[string]repositories.ProcessRecord{}
 	procs, err := s.processRepo.ListProcesses(ctx, authInfo, repositories.ListProcessesMessage{
-		AppGUIDs:  []string{appGUID},
-		SpaceGUID: spaceGUID,
+		AppGUIDs:   []string{appGUID},
+		SpaceGUIDs: []string{spaceGUID},
 	})
 	if err != nil {
 		return nil, err

--- a/api/actions/manifest/state_collector_test.go
+++ b/api/actions/manifest/state_collector_test.go
@@ -98,7 +98,7 @@ var _ = Describe("StateCollector", func() {
 			Expect(processRepo.ListProcessesCallCount()).To(Equal(1))
 			_, _, listMsg := processRepo.ListProcessesArgsForCall(0)
 			Expect(listMsg.AppGUIDs).To(ConsistOf("app-guid"))
-			Expect(listMsg.SpaceGUID).To(Equal("space-guid"))
+			Expect(listMsg.SpaceGUIDs).To(ConsistOf("space-guid"))
 		})
 
 		It("returns an empty map of processes", func() {

--- a/api/handlers/app.go
+++ b/api/handlers/app.go
@@ -334,8 +334,8 @@ func (h *App) getProcesses(r *http.Request) (*routing.Response, error) {
 	}
 
 	fetchProcessesForAppMessage := repositories.ListProcessesMessage{
-		AppGUIDs:  []string{appGUID},
-		SpaceGUID: app.SpaceGUID,
+		AppGUIDs:   []string{appGUID},
+		SpaceGUIDs: []string{app.SpaceGUID},
 	}
 
 	processList, err := h.processRepo.ListProcesses(r.Context(), authInfo, fetchProcessesForAppMessage)
@@ -383,8 +383,8 @@ func (h *App) scaleProcess(r *http.Request) (*routing.Response, error) {
 	}
 
 	appProcesses, err := h.processRepo.ListProcesses(r.Context(), authInfo, repositories.ListProcessesMessage{
-		AppGUIDs:  []string{app.GUID},
-		SpaceGUID: app.SpaceGUID,
+		AppGUIDs:   []string{app.GUID},
+		SpaceGUIDs: []string{app.SpaceGUID},
 	})
 	if err != nil {
 		return nil, apierrors.LogAndReturn(logger, err, "failed to list processes for app")
@@ -561,7 +561,7 @@ func (h *App) getProcess(r *http.Request) (*routing.Response, error) {
 	process, err := h.getSingleProcess(r.Context(), authInfo, repositories.ListProcessesMessage{
 		AppGUIDs:     []string{appGUID},
 		ProcessTypes: []string{processType},
-		SpaceGUID:    app.SpaceGUID,
+		SpaceGUIDs:   []string{app.SpaceGUID},
 	})
 	if err != nil {
 		return nil, apierrors.LogAndReturn(logger, err, "Failed to get process", "AppGUID", appGUID)
@@ -594,7 +594,7 @@ func (h *App) getProcessStats(r *http.Request) (*routing.Response, error) {
 	process, err := h.getSingleProcess(r.Context(), authInfo, repositories.ListProcessesMessage{
 		AppGUIDs:     []string{appGUID},
 		ProcessTypes: []string{processType},
-		SpaceGUID:    app.SpaceGUID,
+		SpaceGUIDs:   []string{app.SpaceGUID},
 	})
 	if err != nil {
 		return nil, apierrors.LogAndReturn(logger, err, "failed to get process")
@@ -698,8 +698,8 @@ func (h *App) restartInstance(r *http.Request) (*routing.Response, error) {
 		return nil, apierrors.LogAndReturn(logger, apierrors.NewNotFoundError(nil, repositories.AppResourceType), "Failed to fetch app from Kubernetes", "AppGUID", appGUID)
 	}
 	appProcesses, err := h.processRepo.ListProcesses(r.Context(), authInfo, repositories.ListProcessesMessage{
-		AppGUIDs:  []string{appGUID},
-		SpaceGUID: app.SpaceGUID,
+		AppGUIDs:   []string{appGUID},
+		SpaceGUIDs: []string{app.SpaceGUID},
 	})
 	if err != nil {
 		return nil, apierrors.LogAndReturn(logger, err, "failed to list processes for app")

--- a/api/handlers/app_test.go
+++ b/api/handlers/app_test.go
@@ -1059,8 +1059,8 @@ var _ = Describe("App", func() {
 			_, actualAuthInfo, listMsg := processRepo.ListProcessesArgsForCall(0)
 			Expect(actualAuthInfo).To(Equal(authInfo))
 			Expect(listMsg).To(Equal(repositories.ListProcessesMessage{
-				AppGUIDs:  []string{appGUID},
-				SpaceGUID: spaceGUID,
+				AppGUIDs:   []string{appGUID},
+				SpaceGUIDs: []string{spaceGUID},
 			}))
 		})
 

--- a/controllers/api/v1alpha1/cfprocess_webhook.go
+++ b/controllers/api/v1alpha1/cfprocess_webhook.go
@@ -55,25 +55,11 @@ func (d *CFProcessDefaulter) Default(ctx context.Context, obj runtime.Object) er
 	process := obj.(*CFProcess)
 	cfprocesslog.V(1).Info("mutating CFProcess webhook handler", "name", process.Name)
 
-	d.defaultLabels(process)
 	d.defaultResources(process)
 	d.defaultInstances(process)
 	d.defaultHealthCheck(process)
 
 	return nil
-}
-
-func (d *CFProcessDefaulter) defaultLabels(process *CFProcess) {
-	processLabels := process.GetLabels()
-
-	if processLabels == nil {
-		processLabels = make(map[string]string)
-	}
-
-	processLabels[CFProcessTypeLabelKey] = process.Spec.ProcessType
-	processLabels[CFAppGUIDLabelKey] = process.Spec.AppRef.Name
-
-	process.SetLabels(processLabels)
 }
 
 func (d *CFProcessDefaulter) defaultResources(process *CFProcess) {

--- a/controllers/api/v1alpha1/cfprocess_webhook_test.go
+++ b/controllers/api/v1alpha1/cfprocess_webhook_test.go
@@ -43,17 +43,6 @@ var _ = Describe("CFProcessMutatingWebhook", func() {
 		Expect(adminClient.Create(context.Background(), cfProcess)).To(Succeed())
 	})
 
-	Describe("labels", func() {
-		It("adds the labels with details about the process and the app", func() {
-			Expect(cfProcess.Labels).To(HaveKeyWithValue(korifiv1alpha1.CFProcessTypeLabelKey, "test-process-type"))
-			Expect(cfProcess.Labels).To(HaveKeyWithValue(korifiv1alpha1.CFAppGUIDLabelKey, cfAppGUID))
-		})
-
-		It("preserves all other labels", func() {
-			Expect(cfProcess.Labels).To(HaveKeyWithValue("foo", "bar"))
-		})
-	})
-
 	Describe("memory, disk and timeout", func() {
 		It("sets the configured default memory, disk and timeout", func() {
 			Expect(cfProcess.Spec.MemoryMB).To(BeEquivalentTo(defaultMemoryMB))

--- a/controllers/webhooks/common_labels/suite_test.go
+++ b/controllers/webhooks/common_labels/suite_test.go
@@ -11,11 +11,8 @@ import (
 	"code.cloudfoundry.org/korifi/controllers/webhooks/common_labels"
 	"code.cloudfoundry.org/korifi/tests/helpers"
 
-	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -29,7 +26,6 @@ var (
 	stopClientCache context.CancelFunc
 	testEnv         *envtest.Environment
 	adminClient     client.Client
-	namespace       string
 )
 
 func TestWorkloadsWebhooks(t *testing.T) {
@@ -73,12 +69,6 @@ var _ = BeforeSuite(func() {
 	stopManager = helpers.StartK8sManager(k8sManager)
 
 	ctx = context.Background()
-	namespace = uuid.NewString()
-	Expect(adminClient.Create(ctx, &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: namespace,
-		},
-	})).To(Succeed())
 })
 
 var _ = AfterSuite(func() {

--- a/controllers/webhooks/common_labels/webhook.go
+++ b/controllers/webhooks/common_labels/webhook.go
@@ -1,6 +1,6 @@
 package common_labels
 
-//+kubebuilder:webhook:path=/mutate-korifi-cloudfoundry-org-v1alpha1-controllers-common-labels,mutating=true,failurePolicy=fail,sideEffects=None,groups=korifi.cloudfoundry.org,resources=cfapps;cfbuilds;cfdomains;cforgs;cfpackages;cfprocesss;cfroutes;cfsecuritygroups;cfservicebindings;cfservicebrokers;cfserviceinstances;cfservices;cfservices;cfspaces;cftasks,verbs=create;update,versions=v1alpha1,name=mcfcommonlabels.korifi.cloudfoundry.org,admissionReviewVersions={v1,v1beta1}
+//+kubebuilder:webhook:path=/mutate-korifi-cloudfoundry-org-v1alpha1-controllers-common-labels,mutating=true,failurePolicy=fail,sideEffects=None,groups=korifi.cloudfoundry.org,resources=cfapps;cfbuilds;cfdomains;cforgs;cfpackages;cfprocesses;cfroutes;cfsecuritygroups;cfservicebindings;cfservicebrokers;cfserviceinstances;cfserviceofferings;cfserviceplans;cfspaces;cftasks,verbs=create;update,versions=v1alpha1,name=mcfcommonlabels.korifi.cloudfoundry.org,admissionReviewVersions={v1,v1beta1}
 
 import (
 	"context"

--- a/controllers/webhooks/common_labels/webhook_test.go
+++ b/controllers/webhooks/common_labels/webhook_test.go
@@ -8,82 +8,178 @@ import (
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gstruct"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("CommonLabelsWebhook", func() {
-	var route *korifiv1alpha1.CFRoute
-
-	BeforeEach(func() {
-		route = &korifiv1alpha1.CFRoute{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      uuid.NewString(),
-				Namespace: namespace,
+	Describe("CFApp", test(&korifiv1alpha1.CFApp{
+		Spec: korifiv1alpha1.CFAppSpec{
+			DisplayName:  "cfapp",
+			DesiredState: "STOPPED",
+			Lifecycle: korifiv1alpha1.Lifecycle{
+				Type: "buildpack",
 			},
-			Spec: korifiv1alpha1.CFRouteSpec{
-				Host: "example",
-				Path: "/example",
-				DomainRef: corev1.ObjectReference{
-					Name: "example.com",
-				},
+		},
+	}))
+
+	Describe("CFBuild", test(&korifiv1alpha1.CFBuild{
+		Spec: korifiv1alpha1.CFBuildSpec{
+			Lifecycle: korifiv1alpha1.Lifecycle{
+				Type: "buildpack",
 			},
-		}
-		Expect(adminClient.Create(ctx, route)).To(Succeed())
-	})
+		},
+	}))
 
-	It("sets the created_at label", func() {
-		Eventually(func(g Gomega) {
-			g.Expect(adminClient.Get(ctx, client.ObjectKeyFromObject(route), route)).To(Succeed())
-			g.Expect(route.Labels).To(MatchKeys(IgnoreExtras, Keys{
-				korifiv1alpha1.CreatedAtLabelKey: Equal(route.CreationTimestamp.Format(korifiv1alpha1.LabelDateFormat)),
-			}))
-		}).Should(Succeed())
-	})
+	Describe("CFDomain", test(&korifiv1alpha1.CFDomain{
+		Spec: korifiv1alpha1.CFDomainSpec{
+			Name: "example.com",
+		},
+	}))
 
-	It("does not set the updated_at label", func() {
-		Consistently(func(g Gomega) {
-			g.Expect(adminClient.Get(ctx, client.ObjectKeyFromObject(route), route)).To(Succeed())
-			g.Expect(route.Labels).NotTo(HaveKey(korifiv1alpha1.UpdatedAtLabelKey))
-		}).Should(Succeed())
-	})
+	Describe("CFOrg", test(&korifiv1alpha1.CFOrg{
+		Spec: korifiv1alpha1.CFOrgSpec{
+			DisplayName: "example-org",
+		},
+	}))
 
-	When("the object is updated", func() {
+	Describe("CFPackage", test(&korifiv1alpha1.CFPackage{
+		Spec: korifiv1alpha1.CFPackageSpec{
+			Type: "bits",
+		},
+	}))
+
+	Describe("CFProcess", test(&korifiv1alpha1.CFProcess{}))
+
+	Describe("CFRoute", test(&korifiv1alpha1.CFRoute{
+		Spec: korifiv1alpha1.CFRouteSpec{
+			Host: "example",
+			Path: "/example",
+			DomainRef: corev1.ObjectReference{
+				Name: "example.com",
+			},
+		},
+	}))
+
+	Describe("CFSecurityGroup", test(&korifiv1alpha1.CFSecurityGroup{
+		Spec: korifiv1alpha1.CFSecurityGroupSpec{
+			Rules: []korifiv1alpha1.SecurityGroupRule{},
+		},
+	}))
+
+	Describe("CFServiceBinding", test(&korifiv1alpha1.CFServiceBinding{
+		Spec: korifiv1alpha1.CFServiceBindingSpec{
+			Type: "key",
+		},
+	}))
+
+	Describe("CFServiceBroker", test(&korifiv1alpha1.CFServiceBroker{}))
+
+	Describe("CFServiceInstance", test(&korifiv1alpha1.CFServiceInstance{
+		Spec: korifiv1alpha1.CFServiceInstanceSpec{
+			Type: "user-provided",
+		},
+	}))
+
+	Describe("CFServiceOffering", test(&korifiv1alpha1.CFServiceOffering{}))
+
+	Describe("CFServicePlan", test(&korifiv1alpha1.CFServicePlan{
+		Spec: korifiv1alpha1.CFServicePlanSpec{
+			Visibility: korifiv1alpha1.ServicePlanVisibility{
+				Type: korifiv1alpha1.PublicServicePlanVisibilityType,
+			},
+		},
+	}))
+
+	Describe("CFSpace", test(&korifiv1alpha1.CFSpace{
+		Spec: korifiv1alpha1.CFSpaceSpec{
+			DisplayName: "asdf",
+		},
+	}))
+
+	Describe("CFTask", test(&korifiv1alpha1.CFTask{}))
+})
+
+func test(testObj client.Object) func() {
+	GinkgoHelper()
+
+	return func() {
+		var obj client.Object
+
 		BeforeEach(func() {
-			time.Sleep(1100 * time.Millisecond)
-			Expect(k8s.PatchResource(ctx, adminClient, route, func() {
-				route.Labels["foo"] = "bar"
+			obj = testObj.DeepCopyObject().(client.Object)
+			namespace := uuid.NewString()
+			Expect(adminClient.Create(ctx, &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: namespace,
+				},
 			})).To(Succeed())
+
+			obj.SetName(uuid.NewString())
+			obj.SetNamespace(namespace)
+			Expect(adminClient.Create(ctx, obj)).To(Succeed())
 		})
 
-		It("sets the updated_at label", func() {
+		It("sets the created_at label", func() {
 			Eventually(func(g Gomega) {
-				g.Expect(adminClient.Get(ctx, client.ObjectKeyFromObject(route), route)).To(Succeed())
-				g.Expect(route.Labels).To(HaveKey(korifiv1alpha1.UpdatedAtLabelKey))
-
-				updatedAt, err := time.Parse(korifiv1alpha1.LabelDateFormat, route.Labels[korifiv1alpha1.UpdatedAtLabelKey])
-				Expect(err).NotTo(HaveOccurred())
-				g.Expect(updatedAt).To(BeTemporally(">", route.CreationTimestamp.Time))
+				g.Expect(adminClient.Get(ctx, client.ObjectKeyFromObject(obj), obj)).To(Succeed())
+				g.Expect(obj.GetLabels()).To(HaveKey(korifiv1alpha1.CreatedAtLabelKey))
+				g.Expect(parseTime(obj.GetLabels()[korifiv1alpha1.CreatedAtLabelKey])).To(
+					BeTemporally("~", obj.GetCreationTimestamp().Time),
+				)
 			}).Should(Succeed())
 		})
 
-		When("the object has no created_at label (it has been created before this webhook has been applied)", func() {
+		It("does not set the updated_at label", func() {
+			Consistently(func(g Gomega) {
+				g.Expect(adminClient.Get(ctx, client.ObjectKeyFromObject(obj), obj)).To(Succeed())
+				g.Expect(obj.GetLabels()).NotTo(HaveKey(korifiv1alpha1.UpdatedAtLabelKey))
+			}).Should(Succeed())
+		})
+
+		When("the object is updated", func() {
 			BeforeEach(func() {
-				Expect(k8s.PatchResource(ctx, adminClient, route, func() {
-					delete(route.Labels, korifiv1alpha1.CreatedAtLabelKey)
+				time.Sleep(1100 * time.Millisecond)
+				Expect(k8s.PatchResource(ctx, adminClient, obj, func() {
+					obj.GetLabels()["foo"] = "bar"
 				})).To(Succeed())
 			})
 
-			It("sets the created_at label", func() {
+			It("sets the updated_at label", func() {
 				Eventually(func(g Gomega) {
-					g.Expect(adminClient.Get(ctx, client.ObjectKeyFromObject(route), route)).To(Succeed())
-					g.Expect(route.Labels).To(MatchKeys(IgnoreExtras, Keys{
-						korifiv1alpha1.CreatedAtLabelKey: Equal(route.CreationTimestamp.Format(korifiv1alpha1.LabelDateFormat)),
-					}))
+					g.Expect(adminClient.Get(ctx, client.ObjectKeyFromObject(obj), obj)).To(Succeed())
+
+					g.Expect(obj.GetLabels()).To(HaveKey(korifiv1alpha1.UpdatedAtLabelKey))
+					g.Expect(parseTime(obj.GetLabels()[korifiv1alpha1.UpdatedAtLabelKey])).To(
+						BeTemporally(">", obj.GetCreationTimestamp().Time),
+					)
 				}).Should(Succeed())
 			})
+
+			When("the object has no created_at label (it has been created before this webhook has been applied)", func() {
+				BeforeEach(func() {
+					Expect(k8s.PatchResource(ctx, adminClient, obj, func() {
+						delete(obj.GetLabels(), korifiv1alpha1.CreatedAtLabelKey)
+					})).To(Succeed())
+				})
+
+				It("sets the created_at label", func() {
+					Eventually(func(g Gomega) {
+						g.Expect(adminClient.Get(ctx, client.ObjectKeyFromObject(obj), obj)).To(Succeed())
+						g.Expect(obj.GetLabels()).To(HaveKey(korifiv1alpha1.CreatedAtLabelKey))
+						g.Expect(parseTime(obj.GetLabels()[korifiv1alpha1.CreatedAtLabelKey])).To(
+							BeTemporally("~", obj.GetCreationTimestamp().Time),
+						)
+					}).Should(Succeed())
+				})
+			})
 		})
-	})
-})
+	}
+}
+
+func parseTime(s string) time.Time {
+	t, err := time.Parse(korifiv1alpha1.LabelDateFormat, s)
+	Expect(err).NotTo(HaveOccurred())
+	return t
+}

--- a/controllers/webhooks/label_indexer/webhook.go
+++ b/controllers/webhooks/label_indexer/webhook.go
@@ -65,6 +65,8 @@ func NewWebhook() *LabelIndexerWebhook {
 			},
 			"CFProcess": {
 				LabelRule{Label: korifiv1alpha1.SpaceGUIDKey, IndexingFunc: Unquote(JSONValue("$.metadata.namespace"))},
+				LabelRule{Label: korifiv1alpha1.CFAppGUIDLabelKey, IndexingFunc: Unquote(JSONValue("$.spec.appRef.name"))},
+				LabelRule{Label: korifiv1alpha1.CFProcessTypeLabelKey, IndexingFunc: Unquote(JSONValue("$.spec.processType"))},
 			},
 			"CFServiceInstance": {
 				LabelRule{Label: korifiv1alpha1.SpaceGUIDKey, IndexingFunc: Unquote(JSONValue("$.metadata.namespace"))},

--- a/controllers/webhooks/label_indexer/webhook_test.go
+++ b/controllers/webhooks/label_indexer/webhook_test.go
@@ -238,6 +238,10 @@ var _ = Describe("LabelIndexerWebhook", func() {
 					Name:      uuid.NewString(),
 					Namespace: namespace,
 				},
+				Spec: korifiv1alpha1.CFProcessSpec{
+					AppRef:      corev1.LocalObjectReference{Name: uuid.NewString()},
+					ProcessType: "web",
+				},
 			}
 		})
 
@@ -249,7 +253,9 @@ var _ = Describe("LabelIndexerWebhook", func() {
 			Eventually(func(g Gomega) {
 				g.Expect(adminClient.Get(ctx, client.ObjectKeyFromObject(process), process)).To(Succeed())
 				g.Expect(process.Labels).To(MatchKeys(IgnoreExtras, Keys{
-					korifiv1alpha1.SpaceGUIDKey: Equal(process.Namespace),
+					korifiv1alpha1.SpaceGUIDKey:          Equal(process.Namespace),
+					korifiv1alpha1.CFAppGUIDLabelKey:     Equal(process.Spec.AppRef.Name),
+					korifiv1alpha1.CFProcessTypeLabelKey: Equal(process.Spec.ProcessType),
 				}))
 			}).Should(Succeed())
 		})

--- a/helm/korifi/controllers/manifests.yaml
+++ b/helm/korifi/controllers/manifests.yaml
@@ -75,14 +75,14 @@ webhooks:
           - cfdomains
           - cforgs
           - cfpackages
-          - cfprocesss
+          - cfprocesses
           - cfroutes
           - cfsecuritygroups
           - cfservicebindings
           - cfservicebrokers
           - cfserviceinstances
-          - cfservices
-          - cfservices
+          - cfserviceofferings
+          - cfserviceplans
           - cfspaces
           - cftasks
     sideEffects: None


### PR DESCRIPTION
## Is there a related GitHub Issue?
#3988

## What is this change about?
Usee label selectors to filter cfprocesses on the server side when listing

Also:
- The process can be filtered by multiple space guids, so fix that
- Move the appGUIS and processType labels to the label indexer webhook
- Fix the common_labels webhook kubebuilder annotation and added tests
  for each type of resource
