### PR TITLE
Do not set index labels on Korifi resources in repo tests

### DIFF
--- a/api/repositories/build_repository_test.go
+++ b/api/repositories/build_repository_test.go
@@ -46,11 +46,6 @@ var _ = Describe("BuildRepository", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      uuid.NewString(),
 				Namespace: cfSpace.Name,
-				Labels: map[string]string{
-					korifiv1alpha1.SpaceGUIDKey:          cfSpace.Name,
-					korifiv1alpha1.CFAppGUIDLabelKey:     appGUID,
-					korifiv1alpha1.CFPackageGUIDLabelKey: packageGUID,
-				},
 			},
 			Spec: korifiv1alpha1.CFBuildSpec{
 				PackageRef: corev1.LocalObjectReference{
@@ -164,9 +159,6 @@ var _ = Describe("BuildRepository", func() {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      build.Name,
 							Namespace: anotherSpace.Name,
-							Labels: map[string]string{
-								korifiv1alpha1.SpaceGUIDKey: anotherSpace.Name,
-							},
 						},
 						Spec: korifiv1alpha1.CFBuildSpec{
 							Lifecycle: korifiv1alpha1.Lifecycle{
@@ -225,10 +217,6 @@ var _ = Describe("BuildRepository", func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      uuid.NewString(),
 						Namespace: cfSpace.Name,
-						Labels: map[string]string{
-							korifiv1alpha1.SpaceGUIDKey:      cfSpace.Name,
-							korifiv1alpha1.CFAppGUIDLabelKey: appGUID,
-						},
 					},
 					Spec: korifiv1alpha1.CFBuildSpec{
 						AppRef: corev1.LocalObjectReference{
@@ -398,11 +386,6 @@ var _ = Describe("BuildRepository", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      uuid.NewString(),
 					Namespace: cfSpace.Name,
-					Labels: map[string]string{
-						korifiv1alpha1.SpaceGUIDKey:          cfSpace.Name,
-						korifiv1alpha1.CFAppGUIDLabelKey:     app2GUID,
-						korifiv1alpha1.CFPackageGUIDLabelKey: package2GUID,
-					},
 				},
 				Spec: korifiv1alpha1.CFBuildSpec{
 					PackageRef: corev1.LocalObjectReference{

--- a/api/repositories/domain_repository_test.go
+++ b/api/repositories/domain_repository_test.go
@@ -37,9 +37,6 @@ var _ = Describe("DomainRepository", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      domainGUID,
 				Namespace: rootNamespace,
-				Labels: map[string]string{
-					korifiv1alpha1.CFEncodedDomainNameLabelKey: tools.EncodeValueToSha224(domainName),
-				},
 			},
 			Spec: korifiv1alpha1.CFDomainSpec{
 				Name: domainName,

--- a/api/repositories/droplet_repository_test.go
+++ b/api/repositories/droplet_repository_test.go
@@ -45,11 +45,8 @@ var _ = Describe("DropletRepository", func() {
 				Name:      uuid.NewString(),
 				Namespace: space.Name,
 				Labels: map[string]string{
-					"key1":                               "val1",
-					"key2":                               "val2",
-					korifiv1alpha1.CFPackageGUIDLabelKey: packageGUID,
-					korifiv1alpha1.CFAppGUIDLabelKey:     appGUID,
-					korifiv1alpha1.SpaceGUIDKey:          space.Name,
+					"key1": "val1",
+					"key2": "val2",
 				},
 				Annotations: map[string]string{
 					"key1": "val1",
@@ -198,11 +195,6 @@ var _ = Describe("DropletRepository", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      uuid.NewString(),
 					Namespace: build.Namespace,
-					Labels: map[string]string{
-						korifiv1alpha1.CFPackageGUIDLabelKey: uuid.NewString(),
-						korifiv1alpha1.CFAppGUIDLabelKey:     uuid.NewString(),
-						korifiv1alpha1.SpaceGUIDKey:          build.Namespace,
-					},
 				},
 				Spec: korifiv1alpha1.CFBuildSpec{
 					Lifecycle: korifiv1alpha1.Lifecycle{

--- a/api/repositories/package_repository_test.go
+++ b/api/repositories/package_repository_test.go
@@ -491,9 +491,6 @@ var _ = Describe("PackageRepository", func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      package1GUID,
 						Namespace: space.Name,
-						Labels: map[string]string{
-							korifiv1alpha1.SpaceGUIDKey: space.Name,
-						},
 					},
 					Spec: korifiv1alpha1.CFPackageSpec{
 						Type: "bits",
@@ -508,9 +505,6 @@ var _ = Describe("PackageRepository", func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      package2GUID,
 						Namespace: space2.Name,
-						Labels: map[string]string{
-							korifiv1alpha1.SpaceGUIDKey: space2.Name,
-						},
 					},
 					Spec: korifiv1alpha1.CFPackageSpec{
 						Type: "bits",
@@ -535,9 +529,6 @@ var _ = Describe("PackageRepository", func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      noPermissionsPackageGUID,
 						Namespace: noPermissionsSpace.Name,
-						Labels: map[string]string{
-							korifiv1alpha1.SpaceGUIDKey: noPermissionsSpace.Name,
-						},
 					},
 					Spec: korifiv1alpha1.CFPackageSpec{
 						Type: "bits",

--- a/api/repositories/process_repository_test.go
+++ b/api/repositories/process_repository_test.go
@@ -40,11 +40,6 @@ var _ = Describe("ProcessRepo", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      uuid.NewString(),
 				Namespace: space.Name,
-				Labels: map[string]string{
-					korifiv1alpha1.CFAppGUIDLabelKey:     appGUID,
-					korifiv1alpha1.SpaceGUIDKey:          space.Name,
-					korifiv1alpha1.CFProcessTypeLabelKey: "web",
-				},
 			},
 			Spec: korifiv1alpha1.CFProcessSpec{
 				AppRef: corev1.LocalObjectReference{
@@ -167,10 +162,6 @@ var _ = Describe("ProcessRepo", func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      cfProcess.Name,
 						Namespace: anotherNamespace.Name,
-						Labels: map[string]string{
-							korifiv1alpha1.CFAppGUIDLabelKey: app2GUID,
-							korifiv1alpha1.SpaceGUIDKey:      space.Name,
-						},
 					},
 					Spec: korifiv1alpha1.CFProcessSpec{
 						AppRef: corev1.LocalObjectReference{
@@ -217,11 +208,6 @@ var _ = Describe("ProcessRepo", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      uuid.NewString(),
 					Namespace: space2.Name,
-					Labels: map[string]string{
-						korifiv1alpha1.CFAppGUIDLabelKey:     appGUID,
-						korifiv1alpha1.SpaceGUIDKey:          space2.Name,
-						korifiv1alpha1.CFProcessTypeLabelKey: "web",
-					},
 				},
 				Spec: korifiv1alpha1.CFProcessSpec{
 					AppRef: corev1.LocalObjectReference{

--- a/api/repositories/route_repository_test.go
+++ b/api/repositories/route_repository_test.go
@@ -67,9 +67,6 @@ var _ = Describe("RouteRepository", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      routeGUID,
 					Namespace: space.Name,
-					Labels: map[string]string{
-						korifiv1alpha1.SpaceGUIDKey: space.Name,
-					},
 				},
 				Spec: korifiv1alpha1.CFRouteSpec{
 					Host:     "my-subdomain-1",
@@ -215,9 +212,6 @@ var _ = Describe("RouteRepository", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      routeGUID,
 					Namespace: space.Name,
-					Labels: map[string]string{
-						korifiv1alpha1.SpaceGUIDKey: space.Name,
-					},
 				},
 				Spec: korifiv1alpha1.CFRouteSpec{
 					Host:     "my-subdomain-1-a",
@@ -335,10 +329,6 @@ var _ = Describe("RouteRepository", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      routeGUID,
 					Namespace: space.Name,
-					Labels: map[string]string{
-						korifiv1alpha1.SpaceGUIDKey:                            space.Name,
-						korifiv1alpha1.DestinationAppGUIDLabelPrefix + appGUID: "",
-					},
 				},
 				Spec: korifiv1alpha1.CFRouteSpec{
 					Host:     "my-subdomain-1",
@@ -460,9 +450,6 @@ var _ = Describe("RouteRepository", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      routeGUID,
 					Namespace: space.Name,
-					Labels: map[string]string{
-						korifiv1alpha1.SpaceGUIDKey: space.Name,
-					},
 				},
 				Spec: korifiv1alpha1.CFRouteSpec{
 					Host:     "my-subdomain-1",
@@ -537,9 +524,6 @@ var _ = Describe("RouteRepository", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      uuid.NewString(),
 					Namespace: space.Name,
-					Labels: map[string]string{
-						korifiv1alpha1.SpaceGUIDKey: space.Name,
-					},
 				},
 				Spec: korifiv1alpha1.CFRouteSpec{
 					Host:     "my-subdomain-1",
@@ -570,10 +554,6 @@ var _ = Describe("RouteRepository", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      uuid.NewString(),
 					Namespace: space.Name,
-					Labels: map[string]string{
-						korifiv1alpha1.SpaceGUIDKey:              space.Name,
-						korifiv1alpha1.CFRouteIsUnmappedLabelKey: "true",
-					},
 				},
 				Spec: korifiv1alpha1.CFRouteSpec{
 					Host:     "my-subdomain-1",
@@ -663,22 +643,6 @@ var _ = Describe("RouteRepository", func() {
 					var err error
 					existingRecord, err = routeRepo.CreateRoute(ctx, authInfo, createRouteMessage)
 					Expect(err).NotTo(HaveOccurred())
-
-					route := &korifiv1alpha1.CFRoute{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      existingRecord.GUID,
-							Namespace: existingRecord.SpaceGUID,
-						},
-					}
-					Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(route), route)).To(Succeed())
-					Expect(k8s.Patch(ctx, k8sClient, route, func() {
-						route.Labels = map[string]string{
-							korifiv1alpha1.SpaceGUIDKey:         existingRecord.SpaceGUID,
-							korifiv1alpha1.CFDomainGUIDLabelKey: existingRecord.Domain.GUID,
-							korifiv1alpha1.CFRouteHostLabelKey:  routeHost,
-							korifiv1alpha1.CFRoutePathLabelKey:  tools.EncodeValueToSha224(routePath),
-						}
-					})).To(Succeed())
 				})
 
 				It("doesn't create a new route", func() {
@@ -726,9 +690,6 @@ var _ = Describe("RouteRepository", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      routeGUID,
 					Namespace: space.Name,
-					Labels: map[string]string{
-						korifiv1alpha1.SpaceGUIDKey: space.Name,
-					},
 				},
 				Spec: korifiv1alpha1.CFRouteSpec{
 					Host: routeHost,
@@ -1020,9 +981,6 @@ var _ = Describe("RouteRepository", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      routeGUID,
 					Namespace: space.Name,
-					Labels: map[string]string{
-						korifiv1alpha1.SpaceGUIDKey: space.Name,
-					},
 				},
 				Spec: korifiv1alpha1.CFRouteSpec{
 					Host: routeHost,
@@ -1104,9 +1062,6 @@ var _ = Describe("RouteRepository", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      routeGUID,
 					Namespace: space.Name,
-					Labels: map[string]string{
-						korifiv1alpha1.SpaceGUIDKey: space.Name,
-					},
 				},
 				Spec: korifiv1alpha1.CFRouteSpec{
 					Host:     "my-subdomain-1-a",
@@ -1306,9 +1261,6 @@ var _ = Describe("RouteRepository", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      routeGUID,
 					Namespace: space.Name,
-					Labels: map[string]string{
-						korifiv1alpha1.SpaceGUIDKey: space.Name,
-					},
 				},
 				Spec: korifiv1alpha1.CFRouteSpec{
 					Host:     "my-subdomain-1",

--- a/api/repositories/service_binding_repository_test.go
+++ b/api/repositories/service_binding_repository_test.go
@@ -116,9 +116,6 @@ var _ = Describe("ServiceBindingRepo", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      uuid.NewString(),
 					Namespace: space.Name,
-					Labels: map[string]string{
-						korifiv1alpha1.SpaceGUIDKey: space.Name,
-					},
 				},
 				Spec: korifiv1alpha1.CFServiceBindingSpec{
 					Service: corev1.ObjectReference{
@@ -201,9 +198,6 @@ var _ = Describe("ServiceBindingRepo", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      uuid.NewString(),
 					Namespace: space.Name,
-					Labels: map[string]string{
-						korifiv1alpha1.SpaceGUIDKey: space.Name,
-					},
 				},
 				Spec: korifiv1alpha1.CFServiceBindingSpec{
 					Type: korifiv1alpha1.CFServiceBindingTypeApp,
@@ -467,9 +461,6 @@ var _ = Describe("ServiceBindingRepo", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      uuid.NewString(),
 					Namespace: space.Name,
-					Labels: map[string]string{
-						korifiv1alpha1.SpaceGUIDKey: space.Name,
-					},
 				},
 				Spec: korifiv1alpha1.CFServiceBindingSpec{
 					Service: corev1.ObjectReference{
@@ -791,9 +782,6 @@ var _ = Describe("ServiceBindingRepo", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      serviceBindingGUID,
 					Namespace: space.Name,
-					Labels: map[string]string{
-						korifiv1alpha1.SpaceGUIDKey: space.Name,
-					},
 					Annotations: map[string]string{
 						korifiv1alpha1.ServiceInstanceTypeAnnotation: korifiv1alpha1.UserProvidedType,
 					},
@@ -934,7 +922,6 @@ var _ = Describe("ServiceBindingRepo", func() {
 					Namespace: space.Name,
 					Labels: map[string]string{
 						korifiv1alpha1.PlanGUIDLabelKey: "plan-1",
-						korifiv1alpha1.SpaceGUIDKey:     space.Name,
 					},
 				},
 				Spec: korifiv1alpha1.CFServiceBindingSpec{
@@ -961,7 +948,6 @@ var _ = Describe("ServiceBindingRepo", func() {
 					Namespace: space2.Name,
 					Labels: map[string]string{
 						korifiv1alpha1.PlanGUIDLabelKey: "plan-2",
-						korifiv1alpha1.SpaceGUIDKey:     space2.Name,
 					},
 				},
 				Spec: korifiv1alpha1.CFServiceBindingSpec{
@@ -987,7 +973,6 @@ var _ = Describe("ServiceBindingRepo", func() {
 					Namespace: space2.Name,
 					Labels: map[string]string{
 						korifiv1alpha1.PlanGUIDLabelKey: "plan-3",
-						korifiv1alpha1.SpaceGUIDKey:     space.Name,
 					},
 				},
 				Spec: korifiv1alpha1.CFServiceBindingSpec{
@@ -1010,7 +995,6 @@ var _ = Describe("ServiceBindingRepo", func() {
 					Namespace: space2.Name,
 					Labels: map[string]string{
 						korifiv1alpha1.PlanGUIDLabelKey: "plan-4",
-						korifiv1alpha1.SpaceGUIDKey:     space.Name,
 					},
 				},
 				Spec: korifiv1alpha1.CFServiceBindingSpec{
@@ -1242,9 +1226,6 @@ var _ = Describe("ServiceBindingRepo", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      serviceBindingGUID,
 					Namespace: space.Name,
-					Labels: map[string]string{
-						korifiv1alpha1.SpaceGUIDKey: space.Name,
-					},
 				},
 				Spec: korifiv1alpha1.CFServiceBindingSpec{
 					Service: corev1.ObjectReference{
@@ -1367,9 +1348,6 @@ var _ = Describe("ServiceBindingRepo", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      serviceBindingGUID,
 					Namespace: space.Name,
-					Labels: map[string]string{
-						korifiv1alpha1.SpaceGUIDKey: space.Name,
-					},
 				},
 				Spec: korifiv1alpha1.CFServiceBindingSpec{
 					Service: corev1.ObjectReference{
@@ -1435,8 +1413,7 @@ var _ = Describe("ServiceBindingRepo", func() {
 					Name:      prefixedGUID("binding"),
 					Namespace: space.Name,
 					Labels: map[string]string{
-						"foo":                       "bar",
-						korifiv1alpha1.SpaceGUIDKey: space.Name,
+						"foo": "bar",
 					},
 					Annotations: map[string]string{
 						"baz": "bat",

--- a/api/repositories/service_instance_repository_test.go
+++ b/api/repositories/service_instance_repository_test.go
@@ -710,9 +710,6 @@ var _ = Describe("ServiceInstanceRepository", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: space.Name,
 					Name:      "service-instance-1" + uuid.NewString(),
-					Labels: map[string]string{
-						korifiv1alpha1.SpaceGUIDKey: space.Name,
-					},
 				},
 				Spec: korifiv1alpha1.CFServiceInstanceSpec{
 					DisplayName: "service-instance-1",
@@ -726,9 +723,6 @@ var _ = Describe("ServiceInstanceRepository", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: space2.Name,
 					Name:      "service-instance-2" + uuid.NewString(),
-					Labels: map[string]string{
-						korifiv1alpha1.SpaceGUIDKey: space2.Name,
-					},
 				},
 				Spec: korifiv1alpha1.CFServiceInstanceSpec{
 					DisplayName: "service-instance-2",
@@ -742,9 +736,6 @@ var _ = Describe("ServiceInstanceRepository", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: space2.Name,
 					Name:      "service-instance-3" + uuid.NewString(),
-					Labels: map[string]string{
-						korifiv1alpha1.SpaceGUIDKey: space2.Name,
-					},
 				},
 				Spec: korifiv1alpha1.CFServiceInstanceSpec{
 					DisplayName: "service-instance-3",
@@ -759,9 +750,6 @@ var _ = Describe("ServiceInstanceRepository", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: space3.Name,
 					Name:      uuid.NewString(),
-					Labels: map[string]string{
-						korifiv1alpha1.SpaceGUIDKey: space3.Name,
-					},
 				},
 				Spec: korifiv1alpha1.CFServiceInstanceSpec{
 					DisplayName: uuid.NewString(),

--- a/api/repositories/service_offering_repository_test.go
+++ b/api/repositories/service_offering_repository_test.go
@@ -52,7 +52,6 @@ var _ = Describe("ServiceOfferingRepo", func() {
 			offeringGUID = uuid.NewString()
 
 			brokerGUID := uuid.NewString()
-			offeringName := uuid.NewString()
 			broker = &korifiv1alpha1.CFServiceBroker{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: rootNamespace,
@@ -62,7 +61,7 @@ var _ = Describe("ServiceOfferingRepo", func() {
 					},
 				},
 				Spec: korifiv1alpha1.CFServiceBrokerSpec{
-					Name: offeringName,
+					Name: uuid.NewString(),
 				},
 			}
 			Expect(k8sClient.Create(ctx, broker)).To(Succeed())
@@ -78,7 +77,6 @@ var _ = Describe("ServiceOfferingRepo", func() {
 					Labels: map[string]string{
 						korifiv1alpha1.RelServiceBrokerGUIDLabel: broker.Name,
 						korifiv1alpha1.RelServiceBrokerNameLabel: tools.EncodeValueToSha224(broker.Spec.Name),
-						korifiv1alpha1.CFServiceOfferingNameKey:  tools.EncodeValueToSha224(offeringName),
 						korifiv1alpha1.GUIDLabelKey:              offeringGUID,
 					},
 					Annotations: map[string]string{
@@ -191,7 +189,6 @@ var _ = Describe("ServiceOfferingRepo", func() {
 					Labels: map[string]string{
 						korifiv1alpha1.RelServiceBrokerGUIDLabel: broker.Name,
 						korifiv1alpha1.RelServiceBrokerNameLabel: tools.EncodeValueToSha224(broker.Spec.Name),
-						korifiv1alpha1.CFServiceOfferingNameKey:  tools.EncodeValueToSha224("my-offering"),
 						korifiv1alpha1.GUIDLabelKey:              offeringGUID,
 					},
 					Annotations: map[string]string{
@@ -373,10 +370,6 @@ var _ = Describe("ServiceOfferingRepo", func() {
 					Finalizers: []string{
 						korifiv1alpha1.CFServiceInstanceFinalizerName,
 					},
-					Labels: map[string]string{
-						korifiv1alpha1.SpaceGUIDKey:     space.Name,
-						korifiv1alpha1.PlanGUIDLabelKey: plan.Name,
-					},
 				},
 				Spec: korifiv1alpha1.CFServiceInstanceSpec{
 					PlanGUID: plan.Name,
@@ -389,10 +382,6 @@ var _ = Describe("ServiceOfferingRepo", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      uuid.NewString(),
 					Namespace: space.Name,
-					Labels: map[string]string{
-						korifiv1alpha1.SpaceGUIDKey:                  space.Name,
-						korifiv1alpha1.CFServiceInstanceGUIDLabelKey: instance.Name,
-					},
 					Finalizers: []string{
 						korifiv1alpha1.CFServiceBindingFinalizerName,
 					},

--- a/api/repositories/service_plan_repository_test.go
+++ b/api/repositories/service_plan_repository_test.go
@@ -66,8 +66,6 @@ var _ = Describe("ServicePlanRepo", func() {
 					korifiv1alpha1.RelServiceOfferingNameLabel: tools.EncodeValueToSha224("offering-name"),
 					korifiv1alpha1.RelServiceBrokerGUIDLabel:   "broker-guid",
 					korifiv1alpha1.GUIDLabelKey:                planGUID,
-					korifiv1alpha1.CFServicePlanNameKey:        tools.EncodeValueToSha224("my-service-plan"),
-					korifiv1alpha1.CFServicePlanAvailableKey:   "false",
 				},
 				Annotations: map[string]string{
 					"annotation": "annotation-value",
@@ -177,7 +175,7 @@ var _ = Describe("ServicePlanRepo", func() {
 					},
 				}
 				Expect(k8s.PatchResource(ctx, k8sClient, cfServicePlan, func() {
-					cfServicePlan.Labels = tools.SetMapValue(cfServicePlan.Labels, korifiv1alpha1.CFServicePlanAvailableKey, "true")
+					cfServicePlan.Spec.Visibility.Type = korifiv1alpha1.PublicServicePlanVisibilityType
 				})).To(Succeed())
 			})
 
@@ -207,8 +205,6 @@ var _ = Describe("ServicePlanRepo", func() {
 						korifiv1alpha1.RelServiceOfferingNameLabel: tools.EncodeValueToSha224("other-offering-name"),
 						korifiv1alpha1.RelServiceBrokerGUIDLabel:   "other-broker-guid",
 						korifiv1alpha1.GUIDLabelKey:                otherPlanGUID,
-						korifiv1alpha1.CFServicePlanNameKey:        tools.EncodeValueToSha224("other-plan"),
-						korifiv1alpha1.CFServicePlanAvailableKey:   "true",
 					},
 				},
 				Spec: korifiv1alpha1.CFServicePlanSpec{

--- a/api/repositories/space_repository_test.go
+++ b/api/repositories/space_repository_test.go
@@ -66,8 +66,7 @@ var _ = Describe("SpaceRepository", func() {
 
 				namespace := &corev1.Namespace{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:   cfSpace.Name,
-						Labels: map[string]string{korifiv1alpha1.CFSpaceDisplayNameKey: cfSpace.Spec.DisplayName},
+						Name: cfSpace.Name,
 					},
 				}
 				Expect(k8sClient.Create(ctx, namespace)).To(Succeed())

--- a/api/repositories/task_repository_test.go
+++ b/api/repositories/task_repository_test.go
@@ -372,9 +372,6 @@ var _ = Describe("TaskRepository", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      prefixedGUID("task1"),
 					Namespace: space.Name,
-					Labels: map[string]string{
-						korifiv1alpha1.SpaceGUIDKey: space.Name,
-					},
 				},
 				Spec: korifiv1alpha1.CFTaskSpec{
 					Command: "echo hello",
@@ -389,9 +386,6 @@ var _ = Describe("TaskRepository", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      prefixedGUID("task2"),
 					Namespace: space2.Name,
-					Labels: map[string]string{
-						korifiv1alpha1.SpaceGUIDKey: space2.Name,
-					},
 				},
 				Spec: korifiv1alpha1.CFTaskSpec{
 					Command: "echo hello",
@@ -465,9 +459,6 @@ var _ = Describe("TaskRepository", func() {
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      prefixedGUID("task21"),
 								Namespace: space2.Name,
-								Labels: map[string]string{
-									korifiv1alpha1.SpaceGUIDKey: space2.Name,
-								},
 							},
 							Spec: korifiv1alpha1.CFTaskSpec{
 								Command: "echo hello",

--- a/tests/helpers/webhooks.go
+++ b/tests/helpers/webhooks.go
@@ -5,21 +5,27 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 
+	"github.com/BooleanCat/go-functional/v2/it"
 	. "github.com/onsi/ginkgo/v2" //lint:ignore ST1001 this is a test file
 	. "github.com/onsi/gomega"    //lint:ignore ST1001 this is a test file
 	"github.com/onsi/gomega/gexec"
 )
 
-func GenerateWebhookManifest(path string) string {
+func GenerateWebhookManifest(paths ...string) string {
 	tmpDir, err := os.MkdirTemp("", "")
 	Expect(err).NotTo(HaveOccurred())
 
 	controllerGenSession, err := gexec.Start(exec.Command(
 		"controller-gen",
-		"paths="+path,
-		"webhook",
-		fmt.Sprintf("output:webhook:artifacts:config=%s", tmpDir),
+		append(
+			slices.Collect(it.Map(slices.Values(paths), func(path string) string {
+				return "paths=" + path
+			})),
+			"webhook",
+			fmt.Sprintf("output:webhook:artifacts:config=%s", tmpDir),
+		)...,
 	), GinkgoWriter, GinkgoWriter)
 
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
## Is there a related GitHub Issue?
#3988
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
* Enable the label indexer webhook in the repositories suite
* Do not set the labels form the webhook in tests, rely on the webhook
  instead
<!-- _Please describe the change here._ -->

