### PR TITLE
Perform tls validation in log cache client unless explicitly disabled

### DIFF
--- a/api/config/config.go
+++ b/api/config/config.go
@@ -12,14 +12,12 @@ import (
 )
 
 const (
-	defaultExternalProtocol           = "https"
-	OrgRole                 RoleLevel = "org"
-	SpaceRole               RoleLevel = "space"
+	OrgRole   RoleLevel = "org"
+	SpaceRole RoleLevel = "space"
 )
 
 type (
 	APIConfig struct {
-		InternalPort      int `yaml:"internalPort"`
 		IdleTimeout       int `yaml:"idleTimeout"`
 		ReadTimeout       int `yaml:"readTimeout"`
 		ReadHeaderTimeout int `yaml:"readHeaderTimeout"`
@@ -27,6 +25,9 @@ type (
 
 		ExternalFQDN string `yaml:"externalFQDN"`
 		ExternalPort int    `yaml:"externalPort"`
+
+		InternalFQDN string `yaml:"internalFQDN"`
+		InternalPort int    `yaml:"internalPort"`
 
 		ServerURL string
 
@@ -120,10 +121,7 @@ func LoadFromPath(path string) (*APIConfig, error) {
 		return nil, err
 	}
 
-	config.ServerURL, err = config.composeServerURL()
-	if err != nil {
-		return nil, err
-	}
+	config.ServerURL = fmt.Sprintf("https://%s:%d", config.ExternalFQDN, config.ExternalPort)
 
 	return &config, nil
 }
@@ -169,16 +167,6 @@ func (c *APIConfig) GetUserCertificateDuration() time.Duration {
 	}
 	d, _ := time.ParseDuration(c.UserCertificateExpirationWarningDuration)
 	return d
-}
-
-func (c *APIConfig) composeServerURL() (string, error) {
-	toReturn := defaultExternalProtocol + "://" + c.ExternalFQDN
-
-	if c.ExternalPort != 0 {
-		toReturn += ":" + fmt.Sprint(c.ExternalPort)
-	}
-
-	return toReturn, nil
 }
 
 func (c *APIConfig) GenerateK8sClientConfig(k8sClientConfig *rest.Config) *rest.Config {

--- a/api/config/config_test.go
+++ b/api/config/config_test.go
@@ -27,13 +27,16 @@ var _ = Describe("Config", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		configMap = map[string]interface{}{
-			"internalPort":      1,
 			"idleTimeout":       2,
 			"readTimeout":       3,
 			"readHeaderTimeout": 4,
 			"writeTimeout":      5,
 
-			"externalFQDN": "api.foo",
+			"externalFQDN": "api.external",
+			"externalPort": 443,
+
+			"internalFQDN": "api.internal",
+			"internalPort": 1443,
 
 			"rootNamespace":                            "root-ns",
 			"builderName":                              "my-builder",
@@ -86,13 +89,14 @@ var _ = Describe("Config", func() {
 
 	It("populates the config", func() {
 		Expect(loadErr).NotTo(HaveOccurred())
-		Expect(cfg.InternalPort).To(Equal(1))
+		Expect(cfg.InternalPort).To(Equal(1443))
 		Expect(cfg.IdleTimeout).To(Equal(2))
 		Expect(cfg.ReadTimeout).To(Equal(3))
 		Expect(cfg.ReadHeaderTimeout).To(Equal(4))
 		Expect(cfg.WriteTimeout).To(Equal(5))
-		Expect(cfg.ExternalFQDN).To(Equal("api.foo"))
-		Expect(cfg.ServerURL).To(Equal("https://api.foo"))
+		Expect(cfg.ExternalFQDN).To(Equal("api.external"))
+		Expect(cfg.InternalFQDN).To(Equal("api.internal"))
+		Expect(cfg.ServerURL).To(Equal("https://api.external:443"))
 		Expect(cfg.RootNamespace).To(Equal("root-ns"))
 		Expect(cfg.BuilderName).To(Equal("my-builder"))
 		Expect(cfg.ContainerRepositoryPrefix).To(Equal("container.registry/my-prefix"))
@@ -220,7 +224,7 @@ var _ = Describe("Config", func() {
 
 		It("populates the server URL", func() {
 			Expect(loadErr).NotTo(HaveOccurred())
-			Expect(cfg.ServerURL).To(Equal("https://api.foo:1234"))
+			Expect(cfg.ServerURL).To(Equal("https://api.external:1234"))
 		})
 	})
 })

--- a/api/main.go
+++ b/api/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"log"
 	"net/http"
@@ -293,32 +294,12 @@ func main() {
 		orgRepo,
 	)
 
-	instancesStateCollector := stats.NewProcessInstanceStateCollector(processRepo)
-	gaugesCollector := stats.NewGaugesCollector(
-		fmt.Sprintf("https://localhost:%d", cfg.InternalPort),
-		&http.Client{
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // #nosec G402
-			},
-		},
-	)
-
-	logCacheURL := serverURL
-	if cfg.Experimental.ExternalLogCache.Enabled {
-		logCacheURL, err = url.Parse(cfg.Experimental.ExternalLogCache.URL)
-		if err != nil {
-			panic(fmt.Sprintf("could not parse external logcache URL: %v", err))
-		}
-		gaugesCollector = stats.NewGaugesCollector(
-			cfg.Experimental.ExternalLogCache.URL,
-			&http.Client{
-				Transport: &http.Transport{
-					TLSClientConfig: &tls.Config{InsecureSkipVerify: cfg.Experimental.ExternalLogCache.TrustInsecureLogCache}, // #nosec G402
-				},
-			},
-		)
+	logCacheURL, gaugesCollector, err := wireGaugeCollector(cfg)
+	if err != nil {
+		panic(fmt.Sprintf("could not create log cache client: %v", err))
 	}
 
+	instancesStateCollector := stats.NewProcessInstanceStateCollector(processRepo)
 	apiHandlers := []routing.Routable{
 		handlers.NewRootV3(*serverURL),
 		handlers.NewRoot(*serverURL, cfg.Experimental.UAA, *logCacheURL),
@@ -517,7 +498,6 @@ func main() {
 	routerBuilder.SetMethodNotAllowedHandler(handlers.NotFound)
 
 	portString := fmt.Sprintf(":%v", cfg.InternalPort)
-	tlsPath, tlsFound := os.LookupEnv("TLSCONFIG")
 
 	srv := &http.Server{
 		Addr:              portString,
@@ -529,6 +509,7 @@ func main() {
 		ErrorLog:          log.New(&tools.LogrWriter{Logger: ctrl.Log, Message: "HTTP server error"}, "", 0),
 	}
 
+	tlsPath, tlsFound := os.LookupEnv("TLSCONFIG")
 	if tlsFound {
 		ctrl.Log.Info("listening with TLS on " + portString)
 		certPath := filepath.Join(tlsPath, "tls.crt")
@@ -572,4 +553,53 @@ func wireIdentityProvider(client client.Client, restConfig *rest.Config) authori
 	tokenReviewer := authorization.NewTokenReviewer(client)
 	certInspector := authorization.NewCertInspector(restConfig)
 	return authorization.NewCertTokenIdentityProvider(tokenReviewer, certInspector)
+}
+
+func wireGaugeCollector(cfg *config.APIConfig) (*url.URL, handlers.GaugesCollector, error) {
+	if !cfg.Experimental.ExternalLogCache.Enabled {
+		logCacheURL, err := url.Parse(cfg.ServerURL)
+		if err != nil {
+			return nil, nil, fmt.Errorf("could not parse internal log cache URL: %w", err)
+		}
+
+		caCertPath := os.Getenv("CACERT")
+		caPath := filepath.Join(caCertPath, "ca.crt")
+		caBundle, err := os.ReadFile(caPath)
+		if err != nil {
+			panic(fmt.Sprintf("could not read CA bundle from file %s: %v", caPath, err))
+		}
+		trustedCAs := x509.NewCertPool()
+
+		if ok := trustedCAs.AppendCertsFromPEM(caBundle); !ok {
+			panic("could not append CA bundle to trustedCAs cert pool")
+		}
+
+		return logCacheURL, stats.NewGaugesCollector(
+			fmt.Sprintf("https://%s", cfg.InternalFQDN),
+			&http.Client{
+				Transport: &http.Transport{
+					TLSClientConfig: &tls.Config{
+						MinVersion: tls.VersionTLS12,
+						RootCAs:    trustedCAs,
+					},
+				},
+			},
+		), nil
+	}
+
+	logCacheURL, err := url.Parse(cfg.Experimental.ExternalLogCache.URL)
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not parse external log cache URL: %w", err)
+	}
+
+	return logCacheURL, stats.NewGaugesCollector(
+		logCacheURL.String(),
+		&http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: cfg.Experimental.ExternalLogCache.TrustInsecureLogCache, // #nosec G402
+				},
+			},
+		},
+	), nil
 }

--- a/helm/korifi/api/configmap.yaml
+++ b/helm/korifi/api/configmap.yaml
@@ -6,7 +6,8 @@ metadata:
 data:
   korifi_api_config.yaml: |
     externalFQDN: {{ .Values.api.apiServer.url }}
-    externalPort: {{ .Values.api.apiServer.port | default 0 }}
+    externalPort: {{ .Values.api.apiServer.port | default 443 }}
+    internalFQDN: korifi-api-svc.{{ .Release.Namespace }}.svc.cluster.local
     internalPort: {{ .Values.api.apiServer.internalPort }}
     idleTimeout: {{ .Values.api.apiServer.timeouts.idle }}
     readTimeout: {{ .Values.api.apiServer.timeouts.read }}

--- a/helm/korifi/api/deployment.yaml
+++ b/helm/korifi/api/deployment.yaml
@@ -23,6 +23,8 @@ spec:
           value: /etc/korifi-api-config
         - name: TLSCONFIG
           value: /etc/korifi-tls-config
+        - name: CACERT
+          value: /etc/korifi-ca-cert
         image: {{ .Values.api.image }}
 {{- if .Values.debug }}
         command:
@@ -49,6 +51,9 @@ spec:
         - mountPath: /etc/korifi-tls-config
           name: korifi-tls-config
           readOnly: true
+        - mountPath: /etc/korifi-ca-cert
+          name: korifi-ca-cert
+          readOnly: true
 {{- if .Values.containerRegistryCACertSecret }}
         - mountPath: /etc/ssl/certs/registry-ca.crt
           name: korifi-registry-ca-cert
@@ -72,6 +77,9 @@ spec:
       - name: korifi-tls-config
         secret:
           secretName: {{ .Values.api.apiServer.ingressCertSecret }}
+      - name: korifi-ca-cert
+        secret:
+          secretName: korifi-selfsigned-ca-secret
 {{- if .Values.containerRegistryCACertSecret }}
       - name: korifi-registry-ca-cert
         secret:

--- a/helm/korifi/api/ingress-cert.yaml
+++ b/helm/korifi/api/ingress-cert.yaml
@@ -8,8 +8,11 @@ spec:
   commonName: {{ .Values.api.apiServer.url }}
   dnsNames:
   - {{ .Values.api.apiServer.url }}
+{{- if not .Values.experimental.externalLogCache.enabled }}
+  - korifi-api-svc.{{ .Release.Namespace }}.svc.cluster.local
+{{- end }}
   issuerRef:
     kind: Issuer
-    name: selfsigned-issuer
+    name: korifi-ca-issuer
   secretName: {{ .Values.api.apiServer.ingressCertSecret }}
 {{- end }}

--- a/helm/korifi/templates/cert-mgr-issuer.yaml
+++ b/helm/korifi/templates/cert-mgr-issuer.yaml
@@ -6,4 +6,30 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: korifi-selfsigned-ca
+  namespace: {{ .Release.Namespace }}
+spec:
+  isCA: true
+  duration: 8760h # 1 year
+  secretName: korifi-selfsigned-ca-secret
+  commonName: korifi-selfsigned-ca
+  privateKey:
+    algorithm: RSA
+    size: 2048
+  issuerRef:
+    name: selfsigned-issuer
+    kind: Issuer
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: korifi-ca-issuer
+  namespace: {{ .Release.Namespace }}
+spec:
+  ca:
+    secretName: korifi-selfsigned-ca-secret
 {{- end}}

--- a/helm/korifi/values.yaml
+++ b/helm/korifi/values.yaml
@@ -42,7 +42,7 @@ api:
   apiServer:
     url: ""
     # To override default port, set port to a non-zero value
-    port: 0
+    port: 443
     internalPort: 9000
     ingressCertSecret: korifi-api-ingress-cert
     timeouts:


### PR DESCRIPTION
## Is there a related GitHub Issue?
#4025
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Do tls validation when talking to local log cache. Do not skip validation unless explicitly configured via helm value
