### PR TITLE
Do not fail if there is no object for a guid

### DIFF
--- a/api/repositories/k8sklient/descriptors/mapper_test.go
+++ b/api/repositories/k8sklient/descriptors/mapper_test.go
@@ -22,7 +22,6 @@ var _ = Describe("Mapper", func() {
 		space *korifiv1alpha1.CFSpace
 
 		mapper      *descriptors.ObjectListMapper
-		mapErr      error
 		objectGUIDs []string
 		objectList  client.ObjectList
 	)
@@ -63,11 +62,15 @@ var _ = Describe("Mapper", func() {
 			Kind:    "CFAppList",
 		}
 
-		objectList, mapErr = mapper.GUIDsToObjectList(ctx, gvk, objectGUIDs)
+		var err error
+		objectList, err = mapper.GUIDsToObjectList(ctx, gvk, objectGUIDs)
+		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("errors due to no permissions on the objects", func() {
-		Expect(mapErr).To(MatchError(ContainSubstring("not found in list")))
+	It("returns an empty list", func() {
+		Expect(objectList).To(BeAssignableToTypeOf(&korifiv1alpha1.CFAppList{}))
+		object := objectList.(*korifiv1alpha1.CFAppList)
+		Expect(object.Items).To(BeEmpty())
 	})
 
 	When("the user is allowed to list the objects", func() {
@@ -77,7 +80,6 @@ var _ = Describe("Mapper", func() {
 		})
 
 		It("returns a list of objects ordered in the specified order", func() {
-			Expect(mapErr).NotTo(HaveOccurred())
 			Expect(objectList).To(BeAssignableToTypeOf(&korifiv1alpha1.CFAppList{}))
 			object := objectList.(*korifiv1alpha1.CFAppList)
 			Expect(object.Items).To(HaveLen(3))
@@ -95,7 +97,6 @@ var _ = Describe("Mapper", func() {
 		})
 
 		It("returns an empty list", func() {
-			Expect(mapErr).NotTo(HaveOccurred())
 			Expect(objectList).To(BeAssignableToTypeOf(&korifiv1alpha1.CFAppList{}))
 			object := objectList.(*korifiv1alpha1.CFAppList)
 			Expect(object.Items).To(BeEmpty())


### PR DESCRIPTION
## Is there a related GitHub Issue?
CI failure: https://ci.korifi.cf-app.com/teams/main/pipelines/main/jobs/run-e2es-periodic/builds/21600#L682b501b:2266
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
When listing objects with the descriptor client, the klient would
perform the following sequence of actions:
1. Collect guids for objects that match label selectors
2. Order and page the guids
3. Map guids to objects

In a real deployment where objects are being created asynchronously, it
could happen that after guids have been fetched, objects for few of the
guids to have been deleted in the meanwhile. If the mapper returns an
error on such an occasion, this would cause the list request to fail.

This commit changes the object mapper to ignore this error and simply
skip the object that is gone.

A more correct solution would be to go back to step 1 and retry list
until all guids are succefully mapped. However, we believe that such a
complexity would be an overkill so we opted for the simpler solution

See CI failure: https://ci.korifi.cf-app.com/teams/main/pipelines/main/jobs/run-e2es-periodic/builds/21600#L682b501b:2266

## Tag your pair, your PM, and/or team
@georgethebeatle
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
