### PR TITLE
Do not migrate security groups

### DIFF
--- a/helm/korifi/migrations/post-upgrade-set-migrated-by.yaml
+++ b/helm/korifi/migrations/post-upgrade-set-migrated-by.yaml
@@ -81,7 +81,7 @@ spec:
           }
 
           main() {
-            set-migrated-by-label cfapps cfbuilds cfdomains cforgs cfpackages cfprocesses cfroutes cfsecuritygroups cfservicebindings cfservicebrokers cfserviceinstances cfserviceofferings cfserviceplans cfspaces cftasks
+            set-migrated-by-label cfapps cfbuilds cfdomains cforgs cfpackages cfprocesses cfroutes cfservicebindings cfservicebrokers cfserviceinstances cfserviceofferings cfserviceplans cfspaces cftasks
           }
 
           main


### PR DESCRIPTION
## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Security groups are new resources therefore they do not need migration
<!-- _Please describe the change here._ -->

