### PR TITLE
Introduce dedicated internal api tls cert

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -49,7 +49,7 @@ DockerHub allows only one private repository per free account. In case the Docke
 
 ### Cert-Manager (optional)
 
-[Cert-Manager](https://cert-manager.io) allows us to automatically generate certificates within the cluster. It is required if you want Korifi to generate self-signed certificates for API and workload ingress or for webhooks. In order to do this you have to set the `generateIngressCertificates` and/or `generateWebhookCertificates` values to `true`. Follow the [instructions](https://cert-manager.io/docs/installation/) to install the latest version.
+[Cert-Manager](https://cert-manager.io) allows us to automatically generate certificates within the cluster. It is required if you want Korifi to generate self-signed certificates for API and workload ingress or for internal use, like webhooks. In order to do this you have to set the `generateIngressCertificates` and/or `generateInternalCertificates` values to `true`. Follow the [instructions](https://cert-manager.io/docs/installation/) to install the latest version.
 
 ### Kpack
 
@@ -157,13 +157,14 @@ Make sure the value of `--docker-server` is a valid [URI authority](https://data
 
 Korifi uses two kinds of TLS certificates:
 1. Ingress certificates: if `generateIngressCertificates` is set to `true`, Korifi will generate self-signed certificates and use them for API and workloads ingress.
-1. Webhook certificates: if `generateWebhookCertificates` is set to `true` (the default value), Korifi will generate self-signed certificates and use them for webhooks.
+1. Internal certificates: if `generateInternalCertificates` is set to `true` (the default value), Korifi will generate self-signed certificates and use them for securing internal communication, like webhooks.
 
 A running cert-manager is a prerequisite for generating self-signed certificates.
 
-If you want to generate certificates yourself, set `generateIngressCertificates` and `generateWebhookCertificates` to `false` and point to your own certificates using the following values:
+If you want to generate certificates yourself, set `generateIngressCertificates` and `generateInternalCertificates` to `false` and point to your own certificates using the following values:
 
 1. `api.apiServer.ingressCertSecret`: the name of the `Secret` in the `$KORIFI_NAMESPACE` namespace containing the API ingress certificate; defaults to `korifi-api-ingress-cert`.
+1. `api.apiServer.internalCertSecret`: the name of the `Secret` in the `$KORIFI_NAMESPACE` namespace containing a certificate that is valid for `korifi-api-svc.korifi.svc.cluster.local` (the internal dns of the korifi api); defaults to `korifi-api-internal-cert`.
 1. `controllers.workloadsTLSSecret`: the name of the `Secret` in the `$KORIFI_NAMESPACE` namespace containing the workload ingress certificate; defaults to `korifi-workloads-ingress-cert`.
 1. `controllers.webhookCertSecret`: the name of the `Secret` in the `$KORIFI_NAMESPACE` namespace containing the webhook certificate for the controllers deployment; defaults to `korifi-controllers-webhook-cert`.
 1. `kpackImageBuilder.webhookCertSecret`: the name of the `Secret` in the `$KORIFI_NAMESPACE` namespace containing the webhook certificate for the kpackImageBuilder deployment; defaults to `korifi-kpack-image-builder-webhook-cert`.

--- a/README.helm.md
+++ b/README.helm.md
@@ -14,6 +14,7 @@ Here are all the values that can be set for the chart:
 - `api`:
   - `apiServer`:
     - `ingressCertSecret` (_String_): The name of the secret containing the TLS certificate for the API ingress.
+    - `internalCertSecret` (_String_): The name of the secret containing the TLS certificate for internal api access. It needs to be valid for 'korifi-api-svc.korifi.svc.cluster.local'.
     - `internalPort` (_Integer_): Port used internally by the API container.
     - `port` (_Integer_): API external port. Defaults to `443`.
     - `timeouts`: HTTP timeouts.
@@ -97,7 +98,7 @@ Here are all the values that can be set for the chart:
     - `enabled` (_Boolean_): Enable UAA support
     - `url` (_String_): The url of a UAA instance
 - `generateIngressCertificates` (_Boolean_): Use `cert-manager` to generate self-signed certificates for the API and app endpoints.
-- `generateWebhookCertificates` (_Boolean_): Use `cert-manager` to generate self-signed certificates for the webhooks.
+- `generateInternalCertificates` (_Boolean_): Use `cert-manager` to generate internal self-signed certificates, e.g. for the webhooks.
 - `helm`:
   - `hooksImage` (_String_): Image for the helm hooks containing kubectl
 - `jobTaskRunner`:

--- a/helm/korifi/api/deployment.yaml
+++ b/helm/korifi/api/deployment.yaml
@@ -21,9 +21,11 @@ spec:
       - env:
         - name: APICONFIG
           value: /etc/korifi-api-config
-        - name: TLSCONFIG
-          value: /etc/korifi-tls-config
-        - name: CACERT
+        - name: CERT_PATH
+          value: /etc/korifi-tls
+        - name: INTERNAL_CERT_PATH
+          value: /etc/korifi-tls-internal
+        - name: CA_PATH
           value: /etc/korifi-ca-cert
         image: {{ .Values.api.image }}
 {{- if .Values.debug }}
@@ -48,8 +50,11 @@ spec:
         - mountPath: /etc/korifi-api-config
           name: korifi-api-config
           readOnly: true
-        - mountPath: /etc/korifi-tls-config
-          name: korifi-tls-config
+        - mountPath: /etc/korifi-tls
+          name: korifi-tls
+          readOnly: true
+        - mountPath: /etc/korifi-tls-internal
+          name: korifi-tls-internal
           readOnly: true
         - mountPath: /etc/korifi-ca-cert
           name: korifi-ca-cert
@@ -74,9 +79,12 @@ spec:
       - configMap:
           name: korifi-api-config
         name: korifi-api-config
-      - name: korifi-tls-config
+      - name: korifi-tls
         secret:
           secretName: {{ .Values.api.apiServer.ingressCertSecret }}
+      - name: korifi-tls-internal
+        secret:
+          secretName: {{ .Values.api.apiServer.internalCertSecret }}
       - name: korifi-ca-cert
         secret:
           secretName: korifi-selfsigned-ca-secret

--- a/helm/korifi/api/ingress-cert.yaml
+++ b/helm/korifi/api/ingress-cert.yaml
@@ -8,11 +8,8 @@ spec:
   commonName: {{ .Values.api.apiServer.url }}
   dnsNames:
   - {{ .Values.api.apiServer.url }}
-{{- if not .Values.experimental.externalLogCache.enabled }}
-  - korifi-api-svc.{{ .Release.Namespace }}.svc.cluster.local
-{{- end }}
   issuerRef:
     kind: Issuer
-    name: korifi-ca-issuer
+    name: selfsigned-issuer
   secretName: {{ .Values.api.apiServer.ingressCertSecret }}
 {{- end }}

--- a/helm/korifi/api/internal-cert.yaml
+++ b/helm/korifi/api/internal-cert.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.generateInternalCertificates }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ .Values.api.apiServer.internalCertSecret }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  commonName: korifi-api-svc.{{ .Release.Namespace }}.svc.cluster.local
+  dnsNames:
+  - korifi-api-svc.{{ .Release.Namespace }}.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: korifi-ca-issuer
+  secretName: {{ .Values.api.apiServer.internalCertSecret }}
+{{- end }}

--- a/helm/korifi/controllers/webhook-cert.yaml
+++ b/helm/korifi/controllers/webhook-cert.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.generateWebhookCertificates }}
+{{- if .Values.generateInternalCertificates }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/helm/korifi/kpack-image-builder/webhook-cert.yaml
+++ b/helm/korifi/kpack-image-builder/webhook-cert.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.generateWebhookCertificates }}
+{{- if .Values.generateInternalCertificates }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/helm/korifi/statefulset-runner/webhook-cert.yaml
+++ b/helm/korifi/statefulset-runner/webhook-cert.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.generateWebhookCertificates }}
+{{- if .Values.generateInternalCertificates }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/helm/korifi/templates/_helpers.yaml
+++ b/helm/korifi/templates/_helpers.yaml
@@ -46,7 +46,7 @@ securityContext:
 
 {{- define "korifi.webhookCaBundle" -}}
 {{- $caBundle := "" -}}
-{{- if not .Values.generateWebhookCertificates -}}
+{{- if not .Values.generateInternalCertificates -}}
 {{- $compValues := index .Values .component -}}
 {{- $webhookCertSecret := $compValues.webhookCertSecret -}}
 {{- $caBundle = index (lookup "v1" "Secret" .Release.Namespace $webhookCertSecret).data "ca.crt" -}}

--- a/helm/korifi/templates/cert-mgr-issuer.yaml
+++ b/helm/korifi/templates/cert-mgr-issuer.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.generateIngressCertificates true) (eq .Values.generateWebhookCertificates true) }}
+{{- if or (eq .Values.generateIngressCertificates true) (eq .Values.generateInternalCertificates true) }}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:

--- a/helm/korifi/values.schema.json
+++ b/helm/korifi/values.schema.json
@@ -26,8 +26,8 @@
       "description": "Use `cert-manager` to generate self-signed certificates for the API and app endpoints.",
       "type": "boolean"
     },
-    "generateWebhookCertificates": {
-      "description": "Use `cert-manager` to generate self-signed certificates for the webhooks.",
+    "generateInternalCertificates": {
+      "description": "Use `cert-manager` to generate internal self-signed certificates, e.g. for the webhooks.",
       "type": "boolean"
     },
     "containerRepositoryPrefix": {
@@ -182,6 +182,10 @@
               "description": "The name of the secret containing the TLS certificate for the API ingress.",
               "type": "string"
             },
+            "internalCertSecret": {
+              "description": "The name of the secret containing the TLS certificate for internal api access. It needs to be valid for 'korifi-api-svc.korifi.svc.cluster.local'.",
+              "type": "string"
+            },
             "timeouts": {
               "type": "object",
               "description": "HTTP timeouts.",
@@ -206,7 +210,7 @@
               "required": ["read", "write", "idle", "readHeader"]
             }
           },
-          "required": ["url", "port", "internalPort", "ingressCertSecret", "timeouts"]
+          "required": ["url", "port", "internalPort", "ingressCertSecret", "internalCertSecret", "timeouts"]
         },
         "image": {
           "description": "Reference to the API container image.",

--- a/helm/korifi/values.yaml
+++ b/helm/korifi/values.yaml
@@ -9,7 +9,7 @@ eksContainerRegistryRoleARN: ""
 containerRegistryCACertSecret:
 systemImagePullSecrets: []
 generateIngressCertificates: false
-generateWebhookCertificates: true
+generateInternalCertificates: true
 
 reconcilers:
   build: kpack-image-builder
@@ -45,6 +45,7 @@ api:
     port: 443
     internalPort: 9000
     ingressCertSecret: korifi-api-ingress-cert
+    internalCertSecret: korifi-api-internal-cert
     timeouts:
       read: 900
       write: 900


### PR DESCRIPTION
## Is there a related GitHub Issue?
No, this is a fix to make acceptance deployment green again
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Introduce dedicated internal api tls cert

- It does not make sense to have both the external and the internal SAN
  in the same certificate
- On acceptance the external cert is issued by letsenctypt, which is a
 limited resource, so it is not optimal to have this cert issued for the
 internal dns name as well
- Instead have a dedicated certificate for the internal api dns that is
  signed by the korifi internal ca
- The korifi api server is configured with both the internal and the
  external certificates and it would serve the correct one depending on
the client request
<!-- _Please describe the change here._ -->

