### PR TITLE
Test for additionalPrinterColumns used for ordering

### DIFF
--- a/api/repositories/k8sklient/descriptors/columns_test.go
+++ b/api/repositories/k8sklient/descriptors/columns_test.go
@@ -1,0 +1,211 @@
+package descriptors_test
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+
+	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
+	"code.cloudfoundry.org/korifi/tools"
+	"github.com/BooleanCat/go-functional/v2/it"
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	. "github.com/onsi/gomega/gstruct"
+	"github.com/onsi/gomega/types"
+)
+
+var _ = DescribeTable("Table Columns For Ordering", testTableColumns,
+	Entry("CFApps", "cfapps", &korifiv1alpha1.CFApp{
+		Spec: korifiv1alpha1.CFAppSpec{
+			DisplayName:  "cfapp",
+			DesiredState: "STOPPED",
+			Lifecycle: korifiv1alpha1.Lifecycle{
+				Type: "buildpack",
+			},
+		},
+	}, MatchKeys(IgnoreExtras, Keys{
+		"Created At":   Equal("obj-creation-timestamp"),
+		"Updated At":   Equal("obj-update-timestamp"),
+		"Display Name": Equal("cfapp"),
+		"State":        Equal("STOPPED"),
+	})),
+
+	Entry("CFBuild", "cfbuilds", &korifiv1alpha1.CFBuild{
+		Spec: korifiv1alpha1.CFBuildSpec{
+			Lifecycle: korifiv1alpha1.Lifecycle{
+				Type: "buildpack",
+			},
+		},
+	}, MatchKeys(IgnoreExtras, Keys{
+		"Created At": Equal("obj-creation-timestamp"),
+		"Updated At": Equal("obj-update-timestamp"),
+	})),
+
+	Entry("CFDomain", "cfdomains", &korifiv1alpha1.CFDomain{
+		Spec: korifiv1alpha1.CFDomainSpec{
+			Name: "example.com",
+		},
+	}, MatchKeys(IgnoreExtras, Keys{
+		"Created At": Equal("obj-creation-timestamp"),
+		"Updated At": Equal("obj-update-timestamp"),
+	})),
+
+	Entry("CFOrg", "cforgs", &korifiv1alpha1.CFOrg{
+		Spec: korifiv1alpha1.CFOrgSpec{
+			DisplayName: "example-org",
+		},
+	}, MatchKeys(IgnoreExtras, Keys{
+		"Created At":   Equal("obj-creation-timestamp"),
+		"Updated At":   Equal("obj-update-timestamp"),
+		"Display Name": Equal("example-org"),
+	})),
+
+	Entry("CFPackage", "cfpackages", &korifiv1alpha1.CFPackage{
+		Spec: korifiv1alpha1.CFPackageSpec{
+			Type: "bits",
+		},
+	}, MatchKeys(IgnoreExtras, Keys{
+		"Created At": Equal("obj-creation-timestamp"),
+		"Updated At": Equal("obj-update-timestamp"),
+	})),
+
+	Entry("CFProcess", "cfprocesses", &korifiv1alpha1.CFProcess{}, MatchKeys(IgnoreExtras, Keys{
+		"Created At": Equal("obj-creation-timestamp"),
+		"Updated At": Equal("obj-update-timestamp"),
+	})),
+
+	Entry("CFRoute", "cfroutes", &korifiv1alpha1.CFRoute{
+		Spec: korifiv1alpha1.CFRouteSpec{
+			Host: "example",
+			Path: "/example",
+			DomainRef: corev1.ObjectReference{
+				Name: "example.com",
+			},
+		},
+	}, MatchKeys(IgnoreExtras, Keys{
+		"Created At": Equal("obj-creation-timestamp"),
+		"Updated At": Equal("obj-update-timestamp"),
+	})),
+
+	Entry("CFSecurityGroup", "cfsecuritygroups", &korifiv1alpha1.CFSecurityGroup{
+		Spec: korifiv1alpha1.CFSecurityGroupSpec{
+			Rules: []korifiv1alpha1.SecurityGroupRule{},
+		},
+	}, MatchKeys(IgnoreExtras, Keys{
+		"Created At": Equal("obj-creation-timestamp"),
+		"Updated At": Equal("obj-update-timestamp"),
+	})),
+
+	Entry("CFServiceBinding", "cfservicebindings", &korifiv1alpha1.CFServiceBinding{
+		Spec: korifiv1alpha1.CFServiceBindingSpec{
+			DisplayName: tools.PtrTo("example-binding"),
+			Type:        "key",
+		},
+	}, MatchKeys(IgnoreExtras, Keys{
+		"Created At":   Equal("obj-creation-timestamp"),
+		"Updated At":   Equal("obj-update-timestamp"),
+		"Display Name": Equal("example-binding"),
+	})),
+
+	Entry("CFServiceBroker", "cfservicebrokers", &korifiv1alpha1.CFServiceBroker{
+		Spec: korifiv1alpha1.CFServiceBrokerSpec{
+			Name: "example-broker",
+		},
+	}, MatchKeys(IgnoreExtras, Keys{
+		"Created At":   Equal("obj-creation-timestamp"),
+		"Updated At":   Equal("obj-update-timestamp"),
+		"Display Name": Equal("example-broker"),
+	})),
+
+	Entry("CFServiceInstance", "cfserviceinstances", &korifiv1alpha1.CFServiceInstance{
+		Spec: korifiv1alpha1.CFServiceInstanceSpec{
+			DisplayName: "example-instance",
+			Type:        "user-provided",
+		},
+	}, MatchKeys(IgnoreExtras, Keys{
+		"Created At":   Equal("obj-creation-timestamp"),
+		"Updated At":   Equal("obj-update-timestamp"),
+		"Display Name": Equal("example-instance"),
+	})),
+
+	Entry("CFServiceOffering", "cfserviceofferings", &korifiv1alpha1.CFServiceOffering{
+		Spec: korifiv1alpha1.CFServiceOfferingSpec{
+			Name: "example-offering",
+		},
+	}, MatchKeys(IgnoreExtras, Keys{
+		"Created At":   Equal("obj-creation-timestamp"),
+		"Updated At":   Equal("obj-update-timestamp"),
+		"Display Name": Equal("example-offering"),
+	})),
+
+	Entry("CFServicePlan", "cfserviceplans", &korifiv1alpha1.CFServicePlan{
+		Spec: korifiv1alpha1.CFServicePlanSpec{
+			Name: "example-plan",
+			Visibility: korifiv1alpha1.ServicePlanVisibility{
+				Type: korifiv1alpha1.PublicServicePlanVisibilityType,
+			},
+		},
+	}, MatchKeys(IgnoreExtras, Keys{
+		"Created At":   Equal("obj-creation-timestamp"),
+		"Updated At":   Equal("obj-update-timestamp"),
+		"Display Name": Equal("example-plan"),
+	})),
+
+	Entry("CFSpace", "cfspaces", &korifiv1alpha1.CFSpace{
+		Spec: korifiv1alpha1.CFSpaceSpec{
+			DisplayName: "example-space",
+		},
+	}, MatchKeys(IgnoreExtras, Keys{
+		"Created At":   Equal("obj-creation-timestamp"),
+		"Updated At":   Equal("obj-update-timestamp"),
+		"Display Name": Equal("example-space"),
+	})),
+
+	Entry("CFTask", "cftasks", &korifiv1alpha1.CFTask{}, MatchKeys(IgnoreExtras, Keys{
+		"Created At": Equal("obj-creation-timestamp"),
+		"Updated At": Equal("obj-update-timestamp"),
+	})),
+)
+
+func testTableColumns(resourceType string, obj client.Object, match types.GomegaMatcher) {
+	namespace := uuid.NewString()
+	Expect(k8sClient.Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: namespace,
+		},
+	})).To(Succeed())
+
+	obj.SetName(uuid.NewString())
+	obj.SetNamespace(namespace)
+	obj.SetLabels(map[string]string{
+		korifiv1alpha1.CreatedAtLabelKey: "obj-creation-timestamp",
+		korifiv1alpha1.UpdatedAtLabelKey: "obj-update-timestamp",
+	})
+	Expect(k8sClient.Create(ctx, obj)).To(Succeed())
+
+	table := &metav1.Table{}
+	Expect(restClient.Get().
+		AbsPath(fmt.Sprintf("/apis/korifi.cloudfoundry.org/v1alpha1/namespaces/%s/%s", namespace, resourceType)).
+		SetHeader("Accept", "application/json;as=Table;g=meta.k8s.io;v=v1").
+		Do(ctx).
+		Into(table),
+	).To(Succeed())
+
+	Expect(columnNameValues(table)).To(match)
+}
+
+func columnNameValues(table *metav1.Table) map[string]any {
+	GinkgoHelper()
+
+	columnsNames := it.Map(slices.Values(table.ColumnDefinitions), func(column metav1.TableColumnDefinition) string {
+		return column.Name
+	})
+	Expect(table.Rows).To(HaveLen(1))
+	firstRowCells := slices.Values(table.Rows[0].Cells)
+	return maps.Collect(it.Zip(columnsNames, firstRowCells))
+}

--- a/controllers/api/v1alpha1/cfapp_types.go
+++ b/controllers/api/v1alpha1/cfapp_types.go
@@ -88,7 +88,7 @@ type CFAppStatus struct {
 //+kubebuilder:printcolumn:name="Display Name",type=string,JSONPath=`.spec.displayName`
 //+kubebuilder:printcolumn:name="Created At",type="string",JSONPath=`.metadata.labels.korifi\.cloudfoundry\.org/created_at`
 //+kubebuilder:printcolumn:name="Updated At",type="string",JSONPath=`.metadata.labels.korifi\.cloudfoundry\.org/updated_at`
-//+kubebuilder:printcolumn:name="State",type=string,JSONPath=`.status.actualState`
+//+kubebuilder:printcolumn:name="State",type=string,JSONPath=`.spec.desiredState`
 //+kubebuilder:printcolumn:name="Age",type="date",JSONPath=`.metadata.creationTimestamp`
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 

--- a/controllers/api/v1alpha1/cforg_types.go
+++ b/controllers/api/v1alpha1/cforg_types.go
@@ -50,6 +50,8 @@ type CFOrgStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="Created At",type="string",JSONPath=`.metadata.labels.korifi\.cloudfoundry\.org/created_at`
+//+kubebuilder:printcolumn:name="Updated At",type="string",JSONPath=`.metadata.labels.korifi\.cloudfoundry\.org/updated_at`
 //+kubebuilder:printcolumn:name="Display Name",type=string,JSONPath=`.spec.displayName`
 //+kubebuilder:printcolumn:name="Age",type="date",JSONPath=`.metadata.creationTimestamp`
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/controllers/api/v1alpha1/cfprocess_types.go
+++ b/controllers/api/v1alpha1/cfprocess_types.go
@@ -97,6 +97,8 @@ type CFProcessStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="Created At",type="string",JSONPath=`.metadata.labels.korifi\.cloudfoundry\.org/created_at`
+//+kubebuilder:printcolumn:name="Updated At",type="string",JSONPath=`.metadata.labels.korifi\.cloudfoundry\.org/updated_at`
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // CFProcess is the Schema for the cfprocesses API

--- a/controllers/api/v1alpha1/cfsecuritygroup_types.go
+++ b/controllers/api/v1alpha1/cfsecuritygroup_types.go
@@ -46,6 +46,8 @@ type CFSecurityGroupStatus struct {
 
 //+kubebuilder:subresource:status
 //+kubebuilder:object:root=true
+//+kubebuilder:printcolumn:name="Created At",type="string",JSONPath=`.metadata.labels.korifi\.cloudfoundry\.org/created_at`
+//+kubebuilder:printcolumn:name="Updated At",type="string",JSONPath=`.metadata.labels.korifi\.cloudfoundry\.org/updated_at`
 //+kubebuilder:printcolumn:name="DisplayName",type=string,JSONPath=`.spec.displayName`
 //+k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 

--- a/controllers/api/v1alpha1/cfservice_offering_types.go
+++ b/controllers/api/v1alpha1/cfservice_offering_types.go
@@ -36,7 +36,9 @@ type BrokerCatalogFeatures struct {
 }
 
 //+kubebuilder:object:root=true
-//+kubebuilder:printcolumn:name="Offering",type=string,JSONPath=`.spec.name`
+//+kubebuilder:printcolumn:name="Created At",type="string",JSONPath=`.metadata.labels.korifi\.cloudfoundry\.org/created_at`
+//+kubebuilder:printcolumn:name="Updated At",type="string",JSONPath=`.metadata.labels.korifi\.cloudfoundry\.org/updated_at`
+//+kubebuilder:printcolumn:name="Display Name",type=string,JSONPath=`.spec.name`
 //+kubebuilder:printcolumn:name="Description",type=string,JSONPath=`.spec.description`
 //+kubebuilder:printcolumn:name="Available",type=string,JSONPath=`.spec.available`
 //+kubebuilder:printcolumn:name="Age",type="date",JSONPath=`.metadata.creationTimestamp`

--- a/controllers/api/v1alpha1/cfservice_plan_types.go
+++ b/controllers/api/v1alpha1/cfservice_plan_types.go
@@ -75,7 +75,9 @@ type ServicePlanVisibility struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:printcolumn:name="Plan",type=string,JSONPath=`.spec.name`
+//+kubebuilder:printcolumn:name="Created At",type="string",JSONPath=`.metadata.labels.korifi\.cloudfoundry\.org/created_at`
+//+kubebuilder:printcolumn:name="Updated At",type="string",JSONPath=`.metadata.labels.korifi\.cloudfoundry\.org/updated_at`
+// +kubebuilder:printcolumn:name="Display Name",type=string,JSONPath=`.spec.name`
 // +kubebuilder:printcolumn:name="Available",type=string,JSONPath=`.spec.available`
 // +kubebuilder:printcolumn:name="Free",type=string,JSONPath=`.spec.free`
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=`.metadata.creationTimestamp`

--- a/controllers/api/v1alpha1/cfservicebroker_types.go
+++ b/controllers/api/v1alpha1/cfservicebroker_types.go
@@ -35,7 +35,9 @@ type CFServiceBrokerStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="Broker Name",type=string,JSONPath=`.spec.name`
+//+kubebuilder:printcolumn:name="Created At",type="string",JSONPath=`.metadata.labels.korifi\.cloudfoundry\.org/created_at`
+//+kubebuilder:printcolumn:name="Updated At",type="string",JSONPath=`.metadata.labels.korifi\.cloudfoundry\.org/updated_at`
+// +kubebuilder:printcolumn:name="Display Name",type=string,JSONPath=`.spec.name`
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=`.metadata.creationTimestamp`
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 

--- a/controllers/api/v1alpha1/cfspace_types.go
+++ b/controllers/api/v1alpha1/cfspace_types.go
@@ -50,6 +50,8 @@ type CFSpaceStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="Created At",type="string",JSONPath=`.metadata.labels.korifi\.cloudfoundry\.org/created_at`
+//+kubebuilder:printcolumn:name="Updated At",type="string",JSONPath=`.metadata.labels.korifi\.cloudfoundry\.org/updated_at`
 //+kubebuilder:printcolumn:name="Display Name",type=string,JSONPath=`.spec.displayName`
 //+kubebuilder:printcolumn:name="Age",type="date",JSONPath=`.metadata.creationTimestamp`
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/controllers/api/v1alpha1/cftask_types.go
+++ b/controllers/api/v1alpha1/cftask_types.go
@@ -61,6 +61,8 @@ type CFTaskStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="Created At",type="string",JSONPath=`.metadata.labels.korifi\.cloudfoundry\.org/created_at`
+//+kubebuilder:printcolumn:name="Updated At",type="string",JSONPath=`.metadata.labels.korifi\.cloudfoundry\.org/updated_at`
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // CFTask is the Schema for the cftasks API

--- a/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfapps.yaml
+++ b/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfapps.yaml
@@ -24,7 +24,7 @@ spec:
     - jsonPath: .metadata.labels.korifi\.cloudfoundry\.org/updated_at
       name: Updated At
       type: string
-    - jsonPath: .status.actualState
+    - jsonPath: .spec.desiredState
       name: State
       type: string
     - jsonPath: .metadata.creationTimestamp

--- a/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cforgs.yaml
+++ b/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cforgs.yaml
@@ -15,6 +15,12 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .metadata.labels.korifi\.cloudfoundry\.org/created_at
+      name: Created At
+      type: string
+    - jsonPath: .metadata.labels.korifi\.cloudfoundry\.org/updated_at
+      name: Updated At
+      type: string
     - jsonPath: .spec.displayName
       name: Display Name
       type: string

--- a/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfprocesses.yaml
+++ b/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfprocesses.yaml
@@ -14,7 +14,14 @@ spec:
     singular: cfprocess
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.labels.korifi\.cloudfoundry\.org/created_at
+      name: Created At
+      type: string
+    - jsonPath: .metadata.labels.korifi\.cloudfoundry\.org/updated_at
+      name: Updated At
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: CFProcess is the Schema for the cfprocesses API

--- a/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfsecuritygroups.yaml
+++ b/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfsecuritygroups.yaml
@@ -15,6 +15,12 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .metadata.labels.korifi\.cloudfoundry\.org/created_at
+      name: Created At
+      type: string
+    - jsonPath: .metadata.labels.korifi\.cloudfoundry\.org/updated_at
+      name: Updated At
+      type: string
     - jsonPath: .spec.displayName
       name: DisplayName
       type: string

--- a/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfservicebrokers.yaml
+++ b/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfservicebrokers.yaml
@@ -15,8 +15,14 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .metadata.labels.korifi\.cloudfoundry\.org/created_at
+      name: Created At
+      type: string
+    - jsonPath: .metadata.labels.korifi\.cloudfoundry\.org/updated_at
+      name: Updated At
+      type: string
     - jsonPath: .spec.name
-      name: Broker Name
+      name: Display Name
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age

--- a/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfserviceofferings.yaml
+++ b/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfserviceofferings.yaml
@@ -15,8 +15,14 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .metadata.labels.korifi\.cloudfoundry\.org/created_at
+      name: Created At
+      type: string
+    - jsonPath: .metadata.labels.korifi\.cloudfoundry\.org/updated_at
+      name: Updated At
+      type: string
     - jsonPath: .spec.name
-      name: Offering
+      name: Display Name
       type: string
     - jsonPath: .spec.description
       name: Description

--- a/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfserviceplans.yaml
+++ b/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfserviceplans.yaml
@@ -15,8 +15,14 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .metadata.labels.korifi\.cloudfoundry\.org/created_at
+      name: Created At
+      type: string
+    - jsonPath: .metadata.labels.korifi\.cloudfoundry\.org/updated_at
+      name: Updated At
+      type: string
     - jsonPath: .spec.name
-      name: Plan
+      name: Display Name
       type: string
     - jsonPath: .spec.available
       name: Available

--- a/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfspaces.yaml
+++ b/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cfspaces.yaml
@@ -15,6 +15,12 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .metadata.labels.korifi\.cloudfoundry\.org/created_at
+      name: Created At
+      type: string
+    - jsonPath: .metadata.labels.korifi\.cloudfoundry\.org/updated_at
+      name: Updated At
+      type: string
     - jsonPath: .spec.displayName
       name: Display Name
       type: string

--- a/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cftasks.yaml
+++ b/helm/korifi/controllers/crds/korifi.cloudfoundry.org_cftasks.yaml
@@ -14,7 +14,14 @@ spec:
     singular: cftask
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.labels.korifi\.cloudfoundry\.org/created_at
+      name: Created At
+      type: string
+    - jsonPath: .metadata.labels.korifi\.cloudfoundry\.org/updated_at
+      name: Updated At
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: CFTask is the Schema for the cftasks API


### PR DESCRIPTION
## Is there a related GitHub Issue?
#3701
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
- As we are using additionalPrinterColumns and the "get as table" feature of kubeapiserver we have to make sure that the table fields that we use for ordering are there and stay there.
- This changes adds tests for all ordering fields of all currently
  implementd v3 resouces in Korifi as per the v3 spec
- Some of the newly added fields are not yet used for ordering
- Some existing fields were changed, minly display names
- The "state" field of the cfapp resource is changed to desired state,
  because this is how it is defined in the spec
<!-- _Please describe the change here._ -->

