### PR TITLE
Make the intenal server cert a valid CA

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -584,7 +584,7 @@ func wireGaugeCollector(cfg *config.APIConfig) (*url.URL, handlers.GaugesCollect
 				Transport: &http.Transport{
 					TLSClientConfig: &tls.Config{
 						MinVersion: tls.VersionTLS12,
-						RootCAs:    loadCA("CA_PATH"),
+						RootCAs:    loadCA("INTERNAL_CERT_PATH"),
 					},
 				},
 			},

--- a/helm/korifi/api/deployment.yaml
+++ b/helm/korifi/api/deployment.yaml
@@ -25,8 +25,6 @@ spec:
           value: /etc/korifi-tls
         - name: INTERNAL_CERT_PATH
           value: /etc/korifi-tls-internal
-        - name: CA_PATH
-          value: /etc/korifi-ca-cert
         image: {{ .Values.api.image }}
 {{- if .Values.debug }}
         command:
@@ -56,9 +54,6 @@ spec:
         - mountPath: /etc/korifi-tls-internal
           name: korifi-tls-internal
           readOnly: true
-        - mountPath: /etc/korifi-ca-cert
-          name: korifi-ca-cert
-          readOnly: true
 {{- if .Values.containerRegistryCACertSecret }}
         - mountPath: /etc/ssl/certs/registry-ca.crt
           name: korifi-registry-ca-cert
@@ -85,9 +80,6 @@ spec:
       - name: korifi-tls-internal
         secret:
           secretName: {{ .Values.api.apiServer.internalCertSecret }}
-      - name: korifi-ca-cert
-        secret:
-          secretName: korifi-selfsigned-ca-secret
 {{- if .Values.containerRegistryCACertSecret }}
       - name: korifi-registry-ca-cert
         secret:

--- a/helm/korifi/api/internal-cert.yaml
+++ b/helm/korifi/api/internal-cert.yaml
@@ -5,11 +5,12 @@ metadata:
   name: {{ .Values.api.apiServer.internalCertSecret }}
   namespace: {{ .Release.Namespace }}
 spec:
+  isCA: true
   commonName: korifi-api-svc.{{ .Release.Namespace }}.svc.cluster.local
   dnsNames:
   - korifi-api-svc.{{ .Release.Namespace }}.svc.cluster.local
   issuerRef:
     kind: Issuer
-    name: korifi-ca-issuer
+    name: selfsigned-issuer
   secretName: {{ .Values.api.apiServer.internalCertSecret }}
 {{- end }}

--- a/helm/korifi/templates/cert-mgr-issuer.yaml
+++ b/helm/korifi/templates/cert-mgr-issuer.yaml
@@ -6,30 +6,4 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   selfSigned: {}
----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: korifi-selfsigned-ca
-  namespace: {{ .Release.Namespace }}
-spec:
-  isCA: true
-  duration: 8760h # 1 year
-  secretName: korifi-selfsigned-ca-secret
-  commonName: korifi-selfsigned-ca
-  privateKey:
-    algorithm: RSA
-    size: 2048
-  issuerRef:
-    name: selfsigned-issuer
-    kind: Issuer
----
-apiVersion: cert-manager.io/v1
-kind: Issuer
-metadata:
-  name: korifi-ca-issuer
-  namespace: {{ .Release.Namespace }}
-spec:
-  ca:
-    secretName: korifi-selfsigned-ca-secret
 {{- end}}


### PR DESCRIPTION
## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
- No need to create a new issuer that uses a cert with isCA: true
- We can generate the korifi-tls-internal cert with isCA: true and use
  it as a CA when doing the logcache intenal loopback.
- No need for a dedicated ca volume and mount - the internal-cert is
  being used as a CA as well
<!-- _Please describe the change here._ -->

