### PR TITLE
Improve credential secret serialization

### DIFF
--- a/api/repositories/service_broker_repository.go
+++ b/api/repositories/service_broker_repository.go
@@ -96,7 +96,7 @@ func NewServiceBrokerRepo(
 }
 
 func (r *ServiceBrokerRepo) CreateServiceBroker(ctx context.Context, authInfo authorization.Info, message CreateServiceBrokerMessage) (ServiceBrokerRecord, error) {
-	credsSecretData, err := tools.ToCredentialsSecretData(map[string]string{
+	credsSecretData, err := tools.ToCredentialsSecretData(map[string]any{
 		"username": message.Credentials.Username,
 		"password": message.Credentials.Password,
 	})
@@ -234,7 +234,7 @@ func (r *ServiceBrokerRepo) UpdateServiceBroker(ctx context.Context, authInfo au
 	}
 
 	if message.Credentials != nil {
-		credsSecretData, err := tools.ToCredentialsSecretData(map[string]string{
+		credsSecretData, err := tools.ToCredentialsSecretData(map[string]any{
 			"username": message.Credentials.Username,
 			"password": message.Credentials.Password,
 		})

--- a/api/repositories/service_broker_repository_test.go
+++ b/api/repositories/service_broker_repository_test.go
@@ -364,7 +364,7 @@ var _ = Describe("ServiceBrokerRepo", func() {
 		)
 
 		BeforeEach(func() {
-			credentialsData, err := tools.ToCredentialsSecretData(map[string]string{
+			credentialsData, err := tools.ToCredentialsSecretData(map[string]any{
 				"username": "user",
 				"password": "pass",
 			})

--- a/controllers/controllers/services/credentials/credentials_test.go
+++ b/controllers/controllers/services/credentials/credentials_test.go
@@ -133,15 +133,12 @@ var _ = Describe("Credentials", func() {
 	})
 
 	Describe("ToCredentialsSecretData", func() {
-		var creds any
+		var creds map[string]any
 
 		BeforeEach(func() {
-			creds = struct {
-				Str string
-				Num int
-			}{
-				Str: "abc",
-				Num: 5,
+			creds = map[string]any{
+				"str": "abc",
+				"num": 5,
 			}
 		})
 
@@ -150,7 +147,7 @@ var _ = Describe("Credentials", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(secretData).To(SatisfyAll(
 				HaveLen(1),
-				HaveKeyWithValue(tools.CredentialsSecretKey, MatchJSON(`{"Str":"abc", "Num":5}`)),
+				HaveKeyWithValue(tools.CredentialsSecretKey, MatchJSON(`{"str":"abc", "num":5}`)),
 			))
 		})
 	})

--- a/tools/secrets.go
+++ b/tools/secrets.go
@@ -11,12 +11,12 @@ const (
 	ParametersSecretKey  = "parameters"
 )
 
-func ToCredentialsSecretData(credentials any) (map[string][]byte, error) {
+func ToCredentialsSecretData(credentials map[string]any) (map[string][]byte, error) {
 	return toSecretData(CredentialsSecretKey, credentials)
 }
 
-func ToParametersSecretData(credentials any) (map[string][]byte, error) {
-	return toSecretData(ParametersSecretKey, credentials)
+func ToParametersSecretData(parameters map[string]any) (map[string][]byte, error) {
+	return toSecretData(ParametersSecretKey, parameters)
 }
 
 func toSecretData(key string, value any) (map[string][]byte, error) {

--- a/tools/secrets_test.go
+++ b/tools/secrets_test.go
@@ -7,26 +7,16 @@ import (
 	. "github.com/onsi/gomega/gstruct"
 )
 
-type dataType struct {
-	Foo string
-	Bar struct {
-		InBar string
-	}
-}
-
 var _ = Describe("Secrets", func() {
 	Describe("Credentials", func() {
 		var (
-			credsObject any
+			credsObject map[string]any
 			secretData  map[string][]byte
 		)
 
 		BeforeEach(func() {
-			credsObject = dataType{
-				Foo: "foo",
-				Bar: struct{ InBar string }{
-					InBar: "in-bar",
-				},
+			credsObject = map[string]any{
+				"foo": "bar",
 			}
 		})
 
@@ -39,12 +29,7 @@ var _ = Describe("Secrets", func() {
 
 			It("creates credentials secret data", func() {
 				Expect(secretData).To(MatchAllKeys(Keys{
-					tools.CredentialsSecretKey: MatchJSON(`{
-				"Foo": "foo",
-				"Bar": {
-					"InBar": "in-bar"
-				}
-			}`),
+					tools.CredentialsSecretKey: MatchJSON(`{"foo": "bar"}`),
 				}))
 			})
 		})
@@ -68,9 +53,7 @@ var _ = Describe("Secrets", func() {
 			It("successfully decodes credentials from secret data", func() {
 				Expect(decodeErr).NotTo(HaveOccurred())
 
-				Expect(decodedCredentials).To(HaveKeyWithValue("Foo", "foo"))
-				Expect(decodedCredentials).To(HaveKey("Bar"))
-				Expect(decodedCredentials["Bar"]).To(HaveKeyWithValue("InBar", "in-bar"))
+				Expect(decodedCredentials).To(HaveKeyWithValue("foo", "bar"))
 			})
 
 			When("the secret data is missing the credentials key", func() {
@@ -101,15 +84,12 @@ var _ = Describe("Secrets", func() {
 
 	Describe("Parameters", func() {
 		var (
-			paramsObject any
+			paramsObject map[string]any
 			secretData   map[string][]byte
 		)
 		BeforeEach(func() {
-			paramsObject = dataType{
-				Foo: "foo",
-				Bar: struct{ InBar string }{
-					InBar: "in-bar",
-				},
+			paramsObject = map[string]any{
+				"foo": "bar",
 			}
 		})
 
@@ -122,12 +102,7 @@ var _ = Describe("Secrets", func() {
 
 			It("creates parameters secret data", func() {
 				Expect(secretData).To(MatchAllKeys(Keys{
-					tools.ParametersSecretKey: MatchJSON(`{
-				"Foo": "foo",
-				"Bar": {
-					"InBar": "in-bar"
-				}
-			}`),
+					tools.ParametersSecretKey: MatchJSON(`{"foo": "bar"}`),
 				}))
 			})
 		})
@@ -151,9 +126,7 @@ var _ = Describe("Secrets", func() {
 			It("successfully decodes parameters from secret data", func() {
 				Expect(decodeErr).NotTo(HaveOccurred())
 
-				Expect(decodedParameters).To(HaveKeyWithValue("Foo", "foo"))
-				Expect(decodedParameters).To(HaveKey("Bar"))
-				Expect(decodedParameters["Bar"]).To(HaveKeyWithValue("InBar", "in-bar"))
+				Expect(decodedParameters).To(HaveKeyWithValue("foo", "bar"))
 			})
 
 			When("the secret data is missing the parameters key", func() {


### PR DESCRIPTION
## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
- Service credentials are stored as json objects under a "credentials"
  key.
- A json object is modelled as map[string]any in golang, but korifi was
  using any, which is a bit too broad.
- Additionally simplify tests

