### PR TITLE
Set the default page size of list results to `5000`

### DIFF
--- a/scripts/deploy-on-kind.sh
+++ b/scripts/deploy-on-kind.sh
@@ -211,6 +211,7 @@ function deploy_korifi() {
       --set=experimental.managedServices.enabled="true" \
       --set=experimental.securityGroups.enabled="true" \
       --set=experimental.managedServices.trustInsecureBrokers="true" \
+      --set=api.list.defaultPageSize="5000" \
       --wait
   }
   popd >/dev/null


### PR DESCRIPTION
## Is there a related GitHub Issue?
#4067
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Configure default list page size to 5000. Thus we ensure that list result contains all resources
<!-- _Please describe the change here._ -->

