### PR TITLE
Ordering for droplets, orgs, packages

### DIFF
--- a/api/handlers/org.go
+++ b/api/handlers/org.go
@@ -120,13 +120,13 @@ func (h *Org) list(r *http.Request) (*routing.Response, error) {
 	authInfo, _ := authorization.InfoFromContext(r.Context())
 	logger := logr.FromContextOrDiscard(r.Context()).WithName("handlers.org.list")
 
-	listFilter := &payloads.OrgList{}
-	err := h.requestValidator.DecodeAndValidateURLValues(r, listFilter)
+	payload := &payloads.OrgList{}
+	err := h.requestValidator.DecodeAndValidateURLValues(r, payload)
 	if err != nil {
 		return nil, apierrors.LogAndReturn(logger, err, "Unable to decode request query parameters")
 	}
 
-	listResult, err := h.orgRepo.ListOrgs(r.Context(), authInfo, listFilter.ToMessage())
+	listResult, err := h.orgRepo.ListOrgs(r.Context(), authInfo, payload.ToMessage())
 	if err != nil {
 		return nil, apierrors.LogAndReturn(logger, err, "failed to fetch orgs")
 	}

--- a/api/handlers/package.go
+++ b/api/handlers/package.go
@@ -207,8 +207,8 @@ func (h Package) listDroplets(r *http.Request) (*routing.Response, error) {
 	authInfo, _ := authorization.InfoFromContext(r.Context())
 	logger := logr.FromContextOrDiscard(r.Context()).WithName("handlers.package.list-droplets")
 
-	packageListDroplets := new(payloads.PackageListDroplets)
-	if err := h.requestValidator.DecodeAndValidateURLValues(r, packageListDroplets); err != nil {
+	payload := new(payloads.PackageDropletList)
+	if err := h.requestValidator.DecodeAndValidateURLValues(r, payload); err != nil {
 		return nil, apierrors.LogAndReturn(logger, err, "Unable to decode request query parameters")
 	}
 
@@ -217,9 +217,7 @@ func (h Package) listDroplets(r *http.Request) (*routing.Response, error) {
 		return nil, apierrors.LogAndReturn(logger, apierrors.ForbiddenAsNotFound(err), "Error fetching package with repository")
 	}
 
-	dropletListMessage := packageListDroplets.ToMessage([]string{packageGUID})
-
-	dropletList, err := h.dropletRepo.ListDroplets(r.Context(), authInfo, dropletListMessage)
+	dropletList, err := h.dropletRepo.ListDroplets(r.Context(), authInfo, payload.ToMessage(packageGUID))
 	if err != nil {
 		return nil, apierrors.LogAndReturn(logger, err, "Error fetching droplet list with repository")
 	}

--- a/api/handlers/package_test.go
+++ b/api/handlers/package_test.go
@@ -703,7 +703,7 @@ var _ = Describe("Package", func() {
 
 			queryString = "?not=used"
 
-			payload := payloads.PackageListDroplets{}
+			payload := payloads.PackageDropletList{}
 			requestValidator.DecodeAndValidateURLValuesStub = decodeAndValidateURLValuesStub(&payload)
 		})
 
@@ -728,6 +728,10 @@ var _ = Describe("Package", func() {
 			_, _, dropletListMessage := dropletRepo.ListDropletsArgsForCall(0)
 			Expect(dropletListMessage).To(Equal(repositories.ListDropletsMessage{
 				PackageGUIDs: []string{packageGUID},
+				Pagination: repositories.Pagination{
+					PerPage: 50,
+					Page:    1,
+				},
 			}))
 
 			Expect(rr).To(HaveHTTPStatus(http.StatusOK))

--- a/api/payloads/app.go
+++ b/api/payloads/app.go
@@ -239,3 +239,100 @@ func (a *AppRoutesList) ToMessage(appGUID string) repositories.ListRoutesMessage
 		OrderBy:    a.OrderBy,
 	}
 }
+
+type AppDropletsList struct {
+	GUIDs      string
+	OrderBy    string
+	Pagination Pagination
+}
+
+func (l *AppDropletsList) SupportedKeys() []string {
+	return []string{
+		"guids",
+		"states",
+		"current",
+		"order_by",
+		"page",
+		"per_page",
+	}
+}
+
+func (l AppDropletsList) Validate() error {
+	return jellidation.ValidateStruct(&l,
+		jellidation.Field(&l.OrderBy, validation.OneOfOrderBy("created_at", "updated_at")),
+		jellidation.Field(&l.Pagination),
+	)
+}
+
+func (l *AppDropletsList) DecodeFromURLValues(values url.Values) error {
+	l.GUIDs = values.Get("guids")
+	l.OrderBy = values.Get("order_by")
+	return l.Pagination.DecodeFromURLValues(values)
+}
+
+func (l *AppDropletsList) ToMessage(appGUID string) repositories.ListDropletsMessage {
+	return repositories.ListDropletsMessage{
+		GUIDs:      parse.ArrayParam(l.GUIDs),
+		AppGUIDs:   []string{appGUID},
+		OrderBy:    l.OrderBy,
+		Pagination: l.Pagination.ToMessage(DefaultPageSize),
+	}
+}
+
+type AppPackagesList struct {
+	OrderBy    string
+	Pagination Pagination
+}
+
+func (l *AppPackagesList) SupportedKeys() []string {
+	return []string{"guids", "states", "order_by", "per_page", "page"}
+}
+
+func (l AppPackagesList) Validate() error {
+	return jellidation.ValidateStruct(&l,
+		jellidation.Field(&l.OrderBy, validation.OneOfOrderBy("created_at", "updated_at")),
+		jellidation.Field(&l.Pagination),
+	)
+}
+
+func (l *AppPackagesList) DecodeFromURLValues(values url.Values) error {
+	l.OrderBy = values.Get("order_by")
+	return l.Pagination.DecodeFromURLValues(values)
+}
+
+func (l *AppPackagesList) ToMessage(appGUID string) repositories.ListPackagesMessage {
+	return repositories.ListPackagesMessage{
+		AppGUIDs:   []string{appGUID},
+		OrderBy:    l.OrderBy,
+		Pagination: l.Pagination.ToMessage(DefaultPageSize),
+	}
+}
+
+type AppProcessList struct {
+	OrderBy    string
+	Pagination Pagination
+}
+
+func (l *AppProcessList) SupportedKeys() []string {
+	return []string{"guids", "types", "order_by", "per_page", "page"}
+}
+
+func (l AppProcessList) Validate() error {
+	return jellidation.ValidateStruct(&l,
+		jellidation.Field(&l.OrderBy, validation.OneOfOrderBy("created_at", "updated_at")),
+		jellidation.Field(&l.Pagination),
+	)
+}
+
+func (l *AppProcessList) DecodeFromURLValues(values url.Values) error {
+	l.OrderBy = values.Get("order_by")
+	return l.Pagination.DecodeFromURLValues(values)
+}
+
+func (l *AppProcessList) ToMessage(appGUID string) repositories.ListProcessesMessage {
+	return repositories.ListProcessesMessage{
+		AppGUIDs:   []string{appGUID},
+		OrderBy:    l.OrderBy,
+		Pagination: l.Pagination.ToMessage(DefaultPageSize),
+	}
+}

--- a/api/payloads/app_test.go
+++ b/api/payloads/app_test.go
@@ -587,3 +587,253 @@ var _ = Describe("AppRoutesList", func() {
 		})
 	})
 })
+
+var _ = Describe("AppDropletList", func() {
+	DescribeTable("valid query",
+		func(query string, expectedDropletList payloads.AppDropletsList) {
+			actualDropletList, decodeErr := decodeQuery[payloads.AppDropletsList](query)
+
+			Expect(decodeErr).NotTo(HaveOccurred())
+			Expect(*actualDropletList).To(Equal(expectedDropletList))
+		},
+		Entry("guids", "guids=guid", payloads.AppDropletsList{GUIDs: "guid"}),
+		Entry("order_by created_at", "order_by=created_at", payloads.AppDropletsList{OrderBy: "created_at"}),
+		Entry("order_by -created_at", "order_by=-created_at", payloads.AppDropletsList{OrderBy: "-created_at"}),
+		Entry("order_by updated_at", "order_by=updated_at", payloads.AppDropletsList{OrderBy: "updated_at"}),
+		Entry("order_by -updated_at", "order_by=-updated_at", payloads.AppDropletsList{OrderBy: "-updated_at"}),
+		Entry("pagination", "page=3", payloads.AppDropletsList{Pagination: payloads.Pagination{Page: "3"}}),
+	)
+
+	DescribeTable("invalid query",
+		func(query string, expectedErrMsg string) {
+			_, decodeErr := decodeQuery[payloads.AppDropletsList](query)
+			Expect(decodeErr).To(MatchError(ContainSubstring(expectedErrMsg)))
+		},
+		Entry("invalid order_by", "order_by=foo", "value must be one of"),
+		Entry("invalid parameter", "foo=bar", "unsupported query parameter: foo"),
+		Entry("invalid pagination", "per_page=foo", "value must be an integer"),
+	)
+
+	Describe("ToMessage", func() {
+		It("translates to repo message", func() {
+			dropletList := payloads.AppDropletsList{
+				GUIDs:   "g1,g2",
+				OrderBy: "created_at",
+				Pagination: payloads.Pagination{
+					PerPage: "3",
+					Page:    "2",
+				},
+			}
+			Expect(dropletList.ToMessage("ag1")).To(Equal(repositories.ListDropletsMessage{
+				GUIDs:    []string{"g1", "g2"},
+				AppGUIDs: []string{"ag1"},
+				OrderBy:  "created_at",
+				Pagination: repositories.Pagination{
+					Page:    2,
+					PerPage: 3,
+				},
+			}))
+		})
+	})
+})
+
+var _ = Describe("AppRoutesList", func() {
+	Describe("Validation", func() {
+		DescribeTable("valid query",
+			func(query string, expectedAppRoutesList payloads.AppRoutesList) {
+				actualAppRoutesList, decodeErr := decodeQuery[payloads.AppRoutesList](query)
+
+				Expect(decodeErr).NotTo(HaveOccurred())
+				Expect(*actualAppRoutesList).To(Equal(expectedAppRoutesList))
+			},
+
+			Entry("order_by created_at", "order_by=created_at", payloads.AppRoutesList{OrderBy: "created_at"}),
+			Entry("order_by -created_at", "order_by=-created_at", payloads.AppRoutesList{OrderBy: "-created_at"}),
+			Entry("order_by updated_at", "order_by=updated_at", payloads.AppRoutesList{OrderBy: "updated_at"}),
+			Entry("order_by -updated_at", "order_by=-updated_at", payloads.AppRoutesList{OrderBy: "-updated_at"}),
+			Entry("page=3", "page=3", payloads.AppRoutesList{Pagination: payloads.Pagination{Page: "3"}}),
+		)
+
+		DescribeTable("invalid query",
+			func(query string, expectedErrMsg string) {
+				_, decodeErr := decodeQuery[payloads.AppRoutesList](query)
+				Expect(decodeErr).To(MatchError(ContainSubstring(expectedErrMsg)))
+			},
+			Entry("invalid order_by", "order_by=foo", "value must be one of"),
+			Entry("per_page is not a number", "per_page=foo", "value must be an integer"),
+		)
+	})
+
+	Describe("ToMessage", func() {
+		var (
+			appList payloads.AppRoutesList
+			message repositories.ListRoutesMessage
+		)
+
+		BeforeEach(func() {
+			appList = payloads.AppRoutesList{
+				OrderBy: "created_at",
+				Pagination: payloads.Pagination{
+					PerPage: "20",
+					Page:    "1",
+				},
+			}
+		})
+
+		JustBeforeEach(func() {
+			message = appList.ToMessage("app-guid")
+		})
+
+		It("translates to repository message", func() {
+			Expect(message).To(Equal(repositories.ListRoutesMessage{
+				AppGUIDs: []string{"app-guid"},
+				OrderBy:  "created_at",
+				Pagination: repositories.Pagination{
+					Page:    1,
+					PerPage: 20,
+				},
+			}))
+		})
+	})
+})
+
+var _ = Describe("AppDropletList", func() {
+	DescribeTable("valid query",
+		func(query string, expectedDropletList payloads.AppDropletsList) {
+			actualDropletList, decodeErr := decodeQuery[payloads.AppDropletsList](query)
+
+			Expect(decodeErr).NotTo(HaveOccurred())
+			Expect(*actualDropletList).To(Equal(expectedDropletList))
+		},
+		Entry("guids", "guids=guid", payloads.AppDropletsList{GUIDs: "guid"}),
+		Entry("order_by created_at", "order_by=created_at", payloads.AppDropletsList{OrderBy: "created_at"}),
+		Entry("order_by -created_at", "order_by=-created_at", payloads.AppDropletsList{OrderBy: "-created_at"}),
+		Entry("order_by updated_at", "order_by=updated_at", payloads.AppDropletsList{OrderBy: "updated_at"}),
+		Entry("order_by -updated_at", "order_by=-updated_at", payloads.AppDropletsList{OrderBy: "-updated_at"}),
+		Entry("pagination", "page=3", payloads.AppDropletsList{Pagination: payloads.Pagination{Page: "3"}}),
+	)
+
+	DescribeTable("invalid query",
+		func(query string, expectedErrMsg string) {
+			_, decodeErr := decodeQuery[payloads.AppDropletsList](query)
+			Expect(decodeErr).To(MatchError(ContainSubstring(expectedErrMsg)))
+		},
+		Entry("invalid order_by", "order_by=foo", "value must be one of"),
+		Entry("invalid parameter", "foo=bar", "unsupported query parameter: foo"),
+		Entry("invalid pagination", "per_page=foo", "value must be an integer"),
+	)
+
+	Describe("ToMessage", func() {
+		It("translates to repo message", func() {
+			dropletList := payloads.AppDropletsList{
+				GUIDs:   "g1,g2",
+				OrderBy: "created_at",
+				Pagination: payloads.Pagination{
+					PerPage: "3",
+					Page:    "2",
+				},
+			}
+			Expect(dropletList.ToMessage("ag1")).To(Equal(repositories.ListDropletsMessage{
+				GUIDs:    []string{"g1", "g2"},
+				AppGUIDs: []string{"ag1"},
+				OrderBy:  "created_at",
+				Pagination: repositories.Pagination{
+					Page:    2,
+					PerPage: 3,
+				},
+			}))
+		})
+	})
+})
+
+var _ = Describe("AppPackageList", func() {
+	DescribeTable("valid query",
+		func(query string, expectedDropletList payloads.AppPackagesList) {
+			actualDropletList, decodeErr := decodeQuery[payloads.AppPackagesList](query)
+
+			Expect(decodeErr).NotTo(HaveOccurred())
+			Expect(*actualDropletList).To(Equal(expectedDropletList))
+		},
+		Entry("order_by created_at", "order_by=created_at", payloads.AppPackagesList{OrderBy: "created_at"}),
+		Entry("order_by -created_at", "order_by=-created_at", payloads.AppPackagesList{OrderBy: "-created_at"}),
+		Entry("order_by updated_at", "order_by=updated_at", payloads.AppPackagesList{OrderBy: "updated_at"}),
+		Entry("order_by -updated_at", "order_by=-updated_at", payloads.AppPackagesList{OrderBy: "-updated_at"}),
+		Entry("pagination", "page=3", payloads.AppPackagesList{Pagination: payloads.Pagination{Page: "3"}}),
+	)
+
+	DescribeTable("invalid query",
+		func(query string, expectedErrMsg string) {
+			_, decodeErr := decodeQuery[payloads.AppPackagesList](query)
+			Expect(decodeErr).To(MatchError(ContainSubstring(expectedErrMsg)))
+		},
+		Entry("invalid order_by", "order_by=foo", "value must be one of"),
+		Entry("invalid parameter", "foo=bar", "unsupported query parameter: foo"),
+		Entry("invalid pagination", "per_page=foo", "value must be an integer"),
+	)
+
+	Describe("ToMessage", func() {
+		It("translates to repo message", func() {
+			dropletList := payloads.AppPackagesList{
+				OrderBy: "created_at",
+				Pagination: payloads.Pagination{
+					PerPage: "3",
+					Page:    "2",
+				},
+			}
+			Expect(dropletList.ToMessage("ag1")).To(Equal(repositories.ListPackagesMessage{
+				AppGUIDs: []string{"ag1"},
+				OrderBy:  "created_at",
+				Pagination: repositories.Pagination{
+					Page:    2,
+					PerPage: 3,
+				},
+			}))
+		})
+	})
+})
+
+var _ = Describe("AppProcessList", func() {
+	DescribeTable("valid query",
+		func(query string, expectedDropletList payloads.AppProcessList) {
+			actualDropletList, decodeErr := decodeQuery[payloads.AppProcessList](query)
+
+			Expect(decodeErr).NotTo(HaveOccurred())
+			Expect(*actualDropletList).To(Equal(expectedDropletList))
+		},
+		Entry("order_by created_at", "order_by=created_at", payloads.AppProcessList{OrderBy: "created_at"}),
+		Entry("order_by -created_at", "order_by=-created_at", payloads.AppProcessList{OrderBy: "-created_at"}),
+		Entry("order_by updated_at", "order_by=updated_at", payloads.AppProcessList{OrderBy: "updated_at"}),
+		Entry("order_by -updated_at", "order_by=-updated_at", payloads.AppProcessList{OrderBy: "-updated_at"}),
+		Entry("pagination", "page=3", payloads.AppProcessList{Pagination: payloads.Pagination{Page: "3"}}),
+	)
+
+	DescribeTable("invalid query",
+		func(query string, expectedErrMsg string) {
+			_, decodeErr := decodeQuery[payloads.AppProcessList](query)
+			Expect(decodeErr).To(MatchError(ContainSubstring(expectedErrMsg)))
+		},
+		Entry("invalid order_by", "order_by=foo", "value must be one of"),
+		Entry("invalid parameter", "foo=bar", "unsupported query parameter: foo"),
+		Entry("invalid pagination", "per_page=foo", "value must be an integer"),
+	)
+
+	Describe("ToMessage", func() {
+		It("translates to repo message", func() {
+			dropletList := payloads.AppProcessList{
+				OrderBy: "created_at",
+				Pagination: payloads.Pagination{
+					PerPage: "3",
+					Page:    "2",
+				},
+			}
+			Expect(dropletList.ToMessage("ag1")).To(Equal(repositories.ListProcessesMessage{
+				AppGUIDs: []string{"ag1"},
+				OrderBy:  "created_at",
+				Pagination: repositories.Pagination{
+					Page:    2,
+					PerPage: 3,
+				},
+			}))
+		})
+	})
+})

--- a/api/payloads/droplet_test.go
+++ b/api/payloads/droplet_test.go
@@ -21,6 +21,10 @@ var _ = Describe("DropletList", func() {
 		Entry("guids", "guids=guid", payloads.DropletList{GUIDs: "guid"}),
 		Entry("app_guids", "app_guids=guid", payloads.DropletList{AppGUIDs: "guid"}),
 		Entry("space_guids", "space_guids=guid", payloads.DropletList{SpaceGUIDs: "guid"}),
+		Entry("order_by created_at", "order_by=created_at", payloads.DropletList{OrderBy: "created_at"}),
+		Entry("order_by -created_at", "order_by=-created_at", payloads.DropletList{OrderBy: "-created_at"}),
+		Entry("order_by updated_at", "order_by=updated_at", payloads.DropletList{OrderBy: "updated_at"}),
+		Entry("order_by -updated_at", "order_by=-updated_at", payloads.DropletList{OrderBy: "-updated_at"}),
 		Entry("pagination", "page=3", payloads.DropletList{Pagination: payloads.Pagination{Page: "3"}}),
 	)
 
@@ -29,6 +33,7 @@ var _ = Describe("DropletList", func() {
 			_, decodeErr := decodeQuery[payloads.DropletList](query)
 			Expect(decodeErr).To(MatchError(ContainSubstring(expectedErrMsg)))
 		},
+		Entry("invalid order_by", "order_by=foo", "value must be one of"),
 		Entry("invalid parameter", "foo=bar", "unsupported query parameter: foo"),
 		Entry("invalid pagination", "per_page=foo", "value must be an integer"),
 	)
@@ -39,6 +44,7 @@ var _ = Describe("DropletList", func() {
 				GUIDs:      "g1,g2",
 				AppGUIDs:   "ag1,ag2",
 				SpaceGUIDs: "sg1,sg2",
+				OrderBy:    "created_at",
 				Pagination: payloads.Pagination{
 					PerPage: "3",
 					Page:    "2",
@@ -48,6 +54,7 @@ var _ = Describe("DropletList", func() {
 				GUIDs:      []string{"g1", "g2"},
 				AppGUIDs:   []string{"ag1", "ag2"},
 				SpaceGUIDs: []string{"sg1", "sg2"},
+				OrderBy:    "created_at",
 				Pagination: repositories.Pagination{
 					Page:    2,
 					PerPage: 3,

--- a/api/payloads/org.go
+++ b/api/payloads/org.go
@@ -4,8 +4,9 @@ import (
 	"net/url"
 
 	"code.cloudfoundry.org/korifi/api/payloads/parse"
+	"code.cloudfoundry.org/korifi/api/payloads/validation"
 	"code.cloudfoundry.org/korifi/api/repositories"
-	"github.com/jellydator/validation"
+	jellidation "github.com/jellydator/validation"
 )
 
 type OrgCreate struct {
@@ -15,8 +16,8 @@ type OrgCreate struct {
 }
 
 func (p OrgCreate) Validate() error {
-	return validation.ValidateStruct(&p,
-		validation.Field(&p.Name, validation.Required),
+	return jellidation.ValidateStruct(&p,
+		jellidation.Field(&p.Name, jellidation.Required),
 	)
 }
 
@@ -35,9 +36,9 @@ type OrgPatch struct {
 }
 
 func (p OrgPatch) Validate() error {
-	return validation.ValidateStruct(&p,
-		validation.Field(&p.Metadata),
-		validation.Field(&p.Name, validation.NilOrNotEmpty),
+	return jellidation.ValidateStruct(&p,
+		jellidation.Field(&p.Metadata),
+		jellidation.Field(&p.Name, jellidation.NilOrNotEmpty),
 	)
 }
 
@@ -54,12 +55,14 @@ func (p OrgPatch) ToMessage(orgGUID string) repositories.PatchOrgMessage {
 
 type OrgList struct {
 	Names      string
+	OrderBy    string
 	Pagination Pagination
 }
 
 func (l *OrgList) ToMessage() repositories.ListOrgsMessage {
 	return repositories.ListOrgsMessage{
 		Names:      parse.ArrayParam(l.Names),
+		OrderBy:    l.OrderBy,
 		Pagination: l.Pagination.ToMessage(DefaultPageSize),
 	}
 }
@@ -70,11 +73,13 @@ func (l *OrgList) SupportedKeys() []string {
 
 func (l *OrgList) DecodeFromURLValues(values url.Values) error {
 	l.Names = values.Get("names")
+	l.OrderBy = values.Get("order_by")
 	return l.Pagination.DecodeFromURLValues(values)
 }
 
 func (l OrgList) Validate() error {
-	return validation.ValidateStruct(&l,
-		validation.Field(&l.Pagination),
+	return jellidation.ValidateStruct(&l,
+		jellidation.Field(&l.OrderBy, validation.OneOfOrderBy("created_at", "updated_at", "name")),
+		jellidation.Field(&l.Pagination),
 	)
 }

--- a/api/payloads/org_test.go
+++ b/api/payloads/org_test.go
@@ -121,6 +121,12 @@ var _ = Describe("Org", func() {
 				Expect(*actualOrgList).To(Equal(expectedOrgList))
 			},
 			Entry("names", "names=o1,o2", payloads.OrgList{Names: "o1,o2"}),
+			Entry("created_at", "order_by=created_at", payloads.OrgList{OrderBy: "created_at"}),
+			Entry("-created_at", "order_by=-created_at", payloads.OrgList{OrderBy: "-created_at"}),
+			Entry("updated_at", "order_by=updated_at", payloads.OrgList{OrderBy: "updated_at"}),
+			Entry("-updated_at", "order_by=-updated_at", payloads.OrgList{OrderBy: "-updated_at"}),
+			Entry("name", "order_by=name", payloads.OrgList{OrderBy: "name"}),
+			Entry("-name", "order_by=-name", payloads.OrgList{OrderBy: "-name"}),
 			Entry("pagination", "page=3", payloads.OrgList{Pagination: payloads.Pagination{Page: "3"}}),
 		)
 
@@ -136,14 +142,16 @@ var _ = Describe("Org", func() {
 		Describe("ToMessage", func() {
 			It("splits names to strings", func() {
 				orgList := payloads.OrgList{
-					Names: "foo,bar",
+					Names:   "foo,bar",
+					OrderBy: "created_at",
 					Pagination: payloads.Pagination{
 						PerPage: "10",
 						Page:    "2",
 					},
 				}
 				Expect(orgList.ToMessage()).To(Equal(repositories.ListOrgsMessage{
-					Names: []string{"foo", "bar"},
+					Names:   []string{"foo", "bar"},
+					OrderBy: "created_at",
 					Pagination: repositories.Pagination{
 						PerPage: 10,
 						Page:    2,

--- a/api/payloads/package.go
+++ b/api/payloads/package.go
@@ -126,18 +126,24 @@ func (p PackageList) Validate() error {
 	)
 }
 
-type PackageListDroplets struct{}
+type PackageDropletList struct {
+	OrderBy    string
+	Pagination Pagination
+}
 
-func (p *PackageListDroplets) ToMessage(packageGUIDs []string) repositories.ListDropletsMessage {
+func (p *PackageDropletList) ToMessage(packageGUID string) repositories.ListDropletsMessage {
 	return repositories.ListDropletsMessage{
-		PackageGUIDs: packageGUIDs,
+		PackageGUIDs: []string{packageGUID},
+		OrderBy:      p.OrderBy,
+		Pagination:   p.Pagination.ToMessage(DefaultPageSize),
 	}
 }
 
-func (p *PackageListDroplets) SupportedKeys() []string {
+func (p *PackageDropletList) SupportedKeys() []string {
 	return []string{"states", "per_page", "page"}
 }
 
-func (p *PackageListDroplets) DecodeFromURLValues(values url.Values) error {
-	return nil
+func (p *PackageDropletList) DecodeFromURLValues(values url.Values) error {
+	p.OrderBy = values.Get("order_by")
+	return p.Pagination.DecodeFromURLValues(values)
 }

--- a/api/payloads/service_offering.go
+++ b/api/payloads/service_offering.go
@@ -3,7 +3,6 @@ package payloads
 import (
 	"fmt"
 	"net/url"
-	"regexp"
 	"strings"
 
 	"code.cloudfoundry.org/korifi/api/payloads/params"
@@ -103,10 +102,6 @@ func (l *ServiceOfferingList) ToMessage() repositories.ListServiceOfferingMessag
 
 func (l *ServiceOfferingList) SupportedKeys() []string {
 	return []string{"names", "service_broker_names", "fields[service_broker]", "page", "per_page"}
-}
-
-func (l *ServiceOfferingList) IgnoredKeys() []*regexp.Regexp {
-	return nil
 }
 
 func (l *ServiceOfferingList) DecodeFromURLValues(values url.Values) error {

--- a/api/repositories/droplet_repository.go
+++ b/api/repositories/droplet_repository.go
@@ -61,6 +61,7 @@ type ListDropletsMessage struct {
 	PackageGUIDs []string
 	AppGUIDs     []string
 	SpaceGUIDs   []string
+	OrderBy      string
 	Pagination   Pagination
 }
 
@@ -71,6 +72,7 @@ func (m *ListDropletsMessage) toListOptions() []ListOption {
 		WithLabelIn(korifiv1alpha1.SpaceGUIDLabelKey, m.SpaceGUIDs),
 		WithLabelIn(korifiv1alpha1.CFDropletGUIDLabelKey, m.GUIDs),
 		WithLabel(korifiv1alpha1.CFBuildStateLabelKey, korifiv1alpha1.BuildStateStaged),
+		WithOrdering(m.OrderBy),
 		WithPaging(m.Pagination),
 	}
 }

--- a/api/repositories/droplet_repository_test.go
+++ b/api/repositories/droplet_repository_test.go
@@ -241,6 +241,7 @@ var _ = Describe("DropletRepository", func() {
 						PackageGUIDs: []string{"p1", "p2"},
 						AppGUIDs:     []string{"a1", "a2"},
 						SpaceGUIDs:   []string{"a1", "a2"},
+						OrderBy:      "created_at",
 						Pagination: repositories.Pagination{
 							Page:    2,
 							PerPage: 10,
@@ -258,6 +259,7 @@ var _ = Describe("DropletRepository", func() {
 						repositories.WithLabelIn(korifiv1alpha1.CFAppGUIDLabelKey, []string{"a1", "a2"}),
 						repositories.WithLabelIn(korifiv1alpha1.SpaceGUIDLabelKey, []string{"a1", "a2"}),
 						repositories.WithLabel(korifiv1alpha1.CFBuildStateLabelKey, korifiv1alpha1.BuildStateStaged),
+						repositories.WithOrdering("created_at"),
 						repositories.WithPaging(repositories.Pagination{
 							Page:    2,
 							PerPage: 10,

--- a/api/repositories/org_repository.go
+++ b/api/repositories/org_repository.go
@@ -31,6 +31,7 @@ type CreateOrgMessage struct {
 type ListOrgsMessage struct {
 	Names      []string
 	GUIDs      []string
+	OrderBy    string
 	Pagination Pagination
 }
 
@@ -46,6 +47,9 @@ func (m *ListOrgsMessage) toListOptions(authorizedOrgGuids []string) []ListOptio
 		WithLabelStrictlyIn(korifiv1alpha1.GUIDLabelKey, selectedGuids),
 		WithLabelIn(korifiv1alpha1.CFOrgDisplayNameKey, tools.EncodeValuesToSha224(m.Names...)),
 		WithLabel(korifiv1alpha1.ReadyLabelKey, string(metav1.ConditionTrue)),
+		WithOrdering(m.OrderBy,
+			"name", "Display Name",
+		),
 		WithPaging(m.Pagination),
 	}
 }

--- a/api/repositories/org_repository_test.go
+++ b/api/repositories/org_repository_test.go
@@ -219,8 +219,9 @@ var _ = Describe("OrgRepository", func() {
 					orgRepo = repositories.NewOrgRepo(fakeKlient, rootNamespace, nsPerms, conditionAwaiter)
 
 					listMessage = repositories.ListOrgsMessage{
-						GUIDs: []string{cfOrg1.Name},
-						Names: []string{"a1", "a2"},
+						GUIDs:   []string{cfOrg1.Name},
+						Names:   []string{"a1", "a2"},
+						OrderBy: "created_at",
 						Pagination: repositories.Pagination{
 							Page:    2,
 							PerPage: 100,
@@ -235,6 +236,7 @@ var _ = Describe("OrgRepository", func() {
 						repositories.WithLabelIn(korifiv1alpha1.GUIDLabelKey, []string{cfOrg1.Name}),
 						repositories.WithLabelIn(korifiv1alpha1.CFOrgDisplayNameKey, tools.EncodeValuesToSha224("a1", "a2")),
 						repositories.WithLabel(korifiv1alpha1.ReadyLabelKey, string(metav1.ConditionTrue)),
+						repositories.WithOrdering("created_at"),
 						repositories.WithPaging(repositories.Pagination{
 							Page:    2,
 							PerPage: 100,

--- a/api/repositories/process_repository.go
+++ b/api/repositories/process_repository.go
@@ -107,6 +107,7 @@ type ListProcessesMessage struct {
 	AppGUIDs     []string
 	ProcessTypes []string
 	SpaceGUIDs   []string
+	OrderBy      string
 	Pagination   Pagination
 }
 
@@ -115,6 +116,7 @@ func (m *ListProcessesMessage) toListOptions() []ListOption {
 		WithLabelIn(korifiv1alpha1.CFAppGUIDLabelKey, m.AppGUIDs),
 		WithLabelIn(korifiv1alpha1.CFProcessTypeLabelKey, m.ProcessTypes),
 		WithLabelIn(korifiv1alpha1.SpaceGUIDLabelKey, m.SpaceGUIDs),
+		WithOrdering(m.OrderBy),
 		WithPaging(m.Pagination),
 	}
 }

--- a/api/repositories/process_repository_test.go
+++ b/api/repositories/process_repository_test.go
@@ -240,6 +240,7 @@ var _ = Describe("ProcessRepo", func() {
 						AppGUIDs:     []string{"app-guid", "another-app-guid"},
 						SpaceGUIDs:   []string{"space-guid", "another-space-guid"},
 						ProcessTypes: []string{"web", "worker"},
+						OrderBy:      "created_at",
 						Pagination: repositories.Pagination{
 							PerPage: 3,
 							Page:    4,
@@ -254,6 +255,7 @@ var _ = Describe("ProcessRepo", func() {
 						repositories.WithLabelIn(korifiv1alpha1.CFAppGUIDLabelKey, []string{"app-guid", "another-app-guid"}),
 						repositories.WithLabelIn(korifiv1alpha1.SpaceGUIDLabelKey, []string{"space-guid", "another-space-guid"}),
 						repositories.WithLabelIn(korifiv1alpha1.CFProcessTypeLabelKey, []string{"web", "worker"}),
+						repositories.WithOrdering("created_at"),
 						repositories.WithPaging(repositories.Pagination{
 							PerPage: 3,
 							Page:    4,


### PR DESCRIPTION

<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
#3701
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Most of this change deals with introducing dedicated payloads for
listing resources in the context of other resources. For example:
- there is a payload for listing droplets via /v3/droplets
- there is an alternative payload for listing the droplets in the
  context of an app via /v3/apps/:guid/droplets
- these payloads are a bit different
- both should support ordering and paging
<!-- _Please describe the change here._ -->

