### PR TITLE
Paging for roles

### DIFF
--- a/api/handlers/fake/cfrole_repository.go
+++ b/api/handlers/fake/cfrole_repository.go
@@ -54,7 +54,7 @@ type CFRoleRepository struct {
 		result1 repositories.RoleRecord
 		result2 error
 	}
-	ListRolesStub        func(context.Context, authorization.Info, repositories.ListRolesMessage) ([]repositories.RoleRecord, error)
+	ListRolesStub        func(context.Context, authorization.Info, repositories.ListRolesMessage) (repositories.ListResult[repositories.RoleRecord], error)
 	listRolesMutex       sync.RWMutex
 	listRolesArgsForCall []struct {
 		arg1 context.Context
@@ -62,11 +62,11 @@ type CFRoleRepository struct {
 		arg3 repositories.ListRolesMessage
 	}
 	listRolesReturns struct {
-		result1 []repositories.RoleRecord
+		result1 repositories.ListResult[repositories.RoleRecord]
 		result2 error
 	}
 	listRolesReturnsOnCall map[int]struct {
-		result1 []repositories.RoleRecord
+		result1 repositories.ListResult[repositories.RoleRecord]
 		result2 error
 	}
 	invocations      map[string][][]interface{}
@@ -268,7 +268,7 @@ func (fake *CFRoleRepository) GetRoleReturnsOnCall(i int, result1 repositories.R
 	}{result1, result2}
 }
 
-func (fake *CFRoleRepository) ListRoles(arg1 context.Context, arg2 authorization.Info, arg3 repositories.ListRolesMessage) ([]repositories.RoleRecord, error) {
+func (fake *CFRoleRepository) ListRoles(arg1 context.Context, arg2 authorization.Info, arg3 repositories.ListRolesMessage) (repositories.ListResult[repositories.RoleRecord], error) {
 	fake.listRolesMutex.Lock()
 	ret, specificReturn := fake.listRolesReturnsOnCall[len(fake.listRolesArgsForCall)]
 	fake.listRolesArgsForCall = append(fake.listRolesArgsForCall, struct {
@@ -295,7 +295,7 @@ func (fake *CFRoleRepository) ListRolesCallCount() int {
 	return len(fake.listRolesArgsForCall)
 }
 
-func (fake *CFRoleRepository) ListRolesCalls(stub func(context.Context, authorization.Info, repositories.ListRolesMessage) ([]repositories.RoleRecord, error)) {
+func (fake *CFRoleRepository) ListRolesCalls(stub func(context.Context, authorization.Info, repositories.ListRolesMessage) (repositories.ListResult[repositories.RoleRecord], error)) {
 	fake.listRolesMutex.Lock()
 	defer fake.listRolesMutex.Unlock()
 	fake.ListRolesStub = stub
@@ -308,28 +308,28 @@ func (fake *CFRoleRepository) ListRolesArgsForCall(i int) (context.Context, auth
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
-func (fake *CFRoleRepository) ListRolesReturns(result1 []repositories.RoleRecord, result2 error) {
+func (fake *CFRoleRepository) ListRolesReturns(result1 repositories.ListResult[repositories.RoleRecord], result2 error) {
 	fake.listRolesMutex.Lock()
 	defer fake.listRolesMutex.Unlock()
 	fake.ListRolesStub = nil
 	fake.listRolesReturns = struct {
-		result1 []repositories.RoleRecord
+		result1 repositories.ListResult[repositories.RoleRecord]
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *CFRoleRepository) ListRolesReturnsOnCall(i int, result1 []repositories.RoleRecord, result2 error) {
+func (fake *CFRoleRepository) ListRolesReturnsOnCall(i int, result1 repositories.ListResult[repositories.RoleRecord], result2 error) {
 	fake.listRolesMutex.Lock()
 	defer fake.listRolesMutex.Unlock()
 	fake.ListRolesStub = nil
 	if fake.listRolesReturnsOnCall == nil {
 		fake.listRolesReturnsOnCall = make(map[int]struct {
-			result1 []repositories.RoleRecord
+			result1 repositories.ListResult[repositories.RoleRecord]
 			result2 error
 		})
 	}
 	fake.listRolesReturnsOnCall[i] = struct {
-		result1 []repositories.RoleRecord
+		result1 repositories.ListResult[repositories.RoleRecord]
 		result2 error
 	}{result1, result2}
 }

--- a/api/payloads/role.go
+++ b/api/payloads/role.go
@@ -137,11 +137,18 @@ type RoleList struct {
 	OrgGUIDs   map[string]bool
 	UserGUIDs  map[string]bool
 	OrderBy    string
+	Pagination Pagination
 }
 
 func (r RoleList) ToMessage() repositories.ListRolesMessage {
 	return repositories.ListRolesMessage{
-		OrderBy: r.OrderBy,
+		GUIDs:      r.GUIDs,
+		Types:      r.Types,
+		SpaceGUIDs: r.SpaceGUIDs,
+		OrgGUIDs:   r.OrgGUIDs,
+		UserGUIDs:  r.UserGUIDs,
+		OrderBy:    r.OrderBy,
+		Pagination: r.Pagination.ToMessage(DefaultPageSize),
 	}
 }
 
@@ -156,12 +163,13 @@ func (r *RoleList) DecodeFromURLValues(values url.Values) error {
 	r.OrgGUIDs = commaSepToSet(values.Get("organization_guids"))
 	r.UserGUIDs = commaSepToSet(values.Get("user_guids"))
 	r.OrderBy = values.Get("order_by")
-	return nil
+	return r.Pagination.DecodeFromURLValues(values)
 }
 
 func (r RoleList) Validate() error {
 	return jellidation.ValidateStruct(&r,
 		jellidation.Field(&r.OrderBy, validation.OneOfOrderBy("created_at", "updated_at")),
+		jellidation.Field(&r.Pagination),
 	)
 }
 

--- a/tests/helpers/set.go
+++ b/tests/helpers/set.go
@@ -1,0 +1,9 @@
+package helpers
+
+func Set(items ...string) map[string]bool {
+	result := make(map[string]bool, len(items))
+	for _, item := range items {
+		result[item] = true
+	}
+	return result
+}

--- a/tests/smoke/list_test.go
+++ b/tests/smoke/list_test.go
@@ -57,7 +57,7 @@ var _ = Describe("list", func() {
 		Entry("packages", "packages", Not(BeEmpty())),
 		Entry("processes", "processes", Not(BeEmpty())),
 		Entry("routes", "routes", Not(BeEmpty())),
-		Entry("routes", "routes", Not(BeEmpty())),
+		Entry("roles", "roles", Not(BeEmpty())),
 		Entry("service_instances", "service_instances", Not(BeEmpty())),
 		Entry("service_credential_bindings", "service_credential_bindings", Not(BeEmpty())),
 		Entry("service brokers", "service_brokers", Not(BeEmpty())),


### PR DESCRIPTION
## Is there a related GitHub Issue?
#3701
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
- There is no crd for roles, so we cannot applly the usual algorithm for
  paging/sorting
- Instead we have to do everything on the client side (for now)
- The filtering logic is moved from handlers to repo along with
  tests
- Paging is done "manually" similarly to how its being done for buildpacks
<!-- _Please describe the change here._ -->
