### PR TITLE
Ensure list is retried when object resolution fails

### DIFF
--- a/api/repositories/k8sklient/descriptors/errors/resolution.go
+++ b/api/repositories/k8sklient/descriptors/errors/resolution.go
@@ -1,0 +1,28 @@
+package errors
+
+import (
+	"errors"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type objectResolutionError struct {
+	guid string
+	gvk  schema.GroupVersionKind
+}
+
+func (e objectResolutionError) Error() string {
+	return fmt.Sprintf("item not found: guid %q, gvk %q", e.guid, e.gvk)
+}
+
+func NewObjectResolutionError(guid string, gvk schema.GroupVersionKind) error {
+	return objectResolutionError{
+		guid: guid,
+		gvk:  gvk,
+	}
+}
+
+func IsObjectResolutionError(err error) bool {
+	return errors.As(err, new(objectResolutionError))
+}

--- a/api/repositories/k8sklient/descriptors/errors/resolution_test.go
+++ b/api/repositories/k8sklient/descriptors/errors/resolution_test.go
@@ -1,0 +1,49 @@
+package errors_test
+
+import (
+	"errors"
+
+	desc_errs "code.cloudfoundry.org/korifi/api/repositories/k8sklient/descriptors/errors"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var _ = Describe("IsObjectResolutionError", func() {
+	var (
+		isObjectResolutionErr bool
+		err                   error
+	)
+
+	BeforeEach(func() {
+		err = nil
+	})
+
+	JustBeforeEach(func() {
+		isObjectResolutionErr = desc_errs.IsObjectResolutionError(err)
+	})
+
+	It("returns false", func() {
+		Expect(isObjectResolutionErr).To(BeFalse())
+	})
+
+	When("the error is a ObjectResulutionError", func() {
+		BeforeEach(func() {
+			err = desc_errs.NewObjectResolutionError("1234", schema.GroupVersionKind{})
+		})
+
+		It("returns true", func() {
+			Expect(isObjectResolutionErr).To(BeTrue())
+		})
+	})
+
+	When("the error is a random error", func() {
+		BeforeEach(func() {
+			err = errors.New("foo")
+		})
+
+		It("returns false", func() {
+			Expect(isObjectResolutionErr).To(BeFalse())
+		})
+	})
+})

--- a/api/repositories/k8sklient/descriptors/errors/suite_test.go
+++ b/api/repositories/k8sklient/descriptors/errors/suite_test.go
@@ -1,0 +1,13 @@
+package errors_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestErrors(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Errors Suite")
+}

--- a/api/repositories/k8sklient/k8sklient_suite_test.go
+++ b/api/repositories/k8sklient/k8sklient_suite_test.go
@@ -2,10 +2,13 @@ package k8sklient_test
 
 import (
 	"context"
+	"log"
 	"testing"
 
 	"code.cloudfoundry.org/korifi/api/authorization"
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
+	"github.com/go-logr/logr"
+	"github.com/go-logr/stdr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -27,5 +30,6 @@ var _ = BeforeEach(func() {
 		Token: "i-am-user",
 	}
 	ctx = authorization.NewContext(context.Background(), &authInfo)
+	ctx = logr.NewContext(ctx, stdr.New(log.New(GinkgoWriter, ">>>", log.LstdFlags)))
 	utilruntime.Must(korifiv1alpha1.AddToScheme(scheme.Scheme))
 })

--- a/api/repositories/k8sklient/lister_test.go
+++ b/api/repositories/k8sklient/lister_test.go
@@ -11,6 +11,7 @@ import (
 	"code.cloudfoundry.org/korifi/api/repositories"
 	"code.cloudfoundry.org/korifi/api/repositories/k8sklient"
 	"code.cloudfoundry.org/korifi/api/repositories/k8sklient/descriptors"
+	desc_errs "code.cloudfoundry.org/korifi/api/repositories/k8sklient/descriptors/errors"
 	descfake "code.cloudfoundry.org/korifi/api/repositories/k8sklient/descriptors/fake"
 	"code.cloudfoundry.org/korifi/api/repositories/k8sklient/fake"
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
@@ -163,7 +164,7 @@ var _ = Describe("Lister", func() {
 				},
 			}
 
-			objectListMapper.GUIDsToObjectListReturnsOnCall(0, nil, descriptors.ObjectResolutionError{})
+			objectListMapper.GUIDsToObjectListReturnsOnCall(0, nil, desc_errs.NewObjectResolutionError("1234", schema.GroupVersionKind{}))
 			objectListMapper.GUIDsToObjectListReturns(appList, nil)
 		})
 


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
In order for the error producer and the error consumer can work
together, we extract the error type and the error predicate in a
dedicated package and define a constructor for the error

The error producer must use the constructor (as the error type is
package visible), and the consumer must use the predefined predicate (as
it cannot create a pointer to the type).

This way we guarantee that no type mismatch will happen
