### PR TITLE
fix(deploy-on-kind): increase timeout for Helm deployment

### DIFF
--- a/scripts/deploy-on-kind.sh
+++ b/scripts/deploy-on-kind.sh
@@ -212,6 +212,7 @@ function deploy_korifi() {
       --set=experimental.securityGroups.enabled="true" \
       --set=experimental.managedServices.trustInsecureBrokers="true" \
       --set=api.list.defaultPageSize="5000" \
+      --timeout="15m" \
       --wait
   }
   popd >/dev/null

--- a/scripts/installer/install-korifi-kind.yaml
+++ b/scripts/installer/install-korifi-kind.yaml
@@ -118,6 +118,7 @@ spec:
             --set=networking.gatewayPorts.https="32443" \
             --set=experimental.managedServices.enabled="true" \
             --set=experimental.managedServices.trustInsecureBrokers="true" \
+            --timeout="15m" \
             --wait
 
           kubectl wait --for=condition=ready clusterbuilder --all=true --timeout=15m


### PR DESCRIPTION
# Problem 
On my machine, deploying the Helm release took more than the [default `5m`](https://helm.sh/docs/intro/using_helm/#helpful-options-for-installupgraderollback) to run the `post-install`-hook. 

<img width="1237" height="209" alt="Screenshot 2025-08-21 at 15 31 04" src="https://github.com/user-attachments/assets/54b34d67-db68-4400-90fd-0f8e2e206462" />


# Solution 
Increasing the `--timeout` to `15m` made the kind deployment pass on my machine.