### PR TITLE
Remove code climate badges from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,6 @@
   <a href="https://ci.korifi.cf-app.com/teams/main/pipelines/main">
       <img alt="Build Status" src="https://ci.korifi.cf-app.com/api/v1/teams/main/pipelines/main/badge" />
   </a>
-  <a href="https://codeclimate.com/github/cloudfoundry/korifi/maintainability">
-    <img alt="Maintainability" src="https://api.codeclimate.com/v1/badges/1112ab5cfa6a0654cfd2/maintainability" />
-  </a>
-  <a href="https://codeclimate.com/github/cloudfoundry/korifi/test_coverage">
-    <img alt="Test Coverage" src="https://api.codeclimate.com/v1/badges/1112ab5cfa6a0654cfd2/test_coverage" />
-  </a>
 </p>
 
 This repository contains an implementation of the [Cloud Foundry V3 API](http://v3-apidocs.cloudfoundry.org) that is backed entirely by Kubernetes [custom resources](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/).


### PR DESCRIPTION
## Is there a related GitHub Issue?
#4164
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
codeclimate badges have been broker for a while. It seems that there is
no easy codeclimate replacement, we are removing them
<!-- _Please describe the change here._ -->

## Tag your pair, your PM, and/or team
@georgethebeatle
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

<!--
## Things to remember
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
