### PR TITLE
[4199][bug-fix] replace Chart.AppVersion by Chart.Version in resources to correctly assign version labels

### DIFF
--- a/helm/korifi/controllers/post-install-app-domain.yaml
+++ b/helm/korifi/controllers/post-install-app-domain.yaml
@@ -10,7 +10,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Chart.Version }}
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
   name: create-app-domain
   namespace: {{ .Release.Namespace }}

--- a/helm/korifi/kpack-image-builder/post-install-builderinfo.yaml
+++ b/helm/korifi/kpack-image-builder/post-install-builderinfo.yaml
@@ -10,7 +10,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Chart.Version }}
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
   name: create-builderinfo
   namespace: {{ .Release.Namespace }}

--- a/helm/korifi/kpack-image-builder/pre-delete-builderinfo.yaml
+++ b/helm/korifi/kpack-image-builder/pre-delete-builderinfo.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Chart.Version }}
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
   name: delete-builderinfo
   namespace: {{ .Release.Namespace }}

--- a/helm/korifi/migration/post-upgrade-migration.yaml
+++ b/helm/korifi/migration/post-upgrade-migration.yaml
@@ -10,7 +10,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Chart.Version }}
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
   name: post-upgrade-migration
   namespace: {{ .Release.Namespace }}

--- a/helm/korifi/statefulset-runner/post-install-runnerinfo.yaml
+++ b/helm/korifi/statefulset-runner/post-install-runnerinfo.yaml
@@ -10,7 +10,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Chart.Version }}
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
   name: create-runnerinfo
   namespace: {{ .Release.Namespace }}


### PR DESCRIPTION

<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
https://github.com/cloudfoundry/korifi/issues/4199

## What is this change about?
replace `Chart.AppVersion` by `Chart.Version` in the labels

## Does this PR introduce a breaking change?
Hopefully not

## Acceptance Steps
Reinstall `helm chart 16.1` via ArgoCD and `kustomization.yaml` and get no conflicts while manifests generation and validation.

## Tag your pair, your PM, and/or team
**anynines GmbH**

<!--
## Things to remember
nothing more serious
