### PR TITLE
deploy-on-kind: Always use local bin/yq

### DIFF
--- a/scripts/deploy-on-kind.sh
+++ b/scripts/deploy-on-kind.sh
@@ -178,7 +178,7 @@ function deploy_korifi() {
       cp -a helm/korifi/* "$chart_dir"
       values_file="$chart_dir/values.yaml"
 
-      yq -i 'with(.; .version=env(VERSION))' "$chart_dir/Chart.yaml"
+      "${ROOT_DIR}/bin/yq" -i 'with(.; .version=env(VERSION))' "$chart_dir/Chart.yaml"
       "${ROOT_DIR}/bin/yq" "with(.sources[]; .docker.buildx.rawOptions += [\"--build-arg\", \"version=$VERSION\"])" $kbld_file |
         kbld \
           --images-annotation=false \


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
I noticed ./scripts/deploy-on-kind.sh is inconsistent in what yq version to use, so I picked the local one under bin/yq

## Does this PR introduce a breaking change?
No