### PR TITLE
Improve the unique name of CFServiceBinding

### DIFF
--- a/controllers/api/v1alpha1/cfservicebinding_types.go
+++ b/controllers/api/v1alpha1/cfservicebinding_types.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	"fmt"
 
+	"code.cloudfoundry.org/korifi/tools"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -118,11 +119,11 @@ func (b *CFServiceBinding) StatusConditions() *[]metav1.Condition {
 }
 
 func (b CFServiceBinding) UniqueName() string {
-	return fmt.Sprintf("sb::%s::%s::%s", b.Spec.AppRef.Name, b.Spec.Service.Namespace, b.Spec.Service.Name)
+	return fmt.Sprintf("sb::%s::%s::%s::%s", b.Spec.AppRef.Name, b.Namespace, b.Spec.Service.Name, *tools.IfNil(b.Spec.DisplayName, &b.Spec.Service.Name))
 }
 
 func (b CFServiceBinding) UniqueValidationErrorMessage() string {
-	return fmt.Sprintf("Service binding already exists: App: %s Service Instance: %s", b.Spec.AppRef.Name, b.Spec.Service.Name)
+	return fmt.Sprintf("Service binding already exists: App: %s Service Instance: %s Service Binding: %s", b.Spec.AppRef.Name, b.Spec.Service.Name, *tools.IfNil(b.Spec.DisplayName, &b.Spec.Service.Name))
 }
 
 func init() {

--- a/controllers/webhooks/services/bindings/validator_test.go
+++ b/controllers/webhooks/services/bindings/validator_test.go
@@ -76,7 +76,23 @@ var _ = Describe("CFServiceBindingValidatingWebhook", func() {
 			_, _, actualNamespace, actualResource := duplicateValidator.ValidateCreateArgsForCall(0)
 			Expect(actualNamespace).To(Equal(defaultNamespace))
 			Expect(actualResource).To(Equal(serviceBinding))
-			Expect(actualResource.UniqueValidationErrorMessage()).To(Equal("Service binding already exists: App: " + appGUID + " Service Instance: " + serviceInstanceGUID))
+			Expect(actualResource.UniqueName()).To(Equal("sb::" + appGUID + "::" + defaultNamespace + "::" + serviceInstanceGUID + "::" + serviceInstanceGUID))
+			Expect(actualResource.UniqueValidationErrorMessage()).To(Equal("Service binding already exists: App: " + appGUID + " Service Instance: " + serviceInstanceGUID + " Service Binding: " + serviceInstanceGUID))
+		})
+
+		When("the service binding has a display name", func() {
+			BeforeEach(func() {
+				serviceBinding.Spec.DisplayName = tools.PtrTo("my-binding")
+			})
+
+			It("uses the display name in the unique name", func() {
+				Expect(duplicateValidator.ValidateCreateCallCount()).To(Equal(1))
+				_, _, actualNamespace, actualResource := duplicateValidator.ValidateCreateArgsForCall(0)
+				Expect(actualNamespace).To(Equal(defaultNamespace))
+				Expect(actualResource).To(Equal(serviceBinding))
+				Expect(actualResource.UniqueName()).To(Equal("sb::" + appGUID + "::" + defaultNamespace + "::" + serviceInstanceGUID + "::my-binding"))
+				Expect(actualResource.UniqueValidationErrorMessage()).To(Equal("Service binding already exists: App: " + appGUID + " Service Instance: " + serviceInstanceGUID + " Service Binding: my-binding"))
+			})
 		})
 
 		When("a duplicate service binding already exists", func() {

--- a/migration/main.go
+++ b/migration/main.go
@@ -7,6 +7,8 @@ import (
 	"runtime"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
+	"code.cloudfoundry.org/korifi/controllers/coordination"
+	bindingswebhook "code.cloudfoundry.org/korifi/controllers/webhooks/services/bindings"
 	"code.cloudfoundry.org/korifi/migration/migration"
 	"code.cloudfoundry.org/korifi/tools"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -33,7 +35,8 @@ func main() {
 
 	workersCount := tools.Max(1, runtime.NumCPU()/2)
 
-	err = migration.New(k8sClient, korifiVersion, workersCount).Run(context.Background())
+	migrator := migration.New(k8sClient, korifiVersion, workersCount, coordination.NewNameRegistry(k8sClient, bindingswebhook.ServiceBindingEntityType))
+	err = migrator.Run(context.Background())
 	if err != nil {
 		panic(err)
 	}

--- a/migration/migration/executor.go
+++ b/migration/migration/executor.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
+	"code.cloudfoundry.org/korifi/controllers/coordination"
 	"code.cloudfoundry.org/korifi/tools"
 	"code.cloudfoundry.org/korifi/tools/k8s"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -17,21 +18,22 @@ import (
 const MigratedByLabelKey = "korifi.cloudfoundry.org/migrated-by"
 
 var korifiObjectLists = []client.ObjectList{
-	&korifiv1alpha1.CFRouteList{},
 	&korifiv1alpha1.CFServiceBindingList{},
 }
 
 type Migrator struct {
-	k8sClient     client.Client
-	korifiVersion string
-	workersCount  int
+	k8sClient                  client.Client
+	korifiVersion              string
+	workersCount               int
+	serviceBindingNameRegistry coordination.NameRegistry
 }
 
-func New(k8sClient client.Client, korifiVersion string, workersCount int) *Migrator {
+func New(k8sClient client.Client, korifiVersion string, workersCount int, serviceBindingNameRegistry coordination.NameRegistry) *Migrator {
 	return &Migrator{
-		k8sClient:     k8sClient,
-		korifiVersion: korifiVersion,
-		workersCount:  workersCount,
+		k8sClient:                  k8sClient,
+		korifiVersion:              korifiVersion,
+		workersCount:               workersCount,
+		serviceBindingNameRegistry: serviceBindingNameRegistry,
 	}
 }
 
@@ -40,7 +42,7 @@ func (m *Migrator) Run(ctx context.Context) error {
 
 	objectsToUpdate, err := m.collectObjects(ctx, korifiObjectLists)
 	if err != nil {
-		panic(err)
+		return fmt.Errorf("failed to collect objects to migrate: %v", err)
 	}
 
 	fmt.Println("==========================================================")
@@ -61,8 +63,18 @@ func (m *Migrator) Run(ctx context.Context) error {
 			defer wg.Done()
 
 			for obj := range objectChan {
-				if err := m.setMigratedByLabel(ctx, obj); err != nil {
-					fmt.Fprintf(os.Stderr, "Failed to set label on object %v %s/%s: %v\n", obj.GetObjectKind(), obj.GetNamespace(), obj.GetName(), err)
+				binding, ok := obj.(*korifiv1alpha1.CFServiceBinding)
+				if !ok {
+					continue
+				}
+
+				if binding.Labels[MigratedByLabelKey] == m.korifiVersion {
+					continue
+				}
+
+				if err := m.migrateServiceBindingUniqueName(ctx, binding); err != nil {
+					fmt.Fprintf(os.Stderr, "failed to migrate lease for service binding %s/%s: %v\n", binding.Namespace, binding.Name, err)
+					continue
 				}
 				fmt.Fprintf(os.Stdout, "%s %s/%s migrated\n", obj.GetObjectKind().GroupVersionKind().GroupKind().Kind, obj.GetNamespace(), obj.GetName())
 			}
@@ -76,6 +88,37 @@ func (m *Migrator) Run(ctx context.Context) error {
 	fmt.Fprintf(os.Stdout, "Migration completed successfully, took %s!\n", time.Since(startTime))
 
 	return nil
+}
+
+func (m *Migrator) migrateServiceBindingUniqueName(ctx context.Context, binding *korifiv1alpha1.CFServiceBinding) error {
+	err := m.registerServiceBindingUniqueName(ctx, binding)
+	if err != nil {
+		return fmt.Errorf("failed to register the new unique name for service binding %s/%s: %v", binding.Namespace, binding.Name, err)
+	}
+
+	err = m.serviceBindingNameRegistry.DeregisterName(ctx, binding.Namespace, oldUniqueName(binding))
+	if err != nil {
+		return fmt.Errorf("failed to unregister old unique name for service binding %s/%s: %v", binding.Namespace, binding.Name, err)
+	}
+
+	return m.setMigratedByLabel(ctx, binding)
+}
+
+func (m *Migrator) registerServiceBindingUniqueName(ctx context.Context, binding *korifiv1alpha1.CFServiceBinding) error {
+	isOwned, err := m.serviceBindingNameRegistry.CheckNameOwnership(ctx, binding.Namespace, binding.UniqueName(), binding.Namespace, binding.Name)
+	// NotFound means that there is no lease for that unique name
+	if client.IgnoreNotFound(err) != nil {
+		return fmt.Errorf("failed to check ownership of the new binding unique name:  %w", err)
+	}
+
+	if isOwned {
+		return nil
+	}
+	return m.serviceBindingNameRegistry.RegisterName(ctx, binding.Namespace, binding.UniqueName(), binding.Namespace, binding.Name)
+}
+
+func oldUniqueName(binding *korifiv1alpha1.CFServiceBinding) string {
+	return fmt.Sprintf("sb::%s::%s::%s", binding.Spec.AppRef.Name, binding.Spec.Service.Namespace, binding.Spec.Service.Name)
 }
 
 func (m *Migrator) setMigratedByLabel(ctx context.Context, obj client.Object) error {

--- a/migration/migration/executor_test.go
+++ b/migration/migration/executor_test.go
@@ -1,61 +1,191 @@
 package migration_test
 
 import (
+	"crypto/sha1"
+	"fmt"
+
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
+	"code.cloudfoundry.org/korifi/controllers/coordination"
+	bindingswebhook "code.cloudfoundry.org/korifi/controllers/webhooks/services/bindings"
 	"code.cloudfoundry.org/korifi/migration/migration"
+	"code.cloudfoundry.org/korifi/tools"
+	"code.cloudfoundry.org/korifi/tools/k8s"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("Executor", func() {
-	Describe("CFRoute", test(&korifiv1alpha1.CFRoute{
-		Spec: korifiv1alpha1.CFRouteSpec{
-			Host: "example",
-			Path: "/example",
-			DomainRef: corev1.ObjectReference{
-				Name: "example.com",
-			},
-		},
-	}))
-
-	Describe("CFServiceBinding", test(&korifiv1alpha1.CFServiceBinding{
-		Spec: korifiv1alpha1.CFServiceBindingSpec{
-			Type: "key",
-		},
-	}))
-})
-
-func test(testObj client.Object) func() {
-	GinkgoHelper()
-
-	return func() {
+	Describe("CFServiceBinding Lease", func() {
 		var (
-			obj      client.Object
-			migrator *migration.Migrator
+			serviceBinding       *korifiv1alpha1.CFServiceBinding
+			migrator             *migration.Migrator
+			existingLease        *coordinationv1.Lease
+			bindingsNameRegistry coordination.NameRegistry
 		)
 
 		BeforeEach(func() {
-			migrator = migration.New(k8sClient, "abc123", 1)
+			bindingsNameRegistry = coordination.NewNameRegistry(k8sClient, bindingswebhook.ServiceBindingEntityType)
+			migrator = migration.New(k8sClient, "test-version", 1, bindingsNameRegistry)
 
-			obj = testObj.DeepCopyObject().(client.Object)
+			serviceBinding = &korifiv1alpha1.CFServiceBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testNamespace,
+					Name:      uuid.NewString(),
+				},
+				Spec: korifiv1alpha1.CFServiceBindingSpec{
+					Type: "app",
+					Service: corev1.ObjectReference{
+						Kind: "CFServiceInstance",
+						Name: uuid.NewString(),
+					},
+					AppRef: corev1.LocalObjectReference{
+						Name: uuid.NewString(),
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, serviceBinding)).To(Succeed())
 
-			obj.SetName(uuid.NewString())
-			obj.SetNamespace(testNamespace)
-			Expect(k8sClient.Create(ctx, obj)).To(Succeed())
+			existingLeaseName := fmt.Sprintf("servicebinding::sb::%s::%s::%s", serviceBinding.Spec.AppRef.Name, serviceBinding.Spec.Service.Namespace, serviceBinding.Spec.Service.Name)
+			existingLease = &coordinationv1.Lease{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testNamespace,
+					Name:      fmt.Sprintf("n-%x", sha1.Sum([]byte(existingLeaseName))),
+				},
+			}
+			Expect(k8sClient.Create(ctx, existingLease)).To(Succeed())
 		})
 
 		JustBeforeEach(func() {
-			Expect(migrator.Run(ctx)).To(Succeed())
+			err := migrator.Run(ctx)
+			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("sets the migrated_by label", func() {
+		It("sets the migrated-by label", func() {
 			Eventually(func(g Gomega) {
-				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(obj), obj)).To(Succeed())
-				g.Expect(obj.GetLabels()).To(HaveKeyWithValue(migration.MigratedByLabelKey, "abc123"))
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(serviceBinding), serviceBinding)).To(Succeed())
+				g.Expect(serviceBinding.Labels).To(HaveKeyWithValue(migration.MigratedByLabelKey, "test-version"))
 			}).Should(Succeed())
 		})
-	}
-}
+
+		It("deletes the existing lease", func() {
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(existingLease), existingLease)
+				g.Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+			}).Should(Succeed())
+		})
+
+		It("creates a new lease in the new format by using the service name", func() {
+			leaseName := fmt.Sprintf("servicebinding::sb::%s::%s::%s::%s", serviceBinding.Spec.AppRef.Name, serviceBinding.Namespace, serviceBinding.Spec.Service.Name, serviceBinding.Spec.Service.Name)
+			newLease := &coordinationv1.Lease{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testNamespace,
+					Name:      fmt.Sprintf("n-%x", sha1.Sum([]byte(leaseName))),
+				},
+			}
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(newLease), newLease)).To(Succeed())
+				g.Expect(newLease.Annotations).To(SatisfyAll(
+					HaveKeyWithValue(coordination.EntityTypeAnnotation, bindingswebhook.ServiceBindingEntityType),
+					HaveKeyWithValue(coordination.NameAnnotation, fmt.Sprintf("sb::%s::%s::%s::%s", serviceBinding.Spec.AppRef.Name, serviceBinding.Namespace, serviceBinding.Spec.Service.Name, serviceBinding.Spec.Service.Name)),
+					HaveKeyWithValue(coordination.NamespaceAnnotation, serviceBinding.Namespace),
+					HaveKeyWithValue(coordination.OwnerNamespaceAnnotation, serviceBinding.Namespace),
+					HaveKeyWithValue(coordination.OwnerNameAnnotation, serviceBinding.Name),
+				))
+			}).Should(Succeed())
+		})
+
+		When("the service binding has a display name", func() {
+			BeforeEach(func() {
+				Expect(k8s.Patch(ctx, k8sClient, serviceBinding, func() {
+					serviceBinding.Spec.DisplayName = tools.PtrTo(uuid.NewString())
+				})).To(Succeed())
+			})
+
+			It("creates a new lease in the new format by using the binding display name", func() {
+				leaseName := fmt.Sprintf("servicebinding::sb::%s::%s::%s::%s", serviceBinding.Spec.AppRef.Name, serviceBinding.Namespace, serviceBinding.Spec.Service.Name, *serviceBinding.Spec.DisplayName)
+				newLease := &coordinationv1.Lease{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: testNamespace,
+						Name:      fmt.Sprintf("n-%x", sha1.Sum([]byte(leaseName))),
+					},
+				}
+				Eventually(func(g Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(newLease), newLease)).To(Succeed())
+					g.Expect(newLease.Annotations).To(SatisfyAll(
+						HaveKeyWithValue(coordination.EntityTypeAnnotation, bindingswebhook.ServiceBindingEntityType),
+						HaveKeyWithValue(coordination.NameAnnotation, fmt.Sprintf("sb::%s::%s::%s::%s", serviceBinding.Spec.AppRef.Name, serviceBinding.Namespace, serviceBinding.Spec.Service.Name, *serviceBinding.Spec.DisplayName)),
+						HaveKeyWithValue(coordination.NamespaceAnnotation, serviceBinding.Namespace),
+						HaveKeyWithValue(coordination.OwnerNamespaceAnnotation, serviceBinding.Namespace),
+						HaveKeyWithValue(coordination.OwnerNameAnnotation, serviceBinding.Name),
+					))
+				}).Should(Succeed())
+			})
+		})
+
+		When("the binding unique name has been already registered for that binding", func() {
+			BeforeEach(func() {
+				Expect(bindingsNameRegistry.RegisterName(ctx, serviceBinding.Namespace, serviceBinding.UniqueName(), serviceBinding.Namespace, serviceBinding.Name)).To(Succeed())
+			})
+
+			It("preserves the new unique name lease", func() {
+				leaseName := fmt.Sprintf("servicebinding::sb::%s::%s::%s::%s", serviceBinding.Spec.AppRef.Name, serviceBinding.Namespace, serviceBinding.Spec.Service.Name, serviceBinding.Spec.Service.Name)
+				newLease := &coordinationv1.Lease{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: testNamespace,
+						Name:      fmt.Sprintf("n-%x", sha1.Sum([]byte(leaseName))),
+					},
+				}
+				Consistently(func(g Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(newLease), newLease)).To(Succeed())
+				}).Should(Succeed())
+			})
+
+			It("deletes the existing lease", func() {
+				Eventually(func(g Gomega) {
+					err := k8sClient.Get(ctx, client.ObjectKeyFromObject(existingLease), existingLease)
+					g.Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+				}).Should(Succeed())
+			})
+		})
+
+		When("the binding has been already migrated by the current version", func() {
+			BeforeEach(func() {
+				Expect(k8s.Patch(ctx, k8sClient, serviceBinding, func() {
+					serviceBinding.Labels = map[string]string{
+						migration.MigratedByLabelKey: "test-version",
+					}
+				})).To(Succeed())
+			})
+
+			It("does not migrate again", func() {
+				Consistently(func(g Gomega) {
+					err := k8sClient.Get(ctx, client.ObjectKeyFromObject(existingLease), existingLease)
+					g.Expect(err).NotTo(HaveOccurred())
+				}).Should(Succeed())
+			})
+		})
+
+		When("the binding has been migrated by another version", func() {
+			BeforeEach(func() {
+				Expect(k8s.Patch(ctx, k8sClient, serviceBinding, func() {
+					serviceBinding.Labels = map[string]string{
+						migration.MigratedByLabelKey: "another-version",
+					}
+				})).To(Succeed())
+			})
+
+			It("migrates the binding", func() {
+				Eventually(func(g Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(serviceBinding), serviceBinding)).To(Succeed())
+					g.Expect(serviceBinding.Labels).To(HaveKeyWithValue(migration.MigratedByLabelKey, "test-version"))
+				}).Should(Succeed())
+			})
+		})
+	})
+})


### PR DESCRIPTION
## Is there a related GitHub Issue?
#4175
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
- Up to now the unique name of a binding would only include the app and
service instance guids
- This means that we could only bind a service instance to an app once
- This change improves the unique name of the binding by:
  - Including the service instance space guid. This has been
    accidentally omitted before, but given that the resource guids are
    already globally unique has not hit us yet. However we can fix it
    while we are at it
  - Including the service binding display name in the binding uinque
    name. If the diplay name is not set, we default it to the name of
    the service instance

This commit also migrates existing CFServiceBindings by using the name
registry to handle deregistering the "old" binding unique name and
register the "new" unique name. Under the hood this takes care to delete
the old lease and create a new one

