### PR TITLE
Fix empty errors in logs when a reconciled resource is not ready

### DIFF
--- a/tools/k8s/reconcile.go
+++ b/tools/k8s/reconcile.go
@@ -73,12 +73,10 @@ func (r *PatchingReconciler[T]) Reconcile(ctx context.Context, req ctrl.Request)
 
 		var notReadyErr NotReadyError
 		if errors.As(delegateErr, &notReadyErr) {
-			reason := notReadyErr.reason
-			if reason == "" {
-				reason = "Unknown"
-			}
+			delegateErr = fmt.Errorf("resource not ready: %w", notReadyErr)
 
-			readyConditionBuilder.WithReason(reason).WithMessage(notReadyErr.message)
+			reason := tools.IfZero(notReadyErr.reason, "Unknown")
+			readyConditionBuilder.WithReason(reason).WithMessage(reason)
 
 			if notReadyErr.noRequeue {
 				result = ctrl.Result{}

--- a/tools/k8s/reconcile_test.go
+++ b/tools/k8s/reconcile_test.go
@@ -233,8 +233,12 @@ var _ = Describe("Reconcile", func() {
 					HasType(Equal(korifiv1alpha1.StatusConditionReady)),
 					HasStatus(Equal(metav1.ConditionFalse)),
 					HasReason(Equal("Unknown")),
-					HasMessage(BeEmpty()),
+					HasMessage(ContainSubstring("resource not ready")),
 				)))
+			})
+
+			It("returns a non-empty error", func() {
+				Expect(err.Error()).To(ContainSubstring("resource not ready"))
 			})
 
 			When("reason is specified", func() {
@@ -270,7 +274,7 @@ var _ = Describe("Reconcile", func() {
 					Expect(updatedOrg.Status.Conditions).To(ContainElement(SatisfyAll(
 						HasType(Equal(korifiv1alpha1.StatusConditionReady)),
 						HasStatus(Equal(metav1.ConditionFalse)),
-						HasMessage(Equal("TestMessage")),
+						HasMessage(ContainSubstring("TestMessage")),
 					)))
 				})
 			})
@@ -289,7 +293,7 @@ var _ = Describe("Reconcile", func() {
 					Expect(updatedOrg.Status.Conditions).To(ContainElement(SatisfyAll(
 						HasType(Equal(korifiv1alpha1.StatusConditionReady)),
 						HasStatus(Equal(metav1.ConditionFalse)),
-						HasMessage(Equal("test-err")),
+						HasMessage(ContainSubstring(("test-err"))),
 					)))
 				})
 			})
@@ -310,7 +314,7 @@ var _ = Describe("Reconcile", func() {
 					Expect(updatedOrg.Status.Conditions).To(ContainElement(SatisfyAll(
 						HasType(Equal(korifiv1alpha1.StatusConditionReady)),
 						HasStatus(Equal(metav1.ConditionFalse)),
-						HasMessage(Equal("TestMessage: test-err")),
+						HasMessage(ContainSubstring("TestMessage: test-err")),
 					)))
 				})
 			})


### PR DESCRIPTION
## Is there a related GitHub Issue?
#3862
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
When logging a `NotReadyError`, controller runtime invokes the
`Error()` method on `error`, rather than the one from `NotReadyError`.
For developers with classic OOP background, that sounds weird, but in
Golang errors are pointers to the built-in error types, hence the logger
has no clue to invoke `NotReadyError.Error()`. Thus we get log lines
with empty errors.

In order to address this, we wrap the incoming error with `errors.New`
to guarantee that the logged error would say `resource not ready`
<!-- _Please describe the change here._ -->

