### PR TITLE
Fix empty errors in logs when a reconciled resource is not ready

### DIFF
--- a/controllers/controllers/workloads/apps/controller.go
+++ b/controllers/controllers/workloads/apps/controller.go
@@ -146,7 +146,7 @@ func (r *Reconciler) ReconcileResource(ctx context.Context, cfApp *korifiv1alpha
 	cfApp.Status.VCAPServicesSecretName = secretName
 
 	if cfApp.Spec.CurrentDropletRef.Name == "" {
-		return ctrl.Result{}, k8s.NewNotReadyError().WithReason("DropletNotAssigned")
+		return ctrl.Result{}, k8s.NewNotReadyError().WithReason("DropletNotAssigned").WithNoRequeue()
 	}
 
 	droplet, err := r.getDroplet(ctx, cfApp)

--- a/kpack-image-builder/controllers/builderinfo_controller_test.go
+++ b/kpack-image-builder/controllers/builderinfo_controller_test.go
@@ -171,7 +171,7 @@ var _ = Describe("BuilderInfoReconciler", func() {
 				g.Expect(readyCondition).NotTo(BeNil())
 				g.Expect(readyCondition.Status).To(Equal(metav1.ConditionFalse))
 				g.Expect(readyCondition.Reason).To(Equal("ClusterBuilderNotReady"))
-				g.Expect(readyCondition.Message).To(Equal(fmt.Sprintf("ClusterBuilder %q is not ready: something happened", clusterBuilderName)))
+				g.Expect(readyCondition.Message).To(ContainSubstring(fmt.Sprintf("ClusterBuilder %q is not ready: something happened", clusterBuilderName)))
 				g.Expect(readyCondition.ObservedGeneration).To(Equal(info.Generation))
 			}).Should(Succeed())
 		})

--- a/tools/k8s/reconcile_test.go
+++ b/tools/k8s/reconcile_test.go
@@ -233,8 +233,12 @@ var _ = Describe("Reconcile", func() {
 					HasType(Equal(korifiv1alpha1.StatusConditionReady)),
 					HasStatus(Equal(metav1.ConditionFalse)),
 					HasReason(Equal("Unknown")),
-					HasMessage(BeEmpty()),
+					HasMessage(ContainSubstring("resource not ready")),
 				)))
+			})
+
+			It("returns a non-empty error", func() {
+				Expect(err.Error()).To(ContainSubstring("resource not ready"))
 			})
 
 			When("reason is specified", func() {
@@ -270,7 +274,7 @@ var _ = Describe("Reconcile", func() {
 					Expect(updatedOrg.Status.Conditions).To(ContainElement(SatisfyAll(
 						HasType(Equal(korifiv1alpha1.StatusConditionReady)),
 						HasStatus(Equal(metav1.ConditionFalse)),
-						HasMessage(Equal("TestMessage")),
+						HasMessage(ContainSubstring("TestMessage")),
 					)))
 				})
 			})
@@ -289,7 +293,7 @@ var _ = Describe("Reconcile", func() {
 					Expect(updatedOrg.Status.Conditions).To(ContainElement(SatisfyAll(
 						HasType(Equal(korifiv1alpha1.StatusConditionReady)),
 						HasStatus(Equal(metav1.ConditionFalse)),
-						HasMessage(Equal("test-err")),
+						HasMessage(ContainSubstring(("test-err"))),
 					)))
 				})
 			})
@@ -310,7 +314,7 @@ var _ = Describe("Reconcile", func() {
 					Expect(updatedOrg.Status.Conditions).To(ContainElement(SatisfyAll(
 						HasType(Equal(korifiv1alpha1.StatusConditionReady)),
 						HasStatus(Equal(metav1.ConditionFalse)),
-						HasMessage(Equal("TestMessage: test-err")),
+						HasMessage(ContainSubstring("TestMessage: test-err")),
 					)))
 				})
 			})


### PR DESCRIPTION
## Is there a related GitHub Issue?
#3862
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
`NotReadyError` ensures that its error message is not empty.

The initial issue was that when the app droplet is not set, the error
gets its reson set to `DropletNotAssigned`, but the reason is not
reflected in the error message. This commit includes the reason, and
ensures that the message is at least `resource not ready`

While being here, do not requeue reconcile when the app droplet is not
set in its spec. It makes no sense to requeue the reconcile event as it
is expected that the droplet is set on the spec externally. When that
happens the app would be reconciled anyway
