### PR TITLE
Remove binding migration

### DIFF
--- a/migration/main.go
+++ b/migration/main.go
@@ -7,8 +7,6 @@ import (
 	"runtime"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
-	"code.cloudfoundry.org/korifi/controllers/coordination"
-	bindingswebhook "code.cloudfoundry.org/korifi/controllers/webhooks/services/bindings"
 	"code.cloudfoundry.org/korifi/migration/migration"
 	"code.cloudfoundry.org/korifi/tools"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -35,7 +33,7 @@ func main() {
 
 	workersCount := tools.Max(1, runtime.NumCPU()/2)
 
-	migrator := migration.New(k8sClient, korifiVersion, workersCount, coordination.NewNameRegistry(k8sClient, bindingswebhook.ServiceBindingEntityType))
+	migrator := migration.New(k8sClient, korifiVersion, workersCount)
 	err = migrator.Run(context.Background())
 	if err != nil {
 		panic(err)

--- a/migration/migration/executor.go
+++ b/migration/migration/executor.go
@@ -8,8 +8,6 @@ import (
 	"sync"
 	"time"
 
-	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
-	"code.cloudfoundry.org/korifi/controllers/coordination"
 	"code.cloudfoundry.org/korifi/tools"
 	"code.cloudfoundry.org/korifi/tools/k8s"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -17,23 +15,19 @@ import (
 
 const MigratedByLabelKey = "korifi.cloudfoundry.org/migrated-by"
 
-var korifiObjectLists = []client.ObjectList{
-	&korifiv1alpha1.CFServiceBindingList{},
-}
+var korifiObjectLists = []client.ObjectList{}
 
 type Migrator struct {
-	k8sClient                  client.Client
-	korifiVersion              string
-	workersCount               int
-	serviceBindingNameRegistry coordination.NameRegistry
+	k8sClient     client.Client
+	korifiVersion string
+	workersCount  int
 }
 
-func New(k8sClient client.Client, korifiVersion string, workersCount int, serviceBindingNameRegistry coordination.NameRegistry) *Migrator {
+func New(k8sClient client.Client, korifiVersion string, workersCount int) *Migrator {
 	return &Migrator{
-		k8sClient:                  k8sClient,
-		korifiVersion:              korifiVersion,
-		workersCount:               workersCount,
-		serviceBindingNameRegistry: serviceBindingNameRegistry,
+		k8sClient:     k8sClient,
+		korifiVersion: korifiVersion,
+		workersCount:  workersCount,
 	}
 }
 
@@ -63,17 +57,9 @@ func (m *Migrator) Run(ctx context.Context) error {
 			defer wg.Done()
 
 			for obj := range objectChan {
-				binding, ok := obj.(*korifiv1alpha1.CFServiceBinding)
-				if !ok {
-					continue
-				}
-
-				if binding.Labels[MigratedByLabelKey] == m.korifiVersion {
-					continue
-				}
-
-				if err := m.migrateServiceBindingUniqueName(ctx, binding); err != nil {
-					fmt.Fprintf(os.Stderr, "failed to migrate lease for service binding %s/%s: %v\n", binding.Namespace, binding.Name, err)
+				err := m.setMigratedByLabel(ctx, obj)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "failed to set migrated-by label on %s %s/%s: %v\n", obj.GetObjectKind().GroupVersionKind().GroupKind().Kind, obj.GetNamespace(), obj.GetName(), err)
 					continue
 				}
 				fmt.Fprintf(os.Stdout, "%s %s/%s migrated\n", obj.GetObjectKind().GroupVersionKind().GroupKind().Kind, obj.GetNamespace(), obj.GetName())
@@ -88,37 +74,6 @@ func (m *Migrator) Run(ctx context.Context) error {
 	fmt.Fprintf(os.Stdout, "Migration completed successfully, took %s!\n", time.Since(startTime))
 
 	return nil
-}
-
-func (m *Migrator) migrateServiceBindingUniqueName(ctx context.Context, binding *korifiv1alpha1.CFServiceBinding) error {
-	err := m.registerServiceBindingUniqueName(ctx, binding)
-	if err != nil {
-		return fmt.Errorf("failed to register the new unique name for service binding %s/%s: %v", binding.Namespace, binding.Name, err)
-	}
-
-	err = m.serviceBindingNameRegistry.DeregisterName(ctx, binding.Namespace, oldUniqueName(binding))
-	if err != nil {
-		return fmt.Errorf("failed to unregister old unique name for service binding %s/%s: %v", binding.Namespace, binding.Name, err)
-	}
-
-	return m.setMigratedByLabel(ctx, binding)
-}
-
-func (m *Migrator) registerServiceBindingUniqueName(ctx context.Context, binding *korifiv1alpha1.CFServiceBinding) error {
-	isOwned, err := m.serviceBindingNameRegistry.CheckNameOwnership(ctx, binding.Namespace, binding.UniqueName(), binding.Namespace, binding.Name)
-	// NotFound means that there is no lease for that unique name
-	if client.IgnoreNotFound(err) != nil {
-		return fmt.Errorf("failed to check ownership of the new binding unique name:  %w", err)
-	}
-
-	if isOwned {
-		return nil
-	}
-	return m.serviceBindingNameRegistry.RegisterName(ctx, binding.Namespace, binding.UniqueName(), binding.Namespace, binding.Name)
-}
-
-func oldUniqueName(binding *korifiv1alpha1.CFServiceBinding) string {
-	return fmt.Sprintf("sb::%s::%s::%s", binding.Spec.AppRef.Name, binding.Spec.Service.Namespace, binding.Spec.Service.Name)
 }
 
 func (m *Migrator) setMigratedByLabel(ctx context.Context, obj client.Object) error {

--- a/migration/migration/executor_test.go
+++ b/migration/migration/executor_test.go
@@ -1,191 +1,26 @@
 package migration_test
 
 import (
-	"crypto/sha1"
-	"fmt"
-
-	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
-	"code.cloudfoundry.org/korifi/controllers/coordination"
-	bindingswebhook "code.cloudfoundry.org/korifi/controllers/webhooks/services/bindings"
 	"code.cloudfoundry.org/korifi/migration/migration"
-	"code.cloudfoundry.org/korifi/tools"
-	"code.cloudfoundry.org/korifi/tools/k8s"
-	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	coordinationv1 "k8s.io/api/coordination/v1"
-	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("Executor", func() {
-	Describe("CFServiceBinding Lease", func() {
-		var (
-			serviceBinding       *korifiv1alpha1.CFServiceBinding
-			migrator             *migration.Migrator
-			existingLease        *coordinationv1.Lease
-			bindingsNameRegistry coordination.NameRegistry
-		)
+	var (
+		migrator     *migration.Migrator
+		migrationErr error
+	)
 
-		BeforeEach(func() {
-			bindingsNameRegistry = coordination.NewNameRegistry(k8sClient, bindingswebhook.ServiceBindingEntityType)
-			migrator = migration.New(k8sClient, "test-version", 1, bindingsNameRegistry)
+	BeforeEach(func() {
+		migrator = migration.New(k8sClient, "test-version", 1)
+	})
 
-			serviceBinding = &korifiv1alpha1.CFServiceBinding{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: testNamespace,
-					Name:      uuid.NewString(),
-				},
-				Spec: korifiv1alpha1.CFServiceBindingSpec{
-					Type: "app",
-					Service: corev1.ObjectReference{
-						Kind: "CFServiceInstance",
-						Name: uuid.NewString(),
-					},
-					AppRef: corev1.LocalObjectReference{
-						Name: uuid.NewString(),
-					},
-				},
-			}
-			Expect(k8sClient.Create(ctx, serviceBinding)).To(Succeed())
+	JustBeforeEach(func() {
+		migrationErr = migrator.Run(ctx)
+	})
 
-			existingLeaseName := fmt.Sprintf("servicebinding::sb::%s::%s::%s", serviceBinding.Spec.AppRef.Name, serviceBinding.Spec.Service.Namespace, serviceBinding.Spec.Service.Name)
-			existingLease = &coordinationv1.Lease{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: testNamespace,
-					Name:      fmt.Sprintf("n-%x", sha1.Sum([]byte(existingLeaseName))),
-				},
-			}
-			Expect(k8sClient.Create(ctx, existingLease)).To(Succeed())
-		})
-
-		JustBeforeEach(func() {
-			err := migrator.Run(ctx)
-			Expect(err).NotTo(HaveOccurred())
-		})
-
-		It("sets the migrated-by label", func() {
-			Eventually(func(g Gomega) {
-				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(serviceBinding), serviceBinding)).To(Succeed())
-				g.Expect(serviceBinding.Labels).To(HaveKeyWithValue(migration.MigratedByLabelKey, "test-version"))
-			}).Should(Succeed())
-		})
-
-		It("deletes the existing lease", func() {
-			Eventually(func(g Gomega) {
-				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(existingLease), existingLease)
-				g.Expect(k8serrors.IsNotFound(err)).To(BeTrue())
-			}).Should(Succeed())
-		})
-
-		It("creates a new lease in the new format by using the service name", func() {
-			leaseName := fmt.Sprintf("servicebinding::sb::%s::%s::%s::%s", serviceBinding.Spec.AppRef.Name, serviceBinding.Namespace, serviceBinding.Spec.Service.Name, serviceBinding.Spec.Service.Name)
-			newLease := &coordinationv1.Lease{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: testNamespace,
-					Name:      fmt.Sprintf("n-%x", sha1.Sum([]byte(leaseName))),
-				},
-			}
-			Eventually(func(g Gomega) {
-				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(newLease), newLease)).To(Succeed())
-				g.Expect(newLease.Annotations).To(SatisfyAll(
-					HaveKeyWithValue(coordination.EntityTypeAnnotation, bindingswebhook.ServiceBindingEntityType),
-					HaveKeyWithValue(coordination.NameAnnotation, fmt.Sprintf("sb::%s::%s::%s::%s", serviceBinding.Spec.AppRef.Name, serviceBinding.Namespace, serviceBinding.Spec.Service.Name, serviceBinding.Spec.Service.Name)),
-					HaveKeyWithValue(coordination.NamespaceAnnotation, serviceBinding.Namespace),
-					HaveKeyWithValue(coordination.OwnerNamespaceAnnotation, serviceBinding.Namespace),
-					HaveKeyWithValue(coordination.OwnerNameAnnotation, serviceBinding.Name),
-				))
-			}).Should(Succeed())
-		})
-
-		When("the service binding has a display name", func() {
-			BeforeEach(func() {
-				Expect(k8s.Patch(ctx, k8sClient, serviceBinding, func() {
-					serviceBinding.Spec.DisplayName = tools.PtrTo(uuid.NewString())
-				})).To(Succeed())
-			})
-
-			It("creates a new lease in the new format by using the binding display name", func() {
-				leaseName := fmt.Sprintf("servicebinding::sb::%s::%s::%s::%s", serviceBinding.Spec.AppRef.Name, serviceBinding.Namespace, serviceBinding.Spec.Service.Name, *serviceBinding.Spec.DisplayName)
-				newLease := &coordinationv1.Lease{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: testNamespace,
-						Name:      fmt.Sprintf("n-%x", sha1.Sum([]byte(leaseName))),
-					},
-				}
-				Eventually(func(g Gomega) {
-					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(newLease), newLease)).To(Succeed())
-					g.Expect(newLease.Annotations).To(SatisfyAll(
-						HaveKeyWithValue(coordination.EntityTypeAnnotation, bindingswebhook.ServiceBindingEntityType),
-						HaveKeyWithValue(coordination.NameAnnotation, fmt.Sprintf("sb::%s::%s::%s::%s", serviceBinding.Spec.AppRef.Name, serviceBinding.Namespace, serviceBinding.Spec.Service.Name, *serviceBinding.Spec.DisplayName)),
-						HaveKeyWithValue(coordination.NamespaceAnnotation, serviceBinding.Namespace),
-						HaveKeyWithValue(coordination.OwnerNamespaceAnnotation, serviceBinding.Namespace),
-						HaveKeyWithValue(coordination.OwnerNameAnnotation, serviceBinding.Name),
-					))
-				}).Should(Succeed())
-			})
-		})
-
-		When("the binding unique name has been already registered for that binding", func() {
-			BeforeEach(func() {
-				Expect(bindingsNameRegistry.RegisterName(ctx, serviceBinding.Namespace, serviceBinding.UniqueName(), serviceBinding.Namespace, serviceBinding.Name)).To(Succeed())
-			})
-
-			It("preserves the new unique name lease", func() {
-				leaseName := fmt.Sprintf("servicebinding::sb::%s::%s::%s::%s", serviceBinding.Spec.AppRef.Name, serviceBinding.Namespace, serviceBinding.Spec.Service.Name, serviceBinding.Spec.Service.Name)
-				newLease := &coordinationv1.Lease{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: testNamespace,
-						Name:      fmt.Sprintf("n-%x", sha1.Sum([]byte(leaseName))),
-					},
-				}
-				Consistently(func(g Gomega) {
-					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(newLease), newLease)).To(Succeed())
-				}).Should(Succeed())
-			})
-
-			It("deletes the existing lease", func() {
-				Eventually(func(g Gomega) {
-					err := k8sClient.Get(ctx, client.ObjectKeyFromObject(existingLease), existingLease)
-					g.Expect(k8serrors.IsNotFound(err)).To(BeTrue())
-				}).Should(Succeed())
-			})
-		})
-
-		When("the binding has been already migrated by the current version", func() {
-			BeforeEach(func() {
-				Expect(k8s.Patch(ctx, k8sClient, serviceBinding, func() {
-					serviceBinding.Labels = map[string]string{
-						migration.MigratedByLabelKey: "test-version",
-					}
-				})).To(Succeed())
-			})
-
-			It("does not migrate again", func() {
-				Consistently(func(g Gomega) {
-					err := k8sClient.Get(ctx, client.ObjectKeyFromObject(existingLease), existingLease)
-					g.Expect(err).NotTo(HaveOccurred())
-				}).Should(Succeed())
-			})
-		})
-
-		When("the binding has been migrated by another version", func() {
-			BeforeEach(func() {
-				Expect(k8s.Patch(ctx, k8sClient, serviceBinding, func() {
-					serviceBinding.Labels = map[string]string{
-						migration.MigratedByLabelKey: "another-version",
-					}
-				})).To(Succeed())
-			})
-
-			It("migrates the binding", func() {
-				Eventually(func(g Gomega) {
-					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(serviceBinding), serviceBinding)).To(Succeed())
-					g.Expect(serviceBinding.Labels).To(HaveKeyWithValue(migration.MigratedByLabelKey, "test-version"))
-				}).Should(Succeed())
-			})
-		})
+	It("is noop", func() {
+		Expect(migrationErr).NotTo(HaveOccurred())
 	})
 })


### PR DESCRIPTION
## Is there a related GitHub Issue?
No
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
Now that Korifi 0.17.0 is released, we no longer need to support
migration from 0.16.1
<!-- _Please describe the change here._ -->

