### PR TITLE
Implement rename org

### DIFF
--- a/api/payloads/app_test.go
+++ b/api/payloads/app_test.go
@@ -313,20 +313,6 @@ var _ = Describe("App payload validation", func() {
 				Expect(decodedPayload).To(gstruct.PointTo(Equal(payload)))
 			})
 
-			When("metadata is invalid", func() {
-				BeforeEach(func() {
-					payload.Metadata = payloads.MetadataPatch{
-						Labels: map[string]*string{
-							"foo.cloudfoundry.org/bar": tools.PtrTo("jim"),
-						},
-					}
-				})
-
-				It("returns an appropriate error", func() {
-					expectUnprocessableEntityError(validatorErr, "label/annotation key cannot use the cloudfoundry.org domain")
-				})
-			})
-
 			When("name is invalid", func() {
 				BeforeEach(func() {
 					payload.Name = "!@#"

--- a/api/payloads/domain_test.go
+++ b/api/payloads/domain_test.go
@@ -165,20 +165,6 @@ var _ = Describe("DomainUpdate", func() {
 		Expect(validatorErr).NotTo(HaveOccurred())
 		Expect(decodedUpdatePayload).To(gstruct.PointTo(Equal(updatePayload)))
 	})
-
-	When("metadata is invalid", func() {
-		BeforeEach(func() {
-			updatePayload.Metadata = payloads.MetadataPatch{
-				Labels: map[string]*string{
-					"foo.cloudfoundry.org/bar": tools.PtrTo("jim"),
-				},
-			}
-		})
-
-		It("returns an appropriate error", func() {
-			expectUnprocessableEntityError(validatorErr, "cannot use the cloudfoundry.org domain")
-		})
-	})
 })
 
 var _ = Describe("DomainList", func() {

--- a/api/payloads/droplet_test.go
+++ b/api/payloads/droplet_test.go
@@ -94,33 +94,5 @@ var _ = Describe("DropletUpdate", func() {
 			Expect(validatorErr).NotTo(HaveOccurred())
 			Expect(decodedDropletPayload).To(gstruct.PointTo(Equal(updatePayload)))
 		})
-
-		When("metadata.labels contains an invalid key", func() {
-			BeforeEach(func() {
-				updatePayload.Metadata = payloads.MetadataPatch{
-					Labels: map[string]*string{
-						"foo.cloudfoundry.org/bar": tools.PtrTo("jim"),
-					},
-				}
-			})
-
-			It("returns an appropriate error", func() {
-				expectUnprocessableEntityError(validatorErr, "cannot use the cloudfoundry.org domain")
-			})
-		})
-
-		When("metadata.annotations contains an invalid key", func() {
-			BeforeEach(func() {
-				updatePayload.Metadata = payloads.MetadataPatch{
-					Annotations: map[string]*string{
-						"foo.cloudfoundry.org/bar": tools.PtrTo("jim"),
-					},
-				}
-			})
-
-			It("returns an appropriate error", func() {
-				expectUnprocessableEntityError(validatorErr, "cannot use the cloudfoundry.org domain")
-			})
-		})
 	})
 })

--- a/api/payloads/metadata.go
+++ b/api/payloads/metadata.go
@@ -1,11 +1,7 @@
 package payloads
 
 import (
-	"errors"
-	"fmt"
-	"net/url"
-	"strings"
-
+	"code.cloudfoundry.org/korifi/api/tools/metadata"
 	"github.com/jellydator/validation"
 )
 
@@ -28,36 +24,12 @@ type Metadata struct {
 
 func (m Metadata) Validate() error {
 	return validation.ValidateStruct(&m,
-		validation.Field(&m.Annotations, validation.Map().Keys(validation.By(cloudfoundryKeyCheck)).AllowExtraKeys()),
-		validation.Field(&m.Labels, validation.Map().Keys(validation.By(cloudfoundryKeyCheck)).AllowExtraKeys()),
+		validation.Field(&m.Annotations, validation.Map().Keys(validation.By(metadata.CloudfoundryKeyCheck)).AllowExtraKeys()),
+		validation.Field(&m.Labels, validation.Map().Keys(validation.By(metadata.CloudfoundryKeyCheck)).AllowExtraKeys()),
 	)
 }
 
 type MetadataPatch struct {
 	Annotations map[string]*string `json:"annotations,omitempty"`
 	Labels      map[string]*string `json:"labels,omitempty"`
-}
-
-func (p MetadataPatch) Validate() error {
-	return validation.ValidateStruct(&p,
-		validation.Field(&p.Annotations, validation.Map().Keys(validation.By(cloudfoundryKeyCheck)).AllowExtraKeys()),
-		validation.Field(&p.Labels, validation.Map().Keys(validation.By(cloudfoundryKeyCheck)).AllowExtraKeys()),
-	)
-}
-
-func cloudfoundryKeyCheck(key any) error {
-	keyStr, ok := key.(string)
-	if !ok {
-		return fmt.Errorf("expected string key, got %T", key)
-	}
-
-	u, err := url.ParseRequestURI("https://" + keyStr) // without the scheme, the hostname will be parsed as a path
-	if err != nil {
-		return nil
-	}
-
-	if strings.HasSuffix(u.Hostname(), "cloudfoundry.org") {
-		return errors.New("label/annotation key cannot use the cloudfoundry.org domain")
-	}
-	return nil
 }

--- a/api/payloads/metadata_test.go
+++ b/api/payloads/metadata_test.go
@@ -84,24 +84,4 @@ var _ = Describe("MetadataPatch", func() {
 		Expect(validatorErr).NotTo(HaveOccurred())
 		Expect(decodedMetadataPatchPayload).To(gstruct.PointTo(Equal(metadataPatchPayload)))
 	})
-
-	When("metadata.labels contains an invalid key", func() {
-		BeforeEach(func() {
-			metadataPatchPayload.Labels["foo.cloudfoundry.org/bar"] = tools.PtrTo("jim")
-		})
-
-		It("returns an appropriate error", func() {
-			expectUnprocessableEntityError(validatorErr, "cannot use the cloudfoundry.org domain")
-		})
-	})
-
-	When("metadata.annotations contains an invalid key", func() {
-		BeforeEach(func() {
-			metadataPatchPayload.Annotations["foo.cloudfoundry.org/bar"] = tools.PtrTo("jim")
-		})
-
-		It("returns an appropriate error", func() {
-			expectUnprocessableEntityError(validatorErr, "cannot use the cloudfoundry.org domain")
-		})
-	})
 })

--- a/api/payloads/org.go
+++ b/api/payloads/org.go
@@ -31,8 +31,9 @@ func (p OrgCreate) ToMessage() repositories.CreateOrgMessage {
 }
 
 type OrgPatch struct {
-	Name     *string       `json:"name"`
-	Metadata MetadataPatch `json:"metadata"`
+	Name      *string       `json:"name"`
+	Suspended bool          `json:"suspended"`
+	Metadata  MetadataPatch `json:"metadata"`
 }
 
 func (p OrgPatch) Validate() error {

--- a/api/payloads/org.go
+++ b/api/payloads/org.go
@@ -32,7 +32,7 @@ func (p OrgCreate) ToMessage() repositories.CreateOrgMessage {
 
 type OrgPatch struct {
 	Name      *string       `json:"name"`
-	Suspended bool          `json:"suspended"`
+	Suspended *bool         `json:"suspended"`
 	Metadata  MetadataPatch `json:"metadata"`
 }
 

--- a/api/payloads/org_test.go
+++ b/api/payloads/org_test.go
@@ -86,18 +86,6 @@ var _ = Describe("Org", func() {
 			Expect(decodedPayload).To(gstruct.PointTo(Equal(payload)))
 		})
 
-		When("the metadata is invalid", func() {
-			BeforeEach(func() {
-				payload.Metadata.Labels["cloudfoundry.org/test"] = tools.PtrTo("production")
-			})
-
-			It("returns an unprocessable entity error", func() {
-				expectUnprocessableEntityError(
-					validatorErr,
-					"label/annotation key cannot use the cloudfoundry.org domain",
-				)
-			})
-		})
 		When("the name is invalid", func() {
 			BeforeEach(func() {
 				payload.Name = tools.PtrTo("")

--- a/api/payloads/package_test.go
+++ b/api/payloads/package_test.go
@@ -282,20 +282,6 @@ var _ = Describe("PackageUpdate", func() {
 			Expect(validatorErr).NotTo(HaveOccurred())
 			Expect(decodedPayload).To(gstruct.PointTo(Equal(payload)))
 		})
-
-		When("metadata is invalid", func() {
-			BeforeEach(func() {
-				payload.Metadata = payloads.MetadataPatch{
-					Labels: map[string]*string{
-						"foo.cloudfoundry.org/bar": tools.PtrTo("jim"),
-					},
-				}
-			})
-
-			It("returns an appropriate error", func() {
-				expectUnprocessableEntityError(validatorErr, "label/annotation key cannot use the cloudfoundry.org domain")
-			})
-		})
 	})
 
 	Describe("ToMessage", func() {

--- a/api/payloads/route_test.go
+++ b/api/payloads/route_test.go
@@ -188,7 +188,6 @@ var _ = Describe("RoutePatch", func() {
 		patchPayload payloads.RoutePatch
 		routePatch   *payloads.RoutePatch
 		validatorErr error
-		apiError     errors.ApiError
 	)
 
 	BeforeEach(func() {
@@ -203,23 +202,11 @@ var _ = Describe("RoutePatch", func() {
 
 	JustBeforeEach(func() {
 		validatorErr = validator.DecodeAndValidateJSONPayload(createJSONRequest(patchPayload), routePatch)
-		apiError, _ = validatorErr.(errors.ApiError)
 	})
 
 	It("succeeds", func() {
 		Expect(validatorErr).NotTo(HaveOccurred())
 		Expect(routePatch).To(gstruct.PointTo(Equal(patchPayload)))
-	})
-
-	When("metadata uses the cloudfoundry domain", func() {
-		BeforeEach(func() {
-			patchPayload.Metadata.Labels["foo.cloudfoundry.org/bar"] = tools.PtrTo("baz")
-		})
-
-		It("fails", func() {
-			Expect(apiError).To(HaveOccurred())
-			Expect(apiError.Detail()).To(ContainSubstring("cannot use the cloudfoundry.org domain"))
-		})
 	})
 })
 

--- a/api/payloads/service_binding_test.go
+++ b/api/payloads/service_binding_test.go
@@ -257,7 +257,6 @@ var _ = Describe("ServiceBindingUpdate", func() {
 		patchPayload        payloads.ServiceBindingUpdate
 		serviceBindingPatch *payloads.ServiceBindingUpdate
 		validatorErr        error
-		apiError            errors.ApiError
 	)
 
 	BeforeEach(func() {
@@ -272,22 +271,10 @@ var _ = Describe("ServiceBindingUpdate", func() {
 
 	JustBeforeEach(func() {
 		validatorErr = validator.DecodeAndValidateJSONPayload(createJSONRequest(patchPayload), serviceBindingPatch)
-		apiError, _ = validatorErr.(errors.ApiError)
 	})
 
 	It("succeeds", func() {
 		Expect(validatorErr).NotTo(HaveOccurred())
 		Expect(serviceBindingPatch).To(PointTo(Equal(patchPayload)))
-	})
-
-	When("metadata uses the cloudfoundry domain", func() {
-		BeforeEach(func() {
-			patchPayload.Metadata.Labels["foo.cloudfoundry.org/bar"] = tools.PtrTo("baz")
-		})
-
-		It("fails", func() {
-			Expect(apiError).To(HaveOccurred())
-			Expect(apiError.Detail()).To(ContainSubstring("cannot use the cloudfoundry.org domain"))
-		})
 	})
 })

--- a/api/payloads/service_instance_test.go
+++ b/api/payloads/service_instance_test.go
@@ -521,16 +521,6 @@ var _ = Describe("ServiceInstancePatch", func() {
 		})
 	})
 
-	When("metadata is invalid", func() {
-		BeforeEach(func() {
-			patchPayload.Metadata.Labels["foo.cloudfoundry.org/bar"] = tools.PtrTo("baz")
-		})
-
-		It("returns an appropriate error", func() {
-			expectUnprocessableEntityError(validatorErr, "label/annotation key cannot use the cloudfoundry.org domain")
-		})
-	})
-
 	Context("ToServiceInstancePatchMessage", func() {
 		It("converts to repo message correctly", func() {
 			msg := serviceInstancePatch.ToServiceInstancePatchMessage("space-guid", "app-guid")

--- a/api/payloads/space_test.go
+++ b/api/payloads/space_test.go
@@ -126,18 +126,6 @@ var _ = Describe("Space", func() {
 			Expect(decodedPayload).To(gstruct.PointTo(Equal(payload)))
 		})
 
-		When("the metadata is invalid", func() {
-			BeforeEach(func() {
-				payload.Metadata.Labels["cloudfoundry.org/test"] = tools.PtrTo("production")
-			})
-
-			It("returns an unprocessable entity error", func() {
-				expectUnprocessableEntityError(
-					validatorErr,
-					"label/annotation key cannot use the cloudfoundry.org domain",
-				)
-			})
-		})
 		When("the name is invalid", func() {
 			BeforeEach(func() {
 				payload.Name = tools.PtrTo("")

--- a/api/payloads/task_test.go
+++ b/api/payloads/task_test.go
@@ -216,20 +216,6 @@ var _ = Describe("TaskUpdate", func() {
 			Expect(validatorErr).NotTo(HaveOccurred())
 			Expect(decodedPayload).To(gstruct.PointTo(Equal(payload)))
 		})
-
-		When("metadata is invalid", func() {
-			BeforeEach(func() {
-				payload.Metadata = payloads.MetadataPatch{
-					Labels: map[string]*string{
-						"foo.cloudfoundry.org/bar": tools.PtrTo("jim"),
-					},
-				}
-			})
-
-			It("returns an appropriate error", func() {
-				expectUnprocessableEntityError(validatorErr, "label/annotation key cannot use the cloudfoundry.org domain")
-			})
-		})
 	})
 
 	Describe("ToMessage()", func() {

--- a/api/repositories/app_repository.go
+++ b/api/repositories/app_repository.go
@@ -249,8 +249,7 @@ func (f *AppRepo) PatchApp(ctx context.Context, authInfo authorization.Info, app
 	}
 
 	err := GetAndPatch(ctx, f.klient, cfApp, func() error {
-		appPatchMessage.Apply(cfApp)
-		return nil
+		return appPatchMessage.Apply(cfApp)
 	})
 	if err != nil {
 		return AppRecord{}, apierrors.FromK8sError(err, AppResourceType)
@@ -554,7 +553,7 @@ func (m *CreateAppMessage) toCFApp() korifiv1alpha1.CFApp {
 	}
 }
 
-func (m *PatchAppMessage) Apply(app *korifiv1alpha1.CFApp) {
+func (m *PatchAppMessage) Apply(app *korifiv1alpha1.CFApp) error {
 	if m.Name != "" {
 		app.Spec.DisplayName = m.Name
 	}
@@ -573,7 +572,7 @@ func (m *PatchAppMessage) Apply(app *korifiv1alpha1.CFApp) {
 		}
 	}
 
-	m.MetadataPatch.Apply(app)
+	return m.MetadataPatch.Apply(app)
 }
 
 func cfAppToAppRecord(cfApp korifiv1alpha1.CFApp) (AppRecord, error) {

--- a/api/repositories/app_repository_test.go
+++ b/api/repositories/app_repository_test.go
@@ -456,6 +456,21 @@ var _ = Describe("AppRepository", func() {
 				createRoleBinding(ctx, userName, spaceDeveloperRole.Name, cfSpace.Name)
 			})
 
+			When("a label is invalid", func() {
+				BeforeEach(func() {
+					appPatchMessage.MetadataPatch.Labels["foo.cloudfoundry.org/bar"] = tools.PtrTo("baz")
+				})
+
+				It("returns an UnprocessableEntityError", func() {
+					var unprocessableEntityError apierrors.UnprocessableEntityError
+					Expect(errors.As(patchErr, &unprocessableEntityError)).To(BeTrue())
+					Expect(unprocessableEntityError.Detail()).To(SatisfyAll(
+						ContainSubstring("invalid labels patch"),
+						ContainSubstring(`"foo.cloudfoundry.org/bar"`),
+					))
+				})
+			})
+
 			It("updates the app", func() {
 				Expect(patchErr).NotTo(HaveOccurred())
 

--- a/api/repositories/domain_repository.go
+++ b/api/repositories/domain_repository.go
@@ -124,8 +124,7 @@ func (r *DomainRepo) UpdateDomain(ctx context.Context, authInfo authorization.In
 	}
 
 	err = r.klient.Patch(ctx, domain, func() error {
-		message.MetadataPatch.Apply(domain)
-		return nil
+		return message.MetadataPatch.Apply(domain)
 	})
 	if err != nil {
 		return DomainRecord{}, fmt.Errorf("failed to patch domain metadata: %w", apierrors.FromK8sError(err, DomainResourceType))

--- a/api/repositories/domain_repository_test.go
+++ b/api/repositories/domain_repository_test.go
@@ -2,6 +2,7 @@ package repositories_test
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	apierrors "code.cloudfoundry.org/korifi/api/errors"
@@ -185,6 +186,21 @@ var _ = Describe("DomainRepository", func() {
 		When("the user is a CFAdmin", func() {
 			BeforeEach(func() {
 				createRoleBinding(ctx, userName, adminRole.Name, rootNamespace)
+			})
+
+			When("a label is invalid", func() {
+				BeforeEach(func() {
+					updatePayload.MetadataPatch.Labels["foo.cloudfoundry.org/bar"] = tools.PtrTo("baz")
+				})
+
+				It("returns an UnprocessableEntityError", func() {
+					var unprocessableEntityError apierrors.UnprocessableEntityError
+					Expect(errors.As(updateErr, &unprocessableEntityError)).To(BeTrue())
+					Expect(unprocessableEntityError.Detail()).To(SatisfyAll(
+						ContainSubstring("invalid labels patch"),
+						ContainSubstring(`"foo.cloudfoundry.org/bar"`),
+					))
+				})
 			})
 
 			It("updates the domain metadata", func() {

--- a/api/repositories/droplet_repository.go
+++ b/api/repositories/droplet_repository.go
@@ -168,9 +168,7 @@ func (r *DropletRepo) UpdateDroplet(ctx context.Context, authInfo authorization.
 	}
 
 	err = r.klient.Patch(ctx, build, func() error {
-		message.MetadataPatch.Apply(build)
-
-		return nil
+		return message.MetadataPatch.Apply(build)
 	})
 	if err != nil {
 		return DropletRecord{}, fmt.Errorf("failed to patch droplet metadata: %w", apierrors.FromK8sError(err, DropletResourceType))

--- a/api/repositories/droplet_repository_test.go
+++ b/api/repositories/droplet_repository_test.go
@@ -1,6 +1,7 @@
 package repositories_test
 
 import (
+	"errors"
 	"time"
 
 	apierrors "code.cloudfoundry.org/korifi/api/errors"
@@ -318,6 +319,21 @@ var _ = Describe("DropletRepository", func() {
 						build.Status.State = korifiv1alpha1.BuildStateStaged
 						build.Status.Droplet = &korifiv1alpha1.BuildDropletStatus{}
 					})).To(Succeed())
+				})
+
+				When("a label is invalid", func() {
+					BeforeEach(func() {
+						dropletUpdateMsg.MetadataPatch.Labels["foo.cloudfoundry.org/bar"] = tools.PtrTo("baz")
+					})
+
+					It("returns an UnprocessableEntityError", func() {
+						var unprocessableEntityError apierrors.UnprocessableEntityError
+						Expect(errors.As(updateError, &unprocessableEntityError)).To(BeTrue())
+						Expect(unprocessableEntityError.Detail()).To(SatisfyAll(
+							ContainSubstring("invalid labels patch"),
+							ContainSubstring(`"foo.cloudfoundry.org/bar"`),
+						))
+					})
 				})
 
 				It("updates the build metadata in kubernetes", func() {

--- a/api/repositories/metadata.go
+++ b/api/repositories/metadata.go
@@ -1,6 +1,13 @@
 package repositories
 
-import "sigs.k8s.io/controller-runtime/pkg/client"
+import (
+	"fmt"
+
+	apierrors "code.cloudfoundry.org/korifi/api/errors"
+	"code.cloudfoundry.org/korifi/api/tools/metadata"
+	"code.cloudfoundry.org/korifi/tools"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
 
 type Metadata struct {
 	Annotations map[string]string
@@ -12,7 +19,11 @@ type MetadataPatch struct {
 	Labels      map[string]*string
 }
 
-func (p *MetadataPatch) Apply(obj client.Object) {
+func (p *MetadataPatch) Apply(obj client.Object) error {
+	if err := p.validate(obj); err != nil {
+		return err
+	}
+
 	if obj.GetAnnotations() == nil {
 		obj.SetAnnotations(map[string]string{})
 	}
@@ -23,6 +34,33 @@ func (p *MetadataPatch) Apply(obj client.Object) {
 
 	patchMap(obj.GetAnnotations(), p.Annotations)
 	patchMap(obj.GetLabels(), p.Labels)
+
+	return nil
+}
+
+func (p *MetadataPatch) validate(obj client.Object) error {
+	for patchKey, patchValue := range p.Annotations {
+		if !isUpdate(obj.GetAnnotations(), patchKey, patchValue) {
+			continue
+		}
+
+		if err := metadata.CloudfoundryKeyCheck(patchKey); err != nil {
+			// TODO: the error message probably may not contain that much details, logging them should be sufficient
+			return apierrors.NewUnprocessableEntityError(err, fmt.Sprintf("invalid annotations patch: %q: %q -> %q", patchKey, obj.GetAnnotations()[patchKey], tools.ZeroIfNil(patchValue)))
+		}
+	}
+
+	for patchKey, patchValue := range p.Labels {
+		if !isUpdate(obj.GetLabels(), patchKey, patchValue) {
+			continue
+		}
+
+		if err := metadata.CloudfoundryKeyCheck(patchKey); err != nil {
+			return apierrors.NewUnprocessableEntityError(err, fmt.Sprintf("invalid labels patch: %q: %q -> %q", patchKey, obj.GetLabels()[patchKey], tools.ZeroIfNil(patchValue)))
+		}
+	}
+
+	return nil
 }
 
 func patchMap(original map[string]string, patch map[string]*string) {
@@ -33,4 +71,13 @@ func patchMap(original map[string]string, patch map[string]*string) {
 			delete(original, key)
 		}
 	}
+}
+
+func isUpdate(valuesMap map[string]string, newKey string, newValuePtr *string) bool {
+	if newValuePtr == nil {
+		// TODO: I think we do not keep nil metadata values, double check that
+		return true
+	}
+
+	return valuesMap[newKey] != *newValuePtr
 }

--- a/api/repositories/metadata_test.go
+++ b/api/repositories/metadata_test.go
@@ -50,7 +50,7 @@ var _ = Describe("MetadataPatch", func() {
 		})
 
 		JustBeforeEach(func() {
-			metadataPatch.Apply(pod)
+			Expect(metadataPatch.Apply(pod)).To(Succeed())
 		})
 
 		It("updates labels and annotations correctly", func() {

--- a/api/repositories/org_repository.go
+++ b/api/repositories/org_repository.go
@@ -60,8 +60,9 @@ type DeleteOrgMessage struct {
 
 type PatchOrgMessage struct {
 	MetadataPatch
-	GUID string
-	Name *string
+	Suspended bool
+	GUID      string
+	Name      *string
 }
 
 func (p *PatchOrgMessage) Apply(org *korifiv1alpha1.CFOrg) {

--- a/api/repositories/org_repository.go
+++ b/api/repositories/org_repository.go
@@ -65,11 +65,11 @@ type PatchOrgMessage struct {
 	Name      *string
 }
 
-func (p *PatchOrgMessage) Apply(org *korifiv1alpha1.CFOrg) {
+func (p *PatchOrgMessage) Apply(org *korifiv1alpha1.CFOrg) error {
 	if p.Name != nil {
 		org.Spec.DisplayName = *p.Name
 	}
-	p.MetadataPatch.Apply(org)
+	return p.MetadataPatch.Apply(org)
 }
 
 type OrgRecord struct {
@@ -189,8 +189,7 @@ func (r *OrgRepo) PatchOrg(ctx context.Context, authInfo authorization.Info, mes
 	}
 
 	err = r.klient.Patch(ctx, cfOrg, func() error {
-		message.Apply(cfOrg)
-		return nil
+		return message.Apply(cfOrg)
 	})
 	if err != nil {
 		return OrgRecord{}, apierrors.FromK8sError(err, OrgResourceType)

--- a/api/repositories/org_repository_test.go
+++ b/api/repositories/org_repository_test.go
@@ -114,7 +114,7 @@ var _ = Describe("OrgRepository", func() {
 				Expect(orgRecord.UpdatedAt).To(PointTo(BeTemporally("~", time.Now(), timeCheckThreshold)))
 				Expect(orgRecord.DeletedAt).To(BeNil())
 				Expect(orgRecord.Labels).To(HaveKeyWithValue("test-label-key", "test-label-val"))
-				Expect(orgRecord.Annotations).To(Equal(map[string]string{"test-annotation-key": "test-annotation-val"}))
+				Expect(orgRecord.Annotations).To(HaveKeyWithValue("test-annotation-key", "test-annotation-val"))
 			})
 
 			It("creates a CFOrg resource in the root namespace", func() {
@@ -125,7 +125,10 @@ var _ = Describe("OrgRepository", func() {
 
 				Expect(cfOrg.Spec.DisplayName).To(Equal(orgGUID))
 				Expect(cfOrg.Labels).To(HaveKeyWithValue("test-label-key", "test-label-val"))
-				Expect(cfOrg.Annotations).To(Equal(map[string]string{"test-annotation-key": "test-annotation-val"}))
+				Expect(cfOrg.Annotations).To(Equal(map[string]string{
+					"test-annotation-key":                      "test-annotation-val",
+					korifiv1alpha1.LabelSignatureAnnotationKey: testLabelSig(cfOrg.Labels),
+				}))
 			})
 
 			It("awaits the ready condition", func() {
@@ -506,6 +509,7 @@ var _ = Describe("OrgRepository", func() {
 						map[string]string{
 							"key-one": "value-one",
 							"key-two": "value-two",
+							korifiv1alpha1.LabelSignatureAnnotationKey: testLabelSig(orgRecord.Labels),
 						},
 					))
 					Expect(orgRecord.Name).To(Equal(*orgNewName))
@@ -523,6 +527,7 @@ var _ = Describe("OrgRepository", func() {
 						map[string]string{
 							"key-one": "value-one",
 							"key-two": "value-two",
+							korifiv1alpha1.LabelSignatureAnnotationKey: testLabelSig(updatedCFOrg.Labels),
 						},
 					))
 					Expect(updatedCFOrg.Spec.DisplayName).To(Equal(*orgNewName))
@@ -568,6 +573,7 @@ var _ = Describe("OrgRepository", func() {
 							"before-key-one": "value-one",
 							"key-one":        "value-one-updated",
 							"key-two":        "value-two",
+							korifiv1alpha1.LabelSignatureAnnotationKey: testLabelSig(orgRecord.Labels),
 						},
 					))
 					Expect(orgRecord.Name).To(Equal(*orgNewName))
@@ -588,6 +594,7 @@ var _ = Describe("OrgRepository", func() {
 							"before-key-one": "value-one",
 							"key-one":        "value-one-updated",
 							"key-two":        "value-two",
+							korifiv1alpha1.LabelSignatureAnnotationKey: testLabelSig(updatedCFOrg.Labels),
 						},
 					))
 					Expect(orgRecord.Name).To(Equal(*orgNewName))

--- a/api/repositories/package_repository.go
+++ b/api/repositories/package_repository.go
@@ -259,9 +259,7 @@ func (r *PackageRepo) UpdatePackage(ctx context.Context, authInfo authorization.
 	}
 
 	err = r.klient.Patch(ctx, cfPackage, func() error {
-		updateMessage.MetadataPatch.Apply(cfPackage)
-
-		return nil
+		return updateMessage.MetadataPatch.Apply(cfPackage)
 	})
 	if err != nil {
 		return PackageRecord{}, fmt.Errorf("failed to patch package metadata: %w", apierrors.FromK8sError(err, PackageResourceType))

--- a/api/repositories/package_repository_test.go
+++ b/api/repositories/package_repository_test.go
@@ -684,16 +684,37 @@ var _ = Describe("PackageRepository", func() {
 				createRoleBinding(ctx, userName, spaceDeveloperRole.Name, space.Name)
 			})
 
+			When("a label is invalid", func() {
+				BeforeEach(func() {
+					updateMessage.MetadataPatch.Labels["foo.cloudfoundry.org/bar"] = tools.PtrTo("baz")
+				})
+
+				It("returns an UnprocessableEntityError", func() {
+					var unprocessableEntityError apierrors.UnprocessableEntityError
+					Expect(errors.As(updateErr, &unprocessableEntityError)).To(BeTrue())
+					Expect(unprocessableEntityError.Detail()).To(SatisfyAll(
+						ContainSubstring("invalid labels patch"),
+						ContainSubstring(`"foo.cloudfoundry.org/bar"`),
+					))
+				})
+			})
+
 			It("succeeds", func() {
 				Expect(updateErr).NotTo(HaveOccurred())
 				Expect(packageRecord.GUID).To(Equal(packageGUID))
 				Expect(packageRecord.Labels).To(HaveKeyWithValue("foo", "bar"))
-				Expect(packageRecord.Annotations).To(Equal(map[string]string{"bar": "baz"}))
+				Expect(packageRecord.Annotations).To(Equal(map[string]string{
+					"bar": "baz",
+					korifiv1alpha1.LabelSignatureAnnotationKey: testLabelSig(packageRecord.Labels),
+				}))
 
 				Eventually(func(g Gomega) {
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cfPackage), cfPackage)).To(Succeed())
 					g.Expect(cfPackage.Labels).To(HaveKeyWithValue("foo", "bar"))
-					g.Expect(cfPackage.Annotations).To(Equal(map[string]string{"bar": "baz"}))
+					g.Expect(cfPackage.Annotations).To(Equal(map[string]string{
+						"bar": "baz",
+						korifiv1alpha1.LabelSignatureAnnotationKey: testLabelSig(cfPackage.Labels),
+					}))
 				}).Should(Succeed())
 			})
 

--- a/api/repositories/process_repository.go
+++ b/api/repositories/process_repository.go
@@ -256,7 +256,9 @@ func (r *ProcessRepo) PatchProcess(ctx context.Context, authInfo authorization.I
 			updatedProcess.Spec.HealthCheck.Data.TimeoutSeconds = *message.HealthCheckTimeoutSeconds
 		}
 		if message.MetadataPatch != nil {
-			message.MetadataPatch.Apply(updatedProcess)
+			if err := message.MetadataPatch.Apply(updatedProcess); err != nil {
+				return err
+			}
 		}
 
 		return nil

--- a/api/repositories/process_repository_test.go
+++ b/api/repositories/process_repository_test.go
@@ -2,6 +2,7 @@ package repositories_test
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	apierrors "code.cloudfoundry.org/korifi/api/errors"
@@ -513,6 +514,22 @@ var _ = Describe("ProcessRepo", func() {
 		When("user has permission", func() {
 			BeforeEach(func() {
 				createRoleBinding(ctx, userName, spaceDeveloperRole.Name, space.Name)
+			})
+
+			When("a label is invalid", func() {
+				BeforeEach(func() {
+					message.MetadataPatch.Labels["foo.cloudfoundry.org/bar"] = tools.PtrTo("baz")
+				})
+
+				It("returns an UnprocessableEntityError", func() {
+					_, err := processRepo.PatchProcess(ctx, authInfo, message)
+					var unprocessableEntityError apierrors.UnprocessableEntityError
+					Expect(errors.As(err, &unprocessableEntityError)).To(BeTrue())
+					Expect(unprocessableEntityError.Detail()).To(SatisfyAll(
+						ContainSubstring("invalid labels patch"),
+						ContainSubstring(`"foo.cloudfoundry.org/bar"`),
+					))
+				})
 			})
 
 			It("updates the process", func() {

--- a/api/repositories/repositories_suite_test.go
+++ b/api/repositories/repositories_suite_test.go
@@ -16,6 +16,7 @@ import (
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"code.cloudfoundry.org/korifi/controllers/webhooks/common_labels"
 	"code.cloudfoundry.org/korifi/controllers/webhooks/label_indexer"
+	"code.cloudfoundry.org/korifi/controllers/webhooks/label_indexer/signer"
 	"code.cloudfoundry.org/korifi/tests/helpers"
 	"code.cloudfoundry.org/korifi/tools/k8s"
 	authv1 "k8s.io/api/authorization/v1"
@@ -116,7 +117,7 @@ var _ = BeforeSuite(func() {
 	k8sManager := helpers.NewK8sManager(testEnv, filepath.Join("helm", "korifi", "controllers", "role.yaml"))
 
 	common_labels.NewWebhook().SetupWebhookWithManager(k8sManager)
-	label_indexer.NewWebhook().SetupWebhookWithManager(k8sManager)
+	label_indexer.NewWebhook([]byte("test-secret")).SetupWebhookWithManager(k8sManager)
 	routesdestwebhook.NewRouteAppDestinationsWebhook().SetupWebhookWithManager(k8sManager)
 
 	stopManager = helpers.StartK8sManager(k8sManager)
@@ -216,6 +217,15 @@ var _ = BeforeEach(func() {
 var _ = AfterEach(func() {
 	Expect(k8sClient.Delete(context.Background(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: rootNamespace}})).To(Succeed())
 })
+
+const testSigningSecret = "test-secret"
+
+// testLabelSig computes the expected label-signature annotation value for a
+// set of labels using the same secret that is configured in the test suite's
+// label indexer webhook.
+func testLabelSig(labels map[string]string) string {
+	return signer.Sign([]byte(testSigningSecret), labels)
+}
 
 func createOrgWithCleanup(ctx context.Context, displayName string) *korifiv1alpha1.CFOrg {
 	guid := uuid.NewString()

--- a/api/repositories/route_repository.go
+++ b/api/repositories/route_repository.go
@@ -448,9 +448,7 @@ func (r *RouteRepo) PatchRouteMetadata(ctx context.Context, authInfo authorizati
 	}
 
 	err := GetAndPatch(ctx, r.klient, route, func() error {
-		message.Apply(route)
-
-		return nil
+		return message.MetadataPatch.Apply(route)
 	})
 	if err != nil {
 		return RouteRecord{}, apierrors.FromK8sError(err, RouteResourceType)

--- a/api/repositories/service_binding_repository.go
+++ b/api/repositories/service_binding_repository.go
@@ -470,8 +470,7 @@ func (r *ServiceBindingRepo) UpdateServiceBinding(ctx context.Context, authInfo 
 	}
 
 	err = r.klient.Patch(ctx, serviceBinding, func() error {
-		updateMsg.MetadataPatch.Apply(serviceBinding)
-		return nil
+		return updateMsg.MetadataPatch.Apply(serviceBinding)
 	})
 	if err != nil {
 		return ServiceBindingRecord{}, fmt.Errorf("failed to patch service binding metadata: %w", apierrors.FromK8sError(err, ServiceBindingResourceType))

--- a/api/repositories/service_binding_repository_test.go
+++ b/api/repositories/service_binding_repository_test.go
@@ -1353,6 +1353,21 @@ var _ = Describe("ServiceBindingRepo", func() {
 				createRoleBinding(ctx, userName, adminRole.Name, space.Name)
 			})
 
+			When("a label is invalid", func() {
+				BeforeEach(func() {
+					updateMessage.MetadataPatch.Labels["foo.cloudfoundry.org/bar"] = tools.PtrTo("baz")
+				})
+
+				It("returns an UnprocessableEntityError", func() {
+					var unprocessableEntityError apierrors.UnprocessableEntityError
+					Expect(errors.As(updateErr, &unprocessableEntityError)).To(BeTrue())
+					Expect(unprocessableEntityError.Detail()).To(SatisfyAll(
+						ContainSubstring("invalid labels patch"),
+						ContainSubstring(`"foo.cloudfoundry.org/bar"`),
+					))
+				})
+			})
+
 			It("updates the service binding metadata", func() {
 				Expect(updateErr).NotTo(HaveOccurred())
 

--- a/api/repositories/service_broker_repository.go
+++ b/api/repositories/service_broker_repository.go
@@ -59,7 +59,7 @@ type UpdateServiceBrokerMessage struct {
 	MetadataPatch MetadataPatch
 }
 
-func (m UpdateServiceBrokerMessage) apply(broker *korifiv1alpha1.CFServiceBroker) {
+func (m UpdateServiceBrokerMessage) apply(broker *korifiv1alpha1.CFServiceBroker) error {
 	if m.Name != nil {
 		broker.Spec.Name = *m.Name
 	}
@@ -68,7 +68,7 @@ func (m UpdateServiceBrokerMessage) apply(broker *korifiv1alpha1.CFServiceBroker
 		broker.Spec.URL = *m.URL
 	}
 
-	m.MetadataPatch.Apply(broker)
+	return m.MetadataPatch.Apply(broker)
 }
 
 type ServiceBrokerRepo struct {
@@ -231,8 +231,7 @@ func (r *ServiceBrokerRepo) UpdateServiceBroker(ctx context.Context, authInfo au
 	}
 
 	if err := GetAndPatch(ctx, r.klient, cfServiceBroker, func() error {
-		message.apply(cfServiceBroker)
-		return nil
+		return message.apply(cfServiceBroker)
 	}); err != nil {
 		return ServiceBrokerRecord{}, apierrors.FromK8sError(err, ServiceBrokerResourceType)
 	}

--- a/api/repositories/service_broker_repository_test.go
+++ b/api/repositories/service_broker_repository_test.go
@@ -1,6 +1,7 @@
 package repositories_test
 
 import (
+	"errors"
 	"time"
 
 	apierrors "code.cloudfoundry.org/korifi/api/errors"
@@ -87,6 +88,7 @@ var _ = Describe("ServiceBrokerRepo", func() {
 						"Labels": HaveKeyWithValue("label", "label-value"),
 						"Annotations": Equal(map[string]string{
 							"annotation": "annotation-value",
+							korifiv1alpha1.LabelSignatureAnnotationKey: testLabelSig(brokerRecord.Metadata.Labels),
 						}),
 					}),
 				}))
@@ -426,6 +428,21 @@ var _ = Describe("ServiceBrokerRepo", func() {
 		When("the user has permissions to update brokers", func() {
 			BeforeEach(func() {
 				createRoleBinding(ctx, userName, adminRole.Name, rootNamespace)
+			})
+
+			When("a label is invalid", func() {
+				BeforeEach(func() {
+					updateMessage.MetadataPatch.Labels["foo.cloudfoundry.org/bar"] = tools.PtrTo("baz")
+				})
+
+				It("returns an UnprocessableEntityError", func() {
+					var unprocessableEntityError apierrors.UnprocessableEntityError
+					Expect(errors.As(updateErr, &unprocessableEntityError)).To(BeTrue())
+					Expect(unprocessableEntityError.Detail()).To(SatisfyAll(
+						ContainSubstring("invalid labels patch"),
+						ContainSubstring(`"foo.cloudfoundry.org/bar"`),
+					))
+				})
 			})
 
 			It("returns an updated ServiceBrokerRecord", func() {

--- a/api/repositories/service_instance_repository.go
+++ b/api/repositories/service_instance_repository.go
@@ -77,14 +77,14 @@ type PatchServiceInstanceMessage struct {
 	MetadataPatch
 }
 
-func (p PatchServiceInstanceMessage) Apply(cfServiceInstance *korifiv1alpha1.CFServiceInstance) {
+func (p PatchServiceInstanceMessage) Apply(cfServiceInstance *korifiv1alpha1.CFServiceInstance) error {
 	if p.Name != nil {
 		cfServiceInstance.Spec.DisplayName = *p.Name
 	}
 	if p.Tags != nil {
 		cfServiceInstance.Spec.Tags = *p.Tags
 	}
-	p.MetadataPatch.Apply(cfServiceInstance)
+	return p.MetadataPatch.Apply(cfServiceInstance)
 }
 
 type ListServiceInstanceMessage struct {
@@ -286,8 +286,7 @@ func (r *ServiceInstanceRepo) PatchServiceInstance(ctx context.Context, authInfo
 	}
 
 	err := r.klient.Patch(ctx, cfServiceInstance, func() error {
-		message.Apply(cfServiceInstance)
-		return nil
+		return message.Apply(cfServiceInstance)
 	})
 	if err != nil {
 		return ServiceInstanceRecord{}, apierrors.FromK8sError(err, ServiceInstanceResourceType)

--- a/api/repositories/service_instance_repository_test.go
+++ b/api/repositories/service_instance_repository_test.go
@@ -551,15 +551,32 @@ var _ = Describe("ServiceInstanceRepository", func() {
 				createRoleBinding(ctx, userName, spaceDeveloperRole.Name, space.Name)
 			})
 
+			When("a label is invalid", func() {
+				BeforeEach(func() {
+					patchMessage.MetadataPatch.Labels["foo.cloudfoundry.org/bar"] = tools.PtrTo("baz")
+				})
+
+				It("returns an UnprocessableEntityError", func() {
+					var unprocessableEntityError apierrors.UnprocessableEntityError
+					Expect(errors.As(err, &unprocessableEntityError)).To(BeTrue())
+					Expect(unprocessableEntityError.Detail()).To(SatisfyAll(
+						ContainSubstring("invalid labels patch"),
+						ContainSubstring(`"foo.cloudfoundry.org/bar"`),
+					))
+				})
+			})
+
 			It("returns the updated record", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(serviceInstanceRecord.Name).To(Equal("new-name"))
 				Expect(serviceInstanceRecord.Tags).To(ConsistOf("new"))
 				Expect(serviceInstanceRecord.Labels).To(HaveKeyWithValue("a-label", "a-label-value"))
 				Expect(serviceInstanceRecord.Labels).To(HaveKeyWithValue("new-label", "new-label-value"))
-				Expect(serviceInstanceRecord.Annotations).To(HaveLen(2))
-				Expect(serviceInstanceRecord.Annotations).To(HaveKeyWithValue("an-annotation", "an-annotation-value"))
-				Expect(serviceInstanceRecord.Annotations).To(HaveKeyWithValue("new-annotation", "new-annotation-value"))
+				Expect(serviceInstanceRecord.Annotations).To(Equal(map[string]string{
+					"an-annotation":  "an-annotation-value",
+					"new-annotation": "new-annotation-value",
+					korifiv1alpha1.LabelSignatureAnnotationKey: testLabelSig(serviceInstanceRecord.Labels),
+				}))
 			})
 
 			It("updates the service instance", func() {
@@ -572,9 +589,11 @@ var _ = Describe("ServiceInstanceRepository", func() {
 					g.Expect(serviceInstance.Spec.Tags).To(ConsistOf("new"))
 					g.Expect(serviceInstance.Labels).To(HaveKeyWithValue("a-label", "a-label-value"))
 					g.Expect(serviceInstance.Labels).To(HaveKeyWithValue("new-label", "new-label-value"))
-					g.Expect(serviceInstance.Annotations).To(HaveLen(2))
-					g.Expect(serviceInstance.Annotations).To(HaveKeyWithValue("an-annotation", "an-annotation-value"))
-					g.Expect(serviceInstance.Annotations).To(HaveKeyWithValue("new-annotation", "new-annotation-value"))
+					g.Expect(serviceInstance.Annotations).To(Equal(map[string]string{
+						"an-annotation":  "an-annotation-value",
+						"new-annotation": "new-annotation-value",
+						korifiv1alpha1.LabelSignatureAnnotationKey: testLabelSig(serviceInstance.Labels),
+					}))
 				}).Should(Succeed())
 			})
 
@@ -845,7 +864,10 @@ var _ = Describe("ServiceInstanceRepository", func() {
 				Expect(record.Tags).To(Equal(serviceInstance.Spec.Tags))
 				Expect(record.Type).To(Equal(string(serviceInstance.Spec.Type)))
 				Expect(record.Labels).To(HaveKeyWithValue("a-label", "a-label-value"))
-				Expect(record.Annotations).To(Equal(map[string]string{"an-annotation": "an-annotation-value"}))
+				Expect(record.Annotations).To(Equal(map[string]string{
+					"an-annotation": "an-annotation-value",
+					korifiv1alpha1.LabelSignatureAnnotationKey: testLabelSig(record.Labels),
+				}))
 				Expect(record.Relationships()).To(Equal(map[string]string{
 					"space": serviceInstance.Namespace,
 				}))

--- a/api/repositories/service_offering_repository.go
+++ b/api/repositories/service_offering_repository.go
@@ -77,8 +77,8 @@ type DeleteServiceOfferingMessage struct {
 	Purge bool
 }
 
-func (m UpdateServiceOfferingMessage) apply(offering *korifiv1alpha1.CFServiceOffering) {
-	m.MetadataPatch.Apply(offering)
+func (m UpdateServiceOfferingMessage) apply(offering *korifiv1alpha1.CFServiceOffering) error {
+	return m.MetadataPatch.Apply(offering)
 }
 
 func (m *ListServiceOfferingMessage) toListOptions() []ListOption {
@@ -289,8 +289,7 @@ func (r *ServiceOfferingRepo) UpdateServiceOffering(ctx context.Context, authInf
 		},
 	}
 	if err := GetAndPatch(ctx, r.rootNSKlient, offering, func() error {
-		message.apply(offering)
-		return nil
+		return message.apply(offering)
 	}); err != nil {
 		return ServiceOfferingRecord{}, fmt.Errorf("failed to patch service offering metadata: %w", apierrors.FromK8sError(err, ServiceOfferingResourceType))
 	}

--- a/api/repositories/service_offering_repository_test.go
+++ b/api/repositories/service_offering_repository_test.go
@@ -510,6 +510,21 @@ var _ = Describe("ServiceOfferingRepo", func() {
 				createRoleBinding(ctx, userName, adminRole.Name, rootNamespace)
 			})
 
+			When("a label is invalid", func() {
+				BeforeEach(func() {
+					updateMessage.MetadataPatch.Labels["foo.cloudfoundry.org/bar"] = tools.PtrTo("baz")
+				})
+
+				It("returns an UnprocessableEntityError", func() {
+					var unprocessableEntityError apierrors.UnprocessableEntityError
+					Expect(errors.As(updateErr, &unprocessableEntityError)).To(BeTrue())
+					Expect(unprocessableEntityError.Detail()).To(SatisfyAll(
+						ContainSubstring("invalid labels patch"),
+						ContainSubstring(`"foo.cloudfoundry.org/bar"`),
+					))
+				})
+			})
+
 			It("updates the service offering metadata", func() {
 				Expect(updateErr).NotTo(HaveOccurred())
 				Expect(updatedServiceOffering.Metadata.Labels).To(SatisfyAll(

--- a/api/repositories/space_repository.go
+++ b/api/repositories/space_repository.go
@@ -63,11 +63,11 @@ type PatchSpaceMessage struct {
 	Name    *string
 }
 
-func (p *PatchSpaceMessage) Apply(space *korifiv1alpha1.CFSpace) {
+func (p *PatchSpaceMessage) Apply(space *korifiv1alpha1.CFSpace) error {
 	if p.Name != nil {
 		space.Spec.DisplayName = *p.Name
 	}
-	p.MetadataPatch.Apply(space)
+	return p.MetadataPatch.Apply(space)
 }
 
 type SpaceRecord struct {
@@ -233,8 +233,7 @@ func (r *SpaceRepo) PatchSpace(ctx context.Context, authInfo authorization.Info,
 	}
 
 	err = r.klient.Patch(ctx, cfSpace, func() error {
-		message.Apply(cfSpace)
-		return nil
+		return message.Apply(cfSpace)
 	})
 	if err != nil {
 		return SpaceRecord{}, apierrors.FromK8sError(err, SpaceResourceType)

--- a/api/repositories/space_repository_test.go
+++ b/api/repositories/space_repository_test.go
@@ -518,6 +518,7 @@ var _ = Describe("SpaceRepository", func() {
 						map[string]string{
 							"key-one": "value-one",
 							"key-two": "value-two",
+							korifiv1alpha1.LabelSignatureAnnotationKey: testLabelSig(spaceRecord.Labels),
 						},
 					))
 					Expect(spaceRecord.Name).To(Equal(*spaceNewName))
@@ -535,6 +536,7 @@ var _ = Describe("SpaceRepository", func() {
 						map[string]string{
 							"key-one": "value-one",
 							"key-two": "value-two",
+							korifiv1alpha1.LabelSignatureAnnotationKey: testLabelSig(updatedCFSpace.Labels),
 						},
 					))
 					Expect(updatedCFSpace.Spec.DisplayName).To(Equal(*spaceNewName))
@@ -582,6 +584,7 @@ var _ = Describe("SpaceRepository", func() {
 							"before-key-one": "value-one",
 							"key-one":        "value-one-updated",
 							"key-two":        "value-two",
+							korifiv1alpha1.LabelSignatureAnnotationKey: testLabelSig(spaceRecord.Labels),
 						},
 					))
 					Expect(spaceRecord.Name).To(Equal(*spaceNewName))
@@ -601,6 +604,7 @@ var _ = Describe("SpaceRepository", func() {
 							"before-key-one": "value-one",
 							"key-one":        "value-one-updated",
 							"key-two":        "value-two",
+							korifiv1alpha1.LabelSignatureAnnotationKey: testLabelSig(updatedCFSpace.Labels),
 						},
 					))
 					Expect(spaceRecord.Name).To(Equal(*spaceNewName))

--- a/api/repositories/task_repository.go
+++ b/api/repositories/task_repository.go
@@ -203,8 +203,7 @@ func (r *TaskRepo) PatchTaskMetadata(ctx context.Context, authInfo authorization
 	}
 
 	err := GetAndPatch(ctx, r.klient, task, func() error {
-		message.Apply(task)
-		return nil
+		return message.MetadataPatch.Apply(task)
 	})
 	if err != nil {
 		return TaskRecord{}, apierrors.FromK8sError(err, TaskResourceType)

--- a/api/repositories/task_repository_test.go
+++ b/api/repositories/task_repository_test.go
@@ -137,7 +137,10 @@ var _ = Describe("TaskRepository", func() {
 				Expect(taskRecord.DropletGUID).To(Equal(cfApp.Spec.CurrentDropletRef.Name))
 				Expect(taskRecord.State).To(Equal(repositories.TaskStatePending))
 				Expect(taskRecord.Labels).To(HaveKeyWithValue("color", "blue"))
-				Expect(taskRecord.Annotations).To(Equal(map[string]string{"extra-bugs": "true"}))
+				Expect(taskRecord.Annotations).To(Equal(map[string]string{
+					"extra-bugs": "true",
+					korifiv1alpha1.LabelSignatureAnnotationKey: testLabelSig(taskRecord.Labels),
+				}))
 			})
 
 			When("the task never becomes initialized", func() {
@@ -629,6 +632,7 @@ var _ = Describe("TaskRepository", func() {
 						map[string]string{
 							"key-one": "value-one",
 							"key-two": "value-two",
+							korifiv1alpha1.LabelSignatureAnnotationKey: testLabelSig(taskRecord.Labels),
 						},
 					))
 				})
@@ -645,6 +649,7 @@ var _ = Describe("TaskRepository", func() {
 						map[string]string{
 							"key-one": "value-one",
 							"key-two": "value-two",
+							korifiv1alpha1.LabelSignatureAnnotationKey: testLabelSig(updatedCFTask.Labels),
 						},
 					))
 				})
@@ -690,6 +695,7 @@ var _ = Describe("TaskRepository", func() {
 							"before-key-one": "value-one",
 							"key-one":        "value-one-updated",
 							"key-two":        "value-two",
+							korifiv1alpha1.LabelSignatureAnnotationKey: testLabelSig(taskRecord.Labels),
 						},
 					))
 				})
@@ -708,6 +714,7 @@ var _ = Describe("TaskRepository", func() {
 							"before-key-one": "value-one",
 							"key-one":        "value-one-updated",
 							"key-two":        "value-two",
+							korifiv1alpha1.LabelSignatureAnnotationKey: testLabelSig(updatedCFTask.Labels),
 						},
 					))
 				})

--- a/api/tools/metadata/keys.go
+++ b/api/tools/metadata/keys.go
@@ -1,0 +1,25 @@
+package metadata
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+func CloudfoundryKeyCheck(key any) error {
+	keyStr, ok := key.(string)
+	if !ok {
+		return fmt.Errorf("expected string key, got %T", key)
+	}
+
+	u, err := url.ParseRequestURI("https://" + keyStr) // without the scheme, the hostname will be parsed as a path
+	if err != nil {
+		return nil
+	}
+
+	if strings.HasSuffix(u.Hostname(), "cloudfoundry.org") {
+		return errors.New("label/annotation key cannot use the cloudfoundry.org domain")
+	}
+	return nil
+}

--- a/controllers/api/v1alpha1/shared_types.go
+++ b/controllers/api/v1alpha1/shared_types.go
@@ -50,6 +50,8 @@ const (
 	PropagateDeletionAnnotation       = "cloudfoundry.org/propagate-deletion"
 	PropagatedFromLabel               = "cloudfoundry.org/propagated-from"
 
+	LabelSignatureAnnotationKey = "korifi.cloudfoundry.org/label-signature"
+
 	RelationshipsLabelPrefix    = "korifi.cloudfoundry.org/rel-"
 	RelServiceBrokerGUIDLabel   = RelationshipsLabelPrefix + "service-broker-guid"
 	RelServiceBrokerNameLabel   = RelationshipsLabelPrefix + "service-broker-name"

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"code.cloudfoundry.org/korifi/controllers/cleanup"
@@ -51,6 +52,7 @@ import (
 	"code.cloudfoundry.org/korifi/controllers/webhooks/common_labels"
 	controllers_finalizer "code.cloudfoundry.org/korifi/controllers/webhooks/finalizer"
 	"code.cloudfoundry.org/korifi/controllers/webhooks/label_indexer"
+	label_validator "code.cloudfoundry.org/korifi/controllers/webhooks/label_validator"
 	domainswebhook "code.cloudfoundry.org/korifi/controllers/webhooks/networking/domains"
 	routeswebhook "code.cloudfoundry.org/korifi/controllers/webhooks/networking/routes"
 	routesdestwebhook "code.cloudfoundry.org/korifi/controllers/webhooks/networking/routes/app_destinations"
@@ -149,6 +151,15 @@ func main() {
 	log.SetOutput(&tools.LogrWriter{Logger: ctrl.Log, Message: "HTTP server error"})
 
 	ctrl.Log.Info("starting Korifi controllers", "version", version.Version)
+
+	labelSigningSecretPath := os.Getenv("LABEL_SIGNING_SECRET_PATH")
+	if labelSigningSecretPath == "" {
+		labelSigningSecretPath = "/etc/korifi-label-signing-secret/key"
+	}
+	labelSigningSecret, err := os.ReadFile(filepath.Clean(labelSigningSecretPath))
+	if err != nil {
+		panic(fmt.Sprintf("could not read label signing secret: %v", err))
+	}
 
 	conf := ctrl.GetConfigOrDie()
 	k8sClient, err := k8sclient.NewForConfig(conf)
@@ -536,7 +547,8 @@ func main() {
 	versionwebhook.NewVersionWebhook(version.Version).SetupWebhookWithManager(mgr)
 	controllers_finalizer.NewControllersFinalizerWebhook().SetupWebhookWithManager(mgr)
 	common_labels.NewWebhook().SetupWebhookWithManager(mgr)
-	label_indexer.NewWebhook().SetupWebhookWithManager(mgr)
+	label_indexer.NewWebhook(labelSigningSecret).SetupWebhookWithManager(mgr)
+	label_validator.NewWebhook(labelSigningSecret).SetupWebhookWithManager(mgr)
 	routesdestwebhook.NewRouteAppDestinationsWebhook().SetupWebhookWithManager(mgr)
 
 	if err = packageswebhook.NewValidator().SetupWebhookWithManager(mgr); err != nil {

--- a/controllers/webhooks/label_indexer/signer/signer.go
+++ b/controllers/webhooks/label_indexer/signer/signer.go
@@ -1,0 +1,37 @@
+package signer
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"sort"
+	"strings"
+)
+
+const ReservedLabelDomain = "korifi.cloudfoundry.org/"
+
+func Sign(secret []byte, labels map[string]string) string {
+	mac := hmac.New(sha256.New, secret)
+	for _, k := range sortedReservedKeys(labels) {
+		mac.Write([]byte(k))
+		mac.Write([]byte("="))
+		mac.Write([]byte(labels[k]))
+		mac.Write([]byte("\n"))
+	}
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+func Verify(secret []byte, labels map[string]string, sig string) bool {
+	return hmac.Equal([]byte(Sign(secret, labels)), []byte(sig))
+}
+
+func sortedReservedKeys(labels map[string]string) []string {
+	keys := make([]string, 0, len(labels))
+	for k := range labels {
+		if strings.HasPrefix(k, ReservedLabelDomain) {
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/controllers/webhooks/label_indexer/webhook.go
+++ b/controllers/webhooks/label_indexer/webhook.go
@@ -8,7 +8,8 @@ import (
 	"net/http"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
-	. "code.cloudfoundry.org/korifi/controllers/webhooks/label_indexer/rules"  //lint:ignore ST1001 for readability
+	. "code.cloudfoundry.org/korifi/controllers/webhooks/label_indexer/rules" //lint:ignore ST1001 for readability
+	"code.cloudfoundry.org/korifi/controllers/webhooks/label_indexer/signer"
 	. "code.cloudfoundry.org/korifi/controllers/webhooks/label_indexer/values" //lint:ignore ST1001 for readability
 	"code.cloudfoundry.org/korifi/tools"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,10 +24,12 @@ type IndexingRule interface {
 type LabelIndexerWebhook struct {
 	decoder       admission.Decoder
 	indexingRules map[string][]IndexingRule
+	signingSecret []byte
 }
 
-func NewWebhook() *LabelIndexerWebhook {
+func NewWebhook(signingSecret []byte) *LabelIndexerWebhook {
 	return &LabelIndexerWebhook{
+		signingSecret: signingSecret,
 		indexingRules: map[string][]IndexingRule{
 			"CFRoute": {
 				LabelRule{Label: korifiv1alpha1.CFDomainGUIDLabelKey, IndexingFunc: Unquote(JSONValue("$.spec.domainRef.name"))},
@@ -156,6 +159,9 @@ func (r *LabelIndexerWebhook) Handle(ctx context.Context, req admission.Request)
 			obj.SetLabels(tools.SetMapValue(obj.GetLabels(), k, v))
 		}
 	}
+
+	sig := signer.Sign(r.signingSecret, obj.GetLabels())
+	obj.SetAnnotations(tools.SetMapValue(obj.GetAnnotations(), korifiv1alpha1.LabelSignatureAnnotationKey, sig))
 
 	marshalled, err := json.Marshal(obj)
 	if err != nil {

--- a/controllers/webhooks/label_validator/suite_test.go
+++ b/controllers/webhooks/label_validator/suite_test.go
@@ -1,4 +1,4 @@
-package label_indexer_test
+package label_validator_test
 
 import (
 	"context"
@@ -9,6 +9,7 @@ import (
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
 	"code.cloudfoundry.org/korifi/controllers/webhooks/label_indexer"
+	"code.cloudfoundry.org/korifi/controllers/webhooks/label_validator"
 	"code.cloudfoundry.org/korifi/tests/helpers"
 
 	"github.com/google/uuid"
@@ -23,6 +24,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
+const testSigningSecret = "test-secret"
+
 var (
 	ctx             context.Context
 	stopManager     context.CancelFunc
@@ -32,12 +35,12 @@ var (
 	namespace       string
 )
 
-func TestWorkloadsWebhooks(t *testing.T) {
+func TestLabelValidatorWebhook(t *testing.T) {
 	SetDefaultEventuallyTimeout(10 * time.Second)
 	SetDefaultEventuallyPollingInterval(250 * time.Millisecond)
 
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Label Indexer Webhook Integration Test Suite")
+	RunSpecs(t, "Label Validator Webhook Integration Test Suite")
 }
 
 var _ = BeforeSuite(func() {
@@ -45,10 +48,12 @@ var _ = BeforeSuite(func() {
 
 	webhookManifestsPath := helpers.GenerateWebhookManifest(
 		"code.cloudfoundry.org/korifi/controllers/webhooks/label_indexer",
+		"code.cloudfoundry.org/korifi/controllers/webhooks/label_validator",
 	)
 	DeferCleanup(func() {
 		Expect(os.RemoveAll(filepath.Dir(webhookManifestsPath))).To(Succeed())
 	})
+
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths: []string{
 			filepath.Join("..", "..", "..", "helm", "korifi", "controllers", "crds"),
@@ -68,7 +73,8 @@ var _ = BeforeSuite(func() {
 
 	adminClient, stopClientCache = helpers.NewCachedClient(testEnv.Config)
 
-	label_indexer.NewWebhook([]byte("test-secret")).SetupWebhookWithManager(k8sManager)
+	label_indexer.NewWebhook([]byte(testSigningSecret)).SetupWebhookWithManager(k8sManager)
+	label_validator.NewWebhook([]byte(testSigningSecret)).SetupWebhookWithManager(k8sManager)
 
 	stopManager = helpers.StartK8sManager(k8sManager)
 

--- a/controllers/webhooks/label_validator/webhook.go
+++ b/controllers/webhooks/label_validator/webhook.go
@@ -1,0 +1,79 @@
+package label_validator
+
+//+kubebuilder:webhook:path=/validate-korifi-cloudfoundry-org-v1alpha1-controllers-label-validator,mutating=false,failurePolicy=fail,sideEffects=None,groups=korifi.cloudfoundry.org,resources=cfroutes;cfapps;cfbuilds;cfdomains;cfpackages;cfprocesses;cfservicebindings;cfserviceinstances;cftasks;cforgs;cfspaces;cfserviceofferings;cfserviceplans;cfservicebrokers,verbs=create;update,versions=v1alpha1,name=vcflabelvalidator.korifi.cloudfoundry.org,admissionReviewVersions={v1,v1beta1}
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
+	"code.cloudfoundry.org/korifi/controllers/webhooks/label_indexer/signer"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+type LabelValidatorWebhook struct {
+	decoder       admission.Decoder
+	signingSecret []byte
+}
+
+func NewWebhook(signingSecret []byte) *LabelValidatorWebhook {
+	return &LabelValidatorWebhook{
+		signingSecret: signingSecret,
+	}
+}
+
+func (r *LabelValidatorWebhook) SetupWebhookWithManager(mgr ctrl.Manager) {
+	mgr.GetWebhookServer().Register("/validate-korifi-cloudfoundry-org-v1alpha1-controllers-label-validator", &admission.Webhook{
+		Handler: r,
+	})
+	r.decoder = admission.NewDecoder(mgr.GetScheme())
+}
+
+func (r *LabelValidatorWebhook) Handle(_ context.Context, req admission.Request) admission.Response {
+	var obj metav1.PartialObjectMetadata
+	if err := r.decoder.Decode(req, &obj); err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	// Reject any label key in the broader cloudfoundry.org domain that is NOT
+	// a korifi-managed key (those are handled by the signature check below).
+	for k := range obj.GetLabels() {
+		if !strings.HasPrefix(k, signer.ReservedLabelDomain) && isCloudfoundryDomain(k) {
+			return admission.Denied(fmt.Sprintf(
+				"label key %q cannot use the cloudfoundry.org domain", k,
+			))
+		}
+	}
+
+	storedSig := obj.GetAnnotations()[korifiv1alpha1.LabelSignatureAnnotationKey]
+
+	// On first create (no existing signature yet) the label indexer has already
+	// run and written a fresh signature, so storedSig will be present.
+	// If it is still absent (e.g. pre-existing objects during rollout) we allow
+	// the request through to avoid blocking legitimate operations.
+	if storedSig == "" {
+		return admission.Allowed("no existing label signature")
+	}
+
+	if !signer.Verify(r.signingSecret, obj.GetLabels(), storedSig) {
+		return admission.Denied(fmt.Sprintf(
+			"reserved %s labels may not be modified by API clients",
+			signer.ReservedLabelDomain,
+		))
+	}
+
+	return admission.Allowed("label signature verified")
+}
+
+func isCloudfoundryDomain(key string) bool {
+	u, err := url.ParseRequestURI("https://" + key)
+	if err != nil {
+		return false
+	}
+	return strings.HasSuffix(u.Hostname(), "cloudfoundry.org")
+}

--- a/controllers/webhooks/label_validator/webhook_test.go
+++ b/controllers/webhooks/label_validator/webhook_test.go
@@ -1,0 +1,94 @@
+package label_validator_test
+
+import (
+	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
+	"code.cloudfoundry.org/korifi/tools/k8s"
+
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("LabelValidatorWebhook", func() {
+	var org *korifiv1alpha1.CFOrg
+
+	BeforeEach(func() {
+		org = &korifiv1alpha1.CFOrg{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      uuid.NewString(),
+				Namespace: namespace,
+			},
+			Spec: korifiv1alpha1.CFOrgSpec{
+				DisplayName: uuid.NewString(),
+			},
+		}
+	})
+
+	Describe("on create", func() {
+		It("allows a resource with no user labels", func() {
+			Expect(adminClient.Create(ctx, org)).To(Succeed())
+			Eventually(func(g Gomega) {
+				g.Expect(adminClient.Get(ctx, client.ObjectKeyFromObject(org), org)).To(Succeed())
+				g.Expect(org.Annotations).To(HaveKey(korifiv1alpha1.LabelSignatureAnnotationKey))
+			}).Should(Succeed())
+		})
+
+		It("allows a resource with arbitrary user labels", func() {
+			org.Labels = map[string]string{"user-label": "value"}
+			Expect(adminClient.Create(ctx, org)).To(Succeed())
+		})
+
+		It("rejects a non-korifi cloudfoundry.org label key", func() {
+			org.Labels = map[string]string{"foo.cloudfoundry.org/bar": "baz"}
+			Expect(adminClient.Create(ctx, org)).To(MatchError(ContainSubstring("cannot use the cloudfoundry.org domain")))
+		})
+	})
+
+	Describe("on update", func() {
+		JustBeforeEach(func() {
+			Expect(adminClient.Create(ctx, org)).To(Succeed())
+			Eventually(func(g Gomega) {
+				g.Expect(adminClient.Get(ctx, client.ObjectKeyFromObject(org), org)).To(Succeed())
+				g.Expect(org.Annotations).To(HaveKey(korifiv1alpha1.LabelSignatureAnnotationKey))
+			}).Should(Succeed())
+		})
+
+		It("allows user labels that don't touch korifi labels", func() {
+			Expect(k8s.Patch(ctx, adminClient, org, func() {
+				if org.Labels == nil {
+					org.Labels = map[string]string{}
+				}
+				org.Labels["my-custom-label"] = "my-value"
+			})).To(Succeed())
+		})
+
+		It("rejects tampering with a korifi.cloudfoundry.org label", func() {
+			originalReservedValue := org.Labels[korifiv1alpha1.CFOrgDisplayNameKey]
+
+			err := k8s.Patch(ctx, adminClient, org, func() {
+				if org.Labels == nil {
+					org.Labels = map[string]string{}
+				}
+				org.Labels[korifiv1alpha1.CFOrgDisplayNameKey] = "tampered-value"
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func(g Gomega) {
+				g.Expect(adminClient.Get(ctx, client.ObjectKeyFromObject(org), org)).To(Succeed())
+				g.Expect(org.Labels).To(HaveKeyWithValue(korifiv1alpha1.CFOrgDisplayNameKey, originalReservedValue))
+			}).Should(Succeed())
+		})
+
+		It("rejects a non-korifi cloudfoundry.org label key", func() {
+			err := k8s.Patch(ctx, adminClient, org, func() {
+				if org.Labels == nil {
+					org.Labels = map[string]string{}
+				}
+				org.Labels["foo.cloudfoundry.org/bar"] = "baz"
+			})
+			Expect(err).To(MatchError(ContainSubstring("cannot use the cloudfoundry.org domain")))
+		})
+	})
+})

--- a/helm/korifi/controllers/deployment.yaml
+++ b/helm/korifi/controllers/deployment.yaml
@@ -58,6 +58,9 @@ spec:
         - mountPath: /etc/korifi-controllers-config
           name: korifi-controllers-config
           readOnly: true
+        - mountPath: /etc/korifi-label-signing-secret
+          name: label-signing-secret
+          readOnly: true
       {{- include "korifi.podSecurityContext" . | indent 6 }}
       serviceAccountName: korifi-controllers-controller-manager
 {{- if .Values.controllers.nodeSelector }}
@@ -77,3 +80,7 @@ spec:
       - configMap:
           name: korifi-controllers-config
         name: korifi-controllers-config
+      - name: label-signing-secret
+        secret:
+          defaultMode: 420
+          secretName: {{ .Values.controllers.labelSigningSecret }}

--- a/helm/korifi/controllers/label-signing-secret.yaml
+++ b/helm/korifi/controllers/label-signing-secret.yaml
@@ -1,0 +1,13 @@
+{{- $existing := lookup "v1" "Secret" .Release.Namespace .Values.controllers.labelSigningSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.controllers.labelSigningSecret }}
+  namespace: {{ .Release.Namespace }}
+type: Opaque
+data:
+  {{- if $existing }}
+  key: {{ index $existing.data "key" }}
+  {{- else }}
+  key: {{ randBytes 32 | b64enc }}
+  {{- end }}

--- a/helm/korifi/controllers/manifests.yaml
+++ b/helm/korifi/controllers/manifests.yaml
@@ -309,6 +309,41 @@ webhooks:
       service:
         name: korifi-controllers-webhook-service
         namespace: '{{ .Release.Namespace }}'
+        path: /validate-korifi-cloudfoundry-org-v1alpha1-controllers-label-validator
+      caBundle: '{{ include "korifi.webhookCaBundle" . }}'
+    failurePolicy: Fail
+    name: vcflabelvalidator.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - cfroutes
+          - cfapps
+          - cfbuilds
+          - cfdomains
+          - cfpackages
+          - cfprocesses
+          - cfservicebindings
+          - cfserviceinstances
+          - cftasks
+          - cforgs
+          - cfspaces
+          - cfserviceofferings
+          - cfserviceplans
+          - cfservicebrokers
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-controllers-webhook-service
+        namespace: '{{ .Release.Namespace }}'
         path: /validate-korifi-cloudfoundry-org-v1alpha1-cforg
       caBundle: '{{ include "korifi.webhookCaBundle" . }}'
     failurePolicy: Fail

--- a/helm/korifi/migration/post-upgrade-migration.yaml
+++ b/helm/korifi/migration/post-upgrade-migration.yaml
@@ -31,7 +31,13 @@ spec:
         env:
         - name: KORIFI_VERSION
           value: "{{ .Chart.Version }}"
+        - name: LABEL_SIGNING_SECRET_PATH
+          value: /etc/korifi-label-signing-secret/key
         image: {{ .Values.migration.image }}
+        volumeMounts:
+        - mountPath: /etc/korifi-label-signing-secret
+          name: label-signing-secret
+          readOnly: true
         securityContext:
           allowPrivilegeEscalation: false
           runAsNonRoot: true
@@ -41,3 +47,8 @@ spec:
             - ALL
           seccompProfile:
             type: RuntimeDefault
+      volumes:
+      - name: label-signing-secret
+        secret:
+          defaultMode: 420
+          secretName: {{ .Values.controllers.labelSigningSecret }}

--- a/helm/korifi/values.yaml
+++ b/helm/korifi/values.yaml
@@ -76,6 +76,7 @@ api:
 controllers:
   image: cloudfoundry/korifi-controllers:latest
   webhookCertSecret: "korifi-controllers-webhook-cert"
+  labelSigningSecret: "korifi-controllers-label-signing-secret"
 
   nodeSelector: {}
   tolerations: []

--- a/migration/main.go
+++ b/migration/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
 
 	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
@@ -31,9 +32,18 @@ func main() {
 		panic("KORIFI_VERSION must be set")
 	}
 
+	labelSigningSecretPath := os.Getenv("LABEL_SIGNING_SECRET_PATH")
+	if labelSigningSecretPath == "" {
+		labelSigningSecretPath = "/etc/korifi-label-signing-secret/key"
+	}
+	labelSigningSecret, err := os.ReadFile(filepath.Clean(labelSigningSecretPath))
+	if err != nil {
+		panic(fmt.Sprintf("could not read label signing secret: %v", err))
+	}
+
 	workersCount := tools.Max(1, runtime.NumCPU()/2)
 
-	migrator := migration.New(k8sClient, korifiVersion, workersCount)
+	migrator := migration.New(k8sClient, korifiVersion, labelSigningSecret, workersCount)
 	err = migrator.Run(context.Background())
 	if err != nil {
 		panic(err)

--- a/migration/migration/executor.go
+++ b/migration/migration/executor.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"time"
 
+	korifiv1alpha1 "code.cloudfoundry.org/korifi/controllers/api/v1alpha1"
+	"code.cloudfoundry.org/korifi/controllers/webhooks/label_indexer/signer"
 	"code.cloudfoundry.org/korifi/tools"
 	"code.cloudfoundry.org/korifi/tools/k8s"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -18,21 +20,44 @@ const MigratedByLabelKey = "korifi.cloudfoundry.org/migrated-by"
 var korifiObjectLists = []client.ObjectList{}
 
 type Migrator struct {
-	k8sClient     client.Client
-	korifiVersion string
-	workersCount  int
+	k8sClient          client.Client
+	korifiVersion      string
+	labelSigningSecret []byte
+	workersCount       int
 }
 
-func New(k8sClient client.Client, korifiVersion string, workersCount int) *Migrator {
+func New(k8sClient client.Client, korifiVersion string, labelSigningSecret []byte, workersCount int) *Migrator {
 	return &Migrator{
-		k8sClient:     k8sClient,
-		korifiVersion: korifiVersion,
-		workersCount:  workersCount,
+		k8sClient:          k8sClient,
+		korifiVersion:      korifiVersion,
+		labelSigningSecret: labelSigningSecret,
+		workersCount:       workersCount,
 	}
+}
+
+var backfillObjectLists = []client.ObjectList{
+	&korifiv1alpha1.CFOrgList{},
+	&korifiv1alpha1.CFSpaceList{},
+	&korifiv1alpha1.CFAppList{},
+	&korifiv1alpha1.CFBuildList{},
+	&korifiv1alpha1.CFPackageList{},
+	&korifiv1alpha1.CFProcessList{},
+	&korifiv1alpha1.CFRouteList{},
+	&korifiv1alpha1.CFDomainList{},
+	&korifiv1alpha1.CFServiceInstanceList{},
+	&korifiv1alpha1.CFServiceBindingList{},
+	&korifiv1alpha1.CFTaskList{},
+	&korifiv1alpha1.CFServiceBrokerList{},
+	&korifiv1alpha1.CFServiceOfferingList{},
+	&korifiv1alpha1.CFServicePlanList{},
 }
 
 func (m *Migrator) Run(ctx context.Context) error {
 	startTime := time.Now()
+
+	if err := m.backfillLabelSignatures(ctx); err != nil {
+		return fmt.Errorf("failed to backfill label signatures: %v", err)
+	}
 
 	objectsToUpdate, err := m.collectObjects(ctx, korifiObjectLists)
 	if err != nil {
@@ -80,6 +105,28 @@ func (m *Migrator) setMigratedByLabel(ctx context.Context, obj client.Object) er
 	return k8s.PatchResource(ctx, m.k8sClient, obj, func() {
 		obj.SetLabels(tools.SetMapValue(obj.GetLabels(), MigratedByLabelKey, m.korifiVersion))
 	})
+}
+
+func (m *Migrator) backfillLabelSignatures(ctx context.Context) error {
+	objects, err := m.collectObjects(ctx, backfillObjectLists)
+	if err != nil {
+		return fmt.Errorf("failed to collect objects for label signature backfill: %v", err)
+	}
+
+	fmt.Fprintf(os.Stdout, "Backfilling label signatures on %d objects\n", len(objects))
+	for _, obj := range objects {
+		if obj.GetAnnotations()[korifiv1alpha1.LabelSignatureAnnotationKey] != "" {
+			continue
+		}
+		sig := signer.Sign(m.labelSigningSecret, obj.GetLabels())
+		if err := k8s.PatchResource(ctx, m.k8sClient, obj, func() {
+			obj.SetAnnotations(tools.SetMapValue(obj.GetAnnotations(), korifiv1alpha1.LabelSignatureAnnotationKey, sig))
+		}); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to backfill label signature on %s %s/%s: %v\n",
+				obj.GetObjectKind().GroupVersionKind().Kind, obj.GetNamespace(), obj.GetName(), err)
+		}
+	}
+	return nil
 }
 
 func (m *Migrator) collectObjects(ctx context.Context, objectLists []client.ObjectList) ([]client.Object, error) {

--- a/migration/migration/executor_test.go
+++ b/migration/migration/executor_test.go
@@ -13,7 +13,7 @@ var _ = Describe("Executor", func() {
 	)
 
 	BeforeEach(func() {
-		migrator = migration.New(k8sClient, "test-version", 1)
+		migrator = migration.New(k8sClient, "test-version", []byte{}, 1)
 	})
 
 	JustBeforeEach(func() {

--- a/tests/e2e/orgs_test.go
+++ b/tests/e2e/orgs_test.go
@@ -250,6 +250,99 @@ var _ = Describe("Orgs", func() {
 		})
 	})
 
+	Describe("rename", func() {
+		var (
+			orgGUID string
+			result  resource
+			errResp cfErrs
+		)
+
+		BeforeEach(func() {
+			orgGUID = createOrg(generateGUID("org"))
+			result = resource{}
+			errResp = cfErrs{}
+		})
+
+		AfterEach(func() {
+			deleteOrg(orgGUID)
+		})
+
+		JustBeforeEach(func() {
+			var err error
+			resp, err = adminClient.R().
+				SetBody(resource{Name: generateGUID("renamed-org")}).
+				SetResult(&result).
+				SetError(&errResp).
+				Patch("/v3/organizations/" + orgGUID)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("succeeds", func() {
+			Expect(resp).To(HaveRestyStatusCode(http.StatusOK))
+			Expect(result.Name).To(HavePrefix("renamed-org"))
+		})
+
+		It("can be renamed again", func() {
+			Expect(resp).To(HaveRestyStatusCode(http.StatusOK))
+
+			var secondResult resource
+			secondResp, err := adminClient.R().
+				SetBody(resource{Name: generateGUID("renamed-again-org")}).
+				SetResult(&secondResult).
+				Patch("/v3/organizations/" + orgGUID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(secondResp).To(HaveRestyStatusCode(http.StatusOK))
+			Expect(secondResult.Name).To(HavePrefix("renamed-again-org"))
+		})
+	})
+
+	Describe("update metadata", func() {
+		var (
+			orgGUID string
+			result  resource
+			errResp cfErrs
+		)
+
+		BeforeEach(func() {
+			orgGUID = createOrg(generateGUID("org"))
+			result = resource{}
+			errResp = cfErrs{}
+		})
+
+		AfterEach(func() {
+			deleteOrg(orgGUID)
+		})
+
+		It("allows user-defined labels", func() {
+			var err error
+			resp, err = adminClient.R().
+				SetBody(metadataResource{Metadata: &metadataPatch{
+					Labels: &map[string]string{"user-label": "value"},
+				}}).
+				SetResult(&result).
+				SetError(&errResp).
+				Patch("/v3/organizations/" + orgGUID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp).To(HaveRestyStatusCode(http.StatusOK))
+			Expect(result.Metadata.Labels).To(HaveKeyWithValue("user-label", "value"))
+		})
+
+		It("rejects cloudfoundry.org domain labels", func() {
+			var err error
+			resp, err = adminClient.R().
+				SetBody(metadataResource{Metadata: &metadataPatch{
+					Labels: &map[string]string{"foo.cloudfoundry.org/bar": "baz"},
+				}}).
+				SetError(&errResp).
+				Patch("/v3/organizations/" + orgGUID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp).To(HaveRestyStatusCode(http.StatusUnprocessableEntity))
+			Expect(errResp.Errors).To(ContainElement(
+				MatchFields(IgnoreExtras, Fields{"Detail": ContainSubstring("invalid labels patch")}),
+			))
+		})
+	})
+
 	Describe("get", func() {
 		var result resource
 

--- a/tests/smoke/orgs_test.go
+++ b/tests/smoke/orgs_test.go
@@ -21,6 +21,21 @@ var _ = Describe("Orgs", func() {
 		)).To(Exit(0))
 	})
 
+	Describe("cf rename-org", func() {
+		It("renames the org", func() {
+			session := helpers.Cf("rename-org", orgName, "renamed-org")
+			Expect(session).To(Exit(0))
+
+			session = helpers.Cf("orgs")
+			Expect(session).To(Exit(0))
+
+			lines := it.MustCollect(it.LinesString(session.Out))
+			Expect(lines).To(ContainElement(
+				matchSubstrings("renamed-org"),
+			))
+		})
+	})
+
 	Describe("cf org", func() {
 		It("returns successful", func() {
 			session := helpers.Cf("org", orgName)


### PR DESCRIPTION
## Summary

This PR completes the org rename fix and hardens metadata protection across Korifi objects described in this [Issue](https://github.com/cloudfoundry/korifi/issues/4245)

It includes three parts:

- Fix org rename handling for PATCH requests.
- Keep Danail’s context-aware [repository validation](https://github.com/cloudfoundry/korifi/commit/7965e315c14954aa614d61a5d51f402ad5ac12f4#diff-676de4e8a003e16a84e31ba23846cb034285b416424aca069fabe0c5ab9b55e6) for metadata patching.
- Add label-signing and a validating webhook to protect Korifi-managed labels at the Kubernetes API level.

## What changed

- Fixed org rename issues in the API patch flow.
- Kept metadata patch validation in repositories, where the code can compare incoming values with the current object and allow unchanged echoed metadata.
- Extended that repository-side validation/error propagation to other metadata patch paths.
- Added label signing for Korifi-managed labels.
- Added a validating webhook that rejects tampering with internal [korifi.cloudfoundry.org/*](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) labels and rejects non-Korifi [*.cloudfoundry.org](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) label keys.
- Added migration/backfill support and Helm wiring for the label-signing secret.
- Updated repository, webhook, e2e, and smoke coverage accordingly.

## Why repository-side validation should co-exist with the webhook solution

Both solutions protect different layers and should both remain in place.

Repository-side validation is still needed because:

- it gives the correct behavior for requests coming through the Korifi API
- it has object context, so it can distinguish between “client echoed existing metadata back unchanged” and “client is trying to modify protected metadata”
- it returns proper Korifi API errors from the handler/repository flow

The webhook solution is also needed because:

- repository validation only runs for requests that go through the Korifi API
- it does not protect direct writes to Korifi CRDs through the Kubernetes API
- the validating webhook blocks those direct mutations at admission time

In short:

- repository validation protects the Korifi API path
- webhooks protect the Kubernetes API path

Together they provide correct API semantics and cluster-level enforcement.

## Testing

- Added/updated repository tests for invalid metadata patch handling
- Added validating webhook integration tests
- Added e2e and smoke coverage for protected labels